### PR TITLE
docs(sandbox): write the control plane comments in English

### DIFF
--- a/infra/sandbox/sandbox_control_plane/src/application/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/__init__.py
@@ -1,6 +1,6 @@
 """
-Application Layer - 应用层
+Application Layer
 
-用例编排层，协调领域对象完成业务功能。
-依赖领域层，被接口层调用。
+The use-case layer: orchestrates the domain objects to deliver a business function.
+Depends on the domain layer and is called by the interface layer.
 """

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/create_session.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/create_session.py
@@ -1,8 +1,8 @@
 """
-创建会话命令
+Create-session command
 
-定义创建会话的命令对象。
-扩展支持依赖安装，按照 sandbox-design-v2.1.md 章节 5 设计。
+The command object for creating a session.
+Extended for dependency installation, following section 5 of sandbox-design-v2.1.md.
 """
 
 import re
@@ -16,18 +16,18 @@ from src.shared.utils.dependencies import DEFAULT_PYTHON_PACKAGE_INDEX_URL
 @dataclass
 class CreateSessionCommand:
     """
-    创建会话命令
+    Create-session command
 
-    扩展支持 Python 依赖安装功能。
+    Extended to support installing Python dependencies.
     """
 
     template_id: Optional[str] = None
     timeout: int = 300
     resource_limit: ResourceLimit | None = None
     env_vars: Dict[str, str] | None = None
-    id: Optional[str] = None  # 手动指定会话 ID（可选）
+    id: Optional[str] = None  # session id, optionally given by the caller
 
-    # 依赖安装相关字段（新增）
+    # Dependency installation fields
     dependencies: List[str] = field(default_factory=list)
     install_timeout: int = 300
     fail_on_dependency_error: bool = True
@@ -35,25 +35,27 @@ class CreateSessionCommand:
     python_package_index_url: str = DEFAULT_PYTHON_PACKAGE_INDEX_URL
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if self.timeout <= 0:
             raise ValueError("timeout must be positive")
 
-        # 安全关键：id / template_id 会经 workspace_path 落入以 root 运行的 s3fs
-        # 挂载脚本（k8s/docker scheduler）。严格白名单兜底，防 shell 命令注入与
-        # 前缀逃逸；request schema 已在入口校验，此处覆盖不经 schema 的调用路径。
+        # Security critical: id and template_id travel through workspace_path into the
+        # s3fs mount script that runs as root (the k8s and docker schedulers). The strict
+        # allowlist is the backstop against shell command injection and prefix escape; the
+        # request schema already validates at the entrance, and this covers the call paths
+        # that bypass the schema.
         for _name, _val in (("id", self.id), ("template_id", self.template_id)):
             if _val is not None and not re.match(r"^[A-Za-z0-9_-]+$", _val):
                 raise ValueError(
                     f"{_name} may only contain letters, digits, '_' and '-'"
                 )
 
-        # 设置默认值
+        # Apply the defaults
         if self.resource_limit is None:
             self.resource_limit = ResourceLimit.default()
         if self.env_vars is None:
             self.env_vars = {}
 
-        # 验证安装超时
+        # Validate the install timeout
         if self.install_timeout < 30 or self.install_timeout > 1800:
             raise ValueError("install_timeout must be between 30 and 1800 seconds")

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/create_template.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/create_template.py
@@ -1,7 +1,7 @@
 """
-创建模板命令
+Create-template command
 
-定义创建模板的命令 DTO。
+The command DTO for creating a template.
 """
 
 from dataclasses import dataclass
@@ -10,7 +10,7 @@ from typing import Optional, Dict
 
 @dataclass
 class CreateTemplateCommand:
-    """创建模板命令"""
+    """Create-template command"""
 
     template_id: str
     name: str

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/execute_code.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/execute_code.py
@@ -1,7 +1,7 @@
 """
-执行代码命令
+Execute-code command
 
-定义执行代码的命令对象。
+The command object for executing code.
 """
 
 from dataclasses import dataclass
@@ -12,7 +12,7 @@ from typing import Literal, Optional
 
 @dataclass
 class ExecuteCodeCommand:
-    """执行代码命令"""
+    """Execute-code command"""
 
     session_id: str
     code: str
@@ -25,7 +25,7 @@ class ExecuteCodeCommand:
     working_directory: Optional[str] = None
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if not self.code:
             raise ValueError("code cannot be empty")
         if self.timeout <= 0:

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/install_session_dependencies.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/install_session_dependencies.py
@@ -1,5 +1,5 @@
 """
-增量安装会话依赖命令。
+Incremental session dependency install command.
 """
 
 from dataclasses import dataclass
@@ -8,7 +8,7 @@ from typing import Optional
 
 @dataclass
 class InstallSessionDependenciesCommand:
-    """增量安装会话依赖命令。"""
+    """Incremental session dependency install command."""
 
     session_id: str
     dependencies: list[str]
@@ -16,6 +16,6 @@ class InstallSessionDependenciesCommand:
     install_timeout: int = 300
 
     def __post_init__(self):
-        """初始化后验证。"""
+        """Validate after construction."""
         if self.install_timeout < 30 or self.install_timeout > 1800:
             raise ValueError("install_timeout must be between 30 and 1800 seconds")

--- a/infra/sandbox/sandbox_control_plane/src/application/commands/update_template.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/commands/update_template.py
@@ -1,7 +1,7 @@
 """
-更新模板命令
+Update-template command
 
-定义更新模板的命令 DTO。
+The command DTO for updating a template.
 """
 
 from dataclasses import dataclass
@@ -10,7 +10,7 @@ from typing import Optional, Dict
 
 @dataclass
 class UpdateTemplateCommand:
-    """更新模板命令"""
+    """Update-template command"""
 
     template_id: str
     name: Optional[str] = None

--- a/infra/sandbox/sandbox_control_plane/src/application/dtos/execution_dto.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/dtos/execution_dto.py
@@ -1,7 +1,7 @@
 """
-执行数据传输对象
+Execution data transfer objects
 
-用于应用层与接口层之间的数据传输。
+Carries data between the application layer and the interface layer.
 """
 
 from dataclasses import dataclass
@@ -13,7 +13,7 @@ from src.domain.value_objects.artifact import Artifact
 
 @dataclass
 class ArtifactDTO:
-    """文件制品数据传输对象"""
+    """File artifact data transfer object"""
 
     path: str
     size: int
@@ -24,7 +24,7 @@ class ArtifactDTO:
 
     @classmethod
     def from_entity(cls, artifact: Artifact) -> "ArtifactDTO":
-        """从领域实体创建 DTO"""
+        """Build the DTO from the domain entity"""
         return cls(
             path=artifact.path,
             size=artifact.size,
@@ -37,13 +37,13 @@ class ArtifactDTO:
 
 @dataclass
 class ExecutionDTO:
-    """执行数据传输对象"""
+    """Execution data transfer object"""
 
     id: str
     session_id: str
     code: str
     language: str
-    timeout: int  # 超时时间（秒）
+    timeout: int  # timeout in seconds
     status: str
     exit_code: Optional[int] = None
     error_message: Optional[str] = None
@@ -56,11 +56,11 @@ class ExecutionDTO:
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     last_heartbeat_at: Optional[datetime] = None
-    return_value: Optional[dict] = None  # handler 函数返回值
-    metrics: Optional[dict] = None  # 性能指标
+    return_value: Optional[dict] = None  # handler return value
+    metrics: Optional[dict] = None  # performance metrics
 
     def __post_init__(self):
-        """初始化默认值"""
+        """Apply the defaults"""
         if self.artifacts is None:
             self.artifacts = []
         if self.created_at is None:
@@ -68,7 +68,7 @@ class ExecutionDTO:
 
     @classmethod
     def from_entity(cls, execution) -> "ExecutionDTO":
-        """从领域实体创建 DTO"""
+        """Build the DTO from the domain entity"""
         return cls(
             id=execution.id,
             session_id=execution.session_id,

--- a/infra/sandbox/sandbox_control_plane/src/application/dtos/session_dto.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/dtos/session_dto.py
@@ -1,7 +1,7 @@
 """
-会话数据传输对象
+Session data transfer object
 
-用于应用层与接口层之间的数据传输。
+Carries data between the application layer and the interface layer.
 """
 
 from dataclasses import dataclass
@@ -13,7 +13,7 @@ from src.shared.utils.dependencies import parse_pip_spec
 
 @dataclass
 class SessionDTO:
-    """会话数据传输对象"""
+    """Session data transfer object"""
 
     id: str
     template_id: str
@@ -40,7 +40,7 @@ class SessionDTO:
     last_activity_at: datetime = None
 
     def __post_init__(self):
-        """初始化默认值"""
+        """Apply the defaults"""
         if self.env_vars is None:
             self.env_vars = {}
         if self.created_at is None:
@@ -56,7 +56,7 @@ class SessionDTO:
 
     @classmethod
     def from_entity(cls, session) -> "SessionDTO":
-        """从领域实体创建 DTO"""
+        """Build the DTO from the domain entity"""
         return cls(
             id=session.id,
             template_id=session.template_id,

--- a/infra/sandbox/sandbox_control_plane/src/application/dtos/template_dto.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/dtos/template_dto.py
@@ -1,7 +1,7 @@
 """
-模板 DTO
+Template DTO
 
-定义模板数据传输对象。
+The template data transfer object.
 """
 
 from dataclasses import dataclass
@@ -13,7 +13,7 @@ from src.domain.entities.template import Template
 
 @dataclass
 class TemplateDTO:
-    """模板数据传输对象"""
+    """Template data transfer object"""
 
     id: str
     name: str
@@ -30,7 +30,7 @@ class TemplateDTO:
 
     @classmethod
     def from_entity(cls, template: Template) -> "TemplateDTO":
-        """从领域实体创建 DTO"""
+        """Build the DTO from the domain entity"""
         import re
 
         def parse_resource(value: str | None, default: int, resource_type: str) -> int:
@@ -74,7 +74,7 @@ class TemplateDTO:
         )
 
     def to_dict(self) -> dict:
-        """转换为字典"""
+        """Convert to a dict"""
         return {
             "id": self.id,
             "name": self.name,

--- a/infra/sandbox/sandbox_control_plane/src/application/queries/get_execution.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/queries/get_execution.py
@@ -1,7 +1,7 @@
 """
-获取执行查询
+Get-execution query
 
-定义获取执行详情的查询 DTO。
+The query DTO for reading the execution details.
 """
 
 from dataclasses import dataclass
@@ -9,6 +9,6 @@ from dataclasses import dataclass
 
 @dataclass
 class GetExecutionQuery:
-    """获取执行查询"""
+    """Get-execution query"""
 
     execution_id: str

--- a/infra/sandbox/sandbox_control_plane/src/application/queries/get_session.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/queries/get_session.py
@@ -1,7 +1,7 @@
 """
-获取会话查询
+Get-session query
 
-定义获取会话的查询对象。
+The query object for reading a session.
 """
 
 from dataclasses import dataclass
@@ -9,11 +9,11 @@ from dataclasses import dataclass
 
 @dataclass
 class GetSessionQuery:
-    """获取会话查询"""
+    """Get-session query"""
 
     session_id: str
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if not self.session_id:
             raise ValueError("session_id cannot be empty")

--- a/infra/sandbox/sandbox_control_plane/src/application/queries/get_template.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/queries/get_template.py
@@ -1,7 +1,7 @@
 """
-获取模板查询
+Get-template query
 
-定义获取模板详情的查询 DTO。
+The query DTO for reading the template details.
 """
 
 from dataclasses import dataclass
@@ -9,6 +9,6 @@ from dataclasses import dataclass
 
 @dataclass
 class GetTemplateQuery:
-    """获取模板查询"""
+    """Get-template query"""
 
     template_id: str

--- a/infra/sandbox/sandbox_control_plane/src/application/services/file_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/file_service.py
@@ -1,7 +1,7 @@
 """
-文件应用服务
+File application service
 
-编排文件上传下载相关的用例。
+Orchestrates the file upload and download use cases.
 """
 
 import io
@@ -21,9 +21,9 @@ from src.shared.i18n import message
 
 class FileService:
     """
-    文件应用服务
+    File application service
 
-    编排文件上传、下载等用例。
+    Orchestrates uploading and downloading files.
     """
 
     def __init__(
@@ -46,13 +46,13 @@ class FileService:
         content_type: str = "application/octet-stream",
     ) -> str:
         """
-        上传文件用例
+        Upload-file use case
 
-        流程：
-        1. 验证会话存在且运行中
-        2. 验证路径格式
-        3. 上传到存储
-        4. 返回文件路径
+        Steps:
+        1. Verify the session exists and is running
+        2. Validate the path
+        3. Upload to storage
+        4. Return the file path
         """
         session = await self._session_repo.find_by_id(session_id)
         if not session:
@@ -78,9 +78,9 @@ class FileService:
         overwrite: bool = False,
     ) -> Dict[str, Any]:
         """
-        上传 ZIP 并解压到会话工作区。
+        Upload a ZIP and extract it into the session workspace.
 
-        返回解压统计结果。
+        Returns the extraction statistics.
         """
         session = await self._session_repo.find_by_id(session_id)
         if not session:
@@ -151,12 +151,12 @@ class FileService:
 
     async def download_file(self, session_id: str, path: str) -> Dict:
         """
-        下载文件用例
+        Download-file use case
 
-        流程：
-        1. 验证会话存在
-        2. 验证文件存在
-        3. 返回文件内容或预签名 URL
+        Steps:
+        1. Verify the session exists
+        2. Verify the file exists
+        3. Return the content, or a presigned URL
         """
         session = await self._session_repo.find_by_id(session_id)
         if not session:
@@ -170,7 +170,7 @@ class FileService:
         file_info = await self._storage_service.get_file_info(s3_path)
         file_size = file_info["size"]
 
-        # 小文件（<10MB）直接返回内容，大文件返回预签名 URL
+        # Return the content directly under 10MB; hand back a presigned URL above it
         SMALL_FILE_THRESHOLD = 10 * 1024 * 1024  # 10MB
 
         if file_size < SMALL_FILE_THRESHOLD:
@@ -191,31 +191,31 @@ class FileService:
         self, session_id: str, path: str = None, limit: int = 1000
     ) -> List[Dict[str, Any]]:
         """
-        列出 session 下的文件
+        List the files of a session
 
         Args:
             session_id: Session ID
-            path: 可选，指定目录路径（相对于 workspace 根目录）
-            limit: 最大返回文件数
+            path: optional directory, relative to the workspace root
+            limit: how many files to return at most
 
         Returns:
-            文件列表，每个文件包含 name, size, modified_time, container_path 等
+            The file list, each entry holding name, size, modified_time, container_path, and more
         """
         session = await self._session_repo.find_by_id(session_id)
         if not session:
             raise NotFoundError(message("Sandbox.Session.NotFound", session_id=session_id))
 
-        # 解析 workspace_path，提取 S3 key 前缀
-        # workspace_path 格式: s3://bucket/sessions/{session_id}/
-        # S3 key 格式: sessions/{session_id}/...
+        # Parse workspace_path to get the S3 key prefix.
+        # workspace_path is s3://bucket/sessions/{session_id}/
+        # and an S3 key is sessions/{session_id}/...
         parsed = urlparse(session.workspace_path)
-        s3_key_prefix = parsed.path.lstrip("/")  # 去掉开头的 /，得到 "sessions/{session_id}/"
+        s3_key_prefix = parsed.path.lstrip("/")  # drop the leading /, leaving "sessions/{session_id}/"
 
-        # 构建 S3 查询前缀
+        # Build the S3 query prefix
         if path:
             normalized_path = path.strip().strip("/")
             if normalized_path:
-                # 确保 s3_key_prefix 以 / 结尾
+                # Make sure s3_key_prefix ends with /
                 base = s3_key_prefix.rstrip("/")
                 prefix = f"{base}/{normalized_path}"
             else:
@@ -230,19 +230,19 @@ class FileService:
         for file in files:
             key = file["key"]
 
-            # 提取相对于 session workspace 的路径
-            # key 格式: sessions/{session_id}/conversation-1231/uploads/temparea/test.csv
-            # s3_key_prefix 格式: sessions/{session_id}/
+            # Work out the path relative to the session workspace.
+            # A key looks like sessions/{session_id}/conversation-1231/uploads/temparea/test.csv
+            # and s3_key_prefix looks like sessions/{session_id}/
             if key.startswith(s3_key_prefix):
                 relative_path = key[len(s3_key_prefix) :].lstrip("/")
             else:
                 relative_path = key.lstrip("/")
 
-            # 过滤掉空路径（目录本身）和以斜杠结尾的目录标记
+            # Drop the empty path, which is the directory itself, and the trailing-slash directory markers
             if not relative_path or relative_path.endswith("/"):
                 continue
 
-            # 容器内挂载路径: /workspace/{relative_path}
+            # The in-container mount path is /workspace/{relative_path}
             container_path = f"/workspace/{relative_path}"
 
             result.append(

--- a/infra/sandbox/sandbox_control_plane/src/application/services/session_cleanup_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/session_cleanup_service.py
@@ -1,7 +1,7 @@
 """
-会话清理服务
+Session cleanup service
 
-负责定期清理空闲会话和过期会话，自动销毁关联的容器和删除关联的文件。
+Periodically reclaims idle and expired sessions, destroying the container and deleting the files that belong to them.
 """
 
 import logging
@@ -19,17 +19,17 @@ logger = logging.getLogger(__name__)
 
 class SessionCleanupService:
     """
-    会话清理服务
+    Session cleanup service
 
-    职责：
-    1. 定期扫描空闲会话（基于 last_activity_at 字段）
-    2. 自动终止超时会话并销毁容器
-    3. 定期扫描 FAILED/TIMEOUT 状态的孤立会话
-    4. 清理会话关联的 S3 文件
+    Responsibilities:
+    1. Periodically scan for idle sessions, using the last_activity_at field
+    2. Terminate timed-out sessions and destroy their containers
+    3. Periodically scan for orphaned sessions left in FAILED or TIMEOUT
+    4. Delete the S3 files that belong to a session
 
-    清理策略：
-    - 空闲超时：30 分钟无活动（可配置，设为 -1 表示禁用空闲清理）
-    - 最大生命周期：6 小时强制清理（可配置，设为 -1 表示禁用生命周期清理）
+    The policy:
+    - Idle timeout: 30 minutes without activity, configurable, -1 disables idle cleanup
+    - Maximum lifetime: forced cleanup after 6 hours, configurable, -1 disables it
     """
 
     def __init__(
@@ -41,14 +41,14 @@ class SessionCleanupService:
         storage_service: Optional[IStorageService] = None,
     ):
         """
-        初始化会话清理服务
+        Initialize the session cleanup service
 
         Args:
-            session_repo: 会话仓储
-            scheduler: 调度器（用于销毁容器）
-            idle_timeout_minutes: 空闲超时时间（分钟），-1 表示无限期（不清理空闲会话）
-            max_lifetime_hours: 最大生命周期（小时），-1 表示无限期
-            storage_service: 存储服务（可选，用于清理 S3 文件）
+            session_repo: session repository
+            scheduler: scheduler, used to destroy containers
+            idle_timeout_minutes: idle timeout in minutes; -1 means never, disabling idle cleanup
+            max_lifetime_hours: maximum lifetime in hours; -1 means never
+            storage_service: storage service, optional, used to delete S3 files
         """
         self._session_repo = session_repo
         self._scheduler = scheduler
@@ -62,18 +62,18 @@ class SessionCleanupService:
 
     async def cleanup_idle_sessions(self) -> Dict[str, int]:
         """
-        清理空闲会话
+        Clean up idle sessions
 
-        清理策略：
-        - 空闲超过阈值的会话自动销毁容器（如果 idle_timeout_minutes != -1）
-        - 创建超过最大生命周期的会话强制销毁（如果 max_lifetime_hours != -1）
+        The policy:
+        - A session idle beyond the threshold has its container destroyed, when idle_timeout_minutes != -1
+        - A session older than the maximum lifetime is destroyed, when max_lifetime_hours != -1
 
         Returns:
-            dict: 清理统计信息
-                - total_checked: 检查的会话数
-                - idle_cleaned: 空闲清理的会话数
-                - expired_cleaned: 过期清理的会话数
-                - errors: 错误列表
+            dict: the cleanup statistics
+                - total_checked: how many sessions were examined
+                - idle_cleaned: how many were reclaimed as idle
+                - expired_cleaned: how many were reclaimed as expired
+                - errors: the error list
         """
         stats = {"total_checked": 0, "idle_cleaned": 0, "expired_cleaned": 0, "errors": []}
 
@@ -82,7 +82,7 @@ class SessionCleanupService:
             idle_threshold = now - self._idle_timeout if self._idle_timeout else None
             max_lifetime_threshold = now - self._max_lifetime if self._max_lifetime else None
 
-            # 查询所有活跃会话
+            # Query every active session
             active_sessions = await self._session_repo.find_by_status("running")
             stats["total_checked"] = len(active_sessions)
 
@@ -93,7 +93,7 @@ class SessionCleanupService:
 
             for session in active_sessions:
                 try:
-                    # 检查是否超过最大生命周期（如果启用）
+                    # Check the maximum lifetime, when that is enabled
                     if (
                         max_lifetime_threshold
                         and session.created_at
@@ -107,8 +107,8 @@ class SessionCleanupService:
                         stats["expired_cleaned"] += 1
                         continue
 
-                    # 检查是否空闲超时（如果启用）
-                    # 使用 last_activity_at，如果不存在则使用 created_at
+                    # Check the idle timeout, when that is enabled.
+                    # Use last_activity_at, falling back to created_at.
                     if idle_threshold:
                         last_activity = session.last_activity_at or session.created_at
                         if last_activity and last_activity < idle_threshold:
@@ -141,15 +141,15 @@ class SessionCleanupService:
 
     async def cleanup_orphaned_sessions(self) -> Dict[str, int]:
         """
-        清理孤立会话（FAILED/TIMEOUT 状态但仍有关联容器的会话）
+        Clean up orphaned sessions: left in FAILED or TIMEOUT while still holding a container
 
         Returns:
-            dict: 清理统计信息
+            dict: the cleanup statistics
         """
         stats = {"total_checked": 0, "cleaned": 0, "errors": []}
 
         try:
-            # 查询失败和超时的会话
+            # Query the failed and timed-out sessions
             failed_sessions = await self._session_repo.find_by_status("failed")
             timeout_sessions = await self._session_repo.find_by_status("timeout")
             orphaned = failed_sessions + timeout_sessions
@@ -157,7 +157,7 @@ class SessionCleanupService:
             stats["total_checked"] = len(orphaned)
 
             for session in orphaned:
-                # 只清理有 container_id 的会话
+                # Only those that still hold a container_id
                 if session.container_id:
                     try:
                         await self._cleanup_session(
@@ -186,14 +186,14 @@ class SessionCleanupService:
 
     async def cleanup_session_files(self, session: Session, reason: str) -> int:
         """
-        删除会话关联的所有文件
+        Delete every file that belongs to a session
 
         Args:
-            session: 要清理的会话
-            reason: 清理原因
+            session: the session to clean up
+            reason: why it is being cleaned up
 
         Returns:
-            删除的文件数量
+            How many files were deleted
         """
         if not self._storage_service:
             logger.debug(
@@ -211,16 +211,16 @@ class SessionCleanupService:
         )
 
         try:
-            # 从 workspace_path 提取 bucket 和 prefix
-            # workspace_path 格式: s3://bucket/sessions/{session_id}/
+            # Pull the bucket and prefix out of workspace_path,
+            # which is formatted as s3://bucket/sessions/{session_id}/
             parsed = urlparse(session.workspace_path)
-            bucket = parsed.netloc  # 存储桶名称
+            bucket = parsed.netloc  # bucket name
 
-            # 构建删除前缀（包含存储桶路径）
-            # 例如: s3://sandbox-workspace/sessions/sess_abc123/
+            # Build the delete prefix, including the bucket path,
+            # for example s3://sandbox-workspace/sessions/sess_abc123/
             delete_prefix = session.workspace_path.rstrip("/")
 
-            # 删除所有带该前缀的文件
+            # Delete everything under that prefix
             deleted_count = await self._storage_service.delete_prefix(delete_prefix)
 
             logger.info(
@@ -236,12 +236,12 @@ class SessionCleanupService:
 
     async def _cleanup_session(self, session: Session, reason: str, detail: str) -> None:
         """
-        清理会话并销毁容器
+        Clean up the session and destroy its container
 
         Args:
-            session: 要清理的会话
-            reason: 清理原因
-            detail: 详细信息
+            session: the session to clean up
+            reason: why it is being cleaned up
+            detail: further detail
         """
         logger.info(
             f"Cleaning up session {session.id}: "
@@ -250,21 +250,21 @@ class SessionCleanupService:
             f"container_id={session.container_id}"
         )
 
-        # 销毁容器（如果调度器支持且容器存在）
+        # Destroy the container, when the scheduler supports it and one exists
         if session.container_id and hasattr(self._scheduler, "destroy_container"):
             try:
                 await self._scheduler.destroy_container(container_id=session.container_id)
                 logger.info(f"Destroyed container {session.container_id} for session {session.id}")
             except Exception as e:
-                # 记录错误但不中断流程
+                # Record the error but keep going
                 logger.warning(
                     f"Failed to destroy container {session.container_id} for session {session.id}: {e}"
                 )
 
-        # 删除 S3 文件（如果配置了存储服务）
+        # Delete the S3 files, when a storage service is configured
         await self.cleanup_session_files(session, reason)
 
-        # 标记会话为已终止
+        # Mark the session terminated
         session.mark_as_terminated()
         await self._session_repo.save(session)
 
@@ -272,13 +272,13 @@ class SessionCleanupService:
 
     async def cleanup_by_ids(self, session_ids: list[str]) -> Dict[str, int]:
         """
-        按会话 ID 列表清理会话
+        Clean up the sessions named by a list of ids
 
         Args:
-            session_ids: 要清理的会话 ID 列表
+            session_ids: the session ids to clean up
 
         Returns:
-            dict: 清理统计信息
+            dict: the cleanup statistics
         """
         stats = {"total": len(session_ids), "cleaned": 0, "not_found": 0, "errors": []}
 

--- a/infra/sandbox/sandbox_control_plane/src/application/services/session_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/session_service.py
@@ -1,7 +1,7 @@
 """
-会话应用服务
+Session application service
 
-编排会话相关的用例。
+Orchestrates the session use cases.
 """
 
 from typing import Callable, List, Optional
@@ -50,9 +50,9 @@ logger = get_logger(__name__)
 
 class SessionService:
     """
-    会话应用服务
+    Session application service
 
-    编排会话创建、执行、终止等用例。
+    Orchestrates creating, executing, and terminating a session.
     """
 
     def __init__(
@@ -75,16 +75,16 @@ class SessionService:
 
     async def create_session(self, command: CreateSessionCommand) -> SessionDTO:
         """
-        创建会话用例
+        Create-session use case
 
-        流程：
-        1. 验证模板存在
-        2. 生成会话 ID
-        3. 调用调度器选择运行时节点
-        4. 创建会话实体
-        5. 保存到仓储
-        6. 创建 Docker 容器
-        7. 更新会话状态为 running
+        Steps:
+        1. Verify the template exists
+        2. Generate the session id
+        3. Ask the scheduler to pick a runtime node
+        4. Build the session entity
+        5. Persist it
+        6. Create the Docker container
+        7. Move the session to running
         """
         if not command.template_id:
             settings = get_settings()
@@ -96,12 +96,12 @@ class SessionService:
             has_dependencies=len(command.dependencies or []) > 0,
         )
 
-        # 1. 验证模板
+        # 1. Verify the template
         template = await self._validate_template(command.template_id)
 
-        # 2. 处理会话 ID（手动指定或自动生成）
+        # 2. Resolve the session id, given or generated
         if command.id:
-            # 手动指定 ID，检查冲突
+            # A given id: check for a collision
             session_id = command.id
             existing_session = await self._session_repo.find_by_id(session_id)
             if existing_session:
@@ -113,14 +113,14 @@ class SessionService:
                 raise ConflictError(f"Session ID already exists: {session_id}")
             logger.debug("Using manually specified session ID", session_id=session_id)
         else:
-            # 自动生成会话 ID
+            # Generate the session id
             session_id = self._generate_session_id()
             logger.debug("Generated session ID", session_id=session_id)
 
-        # 3. 调用调度器
+        # 3. Call the scheduler
         runtime_node = await self._schedule_session(command, session_id)
 
-        # 4. 创建会话实体
+        # 4. Build the session entity
         session = self._create_session_entity(
             session_id=session_id,
             command=command,
@@ -128,11 +128,11 @@ class SessionService:
             runtime_node=runtime_node,
         )
 
-        # 5. 保存到仓储
+        # 5. Persist it
         await self._session_repo.save(session)
         logger.debug("Session saved to repository", session_id=session_id)
 
-        # 6. 创建容器
+        # 6. Create the container
         container_id = await self._create_container_for_session(
             session=session,
             template=template,
@@ -159,7 +159,7 @@ class SessionService:
         return SessionDTO.from_entity(session)
 
     async def _validate_template(self, template_id: str) -> Template:
-        """验证模板存在"""
+        """Verify the template exists"""
         from src.domain.entities.template import Template
 
         template = await self._template_repo.find_by_id(template_id)
@@ -173,7 +173,7 @@ class SessionService:
     async def _schedule_session(
         self, command: CreateSessionCommand, session_id: str
     ) -> RuntimeNode:
-        """调度会话到运行时节点"""
+        """Schedule the session onto a runtime node"""
         schedule_request = ScheduleRequest(
             template_id=command.template_id,
             resource_limit=command.resource_limit or ResourceLimit.default(),
@@ -196,7 +196,7 @@ class SessionService:
         template,
         runtime_node: RuntimeNode,
     ) -> Session:
-        """创建会话实体"""
+        """Build the session entity"""
         from src.domain.entities.template import Template
 
         runtime_type = self._infer_runtime_type(template.image)
@@ -229,7 +229,7 @@ class SessionService:
         command: CreateSessionCommand,
         runtime_node: RuntimeNode,
     ) -> Optional[str]:
-        """为会话创建容器"""
+        """Create the container for a session"""
         from src.domain.entities.template import Template
 
         container_id = None
@@ -295,7 +295,7 @@ class SessionService:
         container_id: Optional[str],
         error: Exception,
     ) -> None:
-        """处理容器创建失败"""
+        """Handle a failed container creation"""
         logger.exception(
             "Container creation failed, starting cleanup",
             session_id=session.id,
@@ -304,7 +304,7 @@ class SessionService:
             error=str(error),
         )
 
-        # 清理已创建的容器
+        # Clean up the container that was created
         if container_id and hasattr(self._scheduler, "destroy_container"):
             try:
                 logger.info("Attempting to clean up failed container", container_id=container_id)
@@ -317,7 +317,7 @@ class SessionService:
                     cleanup_error=str(cleanup_error),
                 )
 
-        # 标记会话为失败状态
+        # Mark the session failed
         session.status = SessionStatus.FAILED
         if session.has_dependencies():
             session.set_dependencies_failed(str(error))
@@ -332,7 +332,7 @@ class SessionService:
         raise ValidationError(message("Sandbox.Session.ContainerCreateFailed", error=error))
 
     async def get_session(self, query: GetSessionQuery) -> SessionDTO:
-        """获取会话用例"""
+        """Get-session use case"""
         session = await self._session_repo.find_by_id(query.session_id)
         if not session:
             raise NotFoundError(message("Sandbox.Session.NotFound", session_id=query.session_id))
@@ -343,7 +343,7 @@ class SessionService:
         self,
         command: InstallSessionDependenciesCommand,
     ) -> SessionDTO:
-        """增量安装会话依赖。"""
+        """Install session dependencies incrementally."""
         session = await self._session_repo.find_by_id(command.session_id)
         if not session:
             raise NotFoundError(message("Sandbox.Session.NotFound", session_id=command.session_id))
@@ -368,7 +368,7 @@ class SessionService:
         session_id: str,
         sync_mode: str = "replace",
     ) -> SessionDTO:
-        """同步指定 session 的依赖配置。"""
+        """Sync the dependency configuration of one session."""
         session = await self._session_repo.find_by_id(session_id)
         if not session:
             raise NotFoundError(message("Sandbox.Session.NotFound", session_id=session_id))
@@ -382,33 +382,33 @@ class SessionService:
         offset: int = 0,
     ) -> dict:
         """
-        列出会话用例
+        List-sessions use case
 
         Args:
-            status: 会话状态筛选（可选）
-            template_id: 模板 ID 筛选（可选）
-            limit: 返回数量限制（1-200，默认 50）
-            offset: 偏移量（用于分页）
+            status: filter by session status, optional
+            template_id: filter by template id, optional
+            limit: how many to return, 1-200, default 50
+            offset: offset, for paging
 
         Returns:
-            包含 items, total, limit, offset, has_more 的字典
+            A dict holding items, total, limit, offset, and has_more
         """
-        # 验证 limit 范围
+        # Validate the limit range
         limit = max(1, min(limit, 200))
         offset = max(0, offset)
 
-        # 获取会话列表
+        # Read the session list
         sessions = await self._session_repo.find_sessions(
             status=status, template_id=template_id, limit=limit, offset=offset
         )
 
-        # 获取总数
+        # Read the total
         total = await self._session_repo.count_sessions(status=status, template_id=template_id)
 
-        # 转换为 DTO
+        # Convert to DTOs
         items = [SessionDTO.from_entity(s) for s in sessions]
 
-        # 计算是否有更多数据
+        # Work out whether more remain
         has_more = (offset + len(items)) < total
 
         return {
@@ -421,14 +421,14 @@ class SessionService:
 
     async def terminate_session(self, session_id: str) -> SessionDTO:
         """
-        终止会话用例（软终止，保留记录）
+        Terminate-session use case: a soft stop that keeps the record
 
-        流程：
-        1. 查找会话
-        2. 验证状态
-        3. 销毁 Docker 容器（如果调度器支持）
-        4. 清理 S3 文件（如果配置了存储服务）
-        5. 更新会话状态
+        Steps:
+        1. Find the session
+        2. Validate its status
+        3. Destroy the Docker container, when the scheduler supports it
+        4. Clean up the S3 files, when a storage service is configured
+        5. Update the session status
         """
         logger.info("Terminating session", session_id=session_id)
 
@@ -450,13 +450,13 @@ class SessionService:
             status=session.status.value,
         )
 
-        # 销毁容器
+        # Destroy the container
         await self._destroy_container(session)
 
-        # 清理 S3 文件
+        # Clean up the S3 files
         await self._cleanup_storage(session)
 
-        # 更新会话状态
+        # Update the session status
         session.mark_as_terminated()
         await self._session_repo.save(session)
 
@@ -470,12 +470,12 @@ class SessionService:
 
     async def delete_session(self, session_id: str) -> None:
         """
-        删除会话用例（硬删除，级联删除执行记录）
+        Delete-session use case: a hard delete that cascades to the execution records
 
-        流程：
-        1. 查找会话
-        2. 执行清理（销毁容器 + 删除 S3）
-        3. 级联删除数据库记录
+        Steps:
+        1. Find the session
+        2. Clean up: destroy the container and delete from S3
+        3. Cascade-delete the database records
         """
         logger.info("Deleting session", session_id=session_id)
 
@@ -491,19 +491,19 @@ class SessionService:
             status=session.status.value,
         )
 
-        # 销毁容器
+        # Destroy the container
         await self._destroy_container(session)
 
-        # 清理 S3 文件
+        # Clean up the S3 files
         await self._cleanup_storage(session)
 
-        # 级联删除数据库记录（session + executions）
+        # Cascade-delete the database records: session plus executions
         await self._session_repo.delete(session_id)
 
         logger.info("Session deleted successfully", session_id=session_id)
 
     async def _destroy_container(self, session: Session) -> None:
-        """销毁会话的容器"""
+        """Destroy the container of a session"""
         if not session.container_id or not hasattr(self._scheduler, "destroy_container"):
             return
 
@@ -526,7 +526,7 @@ class SessionService:
             )
 
     async def _cleanup_storage(self, session: Session) -> None:
-        """清理会话的存储文件"""
+        """Clean up the stored files of a session"""
         if not self._storage_service or not session.workspace_path.startswith("s3://"):
             return
 
@@ -553,14 +553,14 @@ class SessionService:
 
     async def execute_code(self, command: ExecuteCodeCommand) -> ExecutionDTO:
         """
-        执行代码用例
+        Execute-code use case
 
-        流程：
-        1. 验证会话存在且运行中
-        2. 生成执行 ID
-        3. 创建执行实体
-        4. 保存到仓储
-        5. 提交到执行器
+        Steps:
+        1. Verify the session exists and is running
+        2. Generate the execution id
+        3. Build the execution entity
+        4. Persist it
+        5. Submit it to the executor
         """
         logger.info(
             "Executing code",
@@ -569,7 +569,7 @@ class SessionService:
             code_length=len(command.code),
         )
 
-        # 1. 验证会话
+        # 1. Verify the session
         session = await self._session_repo.find_by_id(command.session_id)
         if not session:
             logger.error(
@@ -592,7 +592,7 @@ class SessionService:
             container_id=session.container_id,
         )
 
-        # 2. 生成执行 ID
+        # 2. Generate the execution id
         execution_id = self._generate_execution_id()
 
         logger.debug(
@@ -601,7 +601,7 @@ class SessionService:
             session_id=command.session_id,
         )
 
-        # 3. 创建执行实体
+        # 3. Build the execution entity
         from src.domain.value_objects.execution_status import ExecutionState
 
         execution = Execution(
@@ -614,17 +614,17 @@ class SessionService:
             state=ExecutionState(status=ExecutionStatus.PENDING),
         )
 
-        # 4. 保存到仓储
+        # 4. Persist it
         await self._execution_repo.save(execution)
         logger.debug(
             "Execution saved to repository",
             execution_id=execution_id,
         )
 
-        # 4.5. 提交事务，确保执行记录在执行器回调之前可见
+        # 4.5. Commit, so the execution record is visible before the executor calls back
         await self._execution_repo.commit()
 
-        # 5. 提交到执行器
+        # 5. Submit to the executor
         if not session.container_id:
             logger.error(
                 "Session has no container",
@@ -632,14 +632,15 @@ class SessionService:
             )
             raise ValidationError(message("Sandbox.Session.NoContainer", session_id=command.session_id))
 
-        # 构建执行请求
+        # Build the execution request
         execution_request = ExecutionRequest(
             code=command.code,
             language=command.language,
             event=command.event_data or {},
             timeout=command.timeout or 300,
-            # 会话创建时的值打底，本次执行下发的覆盖它。
-            # 池化会话里留着上一个调用方的身份，不覆盖就会被当前函数读到。
+            # The value from session creation is the floor; what this execution sends overrides it.
+            # A pooled session still holds the previous caller's identity, and without
+            # the override the current function would read that.
             env_vars={**(session.env_vars or {}), **(command.env_vars or {})},
             execution_id=execution_id,
             session_id=session.id,
@@ -654,7 +655,7 @@ class SessionService:
             timeout=execution_request.timeout,
         )
 
-        # 通过调度器提交到执行器
+        # Submit to the executor through the scheduler
         await self._scheduler.execute(
             session_id=session.id,
             container_id=session.container_id,
@@ -670,7 +671,7 @@ class SessionService:
         return ExecutionDTO.from_entity(execution)
 
     async def get_execution(self, query: GetExecutionQuery) -> ExecutionDTO:
-        """获取执行详情用例"""
+        """Get-execution use case"""
         execution = await self._execution_repo.find_by_id(query.execution_id)
         if not execution:
             raise NotFoundError(message("Sandbox.Execution.NotFound", execution_id=query.execution_id))
@@ -680,7 +681,7 @@ class SessionService:
     async def list_executions(
         self, session_id: str, limit: int = 50, offset: int = 0
     ) -> List[ExecutionDTO]:
-        """列出会话的所有执行用例"""
+        """List-executions-of-a-session use case"""
         executions = await self._execution_repo.find_by_session_id(
             session_id=session_id, limit=limit
         )
@@ -691,9 +692,9 @@ class SessionService:
         self, idle_threshold_minutes: int = 30, max_lifetime_hours: int = 6
     ) -> int:
         """
-        清理空闲会话用例
+        Clean-up-idle-sessions use case
 
-        定时任务调用，清理空闲或过期的会话。
+        Called by the scheduled task to reclaim idle or expired sessions.
         """
         idle_threshold = datetime.now() - timedelta(minutes=idle_threshold_minutes)
         max_lifetime = datetime.now() - timedelta(hours=max_lifetime_hours)
@@ -711,11 +712,11 @@ class SessionService:
         return cleaned_count
 
     async def _cleanup_session(self, session: Session) -> bool:
-        """清理单个会话"""
+        """Clean up one session"""
         if not session.is_active():
             return False
 
-        # 销毁容器
+        # Destroy the container
         if session.container_id and hasattr(self._scheduler, "destroy_container"):
             try:
                 await self._scheduler.destroy_container(container_id=session.container_id)
@@ -737,7 +738,7 @@ class SessionService:
         sync_mode: str,
         executor_timeout: int | None = None,
     ) -> SessionDTO:
-        """同步 session 依赖配置到 executor。"""
+        """Sync the session dependency configuration to the executor."""
         if not session.is_active():
             raise ValidationError(message("Sandbox.Session.NotActive", session_id=session.id))
         if not session.container_id:
@@ -802,7 +803,7 @@ class SessionService:
         install_timeout: int,
         dependency_count: int,
     ) -> None:
-        """调度首次依赖安装后台任务。"""
+        """Schedule the background task for the first dependency install."""
         if self._initial_dependency_sync_scheduler is None:
             logger.warning(
                 "Initial dependency sync scheduler is not configured",
@@ -820,13 +821,13 @@ class SessionService:
         self._initial_dependency_sync_scheduler(session_id, install_timeout)
 
     def _generate_session_id(self) -> str:
-        """生成会话 ID"""
+        """Generate the session id"""
         timestamp = datetime.now().strftime("%Y%m%d")
         unique = uuid.uuid4().hex[:8]
         return f"sess_{timestamp}_{unique}"
 
     def _infer_runtime_type(self, image: str) -> str:
-        """从镜像名称推断运行时类型"""
+        """Infer the runtime type from the image name"""
         image_lower = image.lower()
         if "python" in image_lower or "python3" in image_lower:
             return "python3.11"
@@ -837,11 +838,11 @@ class SessionService:
         elif "go" in image_lower or "golang" in image_lower:
             return "go1.21"
         else:
-            # 默认使用 Python
+            # Default to Python
             return "python3.11"
 
     def _generate_execution_id(self) -> str:
-        """生成执行 ID"""
+        """Generate the execution id"""
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
         unique = uuid.uuid4().hex[:8]
         return f"exec_{timestamp}_{unique}"

--- a/infra/sandbox/sandbox_control_plane/src/application/services/session_stuck_creating_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/session_stuck_creating_service.py
@@ -1,8 +1,9 @@
 """
-会话创建超时检测服务
+Session creation timeout service
 
-负责定期检测处于 creating 状态超过阈值的会话，并将其标记为 failed。
-这解决了 executor 容器初始化失败（如依赖安装失败）导致会话永久处于 creating 状态的问题。
+Periodically finds sessions stuck in creating past a threshold and marks them failed.
+This covers a failed executor container start-up, such as a failed dependency install,
+which would otherwise leave the session in creating forever.
 """
 
 import logging
@@ -17,16 +18,16 @@ logger = logging.getLogger(__name__)
 
 class SessionStuckCreatingService:
     """
-    会话创建超时检测服务
+    Session creation timeout service
 
-    职责：
-    1. 定期扫描处于 "creating" 状态的会话
-    2. 检查创建时间是否超过配置的超时阈值
-    3. 将超时会话标记为 "failed" 状态
+    Responsibilities:
+    1. Periodically scan for sessions in "creating"
+    2. Check whether creation started longer ago than the configured timeout
+    3. Mark a timed-out session "failed"
 
-    检测策略：
-    - 默认超时时间：300 秒（5 分钟，可配置）
-    - 检测间隔：默认与 cleanup_interval_seconds 一致（5 分钟）
+    The policy:
+    - Default timeout: 300 seconds, five minutes, configurable
+    - Scan interval: matches cleanup_interval_seconds by default, five minutes
     """
 
     def __init__(
@@ -35,24 +36,24 @@ class SessionStuckCreatingService:
         creating_timeout_seconds: int = 300,
     ):
         """
-        初始化会话创建超时检测服务
+        Initialize the session creation timeout service
 
         Args:
-            session_repo: 会话仓储
-            creating_timeout_seconds: 创建超时时间（秒），必须 >= 30 秒
+            session_repo: session repository
+            creating_timeout_seconds: creation timeout in seconds, at least 30
         """
         self._session_repo = session_repo
         self._timeout = timedelta(seconds=creating_timeout_seconds)
 
     async def check_and_mark_stuck_sessions(self) -> Dict[str, int]:
         """
-        检测并标记处于 creating 状态超时的会话
+        Find and mark the sessions stuck in creating
 
         Returns:
-            dict: 检测统计信息
-                - total_checked: 检查的会话数
-                - marked_failed: 标记为 failed 的会话数
-                - errors: 错误列表
+            dict: the scan statistics
+                - total_checked: how many sessions were examined
+                - marked_failed: how many were marked failed
+                - errors: the error list
         """
         stats = {"total_checked": 0, "marked_failed": 0, "errors": []}
 
@@ -60,7 +61,7 @@ class SessionStuckCreatingService:
             now = datetime.now()
             timeout_threshold = now - self._timeout
 
-            # 查询所有处于 creating 状态的会话
+            # Query every session in "creating"
             creating_sessions = await self._session_repo.find_by_status(SessionStatus.CREATING)
             stats["total_checked"] = len(creating_sessions)
 
@@ -72,7 +73,7 @@ class SessionStuckCreatingService:
 
             for session in creating_sessions:
                 try:
-                    # 检查是否创建时间超过阈值
+                    # Check whether creation started longer ago than the threshold
                     if session.created_at and session.created_at < timeout_threshold:
                         await self._mark_session_as_failed(
                             session,
@@ -82,7 +83,7 @@ class SessionStuckCreatingService:
                         )
                         stats["marked_failed"] += 1
                     else:
-                        # 记录还未超时的会话（调试用）
+                        # Log the ones still inside the window, for debugging
                         if session.created_at:
                             time_in_creating = (now - session.created_at).total_seconds()
                             logger.debug(
@@ -111,12 +112,12 @@ class SessionStuckCreatingService:
 
     async def _mark_session_as_failed(self, session: Session, reason: str, detail: str) -> None:
         """
-        标记会话为失败状态
+        Mark the session failed
 
         Args:
-            session: 要标记的会话
-            reason: 失败原因
-            detail: 详细信息
+            session: the session to mark
+            reason: why it failed
+            detail: further detail
         """
         logger.warning(
             f"Marking session {session.id} as failed: "
@@ -126,7 +127,7 @@ class SessionStuckCreatingService:
             f"created_at={session.created_at}"
         )
 
-        # 标记会话为失败状态
+        # Mark the session failed
         session.mark_as_failed()
         await self._session_repo.save(session)
 

--- a/infra/sandbox/sandbox_control_plane/src/application/services/state_sync_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/state_sync_service.py
@@ -1,7 +1,7 @@
 """
-状态同步服务
+State sync service
 
-负责同步 Session 状态与实际容器状态，支持启动时同步和定时健康检查。
+Keeps the session state aligned with the real container state, at start-up and on a health-check timer.
 """
 
 from datetime import datetime
@@ -20,15 +20,15 @@ logger = get_logger(__name__)
 
 class StateSyncService:
     """
-    状态同步服务
+    State sync service
 
-    职责：
-    1. 启动时全量状态同步
-    2. 定时健康检查（通过 Docker/K8s API）
-    3. 状态不一致时更新 Session 表
-    4. 恢复不健康的容器（创建新容器）
+    Responsibilities:
+    1. Full state sync at start-up
+    2. Periodic health checks, through the Docker or K8s API
+    3. Update the session table when the two disagree
+    4. Recover an unhealthy container by creating a new one
 
-    核心原则：Docker/K8s 是容器状态的唯一真实来源，Session 表只保存关联关系。
+    The core principle: Docker or K8s is the single source of truth for container state, and the session table only records the association.
     """
 
     def __init__(
@@ -49,10 +49,10 @@ class StateSyncService:
 
     async def sync_on_startup(self) -> Dict[str, int]:
         """
-        启动时全量同步
+        Full sync at start-up
 
-        查询所有 RUNNING/CREATING 状态的 Session，检查容器实际状态，
-        尝试恢复不健康的容器或标记为失败。
+        Reads every session in RUNNING or CREATING, checks the real container state, and
+        either recovers an unhealthy container or marks the session failed.
         """
         logger.info("Starting state synchronization on startup")
 
@@ -105,7 +105,7 @@ class StateSyncService:
         return stats
 
     def _is_kubernetes_takeover_enabled(self) -> bool:
-        """仅在 K8s 调度路径启用启动接管。"""
+        """Start-up takeover is enabled on the K8s scheduling path only."""
         cluster_node = getattr(self._scheduler, "_cluster_node", None)
         return bool(
             cluster_node is not None and getattr(cluster_node, "type", None) == "kubernetes"
@@ -120,7 +120,7 @@ class StateSyncService:
         return getattr(owner_context, "pod_name", None)
 
     async def _load_active_sessions(self) -> list[Session]:
-        """全量加载 creating/running 会话，避免仓储默认 limit 截断。"""
+        """Load every creating and running session, so the repository default limit cannot truncate."""
         session_repo_cls = type(self._session_repo)
         has_paginated_query = callable(getattr(session_repo_cls, "find_sessions", None))
         if not has_paginated_query:
@@ -148,7 +148,7 @@ class StateSyncService:
         return active_sessions
 
     async def _take_over_session_on_startup(self, session: Session, stats: Dict[str, int]) -> None:
-        """K8s 启动时对 active session 做 executor 接管。"""
+        """Take over the executors of the active sessions when starting under K8s."""
         try:
             if not session.container_id:
                 logger.warning(
@@ -255,7 +255,7 @@ class StateSyncService:
             stats["errors"].append(error_msg)
 
     async def _mark_interrupted_executions(self, session: Session) -> int:
-        """将 takeover 中断的 in-flight execution 标记为 failed。"""
+        """Mark an in-flight execution that a takeover interrupted as failed."""
         if self._execution_repo is None:
             logger.warning(
                 "Execution repository unavailable during startup takeover",
@@ -295,10 +295,10 @@ class StateSyncService:
 
     async def periodic_health_check(self) -> Dict[str, int]:
         """
-        定时健康检查（每 30 秒）
+        Periodic health check, every 30 seconds
 
-        只检查 RUNNING 状态的 Session，减少查询范围。
-        对不健康的容器尝试恢复。
+        Examines only the sessions in RUNNING, which keeps the query narrow,
+        and tries to recover an unhealthy container.
         """
         logger.info("Starting periodic health check")
 
@@ -339,7 +339,7 @@ class StateSyncService:
         return stats
 
     async def _check_and_recover_session(self, session: Session, stats: Dict[str, int]) -> None:
-        """检查单个会话的健康状态并尝试恢复"""
+        """Check the health of one session and try to recover it"""
         try:
             is_running = await self._container_scheduler.is_container_running(session.container_id)
 
@@ -371,9 +371,9 @@ class StateSyncService:
 
     async def _attempt_recovery(self, session: Session) -> bool:
         """
-        尝试恢复 Session
+        Try to recover the session
 
-        策略：创建新容器（不再使用预热池）
+        The strategy is to create a new container; there is no warm pool any more.
         """
         logger.info("Attempting recovery for session", session_id=session.id)
 
@@ -418,7 +418,7 @@ class StateSyncService:
             return False
 
     async def _create_recovery_container(self, session: Session, image: str) -> str:
-        """按当前运行环境重建 session 的 executor。"""
+        """Rebuild the executor of a session for the current runtime environment."""
         if self._is_kubernetes_takeover_enabled() and self._scheduler is not None:
             container_id = await self._scheduler.create_container_for_session(
                 session_id=session.id,
@@ -461,7 +461,7 @@ class StateSyncService:
         return container_id
 
     async def _get_recovery_image(self, session: Session) -> str:
-        """解析恢复容器时应使用的镜像。"""
+        """Resolve the image to use while recovering a container."""
         if self._template_repo is None:
             raise RuntimeError("Template repository is required for session recovery")
 
@@ -478,7 +478,7 @@ class StateSyncService:
         return template.image
 
     def _get_recovery_runtime_node(self) -> str:
-        """根据当前调度环境推导恢复后的运行时节点。"""
+        """Derive the runtime node to recover onto, from the current scheduling environment."""
         if self._scheduler is not None and hasattr(self._scheduler, "_cluster_node"):
             cluster_node = getattr(self._scheduler, "_cluster_node", None)
             if cluster_node is not None and getattr(cluster_node, "id", None):
@@ -487,7 +487,7 @@ class StateSyncService:
 
     async def check_session_health(self, session_id: str) -> Dict[str, any]:
         """
-        检查单个 Session 的健康状态
+        Check the health of one session
         """
         session = await self._session_repo.find_by_id(session_id)
         if not session:

--- a/infra/sandbox/sandbox_control_plane/src/application/services/template_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/application/services/template_service.py
@@ -1,7 +1,7 @@
 """
-模板应用服务
+Template application service
 
-编排模板相关的用例。
+Orchestrates the template use cases.
 """
 
 from typing import List, Optional
@@ -18,9 +18,9 @@ from src.shared.i18n import message
 
 class TemplateService:
     """
-    模板应用服务
+    Template application service
 
-    编排模板创建、查询、更新、删除等用例。
+    Orchestrates creating, reading, updating, and deleting a template.
     """
 
     def __init__(
@@ -31,20 +31,20 @@ class TemplateService:
 
     async def create_template(self, command: CreateTemplateCommand) -> TemplateDTO:
         """
-        创建模板用例
+        Create-template use case
 
-        流程：
-        1. 验证模板ID唯一性
-        2. 验证模板名称唯一性
-        3. 创建模板实体
-        4. 保存到仓储
+        Steps:
+        1. Check the template id is unique
+        2. Check the template name is unique
+        3. Build the template entity
+        4. Persist it
         """
-        # 检查 ID 唯一性
+        # Check the id is unique
         existing_by_id = await self._template_repo.find_by_id(command.template_id)
         if existing_by_id:
             raise ValidationError(message("Sandbox.Template.IdExists", template_id=command.template_id))
 
-        # 检查名称唯一性
+        # Check the name is unique
         existing = await self._template_repo.find_by_name(command.name)
         if existing:
             raise ValidationError(message("Sandbox.Template.NameExists", name=command.name))
@@ -71,7 +71,7 @@ class TemplateService:
         return TemplateDTO.from_entity(template)
 
     async def get_template(self, query: GetTemplateQuery) -> TemplateDTO:
-        """获取模板用例"""
+        """Get-template use case"""
         template = await self._template_repo.find_by_id(query.template_id)
         if not template:
             raise NotFoundError(message("Sandbox.Template.NotFound", template_id=query.template_id))
@@ -79,40 +79,40 @@ class TemplateService:
         return TemplateDTO.from_entity(template)
 
     async def list_templates(self, limit: int = 50, offset: int = 0) -> List[TemplateDTO]:
-        """列出所有模板"""
+        """List every template"""
         templates = await self._template_repo.find_all(limit=limit, offset=offset)
 
         return [TemplateDTO.from_entity(t) for t in templates]
 
     async def update_template(self, command: UpdateTemplateCommand) -> TemplateDTO:
         """
-        更新模板用例
+        Update-template use case
 
-        流程：
-        1. 查找模板
-        2. 验证名称唯一性（如果更改名称）
-        3. 更新模板字段
-        4. 保存到仓储
+        Steps:
+        1. Find the template
+        2. Check the name is unique, when the name changes
+        3. Update the fields
+        4. Persist it
         """
         template = await self._template_repo.find_by_id(command.template_id)
         if not template:
             raise NotFoundError(message("Sandbox.Template.NotFound", template_id=command.template_id))
 
-        # 验证名称唯一性
+        # Check the name is unique
         if command.name and command.name != template.name:
             existing = await self._template_repo.find_by_name(command.name)
             if existing and existing.id != template.id:
                 raise ValidationError(message("Sandbox.Template.NameExists", name=command.name))
 
-        # 更新名称
+        # Update the name
         if command.name is not None:
             template.update_name(command.name)
 
-        # 更新镜像
+        # Update the image
         if command.image_url is not None:
             template.update_image(command.image_url)
 
-        # 更新资源限制
+        # Update the resource limits
         if any([command.default_cpu_cores, command.default_memory_mb, command.default_disk_mb]):
             from src.domain.value_objects.resource_limit import ResourceLimit
 
@@ -139,7 +139,7 @@ class TemplateService:
                 max_processes=template.default_resources.max_processes,
             )
 
-        # 更新超时时间
+        # Update the timeout
         if command.default_timeout_sec is not None:
             template.update_timeout(command.default_timeout_sec)
 
@@ -148,12 +148,12 @@ class TemplateService:
 
     async def delete_template(self, template_id: str) -> None:
         """
-        删除模板用例
+        Delete-template use case
 
-        流程：
-        1. 查找模板
-        2. 验证无活动会话使用
-        3. 删除模板
+        Steps:
+        1. Find the template
+        2. Check no active session uses it
+        3. Delete it
         """
         template = await self._template_repo.find_by_id(template_id)
         if not template:

--- a/infra/sandbox/sandbox_control_plane/src/domain/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/__init__.py
@@ -1,5 +1,5 @@
 """
-Domain Layer - 领域层
+Domain Layer
 
-核心业务逻辑层，完全独立于任何框架或基础设施。
+The core business logic, entirely independent of any framework or infrastructure.
 """

--- a/infra/sandbox/sandbox_control_plane/src/domain/entities/execution.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/entities/execution.py
@@ -1,7 +1,7 @@
 """
-执行实体
+Execution entity
 
-表示一次代码执行，是会话聚合的一部分。
+One code execution; part of the session aggregate.
 """
 
 from dataclasses import dataclass, field
@@ -14,9 +14,9 @@ from src.domain.value_objects.artifact import Artifact
 @dataclass
 class Execution:
     """
-    执行实体
+    Execution entity
 
-    表示一次代码执行的完整生命周期。
+    The full lifecycle of a single code execution.
     """
 
     id: str
@@ -24,31 +24,31 @@ class Execution:
     code: str
     language: str
     state: ExecutionState
-    timeout: int = 300  # 超时时间（秒）
-    event_data: dict | None = None  # 事件数据（handler 函数输入）
+    timeout: int = 300  # timeout in seconds
+    event_data: dict | None = None  # event payload, the handler function input
     created_at: datetime = field(default_factory=datetime.now)
     completed_at: datetime | None = None
-    execution_time: float | None = None  # 执行耗时（秒）
+    execution_time: float | None = None  # duration in seconds
     stdout: str = ""
     stderr: str = ""
     artifacts: list[Artifact] = field(default_factory=list)
     retry_count: int = 0
     last_heartbeat_at: datetime | None = None
-    # 新增字段：handler 返回值和性能指标
-    return_value: dict | None = None  # handler 函数返回值（JSON 可序列化）
-    metrics: dict | None = None  # 性能指标（JSON 对象）
+    # Handler return value and performance metrics
+    return_value: dict | None = None  # handler return value, JSON serializable
+    metrics: dict | None = None  # performance metrics, a JSON object
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if not self.code:
             raise ValueError("code cannot be empty")
         if not self.language:
             raise ValueError("language cannot be empty")
 
-    # ============== 领域行为 ==============
+    # ============== Domain behaviour ==============
 
     def mark_running(self) -> None:
-        """标记为运行中"""
+        """Mark it running"""
         if self.state.status != ExecutionStatus.PENDING:
             raise ValueError(f"Cannot mark execution as running from status: {self.state.status}")
 
@@ -65,7 +65,7 @@ class Execution:
         return_value: dict | None = None,
         metrics: dict | None = None,
     ) -> None:
-        """标记为已完成"""
+        """Mark it completed"""
         if self.state.status != ExecutionStatus.RUNNING:
             raise ValueError(f"Cannot mark execution as completed from status: {self.state.status}")
 
@@ -74,8 +74,8 @@ class Execution:
         self.stderr = stderr
         self.execution_time = execution_time
         self.artifacts = artifacts or []
-        self.return_value = return_value  # handler 返回值
-        self.metrics = metrics  # 性能指标
+        self.return_value = return_value  # handler return value
+        self.metrics = metrics  # performance metrics
         self.completed_at = datetime.now()
         self.last_heartbeat_at = datetime.now()
 
@@ -86,7 +86,7 @@ class Execution:
         stdout: str | None = None,
         stderr: str | None = None,
     ) -> None:
-        """标记为失败"""
+        """Mark it failed"""
         self.state = ExecutionState(
             status=ExecutionStatus.FAILED, exit_code=exit_code, error_message=error_message
         )
@@ -95,38 +95,38 @@ class Execution:
         self.completed_at = datetime.now()
 
     def mark_timeout(self) -> None:
-        """标记为超时"""
+        """Mark it timed out"""
         self.state = ExecutionState(status=ExecutionStatus.TIMEOUT)
         self.completed_at = datetime.now()
 
     def mark_crashed(self) -> None:
-        """标记为崩溃（可重试）"""
+        """Mark it crashed, which is retryable"""
         self.state = ExecutionState(status=ExecutionStatus.CRASHED)
 
     def update_heartbeat(self) -> None:
-        """更新心跳时间"""
+        """Update the heartbeat time"""
         self.last_heartbeat_at = datetime.now()
 
     def increment_retry_count(self) -> None:
-        """增加重试计数"""
+        """Increment the retry count"""
         self.retry_count += 1
 
-    # ============== 领域查询 ==============
+    # ============== Domain queries ==============
 
     def is_running(self) -> bool:
-        """是否正在运行"""
+        """Whether it is running"""
         return self.state.status == ExecutionStatus.RUNNING
 
     def is_terminal(self) -> bool:
-        """是否为终态"""
+        """Whether it is terminal"""
         return self.state.is_terminal()
 
     def can_retry(self, max_retries: int = 3) -> bool:
-        """是否可以重试"""
+        """Whether it may be retried"""
         return self.state.can_retry() and self.retry_count < max_retries
 
     def is_heartbeat_timeout(self, timeout_seconds: int = 15) -> bool:
-        """心跳是否超时"""
+        """Whether the heartbeat timed out"""
         if not self.last_heartbeat_at or not self.is_running():
             return False
         elapsed = (datetime.now() - self.last_heartbeat_at).total_seconds()

--- a/infra/sandbox/sandbox_control_plane/src/domain/entities/session.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/entities/session.py
@@ -1,7 +1,7 @@
 """
-会话实体
+Session entity
 
-表示一个沙箱会话，是聚合根。
+One sandbox session; this is the aggregate root.
 """
 
 from dataclasses import dataclass, field
@@ -21,26 +21,26 @@ from src.shared.utils.dependencies import (
 @dataclass
 class InstalledDependency:
     """
-    已安装的依赖
+    An installed dependency
 
-    用于跟踪会话中实际安装的依赖包信息。
-    按照 sandbox-design-v2.1.md 章节 5.6 设计。
+    Tracks a package that is actually installed in the session.
+    Follows section 5.6 of sandbox-design-v2.1.md.
     """
 
     name: str
     version: str
-    install_location: str  # 如 "/workspace/.venv/"
+    install_location: str  # such as "/workspace/.venv/"
     install_time: datetime
-    is_from_template: bool  # 是否来自 Template 预装包
+    is_from_template: bool  # whether it came preinstalled with the template
 
 
 @dataclass
 class Session:
     """
-    会话实体
+    Session entity
 
-    聚合根，负责管理会话的生命周期和相关的执行记录。
-    扩展支持依赖安装功能，按照 sandbox-design-v2.1.md 章节 5.6 设计。
+    The aggregate root: owns the session lifecycle and its execution records.
+    Extended for dependency installation, following section 5.6 of sandbox-design-v2.1.md.
     """
 
     id: str
@@ -53,14 +53,14 @@ class Session:
     container_id: str | None = None
     pod_name: str | None = None
     env_vars: dict = field(default_factory=dict)
-    timeout: int = 300  # 默认 5 分钟
+    timeout: int = 300  # 5 minutes by default
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
     completed_at: datetime | None = None
     last_activity_at: datetime = field(default_factory=datetime.now)
     _executions: List[Execution] = field(default_factory=list)
 
-    # 依赖安装相关字段（新增）
+    # Dependency installation fields
     requested_dependencies: List[str] = field(default_factory=list)
     installed_dependencies: List[InstalledDependency] = field(default_factory=list)
     dependency_install_status: str = "pending"  # pending/installing/completed/failed
@@ -70,7 +70,7 @@ class Session:
     dependency_install_completed_at: datetime | None = None
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if self.timeout <= 0:
             raise ValueError("timeout must be positive")
         if not self.workspace_path:
@@ -79,10 +79,10 @@ class Session:
             self.python_package_index_url
         )
 
-    # ============== 领域行为 ==============
+    # ============== Domain behaviour ==============
 
     def mark_as_running(self, runtime_node: str, container_id: str) -> None:
-        """标记会话为运行中"""
+        """Mark the session running"""
         if self.status != SessionStatus.CREATING:
             raise ValueError(f"Cannot mark session as running from status: {self.status}")
 
@@ -92,7 +92,7 @@ class Session:
         self.updated_at = datetime.now()
 
     def mark_as_completed(self) -> None:
-        """标记会话为已完成"""
+        """Mark the session completed"""
         if self.status != SessionStatus.RUNNING:
             raise ValueError(f"Cannot mark session as completed from status: {self.status}")
 
@@ -101,7 +101,7 @@ class Session:
         self.updated_at = datetime.now()
 
     def mark_as_failed(self) -> None:
-        """标记会话为失败"""
+        """Mark the session failed"""
         if self.status not in {SessionStatus.CREATING, SessionStatus.RUNNING}:
             raise ValueError(f"Cannot mark session as failed from status: {self.status}")
 
@@ -110,68 +110,68 @@ class Session:
         self.updated_at = datetime.now()
 
     def mark_as_terminated(self) -> None:
-        """终止会话"""
+        """Terminate the session"""
         if self.status == SessionStatus.TERMINATED:
-            return  # 已经是终止状态
+            return  # already in a terminal state
 
         self.status = SessionStatus.TERMINATED
         self.completed_at = datetime.now()
         self.updated_at = datetime.now()
 
     def update_last_activity(self) -> None:
-        """更新最后活动时间"""
+        """Update the last activity time"""
         self.last_activity_at = datetime.now()
         self.updated_at = datetime.now()
 
-    # ============== 领域查询 ==============
+    # ============== Domain queries ==============
 
     def is_active(self) -> bool:
-        """是否为活跃状态"""
+        """Whether it is active"""
         return self.status in {SessionStatus.CREATING, SessionStatus.RUNNING}
 
     def is_terminated(self) -> bool:
-        """是否已终止"""
+        """Whether it has terminated"""
         return self.status == SessionStatus.TERMINATED
 
     def is_idle(self, threshold_minutes: int = 30) -> bool:
-        """是否空闲（超过阈值时间未活动）"""
+        """Whether it is idle, meaning inactive past the threshold"""
         if not self.is_active():
             return False
         idle_time = datetime.now() - self.last_activity_at
         return idle_time > timedelta(minutes=threshold_minutes)
 
     def is_expired(self, max_hours: int = 6) -> bool:
-        """是否过期（创建超过最大时间）"""
+        """Whether it has expired, meaning older than the maximum lifetime"""
         age = datetime.now() - self.created_at
         return age > timedelta(hours=max_hours)
 
     def should_cleanup(self, idle_threshold_minutes: int = 30, max_lifetime_hours: int = 6) -> bool:
-        """是否应该清理"""
+        """Whether it should be cleaned up"""
         return self.is_idle(idle_threshold_minutes) or self.is_expired(max_lifetime_hours)
 
-    # ============== 执行管理 ==============
+    # ============== Execution management ==============
 
     def add_execution(self, execution: Execution) -> None:
-        """添加执行记录"""
+        """Add an execution record"""
         if execution.session_id != self.id:
             raise ValueError("Execution does not belong to this session")
         self._executions.append(execution)
         self.update_last_activity()
 
     def get_executions(self) -> List[Execution]:
-        """获取所有执行记录"""
+        """Get every execution record"""
         return list(self._executions)
 
     def get_running_executions(self) -> List[Execution]:
-        """获取正在运行的执行"""
+        """Get the running executions"""
         return [e for e in self._executions if e.is_running()]
 
-    # ============== 依赖管理 ==============
+    # ============== Dependency management ==============
 
     def replace_requested_dependencies(
         self, index_url: Optional[str], dependencies: List[str]
     ) -> None:
-        """全量替换目标依赖配置。"""
+        """Replace the target dependency configuration wholesale."""
         self.python_package_index_url = normalize_python_package_index_url(index_url)
         self.requested_dependencies = list(dependencies)
         self.updated_at = datetime.now()
@@ -179,7 +179,7 @@ class Session:
     def merge_requested_dependencies(
         self, index_url: Optional[str], dependencies: List[str]
     ) -> None:
-        """增量合并目标依赖配置。"""
+        """Merge into the target dependency configuration."""
         self.python_package_index_url = normalize_python_package_index_url(
             index_url or self.python_package_index_url
         )
@@ -190,11 +190,11 @@ class Session:
         self.updated_at = datetime.now()
 
     def set_dependencies_installing(self) -> None:
-        """兼容旧接口，标记依赖安装中。"""
+        """Legacy interface: mark the dependency install as in progress."""
         self.mark_dependency_installing()
 
     def mark_dependency_installing(self, started_at: datetime | None = None) -> None:
-        """标记依赖安装中。"""
+        """Mark the dependency install as in progress."""
         self.dependency_install_status = "installing"
         self.dependency_install_started_at = started_at or datetime.now()
         self.dependency_install_completed_at = None
@@ -202,7 +202,7 @@ class Session:
         self.updated_at = datetime.now()
 
     def set_dependencies_completed(self, installed: List[InstalledDependency]) -> None:
-        """兼容旧接口，标记依赖安装完成。"""
+        """Legacy interface: mark the dependency install as finished."""
         self.mark_dependency_install_completed(installed)
 
     def mark_dependency_install_completed(
@@ -210,7 +210,7 @@ class Session:
         installed: List[InstalledDependency],
         completed_at: datetime | None = None,
     ) -> None:
-        """标记依赖安装完成。"""
+        """Mark the dependency install as finished."""
         self.dependency_install_status = "completed"
         self.installed_dependencies = installed
         self.dependency_install_error = None
@@ -218,7 +218,7 @@ class Session:
         self.updated_at = datetime.now()
 
     def set_dependencies_failed(self, error: str) -> None:
-        """兼容旧接口，标记依赖安装失败。"""
+        """Legacy interface: mark the dependency install as failed."""
         self.mark_dependency_install_failed(error)
 
     def mark_dependency_install_failed(
@@ -226,20 +226,20 @@ class Session:
         error: str,
         completed_at: datetime | None = None,
     ) -> None:
-        """标记依赖安装失败。"""
+        """Mark the dependency install as failed."""
         self.dependency_install_status = "failed"
         self.dependency_install_error = error
         self.dependency_install_completed_at = completed_at or datetime.now()
         self.updated_at = datetime.now()
 
     def has_dependencies(self) -> bool:
-        """是否有依赖需要安装"""
+        """Whether any dependency still has to be installed"""
         return len(self.requested_dependencies) > 0
 
     def is_dependency_install_pending(self) -> bool:
-        """依赖是否正在安装或待安装"""
+        """Whether a dependency install is pending or running"""
         return self.dependency_install_status in ("pending", "installing")
 
     def is_dependency_install_successful(self) -> bool:
-        """依赖是否安装成功"""
+        """Whether the dependency install succeeded"""
         return self.dependency_install_status == "completed"

--- a/infra/sandbox/sandbox_control_plane/src/domain/entities/template.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/entities/template.py
@@ -1,7 +1,7 @@
 """
-模板实体
+Template entity
 
-定义沙箱环境模板。
+Defines a sandbox environment template.
 """
 
 from dataclasses import dataclass, field
@@ -14,24 +14,24 @@ from src.domain.value_objects.resource_limit import ResourceLimit
 @dataclass
 class Template:
     """
-    模板实体
+    Template entity
 
-    定义沙箱执行环境的配置模板。
+    The configuration template of a sandbox execution environment.
     """
 
     id: str
     name: str
-    image: str  # Docker 镜像
-    base_image: str  # 基础镜像
+    image: str  # Docker image
+    base_image: str  # base image
     pre_installed_packages: List[str] = field(default_factory=list)
     default_resources: ResourceLimit = field(default_factory=ResourceLimit.default)
-    default_timeout_sec: int = 300  # 默认超时时间（秒）
+    default_timeout_sec: int = 300  # default timeout in seconds
     security_context: Dict = field(default_factory=dict)
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
 
     def __post_init__(self):
-        """初始化后验证"""
+        """Validate after construction"""
         if not self.name:
             raise ValueError("name cannot be empty")
         if not self.image:
@@ -39,52 +39,52 @@ class Template:
         if not self.base_image:
             raise ValueError("base_image cannot be empty")
 
-    # ============== 领域行为 ==============
+    # ============== Domain behaviour ==============
 
     def update_name(self, name: str) -> None:
-        """更新名称"""
+        """Update the name"""
         if not name:
             raise ValueError("name cannot be empty")
         self.name = name
         self.updated_at = datetime.now()
 
     def update_image(self, image: str) -> None:
-        """更新镜像"""
+        """Update the image"""
         if not image:
             raise ValueError("image cannot be empty")
         self.image = image
         self.updated_at = datetime.now()
 
     def add_package(self, package: str) -> None:
-        """添加预装包"""
+        """Add a preinstalled package"""
         if package not in self.pre_installed_packages:
             self.pre_installed_packages.append(package)
             self.updated_at = datetime.now()
 
     def remove_package(self, package: str) -> None:
-        """移除预装包"""
+        """Remove a preinstalled package"""
         if package in self.pre_installed_packages:
             self.pre_installed_packages.remove(package)
             self.updated_at = datetime.now()
 
     def update_default_resources(self, resources: ResourceLimit) -> None:
-        """更新默认资源配置"""
+        """Update the default resource configuration"""
         self.default_resources = resources
         self.updated_at = datetime.now()
 
     def update_timeout(self, timeout_sec: int) -> None:
-        """更新默认超时时间"""
+        """Update the default timeout"""
         if timeout_sec < 0:
             raise ValueError("timeout_sec must be non-negative")
         self.default_timeout_sec = timeout_sec
         self.updated_at = datetime.now()
 
-    # ============== 领域查询 ==============
+    # ============== Domain queries ==============
 
     def has_package(self, package: str) -> bool:
-        """是否包含指定包"""
+        """Whether it holds a given package"""
         return package in self.pre_installed_packages
 
     def get_image_name(self) -> str:
-        """获取镜像名称（不含 tag）"""
+        """The image name without the tag"""
         return self.image.split(":")[0] if ":" in self.image else self.image

--- a/infra/sandbox/sandbox_control_plane/src/domain/repositories/execution_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/repositories/execution_repository.py
@@ -1,7 +1,7 @@
 """
-执行仓储接口
+Execution repository interface
 
-定义执行记录持久化的抽象接口（Port）。
+The port for execution record persistence.
 """
 
 from abc import ABC, abstractmethod
@@ -13,14 +13,14 @@ from src.domain.entities.execution import Execution
 
 class IExecutionRepository(ABC):
     """
-    执行仓储接口
+    Execution repository interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
     """
 
     @abstractmethod
     async def save(self, execution: Execution) -> None:
-        """保存执行记录（创建或更新）"""
+        """Save the execution record, creating or updating it"""
         pass
 
     async def commit(self) -> None:
@@ -29,40 +29,40 @@ class IExecutionRepository(ABC):
 
     @abstractmethod
     async def find_by_id(self, execution_id: str) -> Optional[Execution]:
-        """根据 ID 查找执行记录"""
+        """Find an execution record by id"""
         pass
 
     @abstractmethod
     async def find_by_session_id(self, session_id: str, limit: int = 100) -> List[Execution]:
-        """根据会话 ID 查找执行记录"""
+        """Find the execution records of a session"""
         pass
 
     @abstractmethod
     async def find_by_status(self, status: str, limit: int = 100) -> List[Execution]:
-        """根据状态查找执行记录"""
+        """Find execution records by status"""
         pass
 
     @abstractmethod
     async def find_crashed_executions(self, max_retry_count: int) -> List[Execution]:
-        """查找可重试的崩溃执行"""
+        """Find the crashed executions that may be retried"""
         pass
 
     @abstractmethod
     async def find_heartbeat_timeouts(self, timeout_threshold: datetime) -> List[Execution]:
-        """查找心跳超时的执行"""
+        """Find the executions whose heartbeat timed out"""
         pass
 
     @abstractmethod
     async def delete(self, execution_id: str) -> None:
-        """删除执行记录"""
+        """Delete the execution record"""
         pass
 
     @abstractmethod
     async def delete_by_session_id(self, session_id: str) -> None:
-        """删除会话的所有执行记录"""
+        """Delete every execution record of a session"""
         pass
 
     @abstractmethod
     async def count_by_status(self, status: str) -> int:
-        """统计指定状态的执行数量"""
+        """Count the executions in a status"""
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/repositories/runtime_node_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/repositories/runtime_node_repository.py
@@ -1,7 +1,7 @@
 """
-运行时节点仓储接口
+Runtime node repository interface
 
-定义运行时节点持久化的抽象接口（Port）。
+The port for runtime node persistence.
 """
 
 from abc import ABC, abstractmethod
@@ -10,62 +10,62 @@ from typing import List, Optional
 
 class IRuntimeNodeRepository(ABC):
     """
-    运行时节点仓储接口
+    Runtime node repository interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
     """
 
     @abstractmethod
     async def save(self, node) -> None:
-        """保存节点（创建或更新）"""
+        """Save the node, creating or updating it"""
         pass
 
     @abstractmethod
     async def find_by_id(self, node_id: str) -> Optional:
-        """根据 ID 查找节点"""
+        """Find a node by id"""
         pass
 
     @abstractmethod
     async def find_by_hostname(self, hostname: str) -> Optional:
-        """根据主机名查找节点"""
+        """Find a node by hostname"""
         pass
 
     @abstractmethod
     async def find_by_status(self, status: str) -> List:
-        """根据状态查找节点"""
+        """Find nodes by status"""
         pass
 
     @abstractmethod
     async def find_all(self, offset: int = 0, limit: int = 100) -> List:
-        """查找所有节点"""
+        """Find every node"""
         pass
 
     @abstractmethod
     async def update_status(self, node_id: str, status: str) -> None:
-        """更新节点状态"""
+        """Update the node status"""
         pass
 
     @abstractmethod
     async def update_heartbeat(self, node_id: str) -> None:
-        """更新节点心跳时间"""
+        """Update the node heartbeat time"""
         pass
 
     @abstractmethod
     async def allocate_resources(self, node_id: str, cpu_cores: float, memory_mb: int) -> None:
-        """分配资源"""
+        """Allocate resources"""
         pass
 
     @abstractmethod
     async def release_resources(self, node_id: str, cpu_cores: float, memory_mb: int) -> None:
-        """释放资源"""
+        """Release resources"""
         pass
 
     @abstractmethod
     async def increment_container_count(self, node_id: str) -> None:
-        """增加容器计数"""
+        """Increment the container count"""
         pass
 
     @abstractmethod
     async def decrement_container_count(self, node_id: str) -> None:
-        """减少容器计数"""
+        """Decrement the container count"""
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/repositories/session_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/repositories/session_repository.py
@@ -1,7 +1,7 @@
 """
-会话仓储接口
+Session repository interface
 
-定义会话持久化的抽象接口（Port）。
+The port for session persistence.
 """
 
 from abc import ABC, abstractmethod
@@ -13,64 +13,64 @@ from src.domain.entities.session import Session
 
 class ISessionRepository(ABC):
     """
-    会话仓储接口
+    Session repository interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
     """
 
     @abstractmethod
     async def save(self, session: Session) -> None:
-        """保存会话（创建或更新）"""
+        """Save the session, creating or updating it"""
         pass
 
     @abstractmethod
     async def find_by_id(self, session_id: str) -> Optional[Session]:
-        """根据 ID 查找会话"""
+        """Find a session by id"""
         pass
 
     @abstractmethod
     async def find_by_container_id(self, container_id: str) -> Optional[Session]:
-        """根据容器 ID 查找会话"""
+        """Find a session by container id"""
         pass
 
     @abstractmethod
     async def find_by_status(self, status: str, limit: int = 100) -> List[Session]:
-        """根据状态查找会话"""
+        """Find sessions by status"""
         pass
 
     @abstractmethod
     async def find_by_template(self, template_id: str) -> List[Session]:
-        """根据模板 ID 查找会话"""
+        """Find sessions by template id"""
         pass
 
     @abstractmethod
     async def find_idle_sessions(self, idle_threshold: datetime) -> List[Session]:
-        """查找空闲会话（用于自动清理）"""
+        """Find the idle sessions, for automatic cleanup"""
         pass
 
     @abstractmethod
     async def find_expired_sessions(self, created_before: datetime) -> List[Session]:
-        """查找过期会话（用于自动清理）"""
+        """Find the expired sessions, for automatic cleanup"""
         pass
 
     @abstractmethod
     async def delete(self, session_id: str) -> None:
-        """删除会话"""
+        """Delete the session"""
         pass
 
     @abstractmethod
     async def exists(self, session_id: str) -> bool:
-        """检查会话是否存在"""
+        """Check whether the session exists"""
         pass
 
     @abstractmethod
     async def count_by_status(self, status: str) -> int:
-        """统计指定状态的会话数量"""
+        """Count the sessions in a status"""
         pass
 
     @abstractmethod
     async def count_by_node(self, runtime_node: str) -> int:
-        """统计指定节点的会话数量"""
+        """Count the sessions on a node"""
         pass
 
     @abstractmethod
@@ -82,16 +82,16 @@ class ISessionRepository(ABC):
         offset: int = 0,
     ) -> List[Session]:
         """
-        查找会话列表（支持筛选和分页）
+        Find sessions, with filtering and paging
 
         Args:
-            status: 会话状态筛选（可选）
-            template_id: 模板 ID 筛选（可选）
-            limit: 返回数量限制（1-200，默认 50）
-            offset: 偏移量（用于分页）
+            status: filter by session status, optional
+            template_id: filter by template id, optional
+            limit: how many to return, 1-200, default 50
+            offset: offset, for paging
 
         Returns:
-            会话列表
+            The session list
         """
         pass
 
@@ -100,13 +100,13 @@ class ISessionRepository(ABC):
         self, status: Optional[str] = None, template_id: Optional[str] = None
     ) -> int:
         """
-        统计会话数量（支持筛选）
+        Count the sessions, with filtering
 
         Args:
-            status: 会话状态筛选（可选）
-            template_id: 模板 ID 筛选（可选）
+            status: filter by session status, optional
+            template_id: filter by template id, optional
 
         Returns:
-            会话总数
+            The total
         """
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/repositories/template_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/repositories/template_repository.py
@@ -1,7 +1,7 @@
 """
-模板仓储接口
+Template repository interface
 
-定义模板持久化的抽象接口（Port）。
+The port for template persistence.
 """
 
 from abc import ABC, abstractmethod
@@ -12,47 +12,47 @@ from src.domain.entities.template import Template
 
 class ITemplateRepository(ABC):
     """
-    模板仓储接口
+    Template repository interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
     """
 
     @abstractmethod
     async def save(self, template: Template) -> None:
-        """保存模板（创建或更新）"""
+        """Save the template, creating or updating it"""
         pass
 
     @abstractmethod
     async def find_by_id(self, template_id: str) -> Optional[Template]:
-        """根据 ID 查找模板"""
+        """Find a template by id"""
         pass
 
     @abstractmethod
     async def find_by_name(self, name: str) -> Optional[Template]:
-        """根据名称查找模板"""
+        """Find a template by name"""
         pass
 
     @abstractmethod
     async def find_all(self, offset: int = 0, limit: int = 100) -> List[Template]:
-        """查找所有模板"""
+        """Find every template"""
         pass
 
     @abstractmethod
     async def delete(self, template_id: str) -> None:
-        """删除模板"""
+        """Delete the template"""
         pass
 
     @abstractmethod
     async def exists(self, template_id: str) -> bool:
-        """检查模板是否存在"""
+        """Check whether the template exists"""
         pass
 
     @abstractmethod
     async def exists_by_name(self, name: str) -> bool:
-        """检查模板名称是否存在"""
+        """Check whether the template name exists"""
         pass
 
     @abstractmethod
     async def count(self) -> int:
-        """统计模板总数"""
+        """Count the templates"""
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/services/scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/services/scheduler.py
@@ -1,7 +1,7 @@
 """
-调度器领域服务接口
+Scheduler domain service interface
 
-定义调度器的抽象接口，负责选择最优运行时节点。
+The scheduler abstraction: picking the best runtime node.
 """
 
 from abc import ABC, abstractmethod
@@ -16,11 +16,11 @@ if TYPE_CHECKING:
 
 @dataclass
 class RuntimeNode:
-    """运行时节点值对象"""
+    """Runtime node value object"""
 
     id: str
     type: str  # "docker" or "kubernetes"
-    url: str  # 节点 API 地址
+    url: str  # node API address
     status: str  # "healthy", "unhealthy", "draining"
     cpu_usage: float  # 0.0 - 1.0
     mem_usage: float  # 0.0 - 1.0
@@ -29,21 +29,21 @@ class RuntimeNode:
     cached_templates: List[str]
 
     def is_healthy(self) -> bool:
-        """是否健康"""
+        """Whether it is healthy"""
         return self.status == "healthy"
 
     def get_load_ratio(self) -> float:
-        """获取负载比率 (会话数/最大会话数)"""
+        """The load ratio: sessions divided by maximum sessions"""
         return self.session_count / self.max_sessions if self.max_sessions > 0 else 1.0
 
     def has_template(self, template_id: str) -> bool:
-        """是否已缓存指定模板"""
+        """Whether it has the template cached"""
         return template_id in self.cached_templates
 
 
 @dataclass
 class ScheduleRequest:
-    """调度请求"""
+    """Scheduling request"""
 
     template_id: str
     resource_limit: ResourceLimit
@@ -52,35 +52,35 @@ class ScheduleRequest:
 
 class IScheduler(ABC):
     """
-    调度器接口
+    Scheduler interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
     """
 
     @abstractmethod
     async def schedule(self, request: ScheduleRequest) -> RuntimeNode:
         """
-        调度会话到最优节点
+        Schedule the session onto the best node
 
-        调度策略：
-        1. 优先考虑模板亲和性（镜像已缓存）
-        2. 使用负载均衡选择健康节点
+        The policy:
+        1. Prefer template affinity, meaning the image is already cached
+        2. Otherwise load-balance across the healthy nodes
         """
         pass
 
     @abstractmethod
     async def get_node(self, node_id: str) -> Optional[RuntimeNode]:
-        """获取指定节点"""
+        """Get one node"""
         pass
 
     @abstractmethod
     async def get_healthy_nodes(self) -> List[RuntimeNode]:
-        """获取所有健康节点"""
+        """Get every healthy node"""
         pass
 
     @abstractmethod
     async def mark_node_unhealthy(self, node_id: str) -> None:
-        """标记节点为不健康"""
+        """Mark a node unhealthy"""
         pass
 
     @abstractmethod
@@ -91,18 +91,18 @@ class IScheduler(ABC):
         execution_request: "ExecutionRequest",
     ) -> str:
         """
-        提交执行请求到容器内的执行器
+        Submit an execution request to the executor inside the container
 
         Args:
-            session_id: 会话 ID
-            container_id: 容器 ID
-            execution_request: 执行请求
+            session_id: session id
+            container_id: container id
+            execution_request: the execution request
 
         Returns:
-            execution_id: 执行任务 ID
+            execution_id: execution task id
 
         Raises:
-            ConnectionError: 无法连接到执行器
-            TimeoutError: 执行器响应超时
+            ConnectionError: the executor is unreachable
+            TimeoutError: the executor did not answer in time
         """
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/services/storage.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/services/storage.py
@@ -1,7 +1,7 @@
 """
-存储领域服务接口
+Storage domain service interface
 
-定义存储的抽象接口，负责文件存储操作。
+The storage abstraction: everything that touches stored files.
 """
 
 from abc import ABC, abstractmethod
@@ -10,10 +10,10 @@ from typing import Dict, Optional
 
 class IStorageService(ABC):
     """
-    存储服务接口
+    Storage service interface
 
-    这是领域层定义的 Port，由基础设施层实现 Adapter。
-    负责与 S3 兼容的对象存储进行交互。
+    The port the domain layer defines; the infrastructure layer supplies the adapter.
+    Talks to S3-compatible object storage.
     """
 
     @abstractmethod
@@ -21,101 +21,101 @@ class IStorageService(ABC):
         self, s3_path: str, content: bytes, content_type: str = "application/octet-stream"
     ) -> None:
         """
-        上传文件
+        Upload a file
 
         Args:
-            s3_path: S3 对象路径
-            content: 文件内容
-            content_type: MIME 类型
+            s3_path: S3 object path
+            content: file content
+            content_type: MIME type
         """
         pass
 
     @abstractmethod
     async def download_file(self, s3_path: str) -> bytes:
         """
-        下载文件
+        Download a file
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            文件内容
+            The file content
         """
         pass
 
     @abstractmethod
     async def file_exists(self, s3_path: str) -> bool:
         """
-        检查文件是否存在
+        Check whether a file exists
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            是否存在
+            Whether it exists
         """
         pass
 
     @abstractmethod
     async def get_file_info(self, s3_path: str) -> Dict:
         """
-        获取文件信息
+        Get the file metadata
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            文件信息字典，包含 size, content_type, last_modified 等
+            A dict holding size, content_type, last_modified, and more
         """
         pass
 
     @abstractmethod
     async def generate_presigned_url(self, s3_path: str, expiration_seconds: int = 3600) -> str:
         """
-        生成预签名 URL
+        Generate a presigned URL
 
         Args:
-            s3_path: S3 对象路径
-            expiration_seconds: 过期时间（秒）
+            s3_path: S3 object path
+            expiration_seconds: expiry in seconds
 
         Returns:
-            预签名 URL
+            The presigned URL
         """
         pass
 
     @abstractmethod
     async def delete_file(self, s3_path: str) -> None:
         """
-        删除文件
+        Delete a file
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
         """
         pass
 
     @abstractmethod
     async def list_files(self, prefix: str, limit: int = 1000) -> list:
         """
-        列出文件
+        List files
 
         Args:
-            prefix: S3 路径前缀
-            limit: 最大返回数量
+            prefix: S3 path prefix
+            limit: how many to return at most
 
         Returns:
-            文件列表
+            The file list
         """
         pass
 
     @abstractmethod
     async def delete_prefix(self, prefix: str) -> int:
         """
-        删除指定前缀的所有文件（用于会话清理）
+        Delete every file under a prefix, used when cleaning up a session
 
         Args:
-            prefix: S3 路径前缀（例如: "sessions/sess_abc123/"）
+            prefix: S3 path prefix, such as "sessions/sess_abc123/"
 
         Returns:
-            删除的文件数量
+            How many files were deleted
         """
         pass

--- a/infra/sandbox/sandbox_control_plane/src/domain/value_objects/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/value_objects/__init__.py
@@ -1,7 +1,7 @@
 """
-值对象模块
+Value object package
 
-包含所有领域值对象。
+Holds every domain value object.
 """
 
 from src.domain.value_objects.execution_request import ExecutionRequest

--- a/infra/sandbox/sandbox_control_plane/src/domain/value_objects/artifact.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/value_objects/artifact.py
@@ -1,7 +1,7 @@
 """
-文件制品值对象
+File artifact value object
 
-定义执行生成的文件元数据。
+The metadata of a file an execution produced.
 """
 
 from dataclasses import dataclass
@@ -11,37 +11,37 @@ from enum import Enum
 
 
 class ArtifactType(str, Enum):
-    """制品类型"""
+    """Artifact type"""
 
-    ARTIFACT = "artifact"  # 用户生成的文件
-    LOG = "log"  # 日志文件
-    OUTPUT = "output"  # 标准输出文件
+    ARTIFACT = "artifact"  # a file the user generated
+    LOG = "log"  # a log file
+    OUTPUT = "output"  # a standard output file
 
 
 @dataclass(frozen=True)
 class Artifact:
-    """文件制品值对象（不可变）"""
+    """File artifact value object, immutable"""
 
-    path: str  # 相对于 workspace 的路径
-    size: int  # 文件大小（字节）
-    mime_type: str  # MIME 类型
+    path: str  # path relative to the workspace
+    size: int  # file size in bytes
+    mime_type: str  # MIME type
     type: ArtifactType
     created_at: datetime
-    checksum: str | None = None  # SHA256 校验和
+    checksum: str | None = None  # SHA256 checksum
 
     def __post_init__(self):
-        """验证制品数据"""
+        """Validate the artifact"""
         if self.size < 0:
             raise ValueError("size cannot be negative")
         if not self.path:
             raise ValueError("path cannot be empty")
 
     def is_log(self) -> bool:
-        """是否为日志文件"""
+        """Whether it is a log file"""
         return self.type == ArtifactType.LOG
 
     def is_output(self) -> bool:
-        """是否为输出文件"""
+        """Whether it is an output file"""
         return self.type == ArtifactType.OUTPUT
 
     @classmethod
@@ -53,7 +53,7 @@ class Artifact:
         type: Literal["artifact", "log", "output"] = "artifact",
         checksum: str | None = None,
     ) -> "Artifact":
-        """工厂方法：创建制品"""
+        """Factory method: build an artifact"""
         return cls(
             path=path,
             size=size,

--- a/infra/sandbox/sandbox_control_plane/src/domain/value_objects/execution_request.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/value_objects/execution_request.py
@@ -1,7 +1,7 @@
 """
-执行请求值对象
+Execution request value object
 
-表示提交给沙箱执行器的代码执行请求。
+A code execution request submitted to the sandbox executor.
 """
 
 from dataclasses import dataclass
@@ -13,9 +13,9 @@ from typing import Dict, Any, Optional
 @dataclass
 class ExecutionRequest:
     """
-    执行请求值对象
+    Execution request value object
 
-    包含执行代码所需的所有信息。
+    Carries everything needed to execute the code.
     """
 
     code: str
@@ -28,7 +28,7 @@ class ExecutionRequest:
     working_directory: Optional[str] = None
 
     def __post_init__(self):
-        """验证执行请求"""
+        """Validate the execution request"""
         if not self.code:
             raise ValueError("code cannot be empty")
 

--- a/infra/sandbox/sandbox_control_plane/src/domain/value_objects/execution_status.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/value_objects/execution_status.py
@@ -1,7 +1,7 @@
 """
-执行状态值对象
+Execution status value objects
 
-定义执行和会话的所有可能状态。
+Every state a session or an execution can be in.
 """
 
 from enum import Enum
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 
 class SessionStatus(str, Enum):
-    """会话状态枚举"""
+    """Session status"""
 
     CREATING = "creating"
     RUNNING = "running"
@@ -20,7 +20,7 @@ class SessionStatus(str, Enum):
 
 
 class ExecutionStatus(str, Enum):
-    """执行状态枚举"""
+    """Execution status"""
 
     PENDING = "pending"
     RUNNING = "running"
@@ -32,14 +32,14 @@ class ExecutionStatus(str, Enum):
 
 @dataclass(frozen=True)
 class ExecutionState:
-    """执行状态值对象（不可变）"""
+    """Execution status value object, immutable"""
 
     status: ExecutionStatus
     exit_code: int | None = None
     error_message: str | None = None
 
     def is_terminal(self) -> bool:
-        """是否为终态（不可再变更）"""
+        """Whether it is terminal and can no longer change"""
         return self.status in {
             ExecutionStatus.COMPLETED,
             ExecutionStatus.FAILED,
@@ -47,5 +47,5 @@ class ExecutionState:
         }
 
     def can_retry(self) -> bool:
-        """是否可以重试"""
+        """Whether it may be retried"""
         return self.status == ExecutionStatus.CRASHED

--- a/infra/sandbox/sandbox_control_plane/src/domain/value_objects/resource_limit.py
+++ b/infra/sandbox/sandbox_control_plane/src/domain/value_objects/resource_limit.py
@@ -1,7 +1,7 @@
 """
-资源限制值对象
+Resource limit value object
 
-定义 CPU、内存、磁盘等资源限制。
+CPU, memory, and disk limits.
 """
 
 from dataclasses import dataclass
@@ -10,19 +10,19 @@ from typing import Self
 
 @dataclass(frozen=True)
 class ResourceLimit:
-    """资源限制值对象（不可变）"""
+    """Resource limit value object, immutable"""
 
-    cpu: str  # 如 "1", "2", "0.5"
-    memory: str  # 如 "512Mi", "1Gi", "2Gi"
-    disk: str  # 如 "1Gi", "10Gi"
-    max_processes: int = 128  # 最大进程数
+    cpu: str  # such as "1", "2", or "0.5"
+    memory: str  # such as "512Mi", "1Gi", or "2Gi"
+    disk: str  # such as "1Gi" or "10Gi"
+    max_processes: int = 128  # maximum processes
 
     def __post_init__(self):
-        """验证资源限制值"""
+        """Validate the resource limits"""
         if self.max_processes <= 0:
             raise ValueError("max_processes must be positive")
 
-        # 验证 CPU 格式
+        # Validate the CPU format
         try:
             cpu_value = float(self.cpu)
         except ValueError:
@@ -31,17 +31,17 @@ class ResourceLimit:
         if cpu_value <= 0:
             raise ValueError("cpu must be positive")
 
-        # 验证内存格式
+        # Validate the memory format
         if not self._validate_size_format(self.memory):
             raise ValueError(f"Invalid memory format: {self.memory}")
 
-        # 验证磁盘格式
+        # Validate the disk format
         if not self._validate_size_format(self.disk):
             raise ValueError(f"Invalid disk format: {self.disk}")
 
     @staticmethod
     def _validate_size_format(size: str) -> bool:
-        """验证大小格式（如 512Mi, 1Gi）"""
+        """Validate a size, such as 512Mi or 1Gi"""
         if not size:
             return False
         if size[-2:] in {"Mi", "Gi"}:
@@ -53,18 +53,18 @@ class ResourceLimit:
         return False
 
     def with_cpu(self, cpu: str) -> Self:
-        """返回新的 CPU 限制（不修改原对象）"""
+        """Return a new object with this CPU limit; the original is unchanged"""
         return ResourceLimit(
             cpu=cpu, memory=self.memory, disk=self.disk, max_processes=self.max_processes
         )
 
     def with_memory(self, memory: str) -> Self:
-        """返回新的内存限制（不修改原对象）"""
+        """Return a new object with this memory limit; the original is unchanged"""
         return ResourceLimit(
             cpu=self.cpu, memory=memory, disk=self.disk, max_processes=self.max_processes
         )
 
     @classmethod
     def default(cls) -> Self:
-        """返回默认资源限制"""
+        """The default resource limits"""
         return cls(cpu="1", memory="512Mi", disk="1Gi", max_processes=128)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/background_tasks/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/background_tasks/__init__.py
@@ -1,7 +1,7 @@
 """
-后台任务管理
+Background task management
 
-提供后台任务的启动、停止和生命周期管理。
+Starting, stopping, and managing the lifecycle of background tasks.
 """
 
 from src.infrastructure.background_tasks.task_manager import (

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/background_tasks/task_manager.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/background_tasks/task_manager.py
@@ -1,7 +1,7 @@
 """
-后台任务管理器
+Background task manager
 
-管理周期性后台任务的启动和停止，支持优雅关闭。
+Starts and stops periodic background tasks, with graceful shutdown.
 """
 
 import asyncio
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 class BackgroundTask:
     """
-    后台任务
+    Background task
 
-    表示一个周期性运行的后台任务。
+    One task that runs periodically.
     """
 
     def __init__(
@@ -27,13 +27,13 @@ class BackgroundTask:
         initial_delay_seconds: int = 0,
     ):
         """
-        初始化后台任务
+        Initialize the background task
 
         Args:
-            name: 任务名称
-            func: 异步函数，任务的实际执行逻辑
-            interval_seconds: 执行间隔（秒）
-            initial_delay_seconds: 首次执行前的延迟（秒）
+            name: task name
+            func: the async function the task runs
+            interval_seconds: how often to run, in seconds
+            initial_delay_seconds: how long to wait before the first run, in seconds
         """
         self.name = name
         self.func = func
@@ -45,9 +45,9 @@ class BackgroundTask:
 
     async def start(self) -> None:
         """
-        启动后台任务
+        Start the background task
 
-        如果任务已在运行，则不执行任何操作。
+        Does nothing when the task is already running.
         """
         if self._running:
             logger.warning(f"Task {self.name} is already running")
@@ -60,9 +60,9 @@ class BackgroundTask:
 
     async def stop(self) -> None:
         """
-        停止后台任务
+        Stop the background task
 
-        等待任务完成当前执行后停止，最多等待 30 秒。
+        Waits up to 30 seconds for the current run to finish.
         """
         if not self._running:
             return
@@ -79,23 +79,23 @@ class BackgroundTask:
 
     async def _run(self) -> None:
         """
-        任务运行循环
+        The task loop
 
-        执行流程：
-        1. 等待初始延迟（如果配置）
-        2. 循环执行：
-           - 执行任务函数
-           - 等待间隔或停止事件
+        What it does:
+        1. Wait out the initial delay, when one is configured
+        2. Then loop:
+           - run the task function
+           - wait for the interval, or for the stop event
         """
         try:
-            # 初始延迟
+            # Initial delay
             if self.initial_delay_seconds > 0:
                 await asyncio.sleep(self.initial_delay_seconds)
 
-            # 任务循环
+            # The task loop
             while not self._stop_event.is_set():
                 try:
-                    # 执行任务函数
+                    # Run the task function
                     await self.func()
                 except Exception as e:
                     logger.error(
@@ -103,16 +103,16 @@ class BackgroundTask:
                         exc_info=True,
                     )
 
-                # 等待间隔或停止事件
+                # Wait for the interval, or for the stop event
                 try:
                     await asyncio.wait_for(
                         self._stop_event.wait(),
                         timeout=self.interval_seconds,
                     )
-                    # 如果 wait_for 完成，说明停止事件被设置
+                    # wait_for completing means the stop event was set
                     break
                 except asyncio.TimeoutError:
-                    # 超时，继续循环
+                    # Timed out, so keep looping
                     continue
 
         except asyncio.CancelledError:
@@ -125,15 +125,15 @@ class BackgroundTask:
 
     @property
     def is_running(self) -> bool:
-        """检查任务是否正在运行"""
+        """Check whether the task is running"""
         return self._running and self._task is not None and not self._task.done()
 
 
 class BackgroundTaskManager:
     """
-    后台任务管理器
+    Background task manager
 
-    管理多个后台任务的启动和停止。
+    Starts and stops several background tasks.
     """
 
     def __init__(self):
@@ -148,13 +148,13 @@ class BackgroundTaskManager:
         initial_delay_seconds: int = 0,
     ) -> None:
         """
-        注册一个新的后台任务
+        Register a new background task
 
         Args:
-            name: 任务名称
-            func: 异步函数，任务的实际执行逻辑
-            interval_seconds: 执行间隔（秒）
-            initial_delay_seconds: 首次执行前的延迟（秒）
+            name: task name
+            func: the async function the task runs
+            interval_seconds: how often to run, in seconds
+            initial_delay_seconds: how long to wait before the first run, in seconds
         """
         task = BackgroundTask(
             name=name,
@@ -170,9 +170,9 @@ class BackgroundTaskManager:
 
     async def start_all(self) -> None:
         """
-        启动所有已注册的后台任务
+        Start every registered background task
 
-        如果任务已在运行，则不执行任何操作。
+        Does nothing for a task that is already running.
         """
         if self._running:
             logger.warning("Background tasks already running")
@@ -187,16 +187,16 @@ class BackgroundTaskManager:
 
     async def stop_all(self) -> None:
         """
-        停止所有正在运行的后台任务
+        Stop every running background task
 
-        等待所有任务完成当前执行后停止，最多等待 30 秒。
+        Waits up to 30 seconds for the current runs to finish.
         """
         if not self._running:
             return
 
         self._running = False
 
-        # 并行停止所有任务
+        # Stop them in parallel
         tasks_to_stop = [task.stop() for task in self._tasks]
         await asyncio.gather(*tasks_to_stop, return_exceptions=True)
 
@@ -205,13 +205,13 @@ class BackgroundTaskManager:
     @asynccontextmanager
     async def lifecycle(self):
         """
-        任务生命周期上下文管理器
+        Task lifecycle context manager
 
-        用法：
+        Usage:
             async with task_manager.lifecycle():
-                # 任务正在运行
+                # the tasks are running
                 pass
-            # 任务已停止
+            # the tasks have stopped
         """
         await self.start_all()
         try:
@@ -221,19 +221,19 @@ class BackgroundTaskManager:
 
     @property
     def running(self) -> bool:
-        """检查管理器是否正在运行"""
+        """Check whether the manager is running"""
         return self._running
 
     @property
     def task_count(self) -> int:
-        """获取已注册的任务数量"""
+        """How many tasks are registered"""
         return len(self._tasks)
 
     def get_task_status(self) -> dict:
         """
-        获取所有任务的状态
+        Get the status of every task
 
         Returns:
-            dict: 任务名称到运行状态的映射
+            dict: task name to whether it is running
         """
         return {task.name: task.is_running for task in self._tasks}

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/config/settings.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/config/settings.py
@@ -1,7 +1,7 @@
 """
-应用配置
+Application configuration
 
-使用 Pydantic Settings 管理应用配置。
+Manages the application configuration with Pydantic Settings.
 """
 
 from functools import lru_cache
@@ -12,7 +12,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    """应用配置类"""
+    """Application configuration"""
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -21,49 +21,49 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # ============== 应用配置 ==============
+    # ============== Application ==============
     app_name: str = Field(default="Sandbox Control Plane")
     app_version: str = Field(default="2.1.0")
     environment: str = Field(default="development")
     debug: bool = Field(default=False)
 
-    # ============== 服务器配置 ==============
+    # ============== Server ==============
     host: str = Field(default="0.0.0.0")
     port: int = Field(default=8000)
     workers: int = Field(default=4)
 
-    # ============== 数据库配置 ==============
+    # ============== Database ==============
     database_url: str = Field(default="mysql+aiomysql://sandbox:password@localhost:3308/openbkn")
     db_pool_size: int = Field(default=20)
     db_max_overflow: int = Field(default=40)
     db_pool_recycle: int = Field(default=3600)
 
-    # ============== RDS 数据库配置（从 depServices.rds 注入） ==============
-    # 这些字段优先于 database_url，如果设置了则使用这些值构建数据库连接
-    db_type: str | None = Field(default=None)  # 数据库类型，如 MYSQL, POSTGRESQL
-    db_host: str | None = Field(default=None)  # 主库主机
-    db_port: int | None = Field(default=None)  # 主库端口
-    db_host_read: str | None = Field(default=None)  # 从库主机（读写分离）
-    db_port_read: int | None = Field(default=None)  # 从库端口
-    db_user: str | None = Field(default=None)  # 数据库用户
-    db_password: str | None = Field(default=None)  # 数据库密码
-    db_database: str | None = Field(default=None)  # 数据库名
-    db_max_connections: int | None = Field(default=None)  # 最大连接数
-    db_max_read_connections: int | None = Field(default=None)  # 最大读连接数
-    db_charset: str | None = Field(default=None)  # 字符集
-    db_timeout: int | None = Field(default=None)  # 连接超时
-    db_read_timeout: int | None = Field(default=None)  # 读超时
-    db_write_timeout: int | None = Field(default=None)  # 写超时
+    # ============== RDS database, injected from depServices.rds ==============
+    # These take precedence over database_url: when set, the connection is built from them.
+    db_type: str | None = Field(default=None)  # database type, such as MYSQL or POSTGRESQL
+    db_host: str | None = Field(default=None)  # primary host
+    db_port: int | None = Field(default=None)  # primary port
+    db_host_read: str | None = Field(default=None)  # replica host, for read/write splitting
+    db_port_read: int | None = Field(default=None)  # replica port
+    db_user: str | None = Field(default=None)  # database user
+    db_password: str | None = Field(default=None)  # database password
+    db_database: str | None = Field(default=None)  # database name
+    db_max_connections: int | None = Field(default=None)  # maximum connections
+    db_max_read_connections: int | None = Field(default=None)  # maximum read connections
+    db_charset: str | None = Field(default=None)  # charset
+    db_timeout: int | None = Field(default=None)  # connect timeout
+    db_read_timeout: int | None = Field(default=None)  # read timeout
+    db_write_timeout: int | None = Field(default=None)  # write timeout
 
     @computed_field
     @property
     def effective_database_url(self) -> str:
         """
-        计算有效的数据库 URL
+        Resolve the effective database URL
 
-        优先使用 RDS 环境变量构建数据库连接，如果未设置则使用 database_url
+        The RDS environment variables win; database_url applies when they are unset.
         """
-        # 如果所有必需的 RDS 字段都已设置，则使用 RDS 配置
+        # Use the RDS configuration once every required field is set
         if all(
             [
                 self.db_type,
@@ -74,15 +74,15 @@ class Settings(BaseSettings):
                 self.db_database,
             ]
         ):
-            # 构建 aiomysql 连接 URL
-            # 格式: mysql+aiomysql://user:password@host:port/database
+            # Build the aiomysql connection URL,
+            # formatted as mysql+aiomysql://user:password@host:port/database
             user = quote_plus(self.db_user)
             password = quote_plus(self.db_password)
             host = self.db_host
             port = self.db_port
             database = self.db_database
 
-            # 添加连接参数
+            # Append the connection parameters
             params = []
             if self.db_charset:
                 params.append(f"charset={self.db_charset}")
@@ -93,27 +93,27 @@ class Settings(BaseSettings):
 
             return url
 
-        # 否则使用默认的 database_url
+        # Otherwise fall back to database_url
         return self.database_url
 
-    # ============== S3 配置 ==============
+    # ============== S3 ==============
     s3_bucket: str = Field(default="sandbox-workspace")
     s3_region: str = Field(default="us-east-1")
     s3_access_key_id: str = Field(default="")
     s3_secret_access_key: str = Field(default="")
     s3_endpoint_url: str = Field(default="")
 
-    # ============== Docker 配置 ==============
+    # ============== Docker ==============
     docker_host: str = Field(default="unix:///var/run/docker.sock")
     docker_tls_verify: bool = Field(default=False)
     docker_cert_path: str = Field(default="")
 
-    # ============== Kubernetes 配置 ==============
+    # ============== Kubernetes ==============
     kubernetes_namespace: str = Field(default="sandbox-runtime")
     executor_image_pull_policy: str = Field(default="IfNotPresent")
     executor_image_pull_secrets: str = Field(default="")
 
-    # ============== 执行配置 ==============
+    # ============== Execution ==============
     default_timeout: int = Field(default=300)
     max_timeout: int = Field(default=3600)
     default_cpu: str = Field(default="1")
@@ -124,48 +124,49 @@ class Settings(BaseSettings):
     max_upload_file_size_mb: int = Field(default=100, ge=1)
     max_extracted_file_count: int = Field(default=10000, ge=1)
     max_extracted_total_size_mb: int = Field(default=512, ge=1)
-    disable_bwrap: bool = Field(default=False)  # 禁用 Bubblewrap（本地开发环境）
-    # sandbox_sdk.bkn 回访 BKN 用的集群内 MCP 地址。它是部署配置而非密钥，因此由
-    # 控制面注入一次，不必每个调用方都在 event 里传。留空则要求调用方自己传 mcp。
-    # 令牌走的是另一条路：只认 event，绝不落环境变量——会话池化复用，env 会把上一个
-    # 调用方的凭据留在容器里。
+    disable_bwrap: bool = Field(default=False)  # turn Bubblewrap off, for local development
+    # The in-cluster MCP address sandbox_sdk.bkn calls back into BKN with. It is deployment
+    # configuration rather than a secret, so the control plane injects it once and no caller
+    # has to pass it in the event. Left empty, callers must pass mcp themselves.
+    # The token takes the other path: event only, never an environment variable — sessions are
+    # pooled and reused, and env would leave the previous caller's credential in the container.
     bkn_sandbox_mcp_url: str = Field(default="")
     control_plane_url: str | None = Field(
         default=None
     )  # Control Plane URL for executor callback (None = auto-generate from namespace)
 
-    # ============== 清理配置 ==============
+    # ============== Cleanup ==============
     idle_threshold_minutes: int = Field(
-        default=-1, ge=-1, description="空闲超时时间（分钟），-1 表示无限期（不清理空闲会话）"
+        default=-1, ge=-1, description="Idle timeout in minutes; -1 means never, disabling idle cleanup"
     )
     max_lifetime_hours: int = Field(
-        default=-1, ge=-1, description="最大生命周期（小时），-1 表示无限期"
+        default=-1, ge=-1, description="Maximum lifetime in hours; -1 means never"
     )
     cleanup_interval_seconds: int = Field(default=300, ge=1)
     creating_timeout_seconds: int = Field(
         default=300,
         ge=30,
-        description="会话创建超时时间（秒），超过此时间的 creating 状态会话将被标记为 failed",
+        description="Session creation timeout in seconds; a session left in creating past this is marked failed",
     )
 
-    # ============== 重试配置 ==============
+    # ============== Retry ==============
     max_retry_attempts: int = Field(default=3)
     retry_backoff_base: float = Field(default=1.0)
     retry_backoff_factor: float = Field(default=2.0)
     max_retry_backoff: float = Field(default=10.0)
 
-    # ============== 预热池配置 ==============
+    # ============== Warm pool ==============
     warm_pool_enabled: bool = Field(default=True)
     warm_pool_default_size: int = Field(default=10)
     warm_pool_min_size: int = Field(default=5)
     warm_pool_max_idle_time: int = Field(default=300)
 
-    # ============== 健康检查配置 ==============
+    # ============== Health check ==============
     health_check_interval_seconds: int = Field(default=10)
     heartbeat_interval_seconds: int = Field(default=5)
     heartbeat_timeout_seconds: int = Field(default=15)
 
-    # ============== 日志配置 ==============
+    # ============== Logging ==============
     log_level: str = Field(default="INFO")
     log_format: str = Field(default="text")  # json, text (default: text for human-readable)
 
@@ -185,16 +186,16 @@ class Settings(BaseSettings):
             raise ValueError(f"log_format must be one of {allowed}")
         return v
 
-    # ============== 监控配置 ==============
+    # ============== Monitoring ==============
     metrics_enabled: bool = Field(default=True)
     metrics_port: int = Field(default=9090)
 
-    # ============== 安全配置 ==============
+    # ============== Security ==============
     secret_key: str = Field(default="change-this-in-production")
     allowed_hosts: list[str] = Field(default=["*"])
     cors_origins: list[str] = Field(default=["http://localhost:3000"])
 
-    # ============== 限流配置 ==============
+    # ============== Rate limiting ==============
     rate_limit_enabled: bool = Field(default=True)
     rate_limit_per_minute: int = Field(default=60)
 
@@ -210,8 +211,8 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     """
-    获取配置单例
+    Get the configuration singleton
 
-    使用 lru_cache 确保配置只加载一次。
+    lru_cache makes sure it loads only once.
     """
     return Settings()

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/__init__.py
@@ -1,7 +1,7 @@
 """
-容器调度器包
+Container scheduler package
 
-提供 Docker 和 Kubernetes 容器调度能力。
+Docker and Kubernetes container scheduling.
 """
 
 from src.infrastructure.container_scheduler.base import IContainerScheduler

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/base.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/base.py
@@ -1,7 +1,7 @@
 """
-容器调度器接口
+Container scheduler interface
 
-定义容器操作的抽象接口。
+The abstraction over container operations.
 """
 
 from abc import ABC, abstractmethod
@@ -11,7 +11,7 @@ from typing import Optional, Dict, Any
 
 @dataclass(frozen=True)
 class ControlPlaneOwnerContext:
-    """当前 control plane Pod 的 owner 上下文。"""
+    """The owner context of the current control plane Pod."""
 
     pod_name: str
     pod_uid: str
@@ -19,7 +19,7 @@ class ControlPlaneOwnerContext:
 
 @dataclass(frozen=True)
 class ContainerOwnershipInfo:
-    """容器/POD 当前归属信息。"""
+    """Who a container or Pod currently belongs to."""
 
     owner_pod_name: Optional[str]
     owner_pod_uid: Optional[str]
@@ -29,23 +29,23 @@ class ContainerOwnershipInfo:
 
 @dataclass
 class ContainerConfig:
-    """容器配置"""
+    """Container configuration"""
 
     image: str
     name: str
     env_vars: Dict[str, str]
-    cpu_limit: str  # 如 "1", "2"
-    memory_limit: str  # 如 "512Mi", "1Gi"
-    disk_limit: str  # 如 "1Gi", "10Gi"
-    workspace_path: str  # S3路径，如 "s3://bucket/sessions/{session_id}/"
+    cpu_limit: str  # such as "1" or "2"
+    memory_limit: str  # such as "512Mi" or "1Gi"
+    disk_limit: str  # such as "1Gi" or "10Gi"
+    workspace_path: str  # S3 path, such as "s3://bucket/sessions/{session_id}/"
     labels: Dict[str, str]
-    network_name: str = "sandbox_network"  # Docker 网络名称，默认 sandbox_network
+    network_name: str = "sandbox_network"  # Docker network name
     owner_context: Optional[ControlPlaneOwnerContext] = None
 
 
 @dataclass
 class ContainerInfo:
-    """容器信息"""
+    """Container information"""
 
     id: str
     name: str
@@ -60,7 +60,7 @@ class ContainerInfo:
 
 @dataclass
 class ContainerResult:
-    """容器执行结果"""
+    """Container execution result"""
 
     status: str
     stdout: str
@@ -70,53 +70,53 @@ class ContainerResult:
 
 class IContainerScheduler(ABC):
     """
-    容器调度器接口
+    Container scheduler interface
 
-    定义容器生命周期管理操作。
+    Defines the container lifecycle operations.
     """
 
     @abstractmethod
     async def create_container(self, config: ContainerConfig) -> str:
         """
-        创建容器
+        Create the container
 
-        返回容器ID
+        Returns the container id
         """
         pass
 
     @abstractmethod
     async def start_container(self, container_id: str) -> None:
-        """启动容器"""
+        """Start the container"""
         pass
 
     @abstractmethod
     async def stop_container(self, container_id: str, timeout: int = 10) -> None:
-        """停止容器"""
+        """Stop the container"""
         pass
 
     @abstractmethod
     async def remove_container(self, container_id: str, force: bool = True) -> None:
-        """删除容器"""
+        """Delete the container"""
         pass
 
     @abstractmethod
     async def get_container_status(self, container_id: str) -> ContainerInfo:
-        """获取容器状态"""
+        """Get the container status"""
         pass
 
     @abstractmethod
     async def is_container_running(self, container_id: str) -> bool:
         """
-        检查容器是否正在运行
+        Check whether the container is running
 
-        直接通过 Docker API 查询，不依赖数据库。
-        此方法供 StateSyncService 使用。
+        Queries the Docker API directly, without going through the database.
+        StateSyncService uses this.
 
         Args:
-            container_id: 容器 ID
+            container_id: container id
 
         Returns:
-            bool: 容器是否运行中
+            bool: whether the container is running
         """
         pass
 
@@ -124,19 +124,19 @@ class IContainerScheduler(ABC):
     async def get_container_logs(
         self, container_id: str, tail: int = 100, since: Optional[str] = None
     ) -> str:
-        """获取容器日志"""
+        """Get the container logs"""
         pass
 
     @abstractmethod
     async def wait_container(
         self, container_id: str, timeout: Optional[int] = None
     ) -> ContainerResult:
-        """等待容器执行完成"""
+        """Wait for the container to finish"""
         pass
 
     @abstractmethod
     async def ping(self) -> bool:
-        """检查调度器连接状态"""
+        """Check the scheduler connection"""
         pass
 
     async def get_container_ownership(
@@ -144,8 +144,8 @@ class IContainerScheduler(ABC):
         container_id: str,
     ) -> Optional[ContainerOwnershipInfo]:
         """
-        获取容器归属信息。
+        Get who the container belongs to.
 
-        默认返回 None，供不支持 owner 概念的调度器复用。
+        Returns None by default, so a scheduler without an owner concept can reuse this.
         """
         return None

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/docker_scheduler.py
@@ -1,12 +1,12 @@
 """
-Docker 容器调度器
+Docker container scheduler
 
-使用 aiodocker 实现 Docker 容器的创建和管理。
+Creates and manages Docker containers through aiodocker.
 
-支持 S3 workspace 挂载：当 workspace_path 以 s3:// 开头时，
-容器会通过 s3fs 将 S3 bucket 挂载到 /workspace 目录。
+Supports an S3 workspace mount: when workspace_path starts with s3://, the
+container mounts the S3 bucket on /workspace through s3fs.
 
-支持 Python 依赖安装：按照 sandbox-design-v2.1.md 章节 5 设计。
+Python dependency installation follows section 5 of sandbox-design-v2.1.md.
 """
 
 import asyncio
@@ -33,17 +33,17 @@ logger = get_logger(__name__)
 
 class DockerScheduler(IContainerScheduler):
     """
-    Docker 容器调度器
+    Docker container scheduler
 
-    通过 Docker socket 或 TCP 连接 Docker daemon，管理容器生命周期。
+    Connects to the Docker daemon over a socket or TCP and manages the container lifecycle.
     """
 
     def __init__(self, docker_url: str = "unix:///var/run/docker.sock"):
         """
-        初始化 Docker 调度器
+        Initialize the Docker scheduler
 
         Args:
-            docker_url: Docker daemon 连接URL
+            docker_url: Docker daemon connection URL
                 - unix:///var/run/docker.sock (Unix socket)
                 - tcp://localhost:2375 (TCP)
         """
@@ -52,7 +52,7 @@ class DockerScheduler(IContainerScheduler):
         self._initialized = False
 
     async def _ensure_docker(self) -> Docker:
-        """确保 Docker 客户端已初始化"""
+        """Make sure the Docker client is initialized"""
         if not self._initialized:
             logger.debug(
                 "Initializing Docker client",
@@ -61,7 +61,7 @@ class DockerScheduler(IContainerScheduler):
             self._docker = Docker(url=self._docker_url)
             self._initialized = True
 
-            # 验证 Docker 连接
+            # Verify the Docker connection
             try:
                 version = await self._docker.version()
                 logger.debug(
@@ -79,13 +79,13 @@ class DockerScheduler(IContainerScheduler):
         return self._docker
 
     async def close(self) -> None:
-        """关闭 Docker 连接"""
+        """Close the Docker connection"""
         if self._docker:
             await self._docker.close()
             self._initialized = False
 
     async def _ensure_image_available(self, docker: Docker, image: str) -> None:
-        """确保 Docker 镜像本地可用；缺失时从远端 registry 拉取。"""
+        """Make sure the image is available locally, pulling from the remote registry when it is not."""
         try:
             await docker.images.inspect(image)
             logger.debug("Docker image already available locally", image=image)
@@ -115,13 +115,13 @@ class DockerScheduler(IContainerScheduler):
 
     def _parse_s3_workspace(self, workspace_path: str) -> dict | None:
         """
-        解析 S3 workspace 路径
+        Parse an S3 workspace path
 
         Args:
-            workspace_path: S3 路径，格式: s3://bucket/sessions/{session_id}/
+            workspace_path: S3 path, formatted as s3://bucket/sessions/{session_id}/
 
         Returns:
-            包含 bucket, prefix 的字典，如果不是 S3 路径则返回 None
+            A dict holding bucket and prefix, or None when this is not an S3 path
         """
         if not workspace_path or not workspace_path.startswith("s3://"):
             return None
@@ -142,24 +142,24 @@ class DockerScheduler(IContainerScheduler):
         dependencies: list[str] | None = None,
     ) -> str:
         """
-        构建容器启动脚本，用于挂载 S3 bucket 并安装依赖
+        Build the container start script that mounts the S3 bucket and installs dependencies
 
         Args:
-            s3_bucket: S3 bucket 名称
-            s3_prefix: S3 路径前缀
-            s3_endpoint_url: S3 端点 URL
-            s3_access_key: S3 访问密钥 ID
-            s3_secret_key: S3 访问密钥
-            dependencies: pip 包规范列表（如 ["requests==2.31.0", "pandas>=2.0"]）
+            s3_bucket: S3 bucket name
+            s3_prefix: S3 path prefix
+            s3_endpoint_url: S3 endpoint URL
+            s3_access_key: S3 access key id
+            s3_secret_key: S3 secret key
+            dependencies: pip requirement specifiers, such as ["requests==2.31.0", "pandas>=2.0"]
 
         Returns:
-            Shell 脚本字符串
+            The shell script as a string
 
-        工作原理:
-        1. 挂载 S3 bucket 到 /mnt/s3-root
-        2. 使用 bind mount 将 session 目录挂载到 /workspace
-        3. 安装依赖到 /workspace/.venv/（如果指定）
-        4. 使用 gosu 切换到 sandbox 用户运行 executor
+        How it works:
+        1. Mount the S3 bucket on /mnt/s3-root
+        2. Bind mount the session directory onto /workspace
+        3. Install dependencies into /workspace/.venv/ when any were given
+        4. Drop to the sandbox user with gosu and run the executor
         """
         path_style_option = "-o use_path_request_style" if s3_endpoint_url else ""
         dependency_install_script = format_dependency_install_script_for_shell(dependencies)
@@ -167,12 +167,13 @@ class DockerScheduler(IContainerScheduler):
         return f"""#!/bin/bash
 set -e
 
-# 创建 s3fs 凭证文件
+# Create the s3fs credential file
 echo "{s3_access_key}:{s3_secret_key}" > /tmp/.passwd-s3fs
 chmod 600 /tmp/.passwd-s3fs
 
-# 1) 先以 root 临时挂整桶（不 allow_other），创建会话前缀后立即卸载。
-#    s3fs 无法挂载不存在的前缀，需先确保前缀对象存在。用户代码看不到此临时挂载点。
+# 1) Briefly mount the whole bucket as root (no allow_other) to create the session prefix,
+#    then unmount immediately. s3fs cannot mount a prefix that does not exist yet, and user
+#    code never sees this temporary mount point.
 mkdir -p /mnt/s3-init
 s3fs {s3_bucket} /mnt/s3-init \\
     -o passwd_file=/tmp/.passwd-s3fs \\
@@ -182,8 +183,9 @@ mkdir -p "/mnt/s3-init/{s3_prefix}"
 umount /mnt/s3-init || fusermount -u /mnt/s3-init
 rmdir /mnt/s3-init
 
-# 2) 只把本会话前缀挂到 /workspace，不挂整个 bucket。整桶挂载会让任意会话读写/删除
-#    其它会话的数据，是跨会话数据泄露/破坏面；按前缀挂载后代码只能触及自己的 /workspace。
+# 2) Mount only this session's prefix on /workspace, never the whole bucket. A whole-bucket
+#    mount would let any session read, write, or delete another session's data, which is a
+#    cross-session leak and corruption surface; per-prefix code reaches only its own /workspace.
 echo "Mounting S3 workspace {s3_bucket}:/{s3_prefix} to /workspace..."
 mkdir -p /workspace
 s3fs {s3_bucket}:/{s3_prefix} /workspace \\
@@ -193,17 +195,17 @@ s3fs {s3_bucket}:/{s3_prefix} /workspace \\
     -o allow_other \\
     -o umask=000
 
-# 3) 校验确实挂上了 s3fs，避免静默回落到本地目录。
+# 3) Verify s3fs really mounted, so it cannot silently fall back to a local directory.
 mount | grep -q "on /workspace type fuse" || {{ echo "s3fs failed to mount /workspace" >&2; exit 1; }}
 echo "Workspace mounted (scoped to {s3_prefix}): $(ls -la /workspace)"
 
-# ========== ✅ 新增：安装依赖 ==========
+# ========== Install dependencies ==========
 {dependency_install_script}
 
-# 6. 使用 gosu 切换到 sandbox 用户运行 executor
-# 通过 bash -c 在 gosu 之后设置环境变量
+# 6. Drop to the sandbox user with gosu and run the executor.
+# The environment variables are set after gosu, through bash -c.
 echo "Starting sandbox executor as sandbox user..."
-# 如果安装了依赖，PYTHONPATH 包含本地 venv 目录
+# When dependencies were installed, PYTHONPATH includes the local venv directory.
 if [ -d "/opt/sandbox-venv" ]; then
     export PYTHONPATH="/opt/sandbox-venv:/app:/workspace"
     export SANDBOX_VENV_PATH="/opt/sandbox-venv"
@@ -220,18 +222,18 @@ exec gosu sandbox bash -c 'export PYTHONPATH=$PYTHONPATH; export SANDBOX_VENV_PA
         dependencies: list[str] | None = None,
     ) -> str:
         """
-        构建依赖安装脚本（非 S3 模式）
+        Build the dependency install script for the non-S3 mode
 
         Args:
-            dependencies: pip 包规范列表（如 ["requests==2.31.0", "pandas>=2.0"]）
+            dependencies: pip requirement specifiers, such as ["requests==2.31.0", "pandas>=2.0"]
 
         Returns:
-            Shell 脚本字符串
+            The shell script as a string
 
-        工作原理:
-        1. 以 sandbox 用户运行
-        2. 安装依赖到 /opt/sandbox-venv/（本地文件系统）
-        3. 启动 executor
+        How it works:
+        1. Run as the sandbox user
+        2. Install dependencies into /opt/sandbox-venv/ on the local filesystem
+        3. Start the executor
         """
         dependency_install_script = format_dependency_install_script_for_shell(dependencies)
 
@@ -240,32 +242,32 @@ set -e
 
 echo "🚀 Starting sandbox executor (non-S3 mode)..."
 
-# ========== 安装依赖 ==========
+# ========== Install dependencies ==========
 {dependency_install_script}
 
-# 启动 executor
+# Start the executor
 echo "🎯 Starting executor daemon..."
 exec python -m executor.interfaces.http.rest
 """
 
     async def create_container(self, config: ContainerConfig) -> str:
         """
-        创建 Docker 容器
+        Create the Docker container
 
-        容器配置：
-        - NetworkMode: sandbox_network (容器网络，用于 executor 通信)
-        - CAP_DROP: ALL (移除所有特权)
-        - CAP_ADD: SYS_ADMIN (仅当使用 S3 workspace 时需要，用于 FUSE 挂载)
-        - SecurityOpt: no-new-privileges (禁止获取新权限)
-        - User: 1000:1000 (非特权用户)
-        - ReadonlyRootfs: false (需要写入工作空间)
+        Container configuration:
+        - NetworkMode: sandbox_network, the container network used for executor traffic
+        - CAP_DROP: ALL, drop every capability
+        - CAP_ADD: SYS_ADMIN, needed only for an S3 workspace, for the FUSE mount
+        - SecurityOpt: no-new-privileges
+        - User: 1000:1000, unprivileged
+        - ReadonlyRootfs: false, the workspace has to be writable
 
-        S3 Workspace 挂载：
-        当 workspace_path 以 s3:// 开头时，容器会通过 s3fs 将 S3 bucket 挂载到 /workspace：
-        - 添加 /dev/fuse 设备（FUSE 需要）
-        - 添加 SYS_ADMIN capability（FUSE 挂载需要）
-        - 创建 entrypoint 脚本，在启动 executor 之前先挂载 S3
-        - 容器启动后自动 cd 到 workspace 子目录
+        S3 workspace mount:
+        When workspace_path starts with s3://, the container mounts the bucket on /workspace via s3fs:
+        - add the /dev/fuse device, which FUSE needs
+        - add the SYS_ADMIN capability, which the FUSE mount needs
+        - create an entrypoint script that mounts S3 before starting the executor
+        - cd into the workspace subdirectory once the container is up
         """
         logger.info(
             "Starting container creation",
@@ -279,7 +281,7 @@ exec python -m executor.interfaces.http.rest
         logger.debug("Docker client obtained")
         await self._ensure_image_available(docker, config.image)
 
-        # 解析资源限制
+        # Parse the resource limits
         cpu_quota = int(float(config.cpu_limit) * 100000)
         memory_bytes = self._parse_memory_to_bytes(config.memory_limit)
 
@@ -291,11 +293,11 @@ exec python -m executor.interfaces.http.rest
             memory_bytes=memory_bytes,
         )
 
-        # 检查是否需要 S3 workspace 挂载
+        # Check whether an S3 workspace mount is needed
         s3_workspace = self._parse_s3_workspace(config.workspace_path)
         use_s3_mount = s3_workspace is not None
 
-        # 检查是否需要安装依赖
+        # Check whether dependencies have to be installed
         dependencies_json = config.labels.get("dependencies", "")
         has_dependencies = bool(dependencies_json)
 
@@ -307,23 +309,24 @@ exec python -m executor.interfaces.http.rest
             dependencies_json=dependencies_json,
         )
 
-        # 基础环境变量
+        # Base environment variables
         env_vars = dict(config.env_vars)
 
-        # sandbox_sdk.bkn 的 MCP 地址，与 k8s_scheduler 同一处配置。部署级常量，
-        # 注入一次即可；调用方在 event 里传 mcp 时以 event 为准。
+        # The MCP address for sandbox_sdk.bkn, configured in the same place as in
+        # k8s_scheduler. A deployment-level constant, injected once; a caller that
+        # passes mcp in the event wins.
         bkn_mcp_url = get_settings().bkn_sandbox_mcp_url.strip()
         if bkn_mcp_url:
             env_vars.setdefault("BKN_SANDBOX_MCP_URL", bkn_mcp_url)
 
-        # 基础容器配置
+        # Base container configuration
         container_config = {
             "Image": config.image,
             "Hostname": config.name,
             "Env": [f"{k}={v}" for k, v in env_vars.items()],
             "HostConfig": {
                 "NetworkMode": config.network_name,
-                # 默认配置，S3 mount 模式会覆盖
+                # Default; the S3 mount mode overrides it
                 "CpuQuota": cpu_quota,
                 "CpuPeriod": 100000,
                 "Memory": memory_bytes,
@@ -341,33 +344,33 @@ exec python -m executor.interfaces.http.rest
             network_mode=config.network_name,
         )
 
-        # 注意：StorageOpt.size 仅在 Linux 的 overlay2 + xfs (pquota) 环境下支持
-        # Mac Docker Desktop 不支持，因此这里不设置 StorageOpt
-        # 生产环境可通过 K8s 的 ephemeral-storage 或 Linux 的磁盘配额来限制磁盘使用
+        # StorageOpt.size only works on Linux with overlay2 + xfs (pquota).
+        # Docker Desktop on Mac does not support it, so StorageOpt is left unset.
+        # In production, cap disk usage through K8s ephemeral-storage or a Linux disk quota.
 
-        # 如果不使用 S3 workspace，保持原有安全配置
-        # 注意: Bubblewrap 需要用户命名空间支持，如果遇到权限错误：
-        # 1. 在宿主机启用: sudo sysctl -w kernel.unprivileged_userns_clone=1
-        # 2. 或者设置环境变量 DISABLE_BWRAP=true 来禁用 bubblewrap
+        # Without an S3 workspace, keep the original security configuration.
+        # Bubblewrap needs user-namespace support; on a permission error either:
+        # 1. enable it on the host: sudo sysctl -w kernel.unprivileged_userns_clone=1
+        # 2. or set DISABLE_BWRAP=true to turn bubblewrap off
         if not use_s3_mount:
             logger.debug("Configuring non-S3 container mode")
 
-            # 从 config.labels 中提取依赖列表
+            # Read the dependency list out of config.labels
             dependencies_json = config.labels.get("dependencies", "")
             dependencies = json.loads(dependencies_json) if dependencies_json else None
 
-            # 添加 PYTHONPATH 环境变量以支持依赖导入
+            # Add PYTHONPATH so dependency imports resolve
             if dependencies:
                 container_config["Env"].append("PYTHONPATH=/opt/sandbox-venv:/workspace")
                 container_config["Env"].append("SANDBOX_VENV_PATH=/opt/sandbox-venv")
 
-                # 为依赖安装添加 tmpfs 空间
+                # Give the dependency install some tmpfs space
                 container_config["HostConfig"]["Tmpfs"] = {
                     "/tmp": "size=512M,mode=1777",
                     "/root/.cache": "size=256M,mode=1777",
                 }
 
-                # 如果有依赖，使用动态 entrypoint 脚本
+                # With dependencies, use the dynamic entrypoint script
                 entrypoint_script = self._build_dependency_install_entrypoint(
                     dependencies=dependencies,
                 )
@@ -381,7 +384,7 @@ exec python -m executor.interfaces.http.rest
 
             container_config["HostConfig"]["CapDrop"] = ["ALL"]
             container_config["HostConfig"]["SecurityOpt"] = ["no-new-privileges"]
-            # 添加 seccomp 配置以允许用户命名空间
+            # Add the seccomp configuration that allows user namespaces
             container_config["HostConfig"]["SecurityOpt"].append("seccomp=default")
             container_config["HostConfig"]["User"] = "1000:1000"
 
@@ -392,24 +395,24 @@ exec python -m executor.interfaces.http.rest
                 user="1000:1000",
             )
 
-        # 如果使用 S3 workspace 挂载，添加必要的配置
+        # With an S3 workspace mount, add what that needs
         if use_s3_mount:
             logger.debug("Configuring S3 mount mode")
 
             settings = get_settings()
 
-            # 新增：从 config.labels 中提取依赖列表
+            # Read the dependency list out of config.labels
             dependencies_json = config.labels.get("dependencies", "")
             dependencies = json.loads(dependencies_json) if dependencies_json else None
 
-            # 以 root 用户启动（覆盖 Dockerfile 中的 USER sandbox）
-            # 这样 entrypoint 脚本可以以 root 执行 s3fs 挂载
+            # Start as root, overriding USER sandbox from the Dockerfile,
+            # so the entrypoint script can run the s3fs mount as root.
             container_config["User"] = "root"
 
-            # 添加 SYS_ADMIN capability（FUSE 需要）
+            # Add the SYS_ADMIN capability, which FUSE needs
             container_config["HostConfig"]["CapAdd"] = ["SYS_ADMIN"]
 
-            # 添加 /dev/fuse 设备
+            # Add the /dev/fuse device
             container_config["HostConfig"]["Devices"] = [
                 {
                     "PathOnHost": "/dev/fuse",
@@ -425,28 +428,28 @@ exec python -m executor.interfaces.http.rest
                 devices_added=1,
             )
 
-            # 添加 tmpfs 用于 s3fs 缓存和依赖安装
+            # Add tmpfs for the s3fs cache and the dependency install
             if dependencies:
-                # 有依赖时需要更大的 tmpfs 空间
+                # Dependencies need more tmpfs space
                 container_config["HostConfig"]["Tmpfs"] = {
-                    "/tmp": "size=512M,mode=1777",  # pip 缓存和临时文件
-                    "/root/.cache": "size=256M,mode=1777",  # pip 缓存
+                    "/tmp": "size=512M,mode=1777",  # pip cache and temporary files
+                    "/root/.cache": "size=256M,mode=1777",  # pip cache
                 }
                 logger.info(
                     "Added tmpfs for dependency installation: /tmp=512M, /root/.cache=256M"
                 )
             else:
-                # 无依赖时使用较小的 tmpfs
+                # Without dependencies a smaller tmpfs is enough
                 container_config["HostConfig"]["Tmpfs"] = {"/tmp": "size=100M,mode=1777"}
 
-            # 添加 S3 相关环境变量
+            # Add the S3 environment variables
             s3_env_vars = {
                 "S3_BUCKET": s3_workspace["bucket"],
                 "S3_PREFIX": s3_workspace["prefix"],
                 "S3_ENDPOINT_URL": settings.s3_endpoint_url or "https://s3.amazonaws.com",
                 "S3_REGION": settings.s3_region,
                 "WORKSPACE_MOUNT_POINT": "/workspace",
-                "WORKSPACE_PATH": "/workspace",  # 告诉 executor 使用本地挂载点
+                "WORKSPACE_PATH": "/workspace",  # tell the executor to use the local mount point
             }
             for k, v in s3_env_vars.items():
                 container_config["Env"].append(f"{k}={v}")
@@ -458,20 +461,20 @@ exec python -m executor.interfaces.http.rest
                 s3_endpoint_url=settings.s3_endpoint_url,
             )
 
-            # 新增：添加 PYTHONPATH 环境变量以支持依赖导入
-            # /app 必须在最前面，以便 executor 模块能被找到
+            # Add PYTHONPATH so dependency imports resolve.
+            # /app has to come first so the executor module is found.
             if dependencies:
                 container_config["Env"].append("PYTHONPATH=/opt/sandbox-venv:/app:/workspace")
                 container_config["Env"].append("SANDBOX_VENV_PATH=/opt/sandbox-venv")
 
-            # 修改：传递依赖列表到 entrypoint 脚本
+            # Pass the dependency list through to the entrypoint script
             entrypoint_script = self._build_s3_mount_entrypoint(
                 s3_bucket=s3_workspace["bucket"],
                 s3_prefix=s3_workspace["prefix"],
                 s3_endpoint_url=settings.s3_endpoint_url or "",
                 s3_access_key=settings.s3_access_key_id,
                 s3_secret_key=settings.s3_secret_access_key,
-                dependencies=dependencies,  # 新增参数
+                dependencies=dependencies,
             )
             container_config["Entrypoint"] = ["/bin/sh", "-c"]
             container_config["Cmd"] = [entrypoint_script]
@@ -525,7 +528,7 @@ exec python -m executor.interfaces.http.rest
             raise
 
     async def start_container(self, container_id: str) -> None:
-        """启动容器"""
+        """Start the container"""
         logger.info("Starting container", container_id=container_id)
 
         docker = await self._ensure_docker()
@@ -541,7 +544,7 @@ exec python -m executor.interfaces.http.rest
                 container_id=container_id,
             )
 
-            # 等待一小段时间后检查容器状态
+            # Wait briefly, then check the container status
             await asyncio.sleep(0.5)
 
             try:
@@ -556,7 +559,7 @@ exec python -m executor.interfaces.http.rest
                     error=info["State"].get("Error"),
                 )
 
-                # 如果容器已经退出，记录日志
+                # Log it when the container has already exited
                 if container_status == "exited":
                     exit_code = info["State"].get("ExitCode", -1)
                     logger.error(
@@ -592,7 +595,7 @@ exec python -m executor.interfaces.http.rest
             raise
 
     async def stop_container(self, container_id: str, timeout: int = 10) -> None:
-        """停止容器"""
+        """Stop the container"""
         docker = await self._ensure_docker()
         try:
             container = docker.containers.container(container_id)
@@ -603,7 +606,7 @@ exec python -m executor.interfaces.http.rest
             raise
 
     async def remove_container(self, container_id: str, force: bool = True) -> None:
-        """删除容器"""
+        """Delete the container"""
         docker = await self._ensure_docker()
         try:
             container = docker.containers.container(container_id)
@@ -613,7 +616,7 @@ exec python -m executor.interfaces.http.rest
             logger.warning(f"Failed to remove container {container_id}: {e}")
 
     async def get_container_status(self, container_id: str) -> ContainerInfo:
-        """获取容器状态"""
+        """Get the container status"""
         docker = await self._ensure_docker()
         try:
             container = docker.containers.container(container_id)
@@ -621,11 +624,11 @@ exec python -m executor.interfaces.http.rest
 
             status = info["State"]["Status"]
             if status == "running":
-                # Docker 可能返回运行中，但实际上是 paused
+                # Docker may report running while the container is actually paused
                 if info["State"].get("Paused", False):
                     status = "paused"
             elif status == "exited":
-                # 可以根据 exit_code 判断是 completed/failed
+                # exit_code tells completed from failed
                 pass
 
             return ContainerInfo(
@@ -645,16 +648,16 @@ exec python -m executor.interfaces.http.rest
 
     async def is_container_running(self, container_id: str) -> bool:
         """
-        检查容器是否正在运行
+        Check whether the container is running
 
-        直接通过 Docker API 查询，不依赖数据库。
-        此方法供 StateSyncService 使用。
+        Queries the Docker API directly, without going through the database.
+        StateSyncService uses this.
 
         Args:
-            container_id: 容器 ID
+            container_id: container id
 
         Returns:
-            bool: 容器是否运行中
+            bool: whether the container is running
         """
         try:
             container_info = await self.get_container_status(container_id)
@@ -666,11 +669,11 @@ exec python -m executor.interfaces.http.rest
     async def get_container_logs(
         self, container_id: str, tail: int = 100, since: str | None = None
     ) -> str:
-        """获取容器日志"""
+        """Get the container logs"""
         docker = await self._ensure_docker()
         try:
             container = docker.containers.container(container_id)
-            # 构建日志参数
+            # Build the log parameters
             params = {"stdout": True, "stderr": True, "tail": tail}
             if since:
                 params["since"] = since
@@ -683,13 +686,13 @@ exec python -m executor.interfaces.http.rest
     async def wait_container(
         self, container_id: str, timeout: int | None = None
     ) -> ContainerResult:
-        """等待容器执行完成"""
+        """Wait for the container to finish"""
         docker = await self._ensure_docker()
         try:
             container = docker.containers.container(container_id)
 
             if timeout:
-                # 使用 asyncio.wait_for 实现超时
+                # asyncio.wait_for provides the timeout
                 result = await asyncio.wait_for(container.wait(), timeout=timeout)
             else:
                 result = await container.wait()
@@ -697,7 +700,7 @@ exec python -m executor.interfaces.http.rest
             exit_code = result["StatusCode"]
             status = "completed" if exit_code == 0 else "failed"
 
-            # 获取日志
+            # Read the logs
             logs = await self.get_container_logs(container_id, tail=-1)
 
             return ContainerResult(
@@ -719,10 +722,10 @@ exec python -m executor.interfaces.http.rest
             raise
 
     async def ping(self) -> bool:
-        """检查 Docker 连接状态"""
+        """Check the Docker connection"""
         try:
             docker = await self._ensure_docker()
-            # 尝试获取 Docker 版本信息来验证连接
+            # Read the Docker version to verify the connection
             version = await docker.version()
             return version is not None
         except Exception as e:
@@ -731,13 +734,13 @@ exec python -m executor.interfaces.http.rest
 
     def _parse_memory_to_bytes(self, value: str) -> int:
         """
-        解析内存限制为字节数
+        Parse a memory limit into bytes
 
         Args:
-            value: 如 "512Mi", "1Gi"
+            value: such as "512Mi" or "1Gi"
 
         Returns:
-            字节数
+            The number of bytes
         """
         value = value.strip()
         if value.endswith("Gi") or value.endswith("GB") or value.endswith("G"):
@@ -747,9 +750,9 @@ exec python -m executor.interfaces.http.rest
         elif value.endswith("Ki") or value.endswith("KB") or value.endswith("K"):
             return int(float(value[:-2]) * 1024)
         else:
-            # 默认为 MB
+            # Default to MB
             return int(float(value) * 1024 * 1024)
 
     def _parse_disk_to_bytes(self, value: str) -> int:
-        """解析磁盘限制为字节数"""
+        """Parse a disk limit into bytes"""
         return self._parse_memory_to_bytes(value)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/k8s_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/container_scheduler/k8s_scheduler.py
@@ -1,14 +1,14 @@
 """
-Kubernetes 容器调度器
+Kubernetes container scheduler
 
-使用官方 Python kubernetes 客户端实现 Pod 的创建和管理。
+Creates and manages Pods through the official Python kubernetes client.
 
-MinIO + s3fs 架构：
-- Control Plane 通过 S3 API 将文件写入 MinIO 的 /sessions/{session_id}/ 路径
-- Executor Pod 在启动脚本中挂载 s3fs，将 S3 bucket 的 session 子目录挂载到 /workspace
-- s3fs 进程和 executor 进程运行在同一容器内
+MinIO + s3fs architecture:
+- The control plane writes files into MinIO under /sessions/{session_id}/ via the S3 API
+- The executor Pod mounts s3fs in its start script, mapping that session subdirectory to /workspace
+- The s3fs process and the executor process run inside the same container
 
-Python 依赖安装：按照 sandbox-design-v2.1.md 章节 5 设计。
+Python dependency installation follows section 5 of sandbox-design-v2.1.md.
 """
 
 import asyncio
@@ -54,13 +54,13 @@ logger = get_logger(__name__)
 
 def s3_prefix_from_path(prefix: str) -> str:
     """
-    从 S3 路径前缀中提取会话 ID
+    Extract the session id from an S3 path prefix
 
     Args:
-        prefix: S3 路径前缀，如 "sessions/test-001/workspace"
+        prefix: S3 path prefix, for example "sessions/test-001/workspace"
 
     Returns:
-        会话 ID，如 "test-001"
+        The session id, for example "test-001"
     """
     parts = prefix.strip("/").split("/")
     if len(parts) >= 2 and parts[0] == "sessions":
@@ -70,9 +70,9 @@ def s3_prefix_from_path(prefix: str) -> str:
 
 class K8sScheduler(IContainerScheduler):
     """
-    Kubernetes 容器调度器
+    Kubernetes container scheduler
 
-    通过 Kubernetes API 管理 Pod 生命周期。
+    Manages the Pod lifecycle through the Kubernetes API.
     """
 
     def __init__(
@@ -83,53 +83,53 @@ class K8sScheduler(IContainerScheduler):
         executor_service_account: str = "sandbox-control-plane",
     ):
         """
-        初始化 K8s 调度器
+        Initialize the K8s scheduler
 
         Args:
-            namespace: Kubernetes 命名空间
-            kube_config_path: kubeconfig 文件路径（可选，用于本地开发）
-            service_account_token: ServiceAccount Token（用于 Pod 内运行）
-            executor_service_account: Executor Pod 使用的 ServiceAccount 名称
+            namespace: Kubernetes namespace
+            kube_config_path: path to a kubeconfig file, optional, for local development
+            service_account_token: ServiceAccount token, used when running inside a Pod
+            executor_service_account: name of the ServiceAccount the executor Pod uses
         """
         self._namespace = namespace
         self._executor_service_account = executor_service_account
 
-        # 加载 Kubernetes 配置
+        # Load the Kubernetes configuration
         if service_account_token:
-            # 在 Pod 内运行，使用 ServiceAccount
+            # Running inside a Pod: use the ServiceAccount
             self._load_incluster_config()
         elif kube_config_path:
-            # 使用指定的 kubeconfig 文件
+            # Use the kubeconfig file that was given
             config.load_kube_config(config_file=kube_config_path)
         else:
-            # 尝试加载默认 kubeconfig
+            # Try the default kubeconfig
             try:
                 config.load_kube_config()
             except Exception:
-                # 如果 kubeconfig 不存在，尝试使用 in-cluster 配置
+                # No kubeconfig: try the in-cluster configuration
                 try:
                     self._load_incluster_config()
                 except Exception:
-                    # 最后尝试使用默认配置（用于本地开发）
+                    # Last resort, the default configuration, for local development
                     from kubernetes.client import Configuration
 
                     Configuration.set_default(Configuration())
 
-        # 创建 API 客户端
+        # Create the API clients
         self._core_v1 = client.CoreV1Api()
         self._initialized = False
 
     def _load_incluster_config(self):
-        """加载 in-cluster 配置"""
+        """Load the in-cluster configuration"""
         config.load_incluster_config()
         logger.info("Loaded in-cluster Kubernetes config")
 
     async def _ensure_connected(self) -> bool:
-        """确保 K8s 连接已建立"""
+        """Make sure the K8s connection is established"""
         if not self._initialized:
             try:
-                # 测试连接 - 使用当前 namespace 的 Pod 列表代替 namespace 列表
-                # 这样只需要 namespace 级别的权限，不需要 cluster 级别的权限
+                # Probe the connection by listing Pods in the current namespace
+                # rather than namespaces, so only namespace-level permissions are needed
                 self._core_v1.list_namespaced_pod(self._namespace, limit=1)
                 self._initialized = True
                 logger.info(f"Connected to Kubernetes cluster, namespace: {self._namespace}")
@@ -139,18 +139,18 @@ class K8sScheduler(IContainerScheduler):
         return self._initialized
 
     async def close(self) -> None:
-        """关闭连接（Kubernetes 客户端是无状态的，无需显式关闭）"""
+        """Close the connection. The Kubernetes client is stateless, so there is nothing to close."""
         self._initialized = False
 
     def _parse_s3_workspace(self, workspace_path: str) -> dict | None:
         """
-        解析 S3 workspace 路径
+        Parse an S3 workspace path
 
         Args:
-            workspace_path: S3 路径，格式: s3://bucket/sessions/{session_id}/
+            workspace_path: S3 path, formatted as s3://bucket/sessions/{session_id}/
 
         Returns:
-            包含 bucket, prefix 的字典，如果不是 S3 路径则返回 None
+            A dict holding bucket and prefix, or None when this is not an S3 path
         """
         if not workspace_path or not workspace_path.startswith("s3://"):
             return None
@@ -162,19 +162,19 @@ class K8sScheduler(IContainerScheduler):
         }
 
     def _build_pod_name(self, session_id: str) -> str:
-        """生成 Pod 名称"""
-        # K8s Pod 名称需要符合 DNS 子域名规则
-        # 只能包含小写字母、数字和 '-'，且开头和结尾必须是字母数字
+        """Generate the Pod name"""
+        # A K8s Pod name has to follow the DNS subdomain rules:
+        # lower-case letters, digits, and '-', starting and ending alphanumeric.
         pod_name = f"sandbox-{session_id.lower()}"
-        # 替换不符合规则的字符
+        # Replace anything that does not fit
         pod_name = "".join(c if c.isalnum() or c == "-" else "-" for c in pod_name)
-        # 确保不以 '-' 开头或结尾
+        # Make sure it neither starts nor ends with '-'
         pod_name = pod_name.strip("-")
-        # 限制长度（K8s Pod 名称最多 253 字符）
+        # Cap the length; a K8s Pod name allows at most 253 characters
         return pod_name[:253]
 
     def _build_owner_references(self, config: ContainerConfig) -> list[V1OwnerReference] | None:
-        """基于 control plane owner 上下文构造 ownerReferences。"""
+        """Build ownerReferences from the control plane owner context."""
         if config.owner_context is None:
             return None
 
@@ -190,7 +190,7 @@ class K8sScheduler(IContainerScheduler):
         ]
 
     async def _read_pod(self, pod_name: str) -> V1Pod | None:
-        """读取指定 Pod，不存在时返回 None。"""
+        """Read one Pod, returning None when it does not exist."""
         try:
             return await asyncio.to_thread(
                 self._core_v1.read_namespaced_pod,
@@ -208,7 +208,7 @@ class K8sScheduler(IContainerScheduler):
         timeout_seconds: float = 30.0,
         poll_interval_seconds: float = 1.0,
     ) -> bool:
-        """等待 Pod 从 API 中彻底删除，避免同名重建时出现 409。"""
+        """Wait until the Pod is gone from the API, so recreating the same name cannot 409."""
         deadline = asyncio.get_running_loop().time() + timeout_seconds
         while asyncio.get_running_loop().time() < deadline:
             existing_pod = await self._read_pod(pod_name)
@@ -218,7 +218,7 @@ class K8sScheduler(IContainerScheduler):
         return False
 
     def _build_image_pull_secrets(self) -> list[V1LocalObjectReference] | None:
-        """构造 executor Pod 使用的 imagePullSecrets。"""
+        """Build the imagePullSecrets the executor Pod uses."""
         settings = get_settings()
         secret_names = [
             secret.strip()
@@ -238,23 +238,23 @@ class K8sScheduler(IContainerScheduler):
         s3_workspace: dict = None,
     ) -> V1Container:
         """
-        构建主 executor 容器
+        Build the main executor container
 
-        如果使用 S3 挂载，启动脚本会先挂载 s3fs，然后启动 executor
+        With an S3 mount, the start script mounts s3fs first and then starts the executor
 
         Args:
-            config: 容器配置
-            use_s3_mount: 是否使用 S3 挂载（通过 s3fs 在容器内挂载）
-            has_dependencies: 是否有依赖包
-            session_id: 会话 ID（用于 S3 子目录挂载）
-            s3_workspace: S3 workspace 配置（包含 bucket, prefix）
+            config: container configuration
+            use_s3_mount: whether to mount S3, through s3fs inside the container
+            has_dependencies: whether there are dependency packages
+            session_id: session id, used for the S3 subdirectory mount
+            s3_workspace: S3 workspace configuration, holding bucket and prefix
 
         Returns:
-            V1Container 对象
+            A V1Container object
         """
         env_vars = [V1EnvVar(name=k, value=v) for k, v in config.env_vars.items()]
 
-        # 添加 S3 相关环境变量
+        # Add the S3 environment variables
         s3_workspace = self._parse_s3_workspace(config.workspace_path)
         if s3_workspace:
             env_vars.extend(
@@ -265,19 +265,19 @@ class K8sScheduler(IContainerScheduler):
                 ]
             )
 
-        # sandbox_sdk.bkn 的 MCP 地址。部署级常量，注入一次即可；调用方在 event 里
-        # 传 mcp 时以 event 为准（见 sandbox_sdk/bkn.py 的 _mcp_url）。
+        # The MCP address for sandbox_sdk.bkn. A deployment-level constant, injected
+        # once; a caller that passes mcp in the event wins (see _mcp_url in sandbox_sdk/bkn.py).
         bkn_mcp_url = get_settings().bkn_sandbox_mcp_url.strip()
         if bkn_mcp_url:
             env_vars.append(V1EnvVar(name="BKN_SANDBOX_MCP_URL", value=bkn_mcp_url))
 
-        # 添加 PYTHONPATH 环境变量以支持依赖导入
+        # Add PYTHONPATH so dependency imports resolve
         if has_dependencies:
-            # 依赖安装到本地 /opt/sandbox-venv
+            # Dependencies are installed locally under /opt/sandbox-venv
             env_vars.append(V1EnvVar(name="PYTHONPATH", value="/opt/sandbox-venv:/app:/workspace"))
             env_vars.append(V1EnvVar(name="SANDBOX_VENV_PATH", value="/opt/sandbox-venv"))
 
-        # 资源限制
+        # Resource limits
         resources = V1ResourceRequirements(
             limits={
                 "cpu": config.cpu_limit,
@@ -292,7 +292,7 @@ class K8sScheduler(IContainerScheduler):
             },
         )
 
-        # 容器端口
+        # Container ports
         ports = [
             V1ContainerPort(
                 container_port=8080,
@@ -301,7 +301,7 @@ class K8sScheduler(IContainerScheduler):
             )
         ]
 
-        # 卷挂载
+        # Volume mounts
         volume_mounts = [
             V1VolumeMount(
                 name="workspace",
@@ -317,42 +317,43 @@ class K8sScheduler(IContainerScheduler):
                 )
             )
 
-        # 安全上下文 - s3fs 需要 privileged 和 root 用户
-        # 注意：privileged=True 时容器必须以 root 运行，以便进行 FUSE 挂载
-        # 需要显式设置 runAsUser=0 来覆盖 Dockerfile 中的 USER 指令
-        # 有依赖时也需要 root 来安装依赖，然后用 gosu 切换到 sandbox 用户
+        # Security context: s3fs needs privileged and the root user.
+        # With privileged=True the container has to run as root to perform the FUSE mount,
+        # so runAsUser=0 is set explicitly to override the USER directive in the Dockerfile.
+        # Dependencies also need root to install, after which gosu drops to the sandbox user.
         needs_root = use_s3_mount or has_dependencies
         security_context = V1SecurityContext(
-            # s3fs 挂载或依赖安装需要 root，最终使用 gosu 切换到 sandbox 用户
+            # An s3fs mount or a dependency install needs root; gosu drops to the sandbox user at the end
             run_as_non_root=not needs_root,
-            run_as_user=0 if needs_root else 1000,  # 0 = root，显式设置以覆盖 Dockerfile USER
+            run_as_user=0 if needs_root else 1000,  # 0 = root, set explicitly to override the Dockerfile USER
             run_as_group=0 if needs_root else 1000,
-            allow_privilege_escalation=use_s3_mount,  # s3fs 需要特权
+            allow_privilege_escalation=use_s3_mount,  # s3fs needs privileges
             capabilities=V1Capabilities(drop=["ALL"]) if not needs_root else None,
             read_only_root_filesystem=False,
-            privileged=use_s3_mount,  # s3fs 需要 privileged 模式
+            privileged=use_s3_mount,  # s3fs needs privileged mode
         )
 
-        # 构建启动命令
+        # Build the start command
         command = None
         if use_s3_mount:
-            # 获取设置
+            # Read the settings
             settings = get_settings()
             minio_url = (
                 settings.s3_endpoint_url or "http://minio.sandbox-system.svc.cluster.local:9000"
             )
             bucket = s3_workspace["bucket"]
 
-            # S3 挂载脚本（先建会话前缀，再只挂本会话前缀到 /workspace，不暴露整个 bucket）
+            # S3 mount script: create the session prefix first, then mount only that prefix on /workspace, never the whole bucket
             s3_prefix = s3_workspace["prefix"].rstrip("/")
             mount_script = f"""#!/bin/sh
 set -e
 
 echo "📂 Preparing S3 workspace {bucket}:/{s3_prefix} (session: {session_id})..."
 
-# 1) 先以 root 临时挂整桶（仅 root 可见、不 allow_other），创建会话前缀后立即卸载。
-#    s3fs 无法挂载不存在的前缀，需先确保前缀对象存在。executor 之后才以 sandbox
-#    用户启动，用户代码永远看不到这个临时挂载点。
+# 1) Briefly mount the whole bucket as root (root-visible only, no allow_other) to create
+#    the session prefix, then unmount immediately. s3fs cannot mount a prefix that does not
+#    exist yet. The executor starts as the sandbox user afterwards, so user code never sees
+#    this temporary mount point.
 mkdir -p /mnt/s3-init
 s3fs {bucket} /mnt/s3-init \\
     -o url={minio_url} \\
@@ -362,9 +363,9 @@ mkdir -p "/mnt/s3-init/{s3_prefix}"
 umount /mnt/s3-init || fusermount -u /mnt/s3-init
 rmdir /mnt/s3-init
 
-# 2) 只把本会话前缀挂到 /workspace。不挂整个 bucket —— 整桶挂载（allow_other）会让
-#    任意会话读写/删除其它会话的数据，是跨会话数据泄露/破坏面；按前缀挂载后代码
-#    只能触及自己的 /workspace。
+# 2) Mount only this session's prefix on /workspace. Mounting the whole bucket with
+#    allow_other would let any session read, write, or delete another session's data, which
+#    is a cross-session leak and corruption surface; per-prefix code reaches only its own /workspace.
 s3fs {bucket}:/{s3_prefix} /workspace \\
     -o url={minio_url} \\
     -o use_path_request_style \\
@@ -373,7 +374,7 @@ s3fs {bucket}:/{s3_prefix} /workspace \\
     -o gid=1000 \\
     -o passwd_file=/etc/s3fs-passwd/s3fs-passwd
 
-# 3) 校验确实挂上了 s3fs，避免静默回落到本地 emptyDir 导致数据不落 MinIO。
+# 3) Verify s3fs really mounted, so a silent fall back to the local emptyDir cannot leave data out of MinIO.
 mount | grep -q "on /workspace type fuse" || {{ echo "❌ s3fs failed to mount /workspace" >&2; exit 1; }}
 
 echo "✅ Session workspace mounted (scoped to {s3_prefix})"
@@ -381,7 +382,7 @@ ls -la /workspace/
 
 """
 
-            # 如果有依赖，安装依赖
+            # Install the dependencies when there are any
             if has_dependencies:
                 dependencies_json = config.labels.get("dependencies", "")
                 dependencies = json.loads(dependencies_json) if dependencies_json else []
@@ -405,17 +406,17 @@ export PYTHONPATH="$VENV_DIR:/app:/workspace"
 export SANDBOX_VENV_PATH="$VENV_DIR"
 """
 
-            # 启动 executor (前台) - 使用 gosu 切换到 sandbox 用户
+            # Start the executor in the foreground, dropping to the sandbox user with gosu
             mount_script += """
 echo "🚀 Starting executor as sandbox user..."
-# 使用 gosu 切换到 sandbox 用户并启动 executor
-# gosu 会正确传递信号，避免进程变成僵尸
+# Drop to the sandbox user with gosu and start the executor.
+# gosu forwards signals correctly, which keeps the process from becoming a zombie.
 exec gosu sandbox python -m executor.interfaces.http.rest
 """
             command = ["sh", "-c", mount_script]
 
         elif has_dependencies:
-            # 依赖由 executor 容器在启动时安装
+            # The executor container installs the dependencies at start-up
             dependencies_json = config.labels.get("dependencies", "")
             dependencies = json.loads(dependencies_json) if dependencies_json else []
             install_script = format_dependency_install_script_for_shell(dependencies)
@@ -426,10 +427,10 @@ echo "📦 Installing dependencies..."
 
 {install_script}
 
-# 修复 venv 目录权限（以 root 安装，需要让 sandbox 用户可读）
+# Fix the venv permissions: it was installed as root and the sandbox user has to read it.
 chown -R sandbox:sandbox /opt/sandbox-venv
 
-# 启动 executor - 使用 gosu 切换到 sandbox 用户
+# Start the executor, dropping to the sandbox user with gosu.
 echo "🚀 Starting executor as sandbox user..."
 exec gosu sandbox python -m executor.interfaces.http.rest
 """
@@ -451,13 +452,13 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def create_container(self, config: ContainerConfig) -> str:
         """
-        创建 Kubernetes Pod - 使用 s3fs 在 executor 容器内挂载
+        Create a Kubernetes Pod, mounting s3fs inside the executor container
 
-        架构说明：
-        - Control Plane 通过 S3 API 将文件写入 MinIO 的 /sessions/{session_id}/ 路径
-        - Executor Pod 在启动脚本中挂载 s3fs，将 S3 bucket 的 session 子目录挂载到 /workspace
-        - s3fs 进程和 executor 进程运行在同一容器内
-        - 如果有依赖，executor 容器会在启动时安装依赖
+        How it fits together:
+        - The control plane writes files into MinIO under /sessions/{session_id}/ via the S3 API
+        - The executor Pod mounts s3fs in its start script, mapping that session subdirectory to /workspace
+        - The s3fs process and the executor process run inside the same container
+        - When there are dependencies, the executor container installs them at start-up
         """
         await self._ensure_connected()
 
@@ -465,18 +466,18 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         s3_workspace = self._parse_s3_workspace(config.workspace_path)
         use_s3_mount = s3_workspace is not None
 
-        # 检查是否有依赖
+        # Check whether there are dependencies
         dependencies_json = config.labels.get("dependencies", "")
         has_dependencies = bool(dependencies_json)
 
-        # 提取 session_id 仅用于日志记录（挂载使用完整 s3_prefix）
+        # session_id is extracted for logging only; the mount uses the full s3_prefix
         session_id = s3_prefix_from_path(s3_workspace["prefix"]) if s3_workspace else config.name
 
-        # 构建容器列表 - 只有 executor 容器
+        # Build the container list: the executor container only
         containers = []
 
-        # 构建 executor 容器（在启动脚本中挂载 s3fs）
-        # 注意：挂载脚本使用完整的 s3_prefix，而不是 session_id，以避免路径层级问题
+        # Build the executor container, which mounts s3fs in its start script.
+        # The mount script uses the full s3_prefix rather than session_id, to avoid path-depth problems.
         executor_container = self._build_executor_container(
             config=config,
             use_s3_mount=use_s3_mount,
@@ -486,17 +487,17 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         )
         containers.append(executor_container)
 
-        # 构建卷
+        # Build the volumes
         volumes = []
         if use_s3_mount:
-            # 使用 emptyDir 用于 s3fs 挂载
+            # An emptyDir backs the s3fs mount
             volumes.append(
                 V1Volume(
                     name="workspace",
                     empty_dir=V1EmptyDirVolumeSource(),
                 )
             )
-            # 添加 s3fs-passwd secret
+            # Add the s3fs-passwd secret
             volumes.append(
                 V1Volume(
                     name="s3fs-passwd",
@@ -507,7 +508,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                 )
             )
         else:
-            # 本地 workspace：使用 emptyDir
+            # Local workspace: use an emptyDir
             volumes.append(
                 V1Volume(
                     name="workspace",
@@ -515,11 +516,11 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                 )
             )
 
-        # 构建标签（排除 dependencies，因为 K8s labels 有严格格式限制）
-        # dependencies 不能作为 label，因为包含方括号、引号等非法字符
+        # Build the labels, excluding dependencies, because K8s labels have a strict format
+        # and dependencies contains brackets, quotes, and other illegal characters.
         dependencies_value = config.labels.pop("dependencies", None)
         labels = {
-            "app": "sandbox-executor",  # 匹配 sandbox-executor service selector
+            "app": "sandbox-executor",  # matches the sandbox-executor service selector
             "sandbox-session": config.name,
             "sandbox-type": "execution",
         }
@@ -527,7 +528,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
             labels["mount-method"] = "s3fs"
         labels.update(config.labels)
 
-        # 构建 annotations（dependencies 放在这里，没有格式限制）
+        # Build the annotations; dependencies goes here, where the format is unconstrained
         annotations = {
             "sandbox-session-id": config.name,
         }
@@ -536,11 +537,11 @@ exec gosu sandbox python -m executor.interfaces.http.rest
             annotations["control-plane-pod-uid"] = config.owner_context.pod_uid
         if dependencies_value:
             annotations["dependencies"] = dependencies_value
-        # 恢复 dependencies 到 config.labels，避免影响后续调用
+        # Restore dependencies onto config.labels so later calls are unaffected
         if dependencies_value is not None:
             config.labels["dependencies"] = dependencies_value
 
-        # 构建 Pod Spec
+        # Build the Pod spec
         pod = V1Pod(
             metadata=V1ObjectMeta(
                 name=pod_name,
@@ -551,18 +552,18 @@ exec gosu sandbox python -m executor.interfaces.http.rest
             spec=V1PodSpec(
                 containers=containers,
                 volumes=volumes,
-                restart_policy="Always",  # 确保容器退出后自动重启，保持 runtime 可用
+                restart_policy="Always",  # restart the container after it exits, keeping the runtime available
                 host_network=False,
                 termination_grace_period_seconds=30,
                 service_account_name=self._executor_service_account,
                 image_pull_secrets=self._build_image_pull_secrets(),
-                # 使用默认 DNS 策略 (ClusterFirst)，允许 Pod 使用 K8s 集群 DNS
-                # 这对于 executor 与 control plane 通信很重要
+                # Keep the default DNS policy (ClusterFirst) so the Pod uses cluster DNS,
+                # which matters for executor-to-control-plane communication.
             ),
         )
 
         try:
-            # 创建 Pod
+            # Create the Pod
             created_pod = await asyncio.to_thread(
                 self._core_v1.create_namespaced_pod,
                 namespace=self._namespace,
@@ -609,23 +610,23 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def start_container(self, container_id: str) -> None:
         """
-        启动 Pod
+        Start the Pod
 
-        注意：Kubernetes Pod 创建后会自动启动，此方法为兼容接口保留
+        A Kubernetes Pod starts on its own once created; this method exists for interface compatibility.
         """
         await self._ensure_connected()
-        # K8s Pod 创建后自动启动，无需显式调用
+        # A K8s Pod starts automatically after creation, so there is nothing to call
         logger.debug(f"Pod {container_id} starts automatically after creation")
 
     async def stop_container(self, container_id: str, timeout: int = 30) -> None:
         """
-        停止（删除）Pod
+        Stop, meaning delete, the Pod
 
-        使用 s3fs 方式时，无需清理 PVC，s3fs 挂载在 Pod 删除时自动清理。
+        With s3fs there is no PVC to clean up; the mount goes away with the Pod.
 
         Args:
-            container_id: Pod 名称
-            timeout: 优雅终止超时时间（秒）
+            container_id: Pod name
+            timeout: graceful termination timeout in seconds
         """
         await self._ensure_connected()
 
@@ -646,13 +647,13 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def remove_container(self, container_id: str, force: bool = False) -> None:
         """
-        删除 Pod
+        Delete the Pod
 
-        使用 s3fs 方式时，无需清理 PVC，s3fs 挂载在 Pod 删除时自动清理。
+        With s3fs there is no PVC to clean up; the mount goes away with the Pod.
 
         Args:
-            container_id: Pod 名称
-            force: 是否强制删除（grace_period_seconds=0）
+            container_id: Pod name
+            force: whether to force the delete with grace_period_seconds=0
         """
         await self._ensure_connected()
 
@@ -672,13 +673,13 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def get_container_status(self, container_id: str) -> ContainerInfo:
         """
-        获取 Pod 状态
+        Get the Pod status
 
         Args:
-            container_id: Pod 名称
+            container_id: Pod name
 
         Returns:
-            ContainerInfo 对象
+            A ContainerInfo object
         """
         await self._ensure_connected()
         try:
@@ -688,7 +689,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                 namespace=self._namespace,
             )
 
-            # 转换 K8s Pod 状态到 ContainerInfo
+            # Translate the K8s Pod status into ContainerInfo
             phase = pod.status.phase
             if phase == "Running" and pod.status.container_statuses:
                 for container_status in pod.status.container_statuses:
@@ -707,7 +708,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
             )
             started_at = pod.status.start_time.isoformat() if pod.status.start_time else None
 
-            # 获取退出码（如果已终止）
+            # Read the exit code, when it has terminated
             exit_code = None
             if pod.status.container_statuses:
                 for container_status in pod.status.container_statuses:
@@ -715,7 +716,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                         exit_code = container_status.state.terminated.exit_code
                         break
 
-            # 获取镜像名称
+            # Read the image name
             image = ""
             if pod.spec.containers:
                 for container in pod.spec.containers:
@@ -745,13 +746,13 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def is_container_running(self, container_id: str) -> bool:
         """
-        检查 Pod 是否正在运行
+        Check whether the Pod is running
 
         Args:
-            container_id: Pod 名称
+            container_id: Pod name
 
         Returns:
-            bool: Pod 是否运行中
+            bool: whether the Pod is running
         """
         try:
             container_info = await self.get_container_status(container_id)
@@ -764,7 +765,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         self,
         container_id: str,
     ) -> ContainerOwnershipInfo | None:
-        """读取 Pod 的 ownerReferences 和 takeover 相关 annotations。"""
+        """Read the Pod ownerReferences and the takeover annotations."""
         await self._ensure_connected()
 
         try:
@@ -808,15 +809,15 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         self, container_id: str, tail: int = 100, since: str | None = None
     ) -> str:
         """
-        获取 Pod 日志
+        Get the Pod logs
 
         Args:
-            container_id: Pod 名称
-            tail: 返回最后几行
-            since: 时间戳（可选）
+            container_id: Pod name
+            tail: how many trailing lines to return
+            since: timestamp, optional
 
         Returns:
-            日志字符串
+            The logs as a string
         """
         await self._ensure_connected()
         try:
@@ -826,7 +827,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                 namespace=self._namespace,
                 container="executor",
                 tail_lines=tail,
-                since_seconds=None,  # since_time 需要转换
+                since_seconds=None,  # since_time needs converting
             )
             return logs
         except ApiException as e:
@@ -837,14 +838,14 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         self, container_id: str, timeout: int | None = None
     ) -> ContainerResult:
         """
-        等待 Pod 执行完成
+        Wait for the Pod to finish
 
         Args:
-            container_id: Pod 名称
-            timeout: 超时时间（秒）
+            container_id: Pod name
+            timeout: timeout in seconds
 
         Returns:
-            ContainerResult 对象
+            A ContainerResult object
         """
         await self._ensure_connected()
 
@@ -857,9 +858,9 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                         namespace=self._namespace,
                     )
 
-                    # 检查 Pod 状态
+                    # Check the Pod status
                     if pod.status.phase == "Succeeded":
-                        # 获取日志
+                        # Read the logs
                         logs = await self.get_container_logs(container_id, tail=-1)
                         return ContainerResult(
                             status="completed",
@@ -868,7 +869,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                             exit_code=0,
                         )
                     elif pod.status.phase == "Failed":
-                        # 获取日志
+                        # Read the logs
                         logs = await self.get_container_logs(container_id, tail=-1)
                         return ContainerResult(
                             status="failed",
@@ -877,7 +878,7 @@ exec gosu sandbox python -m executor.interfaces.http.rest
                             exit_code=1,
                         )
 
-                    # 检查容器状态
+                    # Check the container status
                     if pod.status.container_statuses:
                         for container_status in pod.status.container_statuses:
                             if (
@@ -922,10 +923,10 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     async def ping(self) -> bool:
         """
-        检查 Kubernetes 连接状态
+        Check the Kubernetes connection
 
         Returns:
-            bool: 连接是否正常
+            bool: whether the connection is healthy
         """
         try:
             await self._ensure_connected()
@@ -940,13 +941,13 @@ exec gosu sandbox python -m executor.interfaces.http.rest
 
     def _parse_memory_to_bytes(self, value: str) -> int:
         """
-        解析内存限制为字节数
+        Parse a memory limit into bytes
 
         Args:
-            value: 如 "512Mi", "1Gi"
+            value: such as "512Mi" or "1Gi"
 
         Returns:
-            字节数
+            The number of bytes
         """
         value = value.strip()
         if value.endswith("Gi") or value.endswith("GB") or value.endswith("G"):
@@ -956,9 +957,9 @@ exec gosu sandbox python -m executor.interfaces.http.rest
         elif value.endswith("Ki") or value.endswith("KB") or value.endswith("K"):
             return int(float(value[:-2]) * 1024)
         else:
-            # 默认为 MB
+            # Default to MB
             return int(float(value) * 1024 * 1024)
 
     def _parse_disk_to_bytes(self, value: str) -> int:
-        """解析磁盘限制为字节数"""
+        """Parse a disk limit into bytes"""
         return self._parse_memory_to_bytes(value)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/dependencies.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/dependencies.py
@@ -1,7 +1,7 @@
 """
-依赖注入配置
+Dependency injection wiring
 
-配置和提供应用所需的所有依赖项。
+Configures and provides everything the application depends on.
 """
 
 import asyncio
@@ -46,9 +46,9 @@ logger.info(f"Runtime environment: {'Kubernetes' if IS_IN_KUBERNETES else 'Local
 
 
 def _get_docker_url() -> str:
-    """获取 Docker socket URL"""
+    """Get the Docker socket URL"""
     settings = get_settings()
-    # 确保 docker_host 有正确的协议前缀
+    # Make sure docker_host carries the right scheme prefix
     docker_host = settings.docker_host
     if not docker_host.startswith("unix://") and not docker_host.startswith("tcp://"):
         docker_host = f"unix://{docker_host}"
@@ -58,7 +58,7 @@ def _get_docker_url() -> str:
 
 # Mock implementations for development
 class MockSessionRepository(ISessionRepository):
-    """Mock 会话仓储（用于开发测试）"""
+    """Mock session repository, for development and testing"""
 
     def __init__(self):
         self._sessions = {}
@@ -136,7 +136,7 @@ class MockSessionRepository(ISessionRepository):
 
 
 class MockExecutionRepository(IExecutionRepository):
-    """Mock 执行仓储（用于开发测试）"""
+    """Mock execution repository, for development and testing"""
 
     def __init__(self):
         self._executions = {}
@@ -177,14 +177,14 @@ class MockExecutionRepository(IExecutionRepository):
 
 
 class MockTemplateRepository(ITemplateRepository):
-    """Mock 模板仓储（用于开发测试）"""
+    """Mock template repository, for development and testing"""
 
     def __init__(self):
         from datetime import datetime
         from src.domain.entities.template import Template
         from src.domain.value_objects.resource_limit import ResourceLimit
 
-        # 默认模板
+        # Default template
         self._templates = {
             "python-basic": Template(
                 id="python-basic",
@@ -238,10 +238,10 @@ class MockTemplateRepository(ITemplateRepository):
 
 
 class MockScheduler(IScheduler):
-    """Mock 调度器（用于开发测试）"""
+    """Mock scheduler, for development and testing"""
 
     async def schedule(self, request):
-        # 返回一个 mock 运行时节点
+        # Return a mock runtime node
         return RuntimeNode(
             id="node-1",
             type="docker",
@@ -269,7 +269,7 @@ class MockScheduler(IScheduler):
         container_id: str,
         execution_request: ExecutionRequest,
     ) -> str:
-        """Mock 执行方法"""
+        """Mock execute method"""
         return execution_request.execution_id or "mock_execution_id"
 
     async def get_executor_url(self, container_id: str) -> str:
@@ -277,7 +277,7 @@ class MockScheduler(IScheduler):
 
 
 class MockRuntimeNodeRepository:
-    """Mock 运行时节点仓储（用于开发测试）"""
+    """Mock runtime node repository, for development and testing"""
 
     class _NodeModel:
         def __init__(self, id, type, url, status, **kwargs):
@@ -307,7 +307,7 @@ class MockRuntimeNodeRepository:
             )
 
     def __init__(self):
-        # 默认有一个 Docker 节点
+        # One Docker node by default
         self._nodes = {
             "docker-local": self._NodeModel(
                 id="docker-local",
@@ -350,7 +350,7 @@ class MockRuntimeNodeRepository:
 
 
 class MockStorageService(IStorageService):
-    """Mock 存储服务（用于开发测试）"""
+    """Mock storage service, for development and testing"""
 
     async def upload_file(
         self, s3_path: str, content: bytes, content_type: str = "application/octet-stream"
@@ -385,47 +385,48 @@ _scheduler_singleton = None
 
 
 def initialize_dependencies(app: FastAPI):
-    """初始化所有依赖项并存储到应用状态中"""
+    """Initialize every dependency and store it on the application state"""
 
-    # 注意：数据库管理器的初始化现在是异步的，需要在 lifespan 中调用
-    # 这里不再同步调用 initialize()
+    # Initializing the database manager is asynchronous now and belongs in the
+    # lifespan, so initialize() is no longer called synchronously here.
     settings = get_settings()
 
-    # 创建仓储实例（根据配置选择 Mock 或 SQL）
+    # Create the repositories, Mock or SQL depending on the configuration
     if USE_SQL_REPOSITORIES:
-        # SQL 模式：仓储在请求时通过 Depends() 注入
-        # 存储仓储工厂函数引用到 app.state
+        # SQL mode: repositories are injected per request through Depends()
+        # Keep the repository factory references on app.state
         app.state.get_session_repository = get_session_repository
         app.state.get_execution_repository = get_execution_repository
         app.state.get_template_repository = get_template_repository
 
-        # SessionService 也需要动态创建
+        # SessionService also has to be built dynamically
         app.state.get_session_service = get_session_service_db
         app.state.get_template_service = get_template_service_db
         app.state.get_file_service = get_file_service_db
 
-        # 对于向后兼容，也设置仓储实例（用于可能直接访问的情况）
-        app.state.session_repo = None  # 使用工厂函数
+        # For backward compatibility, also set the repository attributes, in case
+        # something reaches for them directly.
+        app.state.session_repo = None  # the factory function is used instead
         app.state.execution_repo = None
         app.state.template_repo = None
 
-        # 服务也使用工厂函数
+        # The services use factory functions too
         app.state.session_service = None
         app.state.template_service = None
         app.state.file_service = None
     else:
-        # Mock 模式：直接创建实例
+        # Mock mode: build the instances directly
         session_repo = MockSessionRepository()
         execution_repo = MockExecutionRepository()
         template_repo = MockTemplateRepository()
 
-        # 创建领域服务实例
+        # Create the domain services
         storage_service = MockStorageService()
 
-        # 创建 Mock 调度器
+        # Create the mock scheduler
         scheduler = MockScheduler()
 
-        # 创建应用服务实例
+        # Create the application services
         session_service = SessionService(
             session_repo=session_repo,
             execution_repo=execution_repo,
@@ -444,25 +445,25 @@ def initialize_dependencies(app: FastAPI):
             max_extracted_total_size_mb=settings.max_extracted_total_size_mb,
         )
 
-        # 存储到应用状态
+        # Store on the application state
         app.state.session_service = session_service
         app.state.template_service = template_service
         app.state.file_service = file_service
 
-        # 也存储仓储（可能需要）
+        # Store the repositories as well, in case they are needed
         app.state.session_repo = session_repo
         app.state.execution_repo = execution_repo
         app.state.template_repo = template_repo
 
-    # 创建容器调度器（模块级单例）
+    # Create the container scheduler as a module-level singleton
     global _container_scheduler_singleton, _scheduler_singleton
 
     if USE_MOCK_SCHEDULER:
-        # Mock 模式：不创建真实调度器
+        # Mock mode: do not build a real scheduler
         _container_scheduler_singleton = None
         _scheduler_singleton = MockScheduler()
     elif IS_IN_KUBERNETES:
-        # Kubernetes 环境：使用 K8s 调度器
+        # Kubernetes: use the K8s scheduler
         from src.infrastructure.container_scheduler.k8s_scheduler import K8sScheduler
 
         settings = get_settings()
@@ -472,36 +473,36 @@ def initialize_dependencies(app: FastAPI):
         )
         logger.info(f"Initialized K8s scheduler with namespace: {settings.kubernetes_namespace}")
 
-        # 调度器服务延迟初始化
+        # The scheduler service initializes lazily
         _scheduler_singleton = None
     else:
-        # 本地开发环境：使用 Docker 调度器
+        # Local development: use the Docker scheduler
         from src.infrastructure.container_scheduler.docker_scheduler import DockerScheduler
 
         _container_scheduler_singleton = DockerScheduler(docker_url=_get_docker_url())
         logger.info(f"Initialized Docker scheduler with URL: {_get_docker_url()}")
 
-        # 调度器服务延迟初始化
+        # The scheduler service initializes lazily
         _scheduler_singleton = None
 
 
 async def cleanup_dependencies(app: FastAPI):
-    """清理依赖项"""
+    """Clean up the dependencies"""
     await db_manager.close()
 
 
 def get_session_service(app: FastAPI) -> SessionService:
-    """获取会话服务"""
+    """Get the session service"""
     return app.state.session_service
 
 
 def get_template_service(app: FastAPI) -> TemplateService:
-    """获取模板服务"""
+    """Get the template service"""
     return app.state.template_service
 
 
 def get_file_service(app: FastAPI) -> FileService:
-    """获取文件服务"""
+    """Get the file service"""
     return app.state.file_service
 
 
@@ -511,13 +512,13 @@ def get_file_service(app: FastAPI) -> FileService:
 
 
 async def get_db_session():
-    """获取数据库会话（FastAPI 依赖）"""
+    """Get the database session, as a FastAPI dependency"""
     async with db_manager.get_session() as session:
         yield session
 
 
 def get_execution_repository(session=Depends(get_db_session)) -> IExecutionRepository:
-    """获取执行仓储（SQL 或 Mock）"""
+    """Get the execution repository, SQL or Mock"""
     if USE_SQL_REPOSITORIES:
         from src.infrastructure.persistence.repositories.sql_execution_repository import (
             SqlExecutionRepository,
@@ -531,7 +532,7 @@ def get_session_repository(
     session=Depends(get_db_session),
     execution_repo: IExecutionRepository = Depends(get_execution_repository),
 ) -> ISessionRepository:
-    """获取会话仓储（SQL 或 Mock）"""
+    """Get the session repository, SQL or Mock"""
     if USE_SQL_REPOSITORIES:
         from src.infrastructure.persistence.repositories.sql_session_repository import (
             SqlSessionRepository,
@@ -542,7 +543,7 @@ def get_session_repository(
 
 
 def get_template_repository(session=Depends(get_db_session)) -> ITemplateRepository:
-    """获取模板仓储（SQL 或 Mock）"""
+    """Get the template repository, SQL or Mock"""
     if USE_SQL_REPOSITORIES:
         from src.infrastructure.persistence.repositories.sql_template_repository import (
             SqlTemplateRepository,
@@ -553,16 +554,16 @@ def get_template_repository(session=Depends(get_db_session)) -> ITemplateReposit
 
 
 def get_scheduler() -> IScheduler:
-    """获取调度器（Mock、Docker 或 K8s）"""
+    """Get the scheduler: Mock, Docker, or K8s"""
     if USE_MOCK_SCHEDULER:
         return MockScheduler()
 
-    # 实际使用时需要通过 session-scoped 依赖获取
+    # In real use this has to come from a session-scoped dependency
     return MockScheduler()
 
 
 def get_runtime_node_repository(session=Depends(get_db_session)):
-    """获取运行时节点仓储（SQL 或 Mock）"""
+    """Get the runtime node repository, SQL or Mock"""
     if USE_SQL_REPOSITORIES:
         from src.infrastructure.persistence.repositories.sql_runtime_node_repository import (
             SqlRuntimeNodeRepository,
@@ -573,7 +574,7 @@ def get_runtime_node_repository(session=Depends(get_db_session)):
 
 
 def get_container_scheduler():
-    """获取容器调度器"""
+    """Get the container scheduler"""
     from src.infrastructure.container_scheduler.docker_scheduler import DockerScheduler
 
     return DockerScheduler(docker_url=_get_docker_url())
@@ -583,7 +584,7 @@ def get_docker_scheduler_service(
     runtime_node_repo=Depends(get_runtime_node_repository),
     template_repo=Depends(get_template_repository),
 ) -> IScheduler:
-    """获取调度服务（Docker 或 K8s）"""
+    """Get the scheduler service, Docker or K8s"""
     return _create_scheduler_service(
         runtime_node_repo=runtime_node_repo,
         template_repo=template_repo,
@@ -595,25 +596,25 @@ def _create_scheduler_service(
     template_repo,
     executor_timeout: float = 30.0,
 ) -> IScheduler:
-    """创建调度服务实例。"""
+    """Create the scheduler service instance."""
     if USE_MOCK_SCHEDULER:
         return MockScheduler()
 
-    # 使用模块级单例
+    # Use the module-level singleton
     container_scheduler = _container_scheduler_singleton
 
-    # 创建 ExecutorClient 实例
+    # Create the ExecutorClient
     executor_client = ExecutorClient(
         timeout=executor_timeout,
         max_retries=3,
         retry_delay=0.5,
     )
 
-    # 为每个请求创建新的调度服务实例
+    # Build a fresh scheduler service per request
     settings = get_settings()
 
     if IS_IN_KUBERNETES:
-        # K8s 环境：使用 K8sSchedulerService
+        # K8s: use K8sSchedulerService
         from src.infrastructure.schedulers.k8s_scheduler_service import K8sSchedulerService
 
         # Build CONTROL_PLANE_URL based on kubernetes_namespace
@@ -632,7 +633,7 @@ def _create_scheduler_service(
             disable_bwrap=settings.disable_bwrap,
         )
     else:
-        # 本地环境：使用 DockerSchedulerService
+        # Local: use DockerSchedulerService
         from src.infrastructure.schedulers.docker_scheduler_service import DockerSchedulerService
 
         return DockerSchedulerService(
@@ -652,11 +653,11 @@ _storage_service_singleton = None
 
 def get_storage_service():
     """
-    获取存储服务（S3 或 Mock）
+    Get the storage service, S3 or Mock
 
-    架构说明：
-    - Control Plane 通过 S3 API 将文件写入 MinIO 的 /sessions/{session_id}/ 路径
-    - Executor Pod 在启动脚本中挂载 s3fs，将 S3 bucket 的 session 子目录挂载到 /workspace
+    How it fits together:
+    - The control plane writes files into MinIO under /sessions/{session_id}/ via the S3 API
+    - The executor Pod mounts s3fs in its start script, mapping that session subdirectory to /workspace
     """
     global _storage_service_singleton
 
@@ -665,7 +666,7 @@ def get_storage_service():
 
     settings = get_settings()
 
-    # 直接使用 S3
+    # Use S3 directly
     if settings.s3_access_key_id:
         from src.infrastructure.storage.s3_storage import S3Storage
 
@@ -673,14 +674,14 @@ def get_storage_service():
         logger.info(f"Using S3 storage: endpoint={settings.s3_endpoint_url}")
         return _storage_service_singleton
 
-    # 降级到 Mock
+    # Fall back to the mock
     logger.warning("No storage backend configured, using MockStorageService")
     _storage_service_singleton = MockStorageService()
     return _storage_service_singleton
 
 
 def get_executor_client() -> ExecutorClient:
-    """获取 ExecutorClient。"""
+    """Get the ExecutorClient."""
     return ExecutorClient(
         timeout=30.0,
         max_retries=3,
@@ -696,7 +697,7 @@ def get_session_service_db(
     storage_service=Depends(get_storage_service),
     executor_client: ExecutorClient = Depends(get_executor_client),
 ) -> SessionService:
-    """获取会话服务（使用数据库仓储和 Docker 调度器）"""
+    """Get the session service, backed by the database repositories and the Docker scheduler"""
     return SessionService(
         session_repo=session_repo,
         execution_repo=execution_repo,
@@ -709,7 +710,7 @@ def get_session_service_db(
 
 
 def get_initial_dependency_sync_scheduler():
-    """获取首次依赖同步后台调度器。"""
+    """Get the background scheduler for the first dependency sync."""
 
     def schedule(session_id: str, install_timeout: int) -> None:
         async def _run() -> None:
@@ -731,7 +732,7 @@ def get_initial_dependency_sync_scheduler():
 
 
 async def _run_initial_dependency_sync(session_id: str, install_timeout: int) -> None:
-    """执行首次依赖同步后台任务。"""
+    """Run the background task for the first dependency sync."""
     deadline = time.monotonic() + install_timeout
     poll_interval = 1.0
     last_status = "unknown"
@@ -836,7 +837,7 @@ async def _run_initial_dependency_sync(session_id: str, install_timeout: int) ->
 
 
 async def _mark_initial_dependency_sync_failed(session_id: str, error: str) -> None:
-    """兜底回写首次依赖同步失败状态。"""
+    """Last-resort write-back of a failed first dependency sync."""
     async with db_manager.get_session() as session:
         from src.infrastructure.persistence.repositories.sql_execution_repository import (
             SqlExecutionRepository,
@@ -862,7 +863,7 @@ async def _mark_initial_dependency_sync_failed(session_id: str, error: str) -> N
 def get_template_service_db(
     template_repo: ITemplateRepository = Depends(get_template_repository),
 ) -> TemplateService:
-    """获取模板服务（使用数据库仓储）"""
+    """Get the template service, backed by the database repositories"""
     return TemplateService(template_repo=template_repo)
 
 
@@ -870,7 +871,7 @@ def get_file_service_db(
     session_repo: ISessionRepository = Depends(get_session_repository),
     storage_service=Depends(get_storage_service),
 ) -> FileService:
-    """获取文件服务（使用数据库仓储）"""
+    """Get the file service, backed by the database repositories"""
     settings = get_settings()
     return FileService(
         session_repo=session_repo,
@@ -889,9 +890,9 @@ _state_sync_service_singleton = None
 
 def _create_direct_session_repository(db_mgr):
     """
-    创建直接使用数据库的会话仓储
+    Create a session repository that goes straight to the database
 
-    用于状态同步服务，避免仓储层开销。
+    Used by the state sync service, to skip the repository-layer overhead.
     """
     from src.infrastructure.persistence.models.session_model import SessionModel
     from src.domain.entities.session import Session, SessionStatus
@@ -899,13 +900,13 @@ def _create_direct_session_repository(db_mgr):
     from sqlalchemy import select
 
     class DirectSessionRepository:
-        """直接使用数据库的仓储，用于状态同步"""
+        """A repository that goes straight to the database, for state sync"""
 
         def __init__(self, db_mgr):
             self._db_mgr = db_mgr
 
         async def find_by_status(self, status: str, limit: int = 100):
-            """直接查询数据库"""
+            """Query the database directly"""
             result = []
             async with self._db_mgr.get_session() as session:
                 stmt = select(SessionModel).filter(SessionModel.f_status == status).limit(limit)
@@ -937,7 +938,7 @@ def _create_direct_session_repository(db_mgr):
             return result
 
         async def find_by_id(self, session_id: str):
-            """通过 ID 查找"""
+            """Find by id"""
             async with self._db_mgr.get_session() as session:
                 model = await session.get(SessionModel, session_id)
                 if model:
@@ -966,13 +967,13 @@ def _create_direct_session_repository(db_mgr):
                 return None
 
         async def save(self, session):
-            """保存 session"""
+            """Save the session"""
             import time
 
             async with self._db_mgr.get_session() as db:
                 model = await db.get(SessionModel, session.id)
                 if model:
-                    # 处理 status 可能是枚举或字符串的情况
+                    # status may be an enum or a string
                     if hasattr(session.status, "value"):
                         model.f_status = session.status.value
                     else:
@@ -1018,9 +1019,9 @@ def _create_direct_session_repository(db_mgr):
 
 def _create_direct_execution_repository(db_mgr):
     """
-    创建直接使用数据库的执行仓储。
+    Create an execution repository that goes straight to the database.
 
-    用于状态同步服务在 takeover 场景回写中断 execution 状态。
+    Used by the state sync service to write back an interrupted execution during a takeover.
     """
     from src.infrastructure.persistence.models.execution_model import ExecutionModel
     from src.domain.value_objects.execution_status import ExecutionStatus
@@ -1061,7 +1062,7 @@ def _create_direct_execution_repository(db_mgr):
                 await session.commit()
 
         async def commit(self):
-            """Direct repository 每次 save 已提交，保留兼容空实现。"""
+            """A direct repository commits on every save; this stays as a compatible no-op."""
             return None
 
     return DirectExecutionRepository(db_mgr)
@@ -1069,9 +1070,9 @@ def _create_direct_execution_repository(db_mgr):
 
 def _create_direct_template_repository(db_mgr):
     """
-    创建直接使用数据库的模板仓储。
+    Create a template repository that goes straight to the database.
 
-    用于状态同步服务恢复 session 时解析真实模板镜像。
+    Used by the state sync service to resolve the real template image while recovering a session.
     """
     from src.infrastructure.persistence.models.template_model import TemplateModel
 
@@ -1088,7 +1089,7 @@ def _create_direct_template_repository(db_mgr):
 
 
 def _create_scheduler_for_state_sync(container_scheduler, template_repo=None):
-    """为状态同步服务创建调度器"""
+    """Create the scheduler for the state sync service"""
     settings = get_settings()
 
     if USE_MOCK_SCHEDULER:
@@ -1113,16 +1114,16 @@ def _create_scheduler_for_state_sync(container_scheduler, template_repo=None):
             disable_bwrap=settings.disable_bwrap,
         )
 
-    # 本地 Docker 环境
+    # Local Docker
     return MockScheduler()
 
 
 def get_state_sync_service():
     """
-    获取状态同步服务（共享单例）
+    Get the state sync service as a shared singleton
 
-    此服务在启动时调用，需要使用已初始化的单例。
-    使用 SQL 数据库直接查询，不依赖仓储模式。
+    Called at start-up, so it has to use the already initialized singleton.
+    Queries the SQL database directly rather than going through the repository pattern.
     """
     global _scheduler_singleton
     from src.application.services.state_sync_service import StateSyncService
@@ -1130,7 +1131,7 @@ def get_state_sync_service():
     settings = get_settings()
     container_scheduler = _container_scheduler_singleton
 
-    # 创建会话仓储
+    # Create the session repository
     if USE_SQL_REPOSITORIES:
         session_repo = _create_direct_session_repository(db_manager)
         execution_repo = _create_direct_execution_repository(db_manager)
@@ -1140,7 +1141,7 @@ def get_state_sync_service():
         execution_repo = MockExecutionRepository()
         template_repo = MockTemplateRepository()
 
-    # 创建或复用调度器
+    # Create or reuse the scheduler
     scheduler = _scheduler_singleton
     if scheduler is None:
         scheduler = _create_scheduler_for_state_sync(

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/__init__.py
@@ -1,7 +1,7 @@
 """
-执行器客户端模块
+Executor client module
 
-提供与沙箱容器内执行器进行 HTTP 通信的客户端。
+The HTTP client for the executor inside a sandbox container.
 """
 
 from src.infrastructure.executors.client import ExecutorClient

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/client.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/client.py
@@ -1,7 +1,7 @@
 """
-执行器 HTTP 客户端
+Executor HTTP client
 
-用于与沙箱容器内的执行器进行 HTTP 通信。
+Talks over HTTP to the executor inside a sandbox container.
 """
 
 import asyncio
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 
 class ExecutorClient:
     """
-    执行器 HTTP 客户端
+    Executor HTTP client
 
-    通过 HTTP 与运行在容器内的 sandbox-executor 通信。
+    Talks over HTTP to the sandbox-executor running in the container.
     """
 
     def __init__(
@@ -42,12 +42,12 @@ class ExecutorClient:
         retry_delay: float = 0.5,
     ):
         """
-        初始化执行器客户端
+        Initialize the executor client
 
         Args:
-            timeout: 请求超时时间（秒）
-            max_retries: 最大重试次数
-            retry_delay: 重试延迟（秒）
+            timeout: request timeout in seconds
+            max_retries: how many times to retry
+            retry_delay: delay between retries, in seconds
         """
         self._timeout = timeout
         self._max_retries = max_retries
@@ -55,17 +55,17 @@ class ExecutorClient:
         self._client: Optional[httpx.AsyncClient] = None
 
     async def __aenter__(self):
-        """进入上下文管理器"""
+        """Enter the context manager"""
         self._client = httpx.AsyncClient(timeout=self._timeout)
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """退出上下文管理器"""
+        """Leave the context manager"""
         if self._client:
             await self._client.aclose()
 
     def _get_client(self) -> httpx.AsyncClient:
-        """获取 HTTP 客户端实例"""
+        """Get the HTTP client"""
         if self._client is None:
             self._client = httpx.AsyncClient(timeout=self._timeout)
         return self._client
@@ -83,27 +83,27 @@ class ExecutorClient:
         working_directory: str | None = None,
     ) -> str:
         """
-        提交执行请求到执行器
+        Submit an execution request to the executor
 
         Args:
-            executor_url: 执行器 URL (e.g., "http://container-name:8080")
-            execution_id: 执行 ID
-            session_id: 会话 ID
-            code: 要执行的代码
-            language: 编程语言
-            event: 事件数据
-            timeout: 超时时间（秒）
-            env_vars: 环境变量
-            working_directory: 可选执行目录，相对于 workspace 根目录
+            executor_url: executor URL, such as "http://container-name:8080"
+            execution_id: execution id
+            session_id: session id
+            code: the code to run
+            language: programming language
+            event: event payload
+            timeout: timeout in seconds
+            env_vars: environment variables
+            working_directory: optional working directory, relative to the workspace root
 
         Returns:
-            execution_id: 执行任务 ID
+            execution_id: execution task id
 
         Raises:
-            ExecutorConnectionError: 无法连接到执行器
-            ExecutorTimeoutError: 执行器响应超时
-            ExecutorValidationError: 请求验证失败
-            ExecutorResponseError: 执行器返回错误
+            ExecutorConnectionError: the executor is unreachable
+            ExecutorTimeoutError: the executor did not answer in time
+            ExecutorValidationError: the request failed validation
+            ExecutorResponseError: the executor returned an error
         """
         client = self._get_client()
         url = f"{executor_url}/execute"
@@ -185,17 +185,17 @@ class ExecutorClient:
 
     async def health_check(self, executor_url: str) -> ExecutorHealthResponse:
         """
-        检查执行器健康状态
+        Check the executor health
 
         Args:
-            executor_url: 执行器 URL
+            executor_url: executor URL
 
         Returns:
-            健康状态响应
+            The health response
 
         Raises:
-            ExecutorConnectionError: 无法连接到执行器
-            ExecutorUnavailableError: 执行器不健康
+            ExecutorConnectionError: the executor is unreachable
+            ExecutorUnavailableError: the executor is unhealthy
         """
         client = self._get_client()
         url = f"{executor_url}/health"
@@ -223,7 +223,7 @@ class ExecutorClient:
         sync_mode: str,
         executor_timeout: float | None = None,
     ) -> ExecutorSyncSessionConfigResponse:
-        """同步会话依赖配置到 executor。"""
+        """Sync the session dependency configuration to the executor."""
         client = self._get_client()
         url = f"{executor_url}/internal/session-config/sync"
         effective_timeout = executor_timeout or self._timeout
@@ -259,7 +259,7 @@ class ExecutorClient:
         raise ExecutorResponseError(executor_url, response.status_code, response.text)
 
     async def close(self) -> None:
-        """关闭客户端"""
+        """Close the client"""
         if self._client:
             await self._client.aclose()
             self._client = None

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/dto.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/dto.py
@@ -1,7 +1,7 @@
 """
-执行器 API 数据传输对象
+Executor API data transfer objects
 
-定义与执行器 HTTP API 通信时使用的请求和响应模型。
+The request and response models used when talking to the executor HTTP API.
 """
 
 from dataclasses import dataclass
@@ -11,9 +11,9 @@ from pydantic import BaseModel, Field
 
 class ExecutorExecuteRequest(BaseModel):
     """
-    执行器执行请求模型
+    Executor execution request
 
-    对应 executor 的 POST /execute 端点。
+    Matches the executor POST /execute endpoint.
     """
 
     execution_id: str = Field(..., description="Unique execution identifier")
@@ -47,9 +47,9 @@ class ExecutorExecuteRequest(BaseModel):
 
 class ExecutorExecuteResponse(BaseModel):
     """
-    执行器执行响应模型
+    Executor execution response
 
-    对应 executor 的 POST /execute 响应。
+    Matches the executor POST /execute response.
     """
 
     execution_id: str = Field(..., description="Execution identifier")
@@ -59,9 +59,9 @@ class ExecutorExecuteResponse(BaseModel):
 
 class ExecutorHealthResponse(BaseModel):
     """
-    执行器健康检查响应模型
+    Executor health check response
 
-    对应 executor 的 GET /health 端点。
+    Matches the executor GET /health endpoint.
     """
 
     status: str = Field(..., description="Health status (healthy/unhealthy)")
@@ -71,7 +71,7 @@ class ExecutorHealthResponse(BaseModel):
 
 
 class ExecutorSyncSessionConfigRequest(BaseModel):
-    """Executor 依赖同步请求。"""
+    """Executor dependency sync request."""
 
     session_id: str = Field(..., description="Session identifier")
     language_runtime: str = Field(..., description="Language runtime type")
@@ -81,7 +81,7 @@ class ExecutorSyncSessionConfigRequest(BaseModel):
 
 
 class ExecutorInstalledDependency(BaseModel):
-    """Executor 返回的已安装依赖。"""
+    """An installed dependency the executor reports."""
 
     name: str
     version: str
@@ -91,7 +91,7 @@ class ExecutorInstalledDependency(BaseModel):
 
 
 class ExecutorSyncSessionConfigResponse(BaseModel):
-    """Executor 依赖同步响应。"""
+    """Executor dependency sync response."""
 
     status: str
     installed_dependencies: list[ExecutorInstalledDependency] = Field(default_factory=list)
@@ -103,9 +103,9 @@ class ExecutorSyncSessionConfigResponse(BaseModel):
 @dataclass
 class ExecutorContainerInfo:
     """
-    执行器容器信息
+    Executor container information
 
-    用于构建执行器 URL。
+    Used to build the executor URL.
     """
 
     container_id: str
@@ -114,5 +114,5 @@ class ExecutorContainerInfo:
 
     @property
     def executor_url(self) -> str:
-        """获取执行器 URL"""
+        """Get the executor URL"""
         return f"http://{self.container_name}:{self.executor_port}"

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/errors.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/executors/errors.py
@@ -1,18 +1,18 @@
 """
-执行器相关错误
+Executor errors
 
-定义与执行器通信时可能出现的错误。
+The errors that can arise while talking to the executor.
 """
 
 
 class ExecutorError(Exception):
-    """执行器错误基类"""
+    """Base executor error"""
 
     pass
 
 
 class ExecutorConnectionError(ExecutorError):
-    """无法连接到执行器"""
+    """The executor is unreachable"""
 
     def __init__(self, executor_url: str, reason: str = ""):
         self.executor_url = executor_url
@@ -21,7 +21,7 @@ class ExecutorConnectionError(ExecutorError):
 
 
 class ExecutorTimeoutError(ExecutorError):
-    """执行器响应超时"""
+    """The executor did not answer in time"""
 
     def __init__(self, executor_url: str, timeout: float):
         self.executor_url = executor_url
@@ -30,7 +30,7 @@ class ExecutorTimeoutError(ExecutorError):
 
 
 class ExecutorUnavailableError(ExecutorError):
-    """执行器不可用（ unhealthy）"""
+    """The executor is unavailable, meaning unhealthy"""
 
     def __init__(self, executor_url: str, status: str = ""):
         self.executor_url = executor_url
@@ -39,7 +39,7 @@ class ExecutorUnavailableError(ExecutorError):
 
 
 class ExecutorResponseError(ExecutorError):
-    """执行器返回错误响应"""
+    """The executor returned an error response"""
 
     def __init__(self, executor_url: str, status_code: int, message: str = ""):
         self.executor_url = executor_url
@@ -49,7 +49,7 @@ class ExecutorResponseError(ExecutorError):
 
 
 class ExecutorValidationError(ExecutorError):
-    """执行器请求验证失败"""
+    """The executor request failed validation"""
 
     def __init__(self, executor_url: str, validation_errors: list):
         self.executor_url = executor_url

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/database.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/database.py
@@ -1,7 +1,7 @@
 """
-数据库连接管理
+Database connection management
 
-配置和管理 SQLAlchemy 异步引擎和会话。
+Configures and manages the SQLAlchemy async engine and sessions.
 """
 
 from contextlib import asynccontextmanager
@@ -25,7 +25,7 @@ from src.infrastructure.logging import get_logger
 
 
 class Base(DeclarativeBase):
-    """SQLAlchemy 基类"""
+    """SQLAlchemy declarative base"""
 
     pass
 
@@ -46,9 +46,9 @@ from src.infrastructure.persistence.models.runtime_node_model import RuntimeNode
 
 class DatabaseManager:
     """
-    数据库管理器
+    Database manager
 
-    负责创建和管理数据库连接。
+    Creates and manages the database connections.
     """
 
     def __init__(self):
@@ -56,12 +56,12 @@ class DatabaseManager:
         self._session_factory: async_sessionmaker[AsyncSession] | None = None
 
     def _get_managed_sandbox_table_names(self) -> set[str]:
-        """返回 control plane 自己管理的沙箱表名白名单。"""
+        """The allowlist of sandbox tables this control plane owns."""
         return set(Base.metadata.tables.keys())
 
     @dataclass(frozen=True)
     class _DatabaseConnectionInfo:
-        """数据库连接信息。"""
+        """Database connection details."""
 
         user: str | None
         password: str | None
@@ -70,7 +70,7 @@ class DatabaseManager:
         database: str
 
     def _get_database_connection_info(self) -> _DatabaseConnectionInfo:
-        """从配置中解析数据库连接信息。"""
+        """Resolve the connection details from the configuration."""
         parsed = urlparse(self._get_runtime_database_url())
         configured_database = parsed.path.lstrip("/")
 
@@ -83,7 +83,7 @@ class DatabaseManager:
         )
 
     def _get_runtime_database_url(self) -> str:
-        """返回运行期使用的数据库 URL，并将旧库名规范化到新库名。"""
+        """Return the database URL used at runtime, normalizing the old name to the new one."""
         settings = get_settings()
         parsed = urlparse(settings.effective_database_url)
         database_name = parsed.path.lstrip("/")
@@ -94,7 +94,7 @@ class DatabaseManager:
         return urlunparse(normalized)
 
     async def _create_server_pool(self) -> aiomysql.Pool:
-        """创建连接到 MySQL 服务端的连接池。"""
+        """Create the connection pool to the MySQL server."""
         connection_info = self._get_database_connection_info()
         return await aiomysql.create_pool(
             host=connection_info.host,
@@ -109,9 +109,9 @@ class DatabaseManager:
 
     async def upgrade_legacy_database_name(self) -> None:
         """
-        启动时迁移旧数据库名到新数据库名。
+        Migrate the old database name to the new one at start-up.
 
-        当前支持将旧库 `adp` 升级为 `openbkn`。
+        Currently this upgrades the old `adp` database to `openbkn`.
         """
         connection_info = self._get_database_connection_info()
         target_database = connection_info.database
@@ -201,7 +201,7 @@ class DatabaseManager:
             await pool.wait_closed()
 
     async def _schema_exists(self, cursor, schema_name: str) -> bool:
-        """检查 schema 是否存在。"""
+        """Check whether the schema exists."""
         await cursor.execute(
             """
             SELECT COUNT(*)
@@ -214,7 +214,7 @@ class DatabaseManager:
         return bool(result and result[0])
 
     async def _list_tables(self, cursor, schema_name: str) -> list[str]:
-        """列出 schema 下的所有基础表。"""
+        """List every base table in the schema."""
         await cursor.execute(
             """
             SELECT TABLE_NAME
@@ -230,10 +230,10 @@ class DatabaseManager:
 
     async def ensure_database_exists(self) -> None:
         """
-        确保数据库存在，如果不存在则创建
+        Make sure the database exists, creating it when it does not
 
-        使用原始连接（不通过 SQLAlchemy）来创建数据库，
-        因为 SQLAlchemy 需要数据库已存在才能创建引擎。
+        Uses a raw connection rather than SQLAlchemy, because SQLAlchemy needs the
+        database to exist before it can build an engine.
         """
         connection_info = self._get_database_connection_info()
         db_name = connection_info.database
@@ -242,11 +242,11 @@ class DatabaseManager:
         try:
             async with pool.acquire() as conn:
                 async with conn.cursor() as cursor:
-                    # 检查数据库是否存在
+                    # Check whether the database exists
                     result = await self._schema_exists(cursor, db_name)
 
                     if not result:
-                        # 数据库不存在，创建它
+                        # It does not, so create it
                         await cursor.execute(
                             f"CREATE DATABASE `{db_name}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                         )
@@ -258,11 +258,11 @@ class DatabaseManager:
             await pool.wait_closed()
 
     async def initialize(self) -> None:
-        """初始化数据库引擎（确保数据库存在）"""
-        # 先确保数据库存在
+        """Initialize the database engine, making sure the database exists"""
+        # Make sure the database exists first
         await self.ensure_database_exists()
 
-        # 然后创建引擎
+        # Then build the engine
         settings = get_settings()
         self._engine = create_async_engine(
             self._get_runtime_database_url(),
@@ -278,7 +278,7 @@ class DatabaseManager:
         )
 
     async def create_tables(self) -> None:
-        """创建所有数据库表"""
+        """Create every database table"""
         if self._engine is None:
             raise RuntimeError("DatabaseManager not initialized. Call initialize() first.")
 
@@ -287,9 +287,9 @@ class DatabaseManager:
 
     async def run_startup_schema_migrations(self) -> None:
         """
-        启动时执行幂等 schema 升级。
+        Run an idempotent schema upgrade at start-up.
 
-        当前用于兼容旧库缺失 `f_python_package_index_url` 字段的场景。
+        Currently this covers an older database missing the `f_python_package_index_url` column.
         """
         if self._engine is None:
             raise RuntimeError("DatabaseManager not initialized. Call initialize() first.")
@@ -347,7 +347,7 @@ class DatabaseManager:
             )
 
     async def _mariadb_table_exists(self, conn, table_name: str) -> bool:
-        """检查 MariaDB 表是否存在。"""
+        """Check whether a MariaDB table exists."""
         result = await conn.execute(
             text("""
                 SELECT COUNT(*)
@@ -360,7 +360,7 @@ class DatabaseManager:
         return bool(result.scalar())
 
     async def _mariadb_column_exists(self, conn, table_name: str, column_name: str) -> bool:
-        """检查 MariaDB 列是否存在。"""
+        """Check whether a MariaDB column exists."""
         result = await conn.execute(
             text("""
                 SELECT COUNT(*)
@@ -377,15 +377,15 @@ class DatabaseManager:
         self, create_tables: bool = False, seed_data: bool = False, force_seed: bool = False
     ) -> dict:
         """
-        初始化数据库并可选地创建表和种子数据
+        Initialize the database, optionally creating the tables and the seed data
 
         Args:
-            create_tables: 是否创建数据库表
-            seed_data: 是否初始化种子数据
-            force_seed: 是否强制重新创建种子数据
+            create_tables: whether to create the database tables
+            seed_data: whether to insert the seed data
+            force_seed: whether to recreate the seed data
 
         Returns:
-            包含初始化结果的字典
+            A dict holding the initialization result
         """
         result = {"tables_created": False, "seeded": False, "seed_stats": {}}
 
@@ -405,11 +405,11 @@ class DatabaseManager:
     @asynccontextmanager
     async def get_session(self) -> AsyncGenerator[AsyncSession, None]:
         """
-        获取数据库会话（上下文管理器）
+        Get a database session, as a context manager
 
-        用法:
+        Usage:
             async with db_manager.get_session() as session:
-                # 使用 session
+                # use the session
         """
         if self._session_factory is None:
             raise RuntimeError("DatabaseManager not initialized. Call initialize() first.")
@@ -423,10 +423,10 @@ class DatabaseManager:
                 raise
 
     async def close(self) -> None:
-        """关闭数据库连接"""
+        """Close the database connections"""
         if self._engine:
             await self._engine.dispose()
 
 
-# 全局数据库管理器实例
+# The global database manager instance
 db_manager = DatabaseManager()

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/execution_model.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/execution_model.py
@@ -1,8 +1,8 @@
 """
-执行 ORM 模型
+Execution ORM model
 
-SQLAlchemy 模型定义，用于数据库持久化。
-按照数据表命名规范: t_{module}_{entity}, f_{field_name}
+The SQLAlchemy model used for persistence.
+Naming convention: t_{module}_{entity} for tables, f_{field_name} for columns.
 """
 
 from datetime import datetime
@@ -16,10 +16,10 @@ from src.infrastructure.persistence.database import Base
 
 class ExecutionModel(Base):
     """
-    执行 ORM 模型 - t_sandbox_execution
+    Execution ORM model, t_sandbox_execution
 
-    这是基础设施层的实现细节，映射到数据库表。
-    按照数据表命名规范实现。
+    An infrastructure-layer detail that maps onto the database table,
+    following the table naming convention.
     """
 
     __tablename__ = "t_sandbox_execution"
@@ -68,7 +68,7 @@ class ExecutionModel(Base):
     )
 
     def to_entity(self):
-        """转换为领域实体"""
+        """Convert to the domain entity"""
         from src.domain.entities.execution import Execution
         from src.domain.value_objects.execution_status import ExecutionStatus, ExecutionState
 
@@ -98,7 +98,7 @@ class ExecutionModel(Base):
 
     @classmethod
     def from_entity(cls, execution):
-        """从领域实体创建 ORM 模型"""
+        """Build the ORM model from the domain entity"""
         import json
 
         now_ms = int(datetime.now().timestamp() * 1000)
@@ -130,7 +130,7 @@ class ExecutionModel(Base):
             f_completed_at=(
                 int(execution.completed_at.timestamp() * 1000) if execution.completed_at else 0
             ),
-            # 审计字段
+            # Audit columns
             f_created_at=(
                 int(execution.created_at.timestamp() * 1000) if execution.created_at else now_ms
             ),
@@ -142,7 +142,7 @@ class ExecutionModel(Base):
         )
 
     def _parse_json(self, value: str):
-        """安全解析 JSON 字符串"""
+        """Parse a JSON string safely"""
         if not value or value.strip() == "":
             return None
         try:
@@ -153,7 +153,7 @@ class ExecutionModel(Base):
             return None
 
     def _millis_to_datetime(self, millis: int):
-        """将毫秒时间戳转换为 datetime"""
+        """Turn a millisecond timestamp into a datetime"""
         if not millis or millis == 0:
             return None
         try:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/runtime_node_model.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/runtime_node_model.py
@@ -1,8 +1,8 @@
 """
-运行时节点 ORM 模型
+Runtime node ORM model
 
-SQLAlchemy 模型定义，用于数据库持久化。
-按照数据表命名规范: t_{module}_{entity}, f_{field_name}
+The SQLAlchemy model used for persistence.
+Naming convention: t_{module}_{entity} for tables, f_{field_name} for columns.
 """
 
 from datetime import datetime
@@ -17,9 +17,9 @@ from src.infrastructure.persistence.database import Base
 
 class RuntimeNodeModel(Base):
     """
-    运行时节点 ORM 模型 - t_sandbox_runtime_node
+    Runtime node ORM model, t_sandbox_runtime_node
 
-    这是基础设施层的实现细节，映射到数据库表。
+    An infrastructure-layer detail that maps onto the database table.
     """
 
     __tablename__ = "t_sandbox_runtime_node"
@@ -76,10 +76,10 @@ class RuntimeNodeModel(Base):
     )
 
     def to_runtime_node(self):
-        """转换为领域 RuntimeNode 值对象"""
+        """Convert to the domain RuntimeNode value object"""
         from src.domain.services.scheduler import RuntimeNode
 
-        # 计算资源使用率
+        # Work out the resource utilization
         cpu_usage = (
             float(self.f_allocated_cpu_cores) / float(self.f_total_cpu_cores)
             if self.f_total_cpu_cores > 0
@@ -91,7 +91,7 @@ class RuntimeNodeModel(Base):
             else 0.0
         )
 
-        # 将状态映射到 RuntimeNode 的状态
+        # Map the stored status onto the RuntimeNode status
         status_mapping = {
             "online": "healthy",
             "offline": "unhealthy",
@@ -113,7 +113,7 @@ class RuntimeNodeModel(Base):
         )
 
     def _parse_json(self, value: str):
-        """安全解析 JSON 字符串"""
+        """Parse a JSON string safely"""
         if not value or value.strip() == "":
             return None
         try:
@@ -124,7 +124,7 @@ class RuntimeNodeModel(Base):
             return None
 
     def _millis_to_datetime(self, millis: int):
-        """将毫秒时间戳转换为 datetime"""
+        """Turn a millisecond timestamp into a datetime"""
         if not millis or millis == 0:
             return None
         try:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/session_model.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/session_model.py
@@ -1,8 +1,8 @@
 """
-会话 ORM 模型
+Session ORM model
 
-SQLAlchemy 模型定义，用于数据库持久化。
-按照数据表命名规范: t_{module}_{entity}, f_{field_name}
+The SQLAlchemy model used for persistence.
+Naming convention: t_{module}_{entity} for tables, f_{field_name} for columns.
 """
 
 from datetime import datetime
@@ -17,10 +17,10 @@ from src.shared.utils.dependencies import DEFAULT_PYTHON_PACKAGE_INDEX_URL
 
 class SessionModel(Base):
     """
-    会话 ORM 模型 - t_sandbox_session
+    Session ORM model, t_sandbox_session
 
-    这是基础设施层的实现细节，映射到数据库表。
-    按照照数据表命名规范实现。
+    An infrastructure-layer detail that maps onto the database table,
+    following the table naming convention.
     """
 
     __tablename__ = "t_sandbox_session"
@@ -90,7 +90,7 @@ class SessionModel(Base):
     )
 
     def to_entity(self):
-        """转换为领域实体"""
+        """Convert to the domain entity"""
         from src.domain.entities.session import Session, InstalledDependency
         from src.domain.value_objects.resource_limit import ResourceLimit
         from src.domain.value_objects.execution_status import SessionStatus
@@ -116,7 +116,7 @@ class SessionModel(Base):
             updated_at=self._millis_to_datetime(self.f_updated_at) or datetime.now(),
             completed_at=self._millis_to_datetime(self.f_completed_at),
             last_activity_at=self._millis_to_datetime(self.f_last_activity_at) or datetime.now(),
-            # 依赖安装字段
+            # Dependency installation columns
             python_package_index_url=self.f_python_package_index_url
             or DEFAULT_PYTHON_PACKAGE_INDEX_URL,
             requested_dependencies=self._parse_json(self.f_requested_dependencies) or [],
@@ -130,7 +130,7 @@ class SessionModel(Base):
             ),
         )
 
-        # 转换 installed_dependencies JSON 为 InstalledDependency 对象列表
+        # Turn the installed_dependencies JSON into InstalledDependency objects
         if self.f_installed_dependencies:
             try:
                 import json
@@ -157,10 +157,10 @@ class SessionModel(Base):
 
     @classmethod
     def from_entity(cls, session):
-        """从领域实体创建 ORM 模型"""
+        """Build the ORM model from the domain entity"""
         import json
 
-        # 转换 installed_dependencies 对象列表为 JSON
+        # Turn the InstalledDependency objects into JSON
         installed_dependencies_json = ""
         if session.installed_dependencies:
             try:
@@ -203,7 +203,7 @@ class SessionModel(Base):
                 if session.last_activity_at
                 else now_ms
             ),
-            # 依赖安装字段
+            # Dependency installation columns
             f_requested_dependencies=(
                 json.dumps(session.requested_dependencies, ensure_ascii=False)
                 if session.requested_dependencies
@@ -222,7 +222,7 @@ class SessionModel(Base):
                 if session.dependency_install_completed_at
                 else 0
             ),
-            # 审计字段
+            # Audit columns
             f_created_at=(
                 int(session.created_at.timestamp() * 1000) if session.created_at else now_ms
             ),
@@ -236,7 +236,7 @@ class SessionModel(Base):
         )
 
     def _parse_json(self, value: str):
-        """安全解析 JSON 字符串"""
+        """Parse a JSON string safely"""
         if not value or value.strip() == "":
             return None
         try:
@@ -247,7 +247,7 @@ class SessionModel(Base):
             return None
 
     def _millis_to_datetime(self, millis: int):
-        """将毫秒时间戳转换为 datetime"""
+        """Turn a millisecond timestamp into a datetime"""
         if not millis or millis == 0:
             return None
         try:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/template_model.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/models/template_model.py
@@ -1,8 +1,8 @@
 """
-模板 ORM 模型
+Template ORM model
 
-SQLAlchemy 模型定义，用于数据库持久化。
-按照数据表命名规范: t_{module}_{entity}, f_{field_name}
+The SQLAlchemy model used for persistence.
+Naming convention: t_{module}_{entity} for tables, f_{field_name} for columns.
 """
 
 from datetime import datetime
@@ -17,9 +17,9 @@ from src.infrastructure.persistence.database import Base
 
 class TemplateModel(Base):
     """
-    模板 ORM 模型 - t_sandbox_template
+    Template ORM model, t_sandbox_template
 
-    这是基础设施层的实现细节，映射到数据库表。
+    An infrastructure-layer detail that maps onto the database table.
     """
 
     __tablename__ = "t_sandbox_template"
@@ -70,13 +70,13 @@ class TemplateModel(Base):
     )
 
     def to_entity(self):
-        """转换为领域实体"""
+        """Convert to the domain entity"""
         from src.domain.entities.template import Template
         from src.domain.value_objects.resource_limit import ResourceLimit
 
-        # 将数据库中的数字转换为带单位的格式
+        # Turn the stored numbers back into values with units
         def format_resource(value):
-            """将数字转换为带单位的格式"""
+            """Turn a number into a value with a unit"""
             if isinstance(value, (int, float)):
                 return f"{int(value)}Mi"
             return str(value)
@@ -101,22 +101,22 @@ class TemplateModel(Base):
 
     @classmethod
     def from_entity(cls, template):
-        """从领域实体创建 ORM 模型"""
+        """Build the ORM model from the domain entity"""
         import re
 
         def parse_mb_value(value: str) -> int:
-            """解析资源值（将 '512Mi', '1Gi' 等转换为 MB）"""
+            """Parse a resource value, turning '512Mi' or '1Gi' into MB"""
             if not value:
-                return 512  # 默认值
+                return 512  # default
 
-            # 提取数字部分
+            # Take the numeric part
             numeric_str = re.sub(r"[^0-9.]", "", value)
             if not numeric_str:
                 return 512
 
             numeric = float(numeric_str)
 
-            # 根据单位转换
+            # Convert by unit
             if "Gi" in value or "GB" in value or "G" in value:
                 return int(numeric * 1024)
             elif "Mi" in value or "MB" in value or "M" in value:
@@ -124,7 +124,7 @@ class TemplateModel(Base):
             elif "Ki" in value or "KB" in value or "K" in value:
                 return int(numeric / 1024)
             else:
-                # 如果没有单位，假设是 MB
+                # Without a unit, assume MB
                 return int(numeric)
 
         import json
@@ -161,7 +161,7 @@ class TemplateModel(Base):
         )
 
     def _parse_json(self, value: str):
-        """安全解析 JSON 字符串"""
+        """Parse a JSON string safely"""
         if not value or value.strip() == "":
             return None
         try:
@@ -172,7 +172,7 @@ class TemplateModel(Base):
             return None
 
     def _millis_to_datetime(self, millis: int):
-        """将毫秒时间戳转换为 datetime"""
+        """Turn a millisecond timestamp into a datetime"""
         if not millis or millis == 0:
             return None
         try:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/repository_factory.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/repository_factory.py
@@ -1,7 +1,7 @@
 """
-仓储工厂
+Repository factory
 
-提供数据库会话感知的仓储实例。
+Provides repository instances bound to a database session.
 """
 
 from contextlib import asynccontextmanager
@@ -23,21 +23,21 @@ from src.domain.repositories.template_repository import ITemplateRepository
 
 class RepositoryFactory:
     """
-    仓储工厂
+    Repository factory
 
-    负责创建仓储实例，并注入数据库会话。
+    Builds the repositories and injects the database session.
     """
 
     @staticmethod
     @asynccontextmanager
     async def get_repositories() -> AsyncGenerator[dict[str, object], None]:
         """
-        获取所有仓储实例（上下文管理器）
+        Get every repository, as a context manager
 
-        用法:
+        Usage:
             async with RepositoryFactory.get_repositories() as repos:
                 session_repo = repos["session_repo"]
-                # 使用仓储
+                # use the repositories
         """
         async with db_manager.get_session() as session:
             yield {
@@ -48,15 +48,15 @@ class RepositoryFactory:
 
     @staticmethod
     def create_session_repository(session) -> ISessionRepository:
-        """创建会话仓储"""
+        """Build the session repository"""
         return SqlSessionRepository(session)
 
     @staticmethod
     def create_execution_repository(session) -> IExecutionRepository:
-        """创建执行仓储"""
+        """Build the execution repository"""
         return SqlExecutionRepository(session)
 
     @staticmethod
     def create_template_repository(session) -> ITemplateRepository:
-        """创建模板仓储"""
+        """Build the template repository"""
         return SqlTemplateRepository(session)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_execution_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_execution_repository.py
@@ -1,8 +1,8 @@
 """
-执行仓储实现
+Execution repository implementation
 
-使用 SQLAlchemy 实现执行仓储接口。
-按照数据表命名规范使用 f_ 前缀字段名。
+Implements the execution repository interface with SQLAlchemy.
+Column names carry the f_ prefix, following the table naming convention.
 """
 
 import time
@@ -18,23 +18,23 @@ from src.infrastructure.persistence.models.execution_model import ExecutionModel
 
 class SqlExecutionRepository(IExecutionRepository):
     """
-    执行仓储实现
+    Execution repository implementation
 
-    这是基础设施层的 Adapter，实现领域层定义的 Port。
+    The infrastructure-layer adapter for the port the domain layer defines.
     """
 
     def __init__(self, session: AsyncSession):
         self._session = session
 
     async def save(self, execution: Execution) -> None:
-        """保存执行记录"""
+        """Save the execution record"""
         import json
 
         model = await self._session.get(ExecutionModel, execution.id)
         now_ms = int(time.time() * 1000)
 
         if model:
-            # 更新现有记录
+            # Update the existing row
             model.f_session_id = execution.session_id
             model.f_code = execution.code
             model.f_language = execution.language
@@ -56,7 +56,7 @@ class SqlExecutionRepository(IExecutionRepository):
             )
             model.f_updated_at = now_ms
         else:
-            # 创建新记录
+            # Insert a new row
             model = ExecutionModel.from_entity(execution)
             self._session.add(model)
 
@@ -67,7 +67,7 @@ class SqlExecutionRepository(IExecutionRepository):
         await self._session.commit()
 
     async def find_by_id(self, execution_id: str) -> Optional[Execution]:
-        """根据 ID 查找执行记录"""
+        """Find an execution record by id"""
         # Use a fresh query to avoid stale data from session cache
         # This is important for the sync execution polling loop
         stmt = select(ExecutionModel).where(ExecutionModel.f_id == execution_id)
@@ -76,7 +76,7 @@ class SqlExecutionRepository(IExecutionRepository):
         return model.to_entity() if model else None
 
     async def find_by_session_id(self, session_id: str, limit: int = 100) -> List[Execution]:
-        """根据会话 ID 查找执行记录"""
+        """Find the execution records of a session"""
         stmt = (
             select(ExecutionModel)
             .where(ExecutionModel.f_session_id == session_id)
@@ -87,36 +87,36 @@ class SqlExecutionRepository(IExecutionRepository):
         return [model.to_entity() for model in result.scalars().all()]
 
     async def find_by_status(self, status: str, limit: int = 100) -> List[Execution]:
-        """根据状态查找执行记录"""
+        """Find execution records by status"""
         stmt = select(ExecutionModel).where(ExecutionModel.f_status == status).limit(limit)
         result = await self._session.execute(stmt)
         return [model.to_entity() for model in result.scalars().all()]
 
     async def find_crashed_executions(self, max_retry_count: int) -> List[Execution]:
-        """查找可重试的崩溃执行"""
-        # 注意：retry_count 字段不在数据库模型中，这里返回空列表
-        # 如需支持，需要添加 f_retry_count 字段到 ExecutionModel
+        """Find the crashed executions that may be retried"""
+        # retry_count is not on the database model, so this returns an empty list.
+        # Supporting it needs an f_retry_count column on ExecutionModel.
         return []
 
     async def find_heartbeat_timeouts(self, timeout_threshold: datetime) -> List[Execution]:
-        """查找心跳超时的执行"""
-        # 注意：last_heartbeat_at 字段不在数据库模型中
+        """Find the executions whose heartbeat timed out"""
+        # last_heartbeat_at is not on the database model
         return []
 
     async def delete(self, execution_id: str) -> None:
-        """删除执行记录"""
+        """Delete the execution record"""
         stmt = delete(ExecutionModel).where(ExecutionModel.f_id == execution_id)
         await self._session.execute(stmt)
         await self._session.flush()
 
     async def delete_by_session_id(self, session_id: str) -> None:
-        """删除会话的所有执行记录"""
+        """Delete every execution record of a session"""
         stmt = delete(ExecutionModel).where(ExecutionModel.f_session_id == session_id)
         await self._session.execute(stmt)
         await self._session.flush()
 
     async def count_by_status(self, status: str) -> int:
-        """统计指定状态的执行数量"""
+        """Count the executions in a status"""
         stmt = (
             select(func.count())
             .select_from(ExecutionModel)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_runtime_node_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_runtime_node_repository.py
@@ -1,8 +1,8 @@
 """
-运行时节点仓储实现
+Runtime node repository implementation
 
-使用 SQLAlchemy 实现运行时节点仓储接口。
-按照数据表命名规范使用 f_ 前缀字段名。
+Implements the runtime node repository interface with SQLAlchemy.
+Column names carry the f_ prefix, following the table naming convention.
 """
 
 import time
@@ -17,23 +17,23 @@ from src.infrastructure.persistence.models.runtime_node_model import RuntimeNode
 
 class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
     """
-    运行时节点仓储实现
+    Runtime node repository implementation
 
-    这是基础设施层的 Adapter，实现领域层定义的 Port。
+    The infrastructure-layer adapter for the port the domain layer defines.
     """
 
     def __init__(self, session: AsyncSession):
         self._session = session
 
     async def save(self, node) -> None:
-        """保存节点（创建或更新）"""
+        """Save the node, creating or updating it"""
         import json
 
         model = await self._session.get(RuntimeNodeModel, node.node_id)
         now_ms = int(time.time() * 1000)
 
         if model:
-            # 更新现有记录
+            # Update the existing row
             model.f_hostname = node.hostname
             model.f_runtime_type = node.type
             model.f_ip_address = node.ip_address
@@ -49,7 +49,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
             )
             model.f_updated_at = now_ms
         else:
-            # 创建新记录
+            # Insert a new row
             model = RuntimeNodeModel(
                 f_node_id=node.node_id,
                 f_hostname=node.hostname,
@@ -82,24 +82,24 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def find_by_id(self, node_id: str) -> Optional:
-        """根据 ID 查找节点"""
+        """Find a node by id"""
         model = await self._session.get(RuntimeNodeModel, node_id)
         return model if model else None
 
     async def find_by_hostname(self, hostname: str) -> Optional:
-        """根据主机名查找节点"""
+        """Find a node by hostname"""
         stmt = select(RuntimeNodeModel).where(RuntimeNodeModel.f_hostname == hostname)
         result = await self._session.execute(stmt)
         return result.scalar_one_or_none()
 
     async def find_by_status(self, status: str) -> List:
-        """根据状态查找节点"""
+        """Find nodes by status"""
         stmt = select(RuntimeNodeModel).where(RuntimeNodeModel.f_status == status)
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
 
     async def find_all(self, offset: int = 0, limit: int = 100) -> List:
-        """查找所有节点"""
+        """Find every node"""
         stmt = (
             select(RuntimeNodeModel)
             .offset(offset)
@@ -110,7 +110,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         return list(result.scalars().all())
 
     async def update_status(self, node_id: str, status: str) -> None:
-        """更新节点状态"""
+        """Update the node status"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)
@@ -120,7 +120,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def update_heartbeat(self, node_id: str) -> None:
-        """更新节点心跳时间"""
+        """Update the node heartbeat time"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)
@@ -130,7 +130,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def allocate_resources(self, node_id: str, cpu_cores: float, memory_mb: int) -> None:
-        """分配资源"""
+        """Allocate resources"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)
@@ -145,7 +145,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def release_resources(self, node_id: str, cpu_cores: float, memory_mb: int) -> None:
-        """释放资源"""
+        """Release resources"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)
@@ -160,7 +160,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def increment_container_count(self, node_id: str) -> None:
-        """增加容器计数"""
+        """Increment the container count"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)
@@ -173,7 +173,7 @@ class SqlRuntimeNodeRepository(IRuntimeNodeRepository):
         await self._session.flush()
 
     async def decrement_container_count(self, node_id: str) -> None:
-        """减少容器计数"""
+        """Decrement the container count"""
         stmt = (
             update(RuntimeNodeModel)
             .where(RuntimeNodeModel.f_node_id == node_id)

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_session_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_session_repository.py
@@ -1,8 +1,8 @@
 """
-会话仓储实现
+Session repository implementation
 
-使用 SQLAlchemy 实现会话仓储接口。
-按照数据表命名规范使用 f_ 前缀字段名。
+Implements the session repository interface with SQLAlchemy.
+Column names carry the f_ prefix, following the table naming convention.
 """
 
 import time
@@ -18,9 +18,9 @@ from src.infrastructure.persistence.models.session_model import SessionModel
 
 class SqlSessionRepository(ISessionRepository):
     """
-    会话仓储实现
+    Session repository implementation
 
-    这是基础设施层的 Adapter，实现领域层定义的 Port。
+    The infrastructure-layer adapter for the port the domain layer defines.
     """
 
     def __init__(self, session: AsyncSession, execution_repo=None):
@@ -28,14 +28,14 @@ class SqlSessionRepository(ISessionRepository):
         self._execution_repo = execution_repo
 
     async def save(self, session: Session) -> None:
-        """保存会话"""
+        """Save the session"""
         import json
 
         model = await self._session.get(SessionModel, session.id)
         now_ms = int(time.time() * 1000)
 
         if model:
-            # 更新现有记录
+            # Update the existing row
             model.f_template_id = session.template_id
             model.f_status = (
                 session.status.value if hasattr(session.status, "value") else session.status
@@ -63,7 +63,7 @@ class SqlSessionRepository(ISessionRepository):
                 int(session.completed_at.timestamp() * 1000) if session.completed_at else 0
             )
 
-            # 依赖安装字段
+            # Dependency installation columns
             model.f_requested_dependencies = (
                 json.dumps(session.requested_dependencies, ensure_ascii=False)
                 if session.requested_dependencies
@@ -94,38 +94,38 @@ class SqlSessionRepository(ISessionRepository):
                 else 0
             )
         else:
-            # 创建新记录
+            # Insert a new row
             model = SessionModel.from_entity(session)
             self._session.add(model)
 
         await self._session.flush()
 
     async def find_by_id(self, session_id: str) -> Optional[Session]:
-        """根据 ID 查找会话"""
+        """Find a session by id"""
         model = await self._session.get(SessionModel, session_id)
         return model.to_entity() if model else None
 
     async def find_by_container_id(self, container_id: str) -> Optional[Session]:
-        """根据容器 ID 查找会话"""
+        """Find a session by container id"""
         stmt = select(SessionModel).where(SessionModel.f_container_id == container_id)
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
         return model.to_entity() if model else None
 
     async def find_by_status(self, status: str, limit: int = 100) -> List[Session]:
-        """根据状态查找会话"""
+        """Find sessions by status"""
         stmt = select(SessionModel).where(SessionModel.f_status == status).limit(limit)
         result = await self._session.execute(stmt)
         return [model.to_entity() for model in result.scalars().all()]
 
     async def find_by_template(self, template_id: str) -> List[Session]:
-        """根据模板 ID 查找会话"""
+        """Find sessions by template id"""
         stmt = select(SessionModel).where(SessionModel.f_template_id == template_id)
         result = await self._session.execute(stmt)
         return [model.to_entity() for model in result.scalars().all()]
 
     async def find_idle_sessions(self, idle_threshold: datetime) -> List[Session]:
-        """查找空闲会话"""
+        """Find the idle sessions"""
         threshold_ms = int(idle_threshold.timestamp() * 1000)
         stmt = select(SessionModel).where(
             SessionModel.f_status.in_(["creating", "running"]),
@@ -135,7 +135,7 @@ class SqlSessionRepository(ISessionRepository):
         return [model.to_entity() for model in result.scalars().all()]
 
     async def find_expired_sessions(self, created_before: datetime) -> List[Session]:
-        """查找过期会话"""
+        """Find the expired sessions"""
         before_ms = int(created_before.timestamp() * 1000)
         stmt = (
             select(SessionModel)
@@ -147,31 +147,31 @@ class SqlSessionRepository(ISessionRepository):
 
     async def delete(self, session_id: str) -> None:
         """
-        删除会话及其所有执行记录（级联删除）
+        Delete the session and every execution record it owns, cascading
 
-        先删除关联的 execution 记录，再删除 session 记录。
+        The execution rows go first, then the session row.
         """
-        # 1. 先删除关联的 execution 记录（级联删除）
+        # 1. Delete the execution rows first, the cascade
         if self._execution_repo:
             await self._execution_repo.delete_by_session_id(session_id)
-        # 2. 再删除 session 记录
+        # 2. Then delete the session row
         stmt = delete(SessionModel).where(SessionModel.f_id == session_id)
         await self._session.execute(stmt)
         await self._session.flush()
 
     async def exists(self, session_id: str) -> bool:
-        """检查会话是否存在"""
+        """Check whether the session exists"""
         model = await self._session.get(SessionModel, session_id)
         return model is not None
 
     async def count_by_status(self, status: str) -> int:
-        """统计指定状态的会话数量"""
+        """Count the sessions in a status"""
         stmt = select(func.count()).select_from(SessionModel).where(SessionModel.f_status == status)
         result = await self._session.execute(stmt)
         return result.scalar() or 0
 
     async def count_by_node(self, runtime_node: str) -> int:
-        """统计指定节点的会话数量"""
+        """Count the sessions on a node"""
         stmt = (
             select(func.count())
             .select_from(SessionModel)
@@ -189,31 +189,31 @@ class SqlSessionRepository(ISessionRepository):
         offset: int = 0,
     ) -> List[Session]:
         """
-        查找会话列表（支持筛选和分页）
+        Find sessions, with filtering and paging
 
         Args:
-            status: 会话状态筛选（可选）
-            template_id: 模板 ID 筛选（可选）
-            limit: 返回数量限制（1-200，默认 50）
-            offset: 偏移量（用于分页）
+            status: filter by session status, optional
+            template_id: filter by template id, optional
+            limit: how many to return, 1-200, default 50
+            offset: offset, for paging
 
         Returns:
-            会话列表
+            The session list
         """
-        # 验证 limit 范围
+        # Validate the limit range
         limit = max(1, min(limit, 200))
         offset = max(0, offset)
 
-        # 构建查询
+        # Build the query
         stmt = select(SessionModel)
 
-        # 添加筛选条件
+        # Apply the filters
         if status:
             stmt = stmt.where(SessionModel.f_status == status)
         if template_id:
             stmt = stmt.where(SessionModel.f_template_id == template_id)
 
-        # 排序和分页
+        # Order and page
         stmt = stmt.order_by(SessionModel.f_created_at.desc()).limit(limit).offset(offset)
 
         result = await self._session.execute(stmt)
@@ -223,18 +223,18 @@ class SqlSessionRepository(ISessionRepository):
         self, status: Optional[str] = None, template_id: Optional[str] = None
     ) -> int:
         """
-        统计会话数量（支持筛选）
+        Count the sessions, with filtering
 
         Args:
-            status: 会话状态筛选（可选）
-            template_id: 模板 ID 筛选（可选）
+            status: filter by session status, optional
+            template_id: filter by template id, optional
 
         Returns:
-            会话总数
+            The total
         """
         stmt = select(func.count()).select_from(SessionModel)
 
-        # 添加筛选条件
+        # Apply the filters
         if status:
             stmt = stmt.where(SessionModel.f_status == status)
         if template_id:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_template_repository.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/repositories/sql_template_repository.py
@@ -1,8 +1,8 @@
 """
-模板仓储实现
+Template repository implementation
 
-使用 SQLAlchemy 实现模板仓储接口。
-按照数据表命名规范使用 f_ 前缀字段名。
+Implements the template repository interface with SQLAlchemy.
+Column names carry the f_ prefix, following the table naming convention.
 """
 
 import re
@@ -20,32 +20,32 @@ from src.infrastructure.persistence.models.template_model import TemplateModel
 
 class SqlTemplateRepository(ITemplateRepository):
     """
-    模板仓储实现
+    Template repository implementation
 
-    这是基础设施层的 Adapter，实现领域层定义的 Port。
+    The infrastructure-layer adapter for the port the domain layer defines.
     """
 
     def __init__(self, session: AsyncSession):
         self._session = session
 
     async def save(self, template: Template) -> None:
-        """保存模板"""
+        """Save the template"""
         model = await self._session.get(TemplateModel, template.id)
         now_ms = int(time.time() * 1000)
 
         def parse_mb_value(value: str) -> int:
-            """解析资源值（将 '512Mi', '1Gi' 等转换为 MB）"""
+            """Parse a resource value, turning '512Mi' or '1Gi' into MB"""
             if not value:
-                return 512  # 默认值
+                return 512  # default
 
-            # 提取数字部分
+            # Take the numeric part
             numeric_str = re.sub(r"[^0-9.]", "", value)
             if not numeric_str:
                 return 512
 
             numeric = float(numeric_str)
 
-            # 根据单位转换
+            # Convert by unit
             if "Gi" in value or "GB" in value or "G" in value:
                 return int(numeric * 1024)
             elif "Mi" in value or "MB" in value or "M" in value:
@@ -53,11 +53,11 @@ class SqlTemplateRepository(ITemplateRepository):
             elif "Ki" in value or "KB" in value or "K" in value:
                 return int(numeric / 1024)
             else:
-                # 如果没有单位，假设是 MB
+                # Without a unit, assume MB
                 return int(numeric)
 
         if model:
-            # 更新现有记录
+            # Update the existing row
             model.f_name = template.name
             model.f_description = ""
             model.f_image_url = template.image
@@ -79,49 +79,49 @@ class SqlTemplateRepository(ITemplateRepository):
             )
             model.f_updated_at = now_ms
         else:
-            # 创建新记录
+            # Insert a new row
             model = TemplateModel.from_entity(template)
             self._session.add(model)
 
         await self._session.flush()
 
     async def find_by_id(self, template_id: str) -> Template | None:
-        """根据 ID 查找模板"""
+        """Find a template by id"""
         model = await self._session.get(TemplateModel, template_id)
         return model.to_entity() if model else None
 
     async def find_by_name(self, name: str) -> Template | None:
-        """根据名称查找模板"""
+        """Find a template by name"""
         stmt = select(TemplateModel).where(TemplateModel.f_name == name)
         result = await self._session.execute(stmt)
         model = result.scalar_one_or_none()
         return model.to_entity() if model else None
 
     async def find_all(self, offset: int = 0, limit: int = 100) -> List[Template]:
-        """查找所有模板"""
+        """Find every template"""
         stmt = select(TemplateModel).offset(offset).limit(limit).order_by(TemplateModel.f_name)
         result = await self._session.execute(stmt)
         return [model.to_entity() for model in result.scalars().all()]
 
     async def delete(self, template_id: str) -> None:
-        """删除模板"""
+        """Delete the template"""
         stmt = delete(TemplateModel).where(TemplateModel.f_id == template_id)
         await self._session.execute(stmt)
         await self._session.flush()
 
     async def exists(self, template_id: str) -> bool:
-        """检查模板是否存在"""
+        """Check whether the template exists"""
         model = await self._session.get(TemplateModel, template_id)
         return model is not None
 
     async def exists_by_name(self, name: str) -> bool:
-        """检查名称是否存在"""
+        """Check whether the name exists"""
         stmt = select(func.count()).select_from(TemplateModel).where(TemplateModel.f_name == name)
         result = await self._session.execute(stmt)
         return (result.scalar() or 0) > 0
 
     async def count(self) -> int:
-        """统计模板数量"""
+        """Count the templates"""
         stmt = select(func.count()).select_from(TemplateModel)
         result = await self._session.execute(stmt)
         return result.scalar() or 0

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/__init__.py
@@ -1,7 +1,7 @@
 """
-数据库种子数据模块
+Database seed data module
 
-提供默认数据定义和初始化逻辑。
+The default data definitions and the seeding logic.
 """
 
 from src.infrastructure.persistence.seed.default_data import (

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/default_data.py
@@ -1,9 +1,9 @@
 """
-默认数据定义
+Default data definitions
 
-定义在不同环境中使用的默认运行时节点和模板。
-所有默认数据的集中定义，方便维护和修改。
-按照数据表命名规范使用 f_ 前缀字段名。
+The default runtime nodes and templates used across environments.
+Keeping every default in one place makes them easier to maintain.
+Column names carry the f_ prefix, following the table naming convention.
 """
 
 from __future__ import annotations
@@ -29,9 +29,9 @@ DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY = "sandbox-template-multi-langu
 
 def get_project_version() -> str:
     """
-    获取项目版本号。
+    Read the project version.
 
-    优先读取 PROJECT_VERSION/TEMPLATE_IMAGE_TAG 环境变量；未设置时读取仓库根目录 VERSION 文件。
+    PROJECT_VERSION and TEMPLATE_IMAGE_TAG win; without them the VERSION file at the repository root applies.
     """
     env_version = os.getenv("TEMPLATE_IMAGE_TAG") or os.getenv("PROJECT_VERSION")
     if env_version:
@@ -57,7 +57,7 @@ def get_project_version() -> str:
 
 
 def build_template_image_url(repository: str) -> str:
-    """根据项目版本生成默认 SWR 模板镜像 URL。"""
+    """Build the default SWR template image URL from the project version."""
     registry = os.getenv("DEFAULT_TEMPLATE_IMAGE_REGISTRY") or DEFAULT_TEMPLATE_IMAGE_REGISTRY
     image_name = f"{registry.rstrip('/')}/{repository.lstrip('/')}" if registry else repository
     return f"{image_name}:{get_project_version()}"
@@ -65,12 +65,12 @@ def build_template_image_url(repository: str) -> str:
 
 def get_default_template_image_url() -> str:
     """
-    获取默认模板镜像 URL
+    Get the default template image URL
 
-    从环境变量 DEFAULT_TEMPLATE_IMAGE 读取，如果未设置则使用 VERSION 文件生成默认 SWR 镜像地址。
+    Read from DEFAULT_TEMPLATE_IMAGE; without it, build the default SWR address from the VERSION file.
 
     Returns:
-        模板镜像 URL
+        The template image URL
     """
     repository = os.getenv(
         "DEFAULT_TEMPLATE_IMAGE_REPOSITORY",
@@ -85,9 +85,9 @@ def get_default_template_image_url() -> str:
 
 def get_multi_language_template_image_url() -> str:
     """
-    获取多语言复合模板镜像 URL。
+    Get the multi-language composite template image URL.
 
-    从环境变量 DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE 读取，如果未设置则使用 VERSION 文件生成默认 SWR 镜像地址。
+    Read from DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE; without it, build the default SWR address from the VERSION file.
     """
     image_url = os.getenv(
         "DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE"
@@ -106,10 +106,10 @@ def get_multi_language_template_image_url() -> str:
 
 def get_default_runtime_nodes() -> list[RuntimeNodeModel]:
     """
-    获取默认运行时节点列表
+    Get the default runtime nodes
 
     Returns:
-        默认运行时节点列表
+        The default runtime nodes
     """
     from src.infrastructure.persistence.models.runtime_node_model import RuntimeNodeModel
 
@@ -131,7 +131,7 @@ def get_default_runtime_nodes() -> list[RuntimeNodeModel]:
             f_cached_images="[]",
             f_labels='{"environment": "development", "type": "default"}',
             f_last_heartbeat_at=now_ms,
-            # 审计字段
+            # Audit columns
             f_created_at=now_ms,
             f_created_by="system",
             f_updated_at=now_ms,
@@ -144,10 +144,10 @@ def get_default_runtime_nodes() -> list[RuntimeNodeModel]:
 
 def get_default_templates() -> list[TemplateModel]:
     """
-    获取默认模板列表
+    Get the default templates
 
     Returns:
-        默认模板列表
+        The default templates
     """
     import json
 
@@ -170,7 +170,7 @@ def get_default_templates() -> list[TemplateModel]:
             f_pre_installed_packages="[]",
             f_default_env_vars="",
             f_security_context="",
-            # 审计字段
+            # Audit columns
             f_created_at=now_ms,
             f_created_by="system",
             f_updated_at=now_ms,
@@ -193,7 +193,7 @@ def get_default_templates() -> list[TemplateModel]:
             f_pre_installed_packages=json.dumps(["python", "go", "bash"]),
             f_default_env_vars="",
             f_security_context="",
-            # 审计字段
+            # Audit columns
             f_created_at=now_ms,
             f_created_by="system",
             f_updated_at=now_ms,

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/seeder.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/seed/seeder.py
@@ -1,7 +1,7 @@
 """
-数据库种子数据初始化
+Database seed data
 
-提供统一的种子数据初始化逻辑，可以在应用启动或独立脚本中调用。
+The shared seeding logic, callable at application start-up or from a standalone script.
 """
 
 from sqlalchemy import select
@@ -20,16 +20,16 @@ logger = get_logger(__name__)
 
 async def seed_runtime_nodes(force: bool = False) -> int:
     """
-    初始化默认运行时节点
+    Create the default runtime nodes
 
     Args:
-        force: 如果为 True，即使节点已存在也会重新创建
+        force: when True, recreate the nodes even if they exist
 
     Returns:
-        创建的节点数量
+        How many nodes were created
     """
     async with db_manager.get_session() as session:
-        # 检查是否已存在节点
+        # Check whether nodes already exist
         result = await session.execute(select(RuntimeNodeModel))
         existing_nodes = result.scalars().all()
 
@@ -39,14 +39,14 @@ async def seed_runtime_nodes(force: bool = False) -> int:
             )
             return 0
 
-        # 如果 force=True，删除现有节点
+        # With force=True, delete the existing nodes
         if existing_nodes and force:
             for node in existing_nodes:
                 await session.delete(node)
             await session.flush()
             logger.info("Deleted existing runtime nodes", count=len(existing_nodes))
 
-        # 创建默认节点
+        # Create the default nodes
         default_nodes = get_default_runtime_nodes()
         for node in default_nodes:
             session.add(node)
@@ -58,31 +58,31 @@ async def seed_runtime_nodes(force: bool = False) -> int:
 
 async def seed_templates(force: bool = False) -> int:
     """
-    初始化默认模板
+    Create the default templates
 
     Args:
-        force: 如果为 True，即使模板已存在也会重新创建
+        force: when True, recreate the templates even if they exist
 
     Returns:
-        创建或更新的模板数量
+        How many templates were created or updated
     """
     async with db_manager.get_session() as session:
-        # 获取默认模板定义
+        # Read the default template definitions
         default_templates = get_default_templates()
         default_template_map = {t.f_id: t for t in default_templates}
 
-        # 检查已存在的模板
+        # Check which templates already exist
         result = await session.execute(select(TemplateModel))
         existing_templates = result.scalars().all()
         existing_template_map = {t.f_id: t for t in existing_templates}
 
         if existing_templates and not force:
-            # 更新已存在模板的镜像地址
+            # Update the image of an existing template
             updated_count = 0
             for template_id, default_template in default_template_map.items():
                 if template_id in existing_template_map:
                     existing_template = existing_template_map[template_id]
-                    # 更新镜像地址和其他可能变化的字段
+                    # Update the image and the other fields that can change
                     if existing_template.f_image_url != default_template.f_image_url:
                         old_image_url = existing_template.f_image_url
                         existing_template.f_image_url = default_template.f_image_url
@@ -94,7 +94,7 @@ async def seed_templates(force: bool = False) -> int:
                             new_image=default_template.f_image_url,
                         )
 
-            # 创建新模板（默认模板中有但数据库中没有的）
+            # Create the templates that are in the defaults but not in the database
             created_count = 0
             for template_id, default_template in default_template_map.items():
                 if template_id not in existing_template_map:
@@ -105,14 +105,14 @@ async def seed_templates(force: bool = False) -> int:
             logger.info("Templates synced", updated=updated_count, created=created_count)
             return updated_count + created_count
 
-        # 如果 force=True，删除现有模板并重新创建
+        # With force=True, delete the existing templates and recreate them
         if existing_templates and force:
             for template in existing_templates:
                 await session.delete(template)
             await session.flush()
             logger.info("Deleted existing templates", count=len(existing_templates))
 
-        # 创建默认模板
+        # Create the default templates
         for template in default_templates:
             logger.info(
                 "Creating template with image URL",
@@ -128,13 +128,13 @@ async def seed_templates(force: bool = False) -> int:
 
 async def seed_default_data(force: bool = False) -> dict:
     """
-    初始化所有默认数据
+    Create all the default data
 
     Args:
-        force: 如果为 True，即使数据已存在也会重新创建
+        force: when True, recreate the data even if it exists
 
     Returns:
-        包含创建项数量的字典
+        A dict holding how many of each were created
     """
     logger.info("Starting default data seeding", force=force)
 

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/utils/timestamp_helper.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/persistence/utils/timestamp_helper.py
@@ -1,8 +1,8 @@
 """
-时间戳辅助工具
+Timestamp helpers
 
-用于在 BIGINT 毫秒时间戳和 datetime 对象之间进行转换。
-按照数据表命名规范，时间戳字段使用 BIGINT 存储毫秒级时间戳。
+Converts between BIGINT millisecond timestamps and datetime objects.
+Per the table naming convention, timestamp columns store milliseconds as BIGINT.
 """
 
 import time
@@ -12,13 +12,13 @@ from typing import Optional
 
 def datetime_to_millis(dt: Optional[datetime]) -> int:
     """
-    将 datetime 对象转换为毫秒时间戳
+    Turn a datetime into a millisecond timestamp
 
     Args:
-        dt: datetime 对象，如果为 None 则返回当前时间的毫秒时间戳
+        dt: the datetime; None means the current time
 
     Returns:
-        毫秒时间戳
+        The millisecond timestamp
     """
     if dt is None:
         return int(time.time() * 1000)
@@ -27,13 +27,13 @@ def datetime_to_millis(dt: Optional[datetime]) -> int:
 
 def millis_to_datetime(millis: Optional[int]) -> Optional[datetime]:
     """
-    将毫秒时间戳转换为 datetime 对象
+    Turn a millisecond timestamp into a datetime
 
     Args:
-        millis: 毫秒时间戳，如果为 None 或 0 则返回 None
+        millis: the millisecond timestamp; None or 0 returns None
 
     Returns:
-        datetime 对象，如果输入无效则返回 None
+        The datetime, or None when the input is invalid
     """
     if not millis or millis == 0:
         return None
@@ -45,19 +45,19 @@ def millis_to_datetime(millis: Optional[int]) -> Optional[datetime]:
 
 def current_millis() -> int:
     """
-    获取当前时间的毫秒时间戳
+    The current time as a millisecond timestamp
 
     Returns:
-        当前时间的毫秒时间戳
+        The current millisecond timestamp
     """
     return int(time.time() * 1000)
 
 
 def current_datetime() -> datetime:
     """
-    获取当前时间的 datetime 对象
+    The current time as a datetime
 
     Returns:
-        当前时间的 datetime 对象
+        The current datetime
     """
     return datetime.now()

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/__init__.py
@@ -1,7 +1,7 @@
 """
-调度器包
+Scheduler package
 
-提供调度服务实现。
+The scheduling service implementations.
 """
 
 from src.infrastructure.schedulers.docker_scheduler_service import DockerSchedulerService

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/docker_scheduler_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/docker_scheduler_service.py
@@ -1,7 +1,7 @@
 """
-Docker 调度服务
+Docker scheduling service
 
-实现调度策略，选择最优节点并创建容器。
+Implements the scheduling policy: pick the best node and create the container.
 """
 
 from typing import List, Optional
@@ -26,13 +26,13 @@ logger = get_logger(__name__)
 
 class DockerSchedulerService(IScheduler):
     """
-    Docker 调度服务
+    Docker scheduling service
 
-    实现调度策略：
-    1. 优先选择有模板亲和性的节点（镜像已缓存）
-    2. 选择负载最低的健康节点
+    The scheduling policy:
+    1. Prefer a node with template affinity, meaning the image is already cached
+    2. Otherwise pick the healthy node with the lowest load
 
-    容器从创建时就绑定到会话，生命周期完全跟随会话。
+    A container is bound to its session from creation and lives exactly as long as it.
     """
 
     def __init__(
@@ -55,11 +55,11 @@ class DockerSchedulerService(IScheduler):
 
     async def schedule(self, request: ScheduleRequest) -> RuntimeNode:
         """
-        调度会话到最优节点
+        Schedule the session onto the best node
 
-        调度策略：
-        1. 检查是否有已缓存该模板的节点（模板亲和性）
-        2. 选择负载最低的健康节点
+        The policy:
+        1. Look for a node that already cached this template, which is template affinity
+        2. Otherwise pick the healthy node with the lowest load
         """
         logger.info(
             "Starting node selection",
@@ -69,7 +69,7 @@ class DockerSchedulerService(IScheduler):
             memory_limit=request.resource_limit.memory,
         )
 
-        # 1. 获取所有健康节点
+        # 1. Read every healthy node
         healthy_nodes = await self.get_healthy_nodes()
         logger.debug(
             "Found healthy nodes",
@@ -81,7 +81,7 @@ class DockerSchedulerService(IScheduler):
             logger.error("No healthy runtime nodes available")
             raise RuntimeError("No healthy runtime nodes available")
 
-        # 2. 按模板亲和性排序
+        # 2. Sort by template affinity
         affinity_nodes = [node for node in healthy_nodes if node.has_template(request.template_id)]
 
         logger.debug(
@@ -92,7 +92,7 @@ class DockerSchedulerService(IScheduler):
         )
 
         if affinity_nodes:
-            # 选择亲和节点中负载最低的
+            # Among the affine nodes, take the least loaded
             selected = self._select_least_loaded(affinity_nodes)
             logger.info(
                 "Selected affinity node",
@@ -104,7 +104,7 @@ class DockerSchedulerService(IScheduler):
             )
             return selected
 
-        # 3. 使用负载均衡选择节点
+        # 3. Fall back to load balancing
         selected = self._select_least_loaded(healthy_nodes)
         logger.info(
             "Selected node by load balancing",
@@ -117,29 +117,29 @@ class DockerSchedulerService(IScheduler):
         return selected
 
     async def get_node(self, node_id: str) -> Optional[RuntimeNode]:
-        """获取指定节点"""
+        """Get one node"""
         node_model = await self._runtime_node_repo.find_by_id(node_id)
         if not node_model:
             return None
         return node_model.to_runtime_node()
 
     async def get_healthy_nodes(self) -> List[RuntimeNode]:
-        """获取所有健康节点"""
+        """Get every healthy node"""
         nodes = await self._runtime_node_repo.find_by_status("online")
         return [node.to_runtime_node() for node in nodes]
 
     async def mark_node_unhealthy(self, node_id: str) -> None:
-        """标记节点为不健康"""
+        """Mark a node unhealthy"""
         await self._runtime_node_repo.update_status(node_id, "offline")
         logger.warning("Marked node as unhealthy", node_id=node_id)
 
     def _select_least_loaded(self, nodes: List[RuntimeNode]) -> RuntimeNode:
         """
-        从节点列表中选择负载最低的节点
+        Pick the least loaded node from a list
 
-        选择逻辑：
-        1. 负载比率最低
-        2. 如果比率相同，选择会话数最少的
+        How it chooses:
+        1. Lowest load ratio
+        2. On a tie, the fewest sessions
         """
         return min(nodes, key=lambda n: (n.get_load_ratio(), n.session_count))
 
@@ -155,22 +155,22 @@ class DockerSchedulerService(IScheduler):
         dependencies: list = None,
     ) -> str:
         """
-        为会话创建容器（同步）
+        Create the container for a session, synchronously
 
-        容器从创建时就绑定到会话。
+        The container is bound to the session from creation.
 
         Args:
-            session_id: 会话 ID
-            template_id: 模板 ID
-            image: 容器镜像
-            resource_limit: 资源限制
-            env_vars: 环境变量
-            workspace_path: 工作空间路径
-            node_id: 目标节点 ID
-            dependencies: Python 依赖列表（pip 规范）[新增]
+            session_id: session id
+            template_id: template id
+            image: container image
+            resource_limit: resource limits
+            env_vars: environment variables
+            workspace_path: workspace path
+            node_id: target node id
+            dependencies: Python dependencies as pip specifiers
 
         Returns:
-            容器ID（使用容器名称作为 ID）
+            The container id, which is the container name
         """
         import json
 
@@ -184,7 +184,7 @@ class DockerSchedulerService(IScheduler):
             dependencies=dependencies,
         )
 
-        # 获取节点信息
+        # Read the node
         node = await self.get_node(node_id)
         if not node:
             logger.error("Node not found", node_id=node_id, session_id=session_id)
@@ -197,8 +197,8 @@ class DockerSchedulerService(IScheduler):
             node_status=node.status,
         )
 
-        # 创建容器配置
-        # dependencies_json 传递给 docker_scheduler.py 用于动态生成 entrypoint 脚本
+        # Build the container configuration.
+        # dependencies_json goes to docker_scheduler.py, which generates the entrypoint script from it.
         dependencies_json = json.dumps(dependencies) if dependencies else ""
 
         container_name = f"sandbox-{session_id}"
@@ -221,7 +221,7 @@ class DockerSchedulerService(IScheduler):
                 "session_id": session_id,
                 "template_id": template_id,
                 "managed_by": "sandbox-control-plane",
-                "dependencies": dependencies_json,  # 传递给 docker_scheduler.py
+                "dependencies": dependencies_json,  # passed through to docker_scheduler.py
             },
         )
 
@@ -236,7 +236,7 @@ class DockerSchedulerService(IScheduler):
             env_vars_count=len(config.env_vars),
         )
 
-        # 同步创建容器（等待完成）
+        # Create the container synchronously and wait for it
         try:
             logger.info(
                 "Creating container",
@@ -264,7 +264,7 @@ class DockerSchedulerService(IScheduler):
                 node_id=node.id,
             )
 
-            # 获取容器状态确认
+            # Read the container status to confirm
             try:
                 container_info = await self._container_scheduler.get_container_status(
                     container_name
@@ -285,7 +285,7 @@ class DockerSchedulerService(IScheduler):
                     error=str(status_error),
                 )
 
-            # 使用容器名称作为 ID（用于执行器通信）
+            # Use the container name as the id, for executor traffic
             return container_name
 
         except Exception as e:
@@ -300,9 +300,9 @@ class DockerSchedulerService(IScheduler):
 
     async def destroy_container(self, container_id: str, timeout: int = 10) -> None:
         """
-        销毁容器
+        Destroy the container
 
-        容器始终被销毁，不再有释放到预热池的逻辑。
+        A container is always destroyed; nothing is released back into a warm pool.
         """
         try:
             await self._container_scheduler.stop_container(container_id, timeout=timeout)
@@ -317,7 +317,7 @@ class DockerSchedulerService(IScheduler):
             raise
 
     async def get_container_info(self, container_id: str):
-        """获取容器信息"""
+        """Get the container information"""
         return await self._container_scheduler.get_container_status(container_id)
 
     async def execute(
@@ -327,28 +327,28 @@ class DockerSchedulerService(IScheduler):
         execution_request: ExecutionRequest,
     ) -> str:
         """
-        提交执行请求到容器内的执行器
+        Submit an execution request to the executor inside the container
 
-        通过 HTTP 与运行在容器内的 sandbox-executor 通信。
+        Talks over HTTP to the sandbox-executor running in the container.
 
         Args:
-            session_id: 会话 ID
-            container_id: 容器 ID
-            execution_request: 执行请求
+            session_id: session id
+            container_id: container id
+            execution_request: the execution request
 
         Returns:
-            execution_id: 执行任务 ID
+            execution_id: execution task id
 
         Raises:
-            ConnectionError: 无法连接到执行器
-            TimeoutError: 执行器响应超时
+            ConnectionError: the executor is unreachable
+            TimeoutError: the executor did not answer in time
         """
-        # 获取容器信息以构建执行器 URL
+        # Read the container information to build the executor URL
         container_info = await self._container_scheduler.get_container_status(container_id)
 
-        # 构建执行器 URL
-        # 使用容器名称在 Docker 内部网络中进行通信
-        # 容器名称格式: sandbox-{session_id}
+        # Build the executor URL.
+        # The container name addresses it inside the Docker network,
+        # in the form sandbox-{session_id}.
         container_name = container_info.name
         executor_url = self._build_executor_url(container_name)
 
@@ -359,7 +359,7 @@ class DockerSchedulerService(IScheduler):
             container_id=container_id,
         )
 
-        # 使用执行器客户端提交请求
+        # Submit through the executor client
         try:
             execution_id = await self._executor_client.submit_execution(
                 executor_url=executor_url,
@@ -390,7 +390,7 @@ class DockerSchedulerService(IScheduler):
             raise
 
     async def get_executor_url(self, container_id: str) -> str:
-        """根据容器 ID 获取 executor URL。"""
+        """Resolve the executor URL from a container id."""
         return self._build_executor_url(container_id)
 
     def _build_executor_url(self, container_name: str) -> str:

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/k8s_scheduler_service.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/schedulers/k8s_scheduler_service.py
@@ -1,7 +1,7 @@
 """
-Kubernetes 调度服务
+Kubernetes scheduling service
 
-实现调度策略，使用 Kubernetes API 创建 Pod。
+Implements the scheduling policy, creating Pods through the Kubernetes API.
 """
 
 import logging
@@ -27,12 +27,12 @@ logger = logging.getLogger(__name__)
 
 class K8sSchedulerService(IScheduler):
     """
-    Kubernetes 调度服务
+    Kubernetes scheduling service
 
-    使用 Kubernetes API 创建和管理 Pod：
-    1. 不需要节点选择逻辑（K8s 调度器自动处理）
-    2. 创建 Pod 而不是容器
-    3. Pod 生命周期跟随会话
+    Creates and manages Pods through the Kubernetes API:
+    1. No node selection of its own; the K8s scheduler handles that
+    2. Creates a Pod rather than a container
+    3. The Pod lives exactly as long as the session
     """
 
     def __init__(
@@ -42,7 +42,7 @@ class K8sSchedulerService(IScheduler):
         executor_client: Optional[ExecutorClient] = None,
         executor_port: int = 8080,
         control_plane_url: str = "http://sandbox-control-plane.sandbox-system.svc.cluster.local:8000",
-        disable_bwrap: bool = True,  # K8s 环境默认禁用 bwrap
+        disable_bwrap: bool = True,  # bwrap is off by default under K8s
     ):
         self._container_scheduler = container_scheduler
         self._template_repo = template_repo
@@ -52,7 +52,7 @@ class K8sSchedulerService(IScheduler):
         self._disable_bwrap = disable_bwrap
         self._owner_context = self._load_owner_context()
 
-        # K8s 集群作为单个逻辑节点
+        # The K8s cluster counts as one logical node
         self._cluster_node = RuntimeNode(
             id="k8s-cluster",
             type="kubernetes",
@@ -66,7 +66,7 @@ class K8sSchedulerService(IScheduler):
         )
 
     def _load_owner_context(self) -> ControlPlaneOwnerContext:
-        """加载当前 control plane Pod 的 owner 上下文。"""
+        """Load the owner context of the current control plane Pod."""
         pod_name = os.getenv("POD_NAME", "").strip()
         pod_uid = os.getenv("POD_UID", "").strip()
         if not pod_name or not pod_uid:
@@ -81,27 +81,27 @@ class K8sSchedulerService(IScheduler):
 
     async def schedule(self, request: ScheduleRequest) -> RuntimeNode:
         """
-        调度会话到 K8s 集群
+        Schedule the session onto the K8s cluster
 
-        在 K8s 环境中，调度决策由 Kubernetes 调度器处理。
-        我们只返回一个表示 K8s 集群的虚拟节点。
+        Under K8s the scheduling decision belongs to the Kubernetes scheduler,
+        so this returns a single virtual node standing for the cluster.
         """
         logger.info(f"Scheduling session to K8s cluster: template={request.template_id}")
         return self._cluster_node
 
     async def get_node(self, node_id: str) -> Optional[RuntimeNode]:
-        """获取指定节点"""
+        """Get one node"""
         if node_id == "k8s-cluster":
             return self._cluster_node
         return None
 
     async def get_healthy_nodes(self) -> List[RuntimeNode]:
-        """获取所有健康节点"""
+        """Get every healthy node"""
         return [self._cluster_node]
 
     async def mark_node_unhealthy(self, node_id: str) -> None:
-        """标记节点为不健康"""
-        # K8s 环境下不需要此操作
+        """Mark a node unhealthy"""
+        # Not needed under K8s
         logger.warning(f"mark_node_unhealthy called in K8s environment: {node_id}")
 
     async def create_container_for_session(
@@ -116,32 +116,32 @@ class K8sSchedulerService(IScheduler):
         dependencies: list = None,
     ) -> str:
         """
-        为会话创建 Pod
+        Create the Pod for a session
 
         Args:
-            session_id: 会话 ID
-            template_id: 模板 ID
-            image: 容器镜像
-            resource_limit: 资源限制
-            env_vars: 环境变量
-            workspace_path: 工作空间路径
-            node_id: 目标节点 ID（K8s 环境下忽略）
-            dependencies: Python 依赖列表
+            session_id: session id
+            template_id: template id
+            image: container image
+            resource_limit: resource limits
+            env_vars: environment variables
+            workspace_path: workspace path
+            node_id: target node id, ignored under K8s
+            dependencies: Python dependencies
 
         Returns:
-            Pod 名称
+            The Pod name
         """
         import json
 
-        # 获取模板信息
+        # Read the template
         template = await self._template_repo.find_by_id(template_id)
         if not template:
             raise RuntimeError(f"Template not found: {template_id}")
 
-        # 创建容器配置
+        # Build the container configuration
         dependencies_json = json.dumps(dependencies) if dependencies else ""
 
-        # Debug: 打印使用的 CONTROL_PLANE_URL
+        # Debug: log the CONTROL_PLANE_URL in use
         logger.info(f"Creating executor pod with CONTROL_PLANE_URL: {self._control_plane_url}")
 
         config = ContainerConfig(
@@ -167,7 +167,7 @@ class K8sSchedulerService(IScheduler):
             owner_context=self._owner_context,
         )
 
-        # 创建 Pod
+        # Create the Pod
         try:
             pod_name = await self._container_scheduler.create_container(config)
             logger.info(f"Created Pod {pod_name} for session {session_id}")
@@ -179,7 +179,7 @@ class K8sSchedulerService(IScheduler):
 
     async def destroy_container(self, container_id: str, timeout: int = 10) -> None:
         """
-        销毁 Pod
+        Destroy the Pod
         """
         try:
             await self._container_scheduler.stop_container(container_id, timeout=timeout)
@@ -190,7 +190,7 @@ class K8sSchedulerService(IScheduler):
             raise
 
     async def get_container_info(self, container_id: str):
-        """获取 Pod 信息"""
+        """Get the Pod information"""
         return await self._container_scheduler.get_container_status(container_id)
 
     async def execute(
@@ -200,23 +200,23 @@ class K8sSchedulerService(IScheduler):
         execution_request: ExecutionRequest,
     ) -> str:
         """
-        提交执行请求到 Pod 内的执行器
+        Submit an execution request to the executor inside the Pod
 
         Args:
-            session_id: 会话 ID
-            container_id: Pod 名称
-            execution_request: 执行请求
+            session_id: session id
+            container_id: Pod name
+            execution_request: the execution request
 
         Returns:
-            execution_id: 执行任务 ID
+            execution_id: execution task id
         """
-        # 从 K8s API 获取 Pod IP
+        # Read the Pod IP from the K8s API
         executor_url = await self.get_executor_url(container_id)
         logger.info(
             f"Submitting execution to executor: {executor_url}, session_id={session_id}, pod_name={container_id}"
         )
 
-        # 使用执行器客户端提交请求
+        # Submit through the executor client
         try:
             execution_id = await self._executor_client.submit_execution(
                 executor_url=executor_url,
@@ -241,7 +241,7 @@ class K8sSchedulerService(IScheduler):
             raise
 
     async def get_executor_url(self, container_id: str) -> str:
-        """根据 Pod 名称获取 executor URL。"""
+        """Resolve the executor URL from a Pod name."""
         import asyncio
 
         pod_name = container_id

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/storage/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/storage/__init__.py
@@ -1,7 +1,7 @@
 """
-存储模块
+Storage module
 
-提供 S3 兼容的对象存储实现（AWS S3、MinIO）
+The S3-compatible object storage implementation, for AWS S3 and MinIO.
 """
 
 from .s3_storage import S3Storage

--- a/infra/sandbox/sandbox_control_plane/src/infrastructure/storage/s3_storage.py
+++ b/infra/sandbox/sandbox_control_plane/src/infrastructure/storage/s3_storage.py
@@ -1,7 +1,7 @@
 """
-S3 存储实现
+S3 storage implementation
 
-使用 boto3 实现 S3 兼容的对象存储，支持 AWS S3 和 MinIO。
+S3-compatible object storage through boto3, for both AWS S3 and MinIO.
 """
 
 import asyncio
@@ -21,31 +21,31 @@ logger = logging.getLogger(__name__)
 
 class S3Storage(IStorageService):
     """
-    S3 兼容的存储实现
+    S3-compatible storage implementation
 
-    支持：
+    Supports:
     - AWS S3
-    - MinIO（用于本地开发）
-    - 任何 S3 兼容的存储（例如：Wasabi、DigitalOcean Spaces）
+    - MinIO, for local development
+    - any S3-compatible storage, such as Wasabi or DigitalOcean Spaces
     """
 
     def __init__(self):
         """
-        初始化 S3 客户端
+        Initialize the S3 client
 
-        从 settings 中读取 S3 配置：
-        - s3_endpoint_url: S3 端点 URL（MinIO 使用）
-        - s3_access_key_id: 访问密钥 ID
-        - s3_secret_access_key: 密钥
-        - s3_region: 区域
-        - s3_bucket: 存储桶名称
+        Reads the S3 configuration from settings:
+        - s3_endpoint_url: S3 endpoint URL, used by MinIO
+        - s3_access_key_id: access key id
+        - s3_secret_access_key: secret key
+        - s3_region: region
+        - s3_bucket: bucket name
         """
         settings = get_settings()
 
-        # 初始化 S3 客户端
+        # Initialize the S3 client
         self._client = boto3.client(
             "s3",
-            endpoint_url=settings.s3_endpoint_url or None,  # AWS S3 不需要 endpoint_url
+            endpoint_url=settings.s3_endpoint_url or None,  # AWS S3 needs no endpoint_url
             aws_access_key_id=settings.s3_access_key_id,
             aws_secret_access_key=settings.s3_secret_access_key,
             region_name=settings.s3_region,
@@ -54,38 +54,38 @@ class S3Storage(IStorageService):
 
     async def initialize(self) -> None:
         """
-        异步初始化，确保 bucket 存在
+        Initialize asynchronously, making sure the bucket exists
 
-        在 control-plane 启动时调用此方法来确保 S3 bucket 已创建。
+        Called while the control plane starts, to ensure the S3 bucket is created.
         """
         try:
             await self._ensure_bucket_exists()
             logger.info(f"S3 storage initialized successfully (bucket: {self._bucket})")
         except Exception as e:
             logger.error(f"Failed to initialize S3 storage: {e}")
-            # 不抛出异常，允许系统在 MinIO 不可用时继续运行
-            # 文件操作会失败，但不会阻止控制平面启动
+            # Do not raise: the system keeps running when MinIO is unavailable.
+            # File operations will fail, but the control plane still starts.
 
     def _parse_s3_path(self, s3_path: str) -> tuple[str, str]:
         """
-        解析 S3 路径，返回 bucket 和 key
+        Parse an S3 path into bucket and key
 
-        支持两种格式：
+        Two formats are accepted:
         1. s3://bucket/key
-        2. bucket/key (相对路径)
+        2. bucket/key, a relative path
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            (bucket, key) 元组
+            A (bucket, key) tuple
         """
         if s3_path.startswith("s3://"):
             parsed = urlparse(s3_path)
             bucket = parsed.netloc
             key = parsed.path.lstrip("/")
         else:
-            # 相对路径，使用默认 bucket
+            # A relative path: use the default bucket
             bucket = self._bucket
             key = s3_path.lstrip("/")
 
@@ -93,28 +93,28 @@ class S3Storage(IStorageService):
 
     def _build_s3_path(self, bucket: str, key: str) -> str:
         """
-        构建 S3 路径
+        Build an S3 path
 
         Args:
-            bucket: 存储桶名称
-            key: 对象键
+            bucket: bucket name
+            key: object key
 
         Returns:
-            S3 路径（s3://bucket/key 格式）
+            The S3 path, in s3://bucket/key form
         """
         return f"s3://{bucket}/{key}"
 
     async def _ensure_bucket_exists(self) -> None:
-        """确保存储桶存在，不存在则创建"""
+        """Make sure the bucket exists, creating it when it does not"""
         try:
             await asyncio.to_thread(self._client.head_bucket, Bucket=self._bucket)
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code")
             if error_code == "404":
-                # 存储桶不存在，创建它
+                # The bucket does not exist, so create it
                 try:
                     if self._client.meta.region_name == "us-east-1":
-                        # us-east-1 不需要 LocationConstraint
+                        # us-east-1 needs no LocationConstraint
                         await asyncio.to_thread(self._client.create_bucket, Bucket=self._bucket)
                     else:
                         await asyncio.to_thread(
@@ -136,24 +136,24 @@ class S3Storage(IStorageService):
         self, s3_path: str, content: bytes, content_type: str = "application/octet-stream"
     ) -> None:
         """
-        上传文件
+        Upload a file
 
         Args:
-            s3_path: S3 对象路径
-            content: 文件内容
-            content_type: MIME 类型
+            s3_path: S3 object path
+            content: file content
+            content_type: MIME type
         """
         await self._ensure_bucket_exists()
 
         bucket, key = self._parse_s3_path(s3_path)
 
-        # 根据内容大小选择上传方式
+        # Pick the upload method by size
         content_size = len(content)
 
-        if content_size > 5 * 1024 * 1024:  # 大于 5MB 使用分片上传
+        if content_size > 5 * 1024 * 1024:  # over 5MB, use a multipart upload
             from boto3.s3.transfer import TransferConfig
 
-            # 先写入临时文件
+            # Write to a temporary file first
             import tempfile
 
             with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
@@ -173,7 +173,7 @@ class S3Storage(IStorageService):
             finally:
                 os.unlink(tmp_file_path)
         else:
-            # 小文件直接上传
+            # Upload a small file directly
             await asyncio.to_thread(
                 self._client.put_object,
                 Bucket=bucket,
@@ -182,33 +182,33 @@ class S3Storage(IStorageService):
                 ContentType=content_type,
             )
 
-        # 清理可能存在的目录标记 (s3fs 兼容性修复)
-        # 当上传 test/test_data.csv 时，S3 可能会创建 test/ 目录标记
-        # 这会导致 s3fs 将 test 显示为文件而非目录
+        # Remove the directory marker if one appeared, an s3fs compatibility fix.
+        # Uploading test/test_data.csv can make S3 create a test/ directory marker,
+        # which makes s3fs show test as a file rather than a directory.
         if "/" in key:
             dir_marker = key.rsplit("/", 1)[0] + "/"
             try:
                 await asyncio.to_thread(self._client.head_object, Bucket=bucket, Key=dir_marker)
-                # 目录标记存在，删除它
+                # The marker exists, so delete it
                 await asyncio.to_thread(self._client.delete_object, Bucket=bucket, Key=dir_marker)
                 logger.debug(f"Removed S3 directory marker for s3fs compatibility: {dir_marker}")
             except ClientError as e:
                 error_code = e.response.get("Error", {}).get("Code")
                 if error_code == "404":
-                    # 目录标记不存在，无需处理
+                    # No marker, nothing to do
                     pass
 
         logger.debug(f"Uploaded file to {s3_path}, size={content_size}")
 
     async def download_file(self, s3_path: str) -> bytes:
         """
-        下载文件
+        Download a file
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            文件内容
+            The file content
         """
         bucket, key = self._parse_s3_path(s3_path)
 
@@ -221,13 +221,13 @@ class S3Storage(IStorageService):
 
     async def file_exists(self, s3_path: str) -> bool:
         """
-        检查文件是否存在
+        Check whether a file exists
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            是否存在
+            Whether it exists
         """
         bucket, key = self._parse_s3_path(s3_path)
 
@@ -243,13 +243,13 @@ class S3Storage(IStorageService):
 
     async def get_file_info(self, s3_path: str) -> dict:
         """
-        获取文件信息
+        Get the file metadata
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
 
         Returns:
-            文件信息字典，包含 size, content_type, last_modified 等
+            A dict holding size, content_type, last_modified, and more
         """
         bucket, key = self._parse_s3_path(s3_path)
 
@@ -264,14 +264,14 @@ class S3Storage(IStorageService):
 
     async def generate_presigned_url(self, s3_path: str, expiration_seconds: int = 3600) -> str:
         """
-        生成预签名 URL
+        Generate a presigned URL
 
         Args:
-            s3_path: S3 对象路径
-            expiration_seconds: 过期时间（秒）
+            s3_path: S3 object path
+            expiration_seconds: expiry in seconds
 
         Returns:
-            预签名 URL
+            The presigned URL
         """
         bucket, key = self._parse_s3_path(s3_path)
 
@@ -288,10 +288,10 @@ class S3Storage(IStorageService):
 
     async def delete_file(self, s3_path: str) -> None:
         """
-        删除文件
+        Delete a file
 
         Args:
-            s3_path: S3 对象路径
+            s3_path: S3 object path
         """
         bucket, key = self._parse_s3_path(s3_path)
 
@@ -301,38 +301,38 @@ class S3Storage(IStorageService):
 
     async def delete_prefix(self, prefix: str) -> int:
         """
-        删除指定前缀的所有文件（用于会话清理）
+        Delete every file under a prefix, used when cleaning up a session
 
         Args:
-            prefix: S3 路径前缀（例如: "sessions/sess_abc123/" 或 "s3://bucket/sessions/sess_abc123/"）
+            prefix: S3 path prefix, such as "sessions/sess_abc123/" or "s3://bucket/sessions/sess_abc123/"
 
         Returns:
-            删除的文件数量
+            How many files were deleted
         """
         deleted_count = 0
         bucket = self._bucket
 
-        # 如果 prefix 包含 bucket，提取出来
+        # Pull the bucket out when the prefix carries one
         if prefix.startswith("s3://"):
             parsed = urlparse(prefix)
             bucket = parsed.netloc
             prefix = parsed.path.lstrip("/")
 
-        # 使用 asyncio.to_thread 执行同步的列表和删除操作
+        # Run the synchronous list and delete through asyncio.to_thread
         def _delete_all_files():
-            """同步函数，执行批量删除"""
+            """Synchronous helper that performs the bulk delete"""
             count = 0
             paginator = self._client.get_paginator("list_objects_v2")
             delete_chunks = []
 
             try:
-                # 直接迭代 paginator（同步操作）
+                # Iterate the paginator directly, which is synchronous
                 for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
                     if "Contents" in page:
                         for obj in page["Contents"]:
                             delete_chunks.append({"Key": obj["Key"]})
 
-                        # 当累积到 1000 个对象时删除
+                # Delete once 1000 objects have accumulated
                         if len(delete_chunks) >= 1000:
                             self._client.delete_objects(
                                 Bucket=bucket, Delete={"Objects": delete_chunks}
@@ -340,7 +340,7 @@ class S3Storage(IStorageService):
                             count += len(delete_chunks)
                             delete_chunks = []
 
-                # 删除剩余的对象
+                # Delete whatever is left
                 if delete_chunks:
                     self._client.delete_objects(Bucket=bucket, Delete={"Objects": delete_chunks})
                     count += len(delete_chunks)
@@ -349,7 +349,7 @@ class S3Storage(IStorageService):
                 logger.error(f"Error deleting files with prefix {prefix}: {e}")
             return count
 
-        # 在线程池中执行同步操作
+        # Run the synchronous work in a thread pool
         deleted_count = await asyncio.to_thread(_delete_all_files)
 
         logger.info(f"Deleted {deleted_count} files with prefix {prefix} (bucket: {bucket})")
@@ -358,30 +358,30 @@ class S3Storage(IStorageService):
 
     async def list_files(self, prefix: str, limit: int = 1000) -> list:
         """
-        列出文件
+        List files
 
         Args:
-            prefix: S3 路径前缀
-            limit: 最大返回数量
+            prefix: S3 path prefix
+            limit: how many to return at most
 
         Returns:
-            文件列表，每个文件包含 key, size, last_modified
+            The file list, each entry holding key, size, and last_modified
         """
         bucket = self._bucket
 
-        # 如果 prefix 包含 bucket，提取出来
+        # Pull the bucket out when the prefix carries one
         if prefix.startswith("s3://"):
             parsed = urlparse(prefix)
             bucket = parsed.netloc
             prefix = parsed.path.lstrip("/")
 
         def _list_all_files():
-            """同步函数，执行列表操作"""
+            """Synchronous helper that performs the listing"""
             files = []
             paginator = self._client.get_paginator("list_objects_v2")
 
             try:
-                # 直接迭代 paginator（同步操作）
+                # Iterate the paginator directly, which is synchronous
                 for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
                     if "Contents" in page:
                         for obj in page["Contents"]:
@@ -401,7 +401,7 @@ class S3Storage(IStorageService):
                 logger.error(f"Error listing objects with prefix {prefix}: {e}")
             return files
 
-        # 在线程池中执行同步操作
+        # Run the synchronous work in a thread pool
         files = await asyncio.to_thread(_list_all_files)
 
         return files

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/__init__.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/__init__.py
@@ -1,7 +1,7 @@
 """
-API v1 路由包
+API v1 route package
 
-包含所有 v1 版本的 API 路由。
+Holds every v1 API route.
 """
 
 from src.interfaces.rest.api.v1 import sessions

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/executions.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/executions.py
@@ -1,7 +1,7 @@
 """
-执行 REST API 路由
+Execution REST API routes
 
-定义执行相关的 HTTP 端点。
+Defines the HTTP endpoints for executions.
 """
 
 import asyncio
@@ -31,9 +31,9 @@ from src.shared.i18n import message
 router = APIRouter(prefix="/executions", tags=["executions"])
 
 
-# 根据模式选择依赖注入函数
-# SQL 模式：使用 get_session_service_db（带 Depends() 注入仓储）
-# Mock 模式：使用 get_mock_session_service（从 app.state 获取）
+# Pick the dependency injection functions by mode.
+# SQL mode: get_session_service_db, which injects the repositories through Depends().
+# Mock mode: get_mock_session_service, which reads them off app.state.
 _get_session_service = get_session_service_db if USE_SQL_REPOSITORIES else get_mock_session_service
 
 
@@ -48,13 +48,13 @@ async def submit_execution(
     service: SessionService = Depends(_get_session_service),
 ):
     """
-    提交代码执行
+    Submit code for execution
 
-    - **code**: 要执行的代码
-    - **language**: 编程语言 (python, javascript, shell)
-    - **timeout**: 超时时间（秒），默认 30
-    - **event**: 事件数据
-    - **working_directory**: 可选执行目录，相对于 workspace 根目录
+    - **code**: the code to run
+    - **language**: programming language (python, javascript, shell)
+    - **timeout**: timeout in seconds, 30 by default
+    - **event**: event payload
+    - **working_directory**: optional working directory, relative to the workspace root
     """
     command = ExecuteCodeCommand(
         session_id=session_id,
@@ -186,7 +186,7 @@ async def _get_execution_with_fresh_session(execution_id: str) -> ExecutionDTO:
 async def get_execution_status(
     execution_id: str, service: SessionService = Depends(_get_session_service)
 ):
-    """获取执行状态"""
+    """Get the execution status"""
     query = GetExecutionQuery(execution_id=execution_id)
     execution_dto = await service.get_execution(query)
     return _map_dto_to_response(execution_dto)
@@ -196,7 +196,7 @@ async def get_execution_status(
 async def get_execution_result(
     execution_id: str, service: SessionService = Depends(_get_session_service)
 ):
-    """获取执行结果"""
+    """Get the execution result"""
     query = GetExecutionQuery(execution_id=execution_id)
     execution_dto = await service.get_execution(query)
     return _map_dto_to_response(execution_dto)
@@ -209,14 +209,14 @@ async def list_executions(
     offset: int = 0,
     service: SessionService = Depends(_get_session_service),
 ):
-    """列出会话的所有执行"""
+    """List every execution of a session"""
     executions = await service.list_executions(session_id=session_id, limit=limit)
 
     return {"items": executions, "total": len(executions), "limit": limit, "offset": offset}
 
 
 def _map_dto_to_response(dto: ExecutionDTO) -> ExecutionResponse:
-    """将 ExecutionDTO 映射为 ExecutionResponse"""
+    """Map an ExecutionDTO onto an ExecutionResponse"""
     return ExecutionResponse(
         id=dto.id,
         session_id=dto.session_id,

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/files.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/files.py
@@ -1,7 +1,7 @@
 """
-文件操作 REST API 路由
+File operation REST API routes
 
-定义文件上传下载相关的 HTTP 端点。
+Defines the HTTP endpoints for uploading and downloading files.
 """
 
 import fastapi
@@ -22,18 +22,18 @@ router = APIRouter(prefix="/sessions/{session_id}/files", tags=["files"])
 async def list_files(
     session_id: str,
     path: Optional[str] = Query(
-        None, description="指定目录路径（相对于 workspace 根目录），不指定则列出所有文件"
+        None, description="A directory, relative to the workspace root. Without it every file is listed."
     ),
-    limit: int = Query(1000, ge=1, le=10000, description="最大返回文件数"),
+    limit: int = Query(1000, ge=1, le=10000, description="How many files to return at most"),
     service: FileService = Depends(get_file_service_db),
 ):
     """
-    列出 session 下的文件
+    List the files of a session
 
-    返回该 session workspace 中的文件列表，支持指定目录路径
+    Returns the files in that session workspace, optionally under one directory.
 
-    - **path**: 可选，指定目录路径（如 "src/" 或 "src/utils"），不指定则列出所有文件
-    - **limit**: 最大返回文件数 (1-10000)
+    - **path**: optional directory, such as "src/" or "src/utils"; without it every file is listed
+    - **limit**: how many files to return, 1-10000
     """
     try:
         files = await service.list_files(session_id=session_id, path=path, limit=limit)
@@ -48,19 +48,19 @@ async def list_files(
 async def upload_file(
     session_id: str,
     path: str,
-    extract: bool = Query(False, description="是否将上传内容按 ZIP 压缩包自动解压到目标目录"),
-    overwrite: bool = Query(False, description="解压时是否覆盖已存在文件"),
+    extract: bool = Query(False, description="Whether to treat the upload as a ZIP and extract it into the target directory"),
+    overwrite: bool = Query(False, description="Whether extraction overwrites existing files"),
     file: UploadFile = File(...),
     service: FileService = Depends(get_file_service_db),
 ):
     """
-    上传文件到会话工作区
+    Upload a file into the session workspace
 
-    - **path**: 文件在工作区中的路径
-    - **file**: 要上传的文件（最大 100MB）
+    - **path**: where the file goes in the workspace
+    - **file**: the file to upload, 100MB at most
     """
     try:
-        # 验证文件大小
+        # Validate the file size
         settings = get_settings()
         content = await file.read()
         max_upload_bytes = settings.max_upload_file_size_mb * 1024 * 1024
@@ -119,9 +119,9 @@ async def download_file(
     session_id: str, file_path: str, service: FileService = Depends(get_file_service_db)
 ):
     """
-    从会话工作区下载文件
+    Download a file from the session workspace
 
-    - **file_path**: 文件在工作区中的路径
+    - **file_path**: where the file lives in the workspace
     """
     try:
         file_data = await service.download_file(session_id=session_id, path=file_path)

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/health.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/health.py
@@ -1,7 +1,7 @@
 """
-健康检查 REST API 路由
+Health check REST API routes
 
-定义健康检查和系统监控相关的 HTTP 端点。
+Defines the HTTP endpoints for health checks and system monitoring.
 """
 
 from fastapi import APIRouter, Depends
@@ -13,12 +13,12 @@ from src.interfaces.rest.schemas.response import HealthResponse
 
 router = APIRouter(prefix="/health", tags=["health"])
 
-# 应用启动时间
+# When the application started
 _start_time = time.time()
 
 
 class SystemStatus(BaseModel):
-    """系统状态"""
+    """System status"""
 
     status: str
     version: str
@@ -28,9 +28,9 @@ class SystemStatus(BaseModel):
 @router.get("", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
     """
-    健康检查端点
+    Health check endpoint
 
-    返回系统状态和运行时间。
+    Returns the system status and uptime.
     """
     return HealthResponse(status="healthy", version="2.1.0", uptime=time.time() - _start_time)
 
@@ -38,14 +38,14 @@ async def health_check() -> HealthResponse:
 @router.get("/detailed")
 async def detailed_health_check() -> dict:
     """
-    详细健康检查
+    Detailed health check
 
-    返回系统状态和依赖项健康状态。
+    Returns the system status and the health of its dependencies.
     """
-    # TODO: 实现依赖项健康检查
-    # - 数据库连接
-    # - S3 存储
-    # - 运行时节点
+    # TODO: check the dependencies
+    # - database connection
+    # - S3 storage
+    # - runtime nodes
     return {
         "status": "healthy",
         "version": "2.1.0",
@@ -57,9 +57,9 @@ async def detailed_health_check() -> dict:
 @router.post("/sync")
 async def trigger_state_sync() -> dict:
     """
-    手动触发状态同步
+    Trigger a state sync by hand
 
-    立即执行一次状态同步和健康检查，用于调试和手动恢复。
+    Runs one state sync and health check immediately, for debugging and manual recovery.
     """
     from src.infrastructure.dependencies import get_state_sync_service
 

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/internal.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/internal.py
@@ -1,8 +1,8 @@
 """
-内部 API 路由
+Internal API routes
 
-定义由 Executor 调用的内部 API 端点。
-这些端点仅在容器网络内可访问。
+The endpoints the executor calls.
+They are reachable only from inside the container network.
 """
 
 import logging
@@ -32,9 +32,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/internal", tags=["internal"])
 
 
-# 根据模式选择依赖注入函数
-# SQL 模式：使用 get_execution_repository（带 Depends() 注入数据库会话）
-# Mock 模式：使用从 app.state 获取仓储的函数
+# Pick the dependency injection functions by mode.
+# SQL mode: get_execution_repository, which injects the database session through Depends().
+# Mock mode: functions that read the repositories off app.state.
 if USE_SQL_REPOSITORIES:
     _get_execution_repository = get_sql_execution_repository
     _get_session_repository = get_sql_session_repository
@@ -56,17 +56,17 @@ async def handle_container_ready(
     session_repo=Depends(_get_session_repository),
 ):
     """
-    处理容器就绪事件
+    Handle the container-ready event
 
-    由 Executor 在启动完成后调用，通知控制平面容器已就绪。
-    更新对应的会话状态为 RUNNING。
+    The executor calls this once it has started, telling the control plane the container is ready.
+    Moves the matching session to RUNNING.
     """
     logger.info(f"Container ready event received: container_id={request.container_id}")
 
-    # 查找对应的会话
+    # Find the session
     session = await session_repo.find_by_container_id(request.container_id)
     if session:
-        # 更新会话状态为 RUNNING
+        # Move the session to RUNNING
         from src.domain.value_objects.execution_status import SessionStatus
 
         session.status = SessionStatus.RUNNING
@@ -82,9 +82,9 @@ async def handle_container_ready(
 @router.post("/containers/exited")
 async def handle_container_exited():
     """
-    处理容器退出事件
+    Handle the container-exit event
 
-    由 Executor 在关闭前调用，通知控制平面容器即将退出。
+    The executor calls this before shutting down, telling the control plane the container is about to exit.
     """
     logger.info("Container exited event received")
     # Currently just acknowledge - future: update container status in database
@@ -94,9 +94,9 @@ async def handle_container_exited():
 @router.post("/executions/{execution_id}/heartbeat")
 async def handle_execution_heartbeat(execution_id: str):
     """
-    处理执行心跳
+    Handle an execution heartbeat
 
-    由 Executor 在执行过程中定期调用，保持执行活跃状态。
+    The executor calls this periodically while running, keeping the execution marked active.
     """
     logger.debug(f"Heartbeat received for execution {execution_id}")
     # Currently just acknowledge - future: update last_heartbeat timestamp
@@ -114,21 +114,21 @@ async def report_execution_result(
     execution_repo: IExecutionRepository = Depends(_get_execution_repository),
 ):
     """
-    上报执行结果
+    Report an execution result
 
-    由 Executor 在执行完成后调用，上报执行结果到控制平面。
+    The executor calls this once execution finishes, reporting the result to the control plane.
 
-    ## 状态映射
+    ## Status mapping
     - API: `"success"` → Domain: `ExecutionStatus.COMPLETED`
     - API: `"failed"` → Domain: `ExecutionStatus.FAILED`
     - API: `"timeout"` → Domain: `ExecutionStatus.TIMEOUT`
     - API: `"crashed"` → Domain: `ExecutionStatus.CRASHED`
 
-    ## 幂等性
-    - 如果执行记录已经是终态，返回 200（重复上报）
-    - 如果是首次上报，更新后返回 201
+    ## Idempotency
+    - When the execution record is already terminal, answer 200; this is a repeat report
+    - On the first report, update and answer 201
     """
-    # 1. 查找执行记录
+    # 1. Find the execution record
     execution = await execution_repo.find_by_id(execution_id)
     if not execution:
         raise HTTPException(
@@ -136,12 +136,12 @@ async def report_execution_result(
             detail=message("Sandbox.Execution.NotFound", execution_id=execution_id),
         )
 
-    # 2. 检查是否已经是终态（幂等性）
+    # 2. Check whether it is already terminal, for idempotency
     if execution.is_terminal():
         logger.info(f"Execution {execution_id} already in terminal state: {execution.state.status}")
         return InternalAPIResponse(message="Result already recorded")
 
-    # 3. 映射 API 状态到域状态
+    # 3. Map the API status onto the domain status
     status_map: Dict[str, ExecutionStatus] = {
         "success": ExecutionStatus.COMPLETED,
         "failed": ExecutionStatus.FAILED,
@@ -156,16 +156,16 @@ async def report_execution_result(
             detail=message("Sandbox.Execution.InvalidStatus", status=report.status),
         )
 
-    # 4. 自动转换 PENDING → RUNNING（如果需要）
-    # 根据领域规则，必须是 PENDING → RUNNING → COMPLETED/FAILED/TIMEOUT/CRASHED
-    # 但 executor 报告结果时可能已经完成了，所以自动处理这个转换
+    # 4. Move PENDING to RUNNING automatically when needed.
+    # The domain rule is PENDING -> RUNNING -> COMPLETED/FAILED/TIMEOUT/CRASHED,
+    # but the executor may report a finished result, so that step happens here.
     if execution.state.status == ExecutionStatus.PENDING:
         execution.mark_running()
 
-    # 5. 根据状态更新执行实体
+    # 5. Update the execution entity for the reported status
     try:
         if domain_status == ExecutionStatus.COMPLETED:
-            # 转换 artifacts 字符串列表为 Artifact 对象
+            # Turn the artifact strings into Artifact objects
             now = datetime.now()
             artifact_objects = [
                 Artifact(
@@ -174,7 +174,7 @@ async def report_execution_result(
                 for path in report.artifacts
             ]
 
-            # 转换 metrics
+            # Convert the metrics
             metrics_dict = None
             if report.metrics:
                 metrics_dict = {
@@ -196,7 +196,7 @@ async def report_execution_result(
             )
 
         elif domain_status == ExecutionStatus.FAILED:
-            # 使用 stderr 作为错误消息，同时保存 stdout 和 stderr
+            # Use stderr as the error message, keeping both stdout and stderr
             error_message = report.stderr if report.stderr else "Execution failed"
             execution.mark_failed(
                 error_message=error_message,
@@ -211,10 +211,10 @@ async def report_execution_result(
         elif domain_status == ExecutionStatus.CRASHED:
             execution.mark_crashed()
 
-        # 6. 保存到仓储
+        # 6. Persist
         await execution_repo.save(execution)
 
-        # 6.5. 提交事务，确保其他请求可以立即看到更新后的执行状态
+        # 6.5. Commit, so other requests see the updated execution status at once
         await execution_repo.commit()
 
         logger.info(
@@ -222,14 +222,14 @@ async def report_execution_result(
             f"exit_code={report.exit_code}"
         )
 
-        # 6. 返回 201 表示首次创建
+        # 6. Answer 201 for the first report
         return JSONResponse(
             status_code=status.HTTP_201_CREATED,
             content={"message": "Result recorded successfully"},
         )
 
     except ValueError as e:
-        # 状态转换错误（例如从未完成状态直接尝试标记为完成）
+        # An invalid status transition, such as marking a never-finished execution complete
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=message("Sandbox.State.Conflict", error=str(e)),

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/sessions.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/sessions.py
@@ -1,7 +1,7 @@
 """
-会话 REST API 路由
+Session REST API routes
 
-定义会话相关的 HTTP 端点。
+Defines the HTTP endpoints for sessions.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status, Response
@@ -45,18 +45,18 @@ async def create_session(
     request: CreateSessionRequest, service: SessionService = Depends(get_session_service_db)
 ):
     """
-    创建会话
+    Create a session
 
-    - **template_id**: 模板 ID；未传时使用 DEFAULT_TEMPLATE_ID 配置
-    - **timeout**: 超时时间（秒），默认 300，最大 3600
-    - **cpu**: CPU 核心数，如 "1", "2"
-    - **memory**: 内存限制，如 "512Mi", "1Gi"
-    - **disk**: 磁盘限制，如 "1Gi", "10Gi"
-    - **env_vars**: 环境变量字典
-    - **dependencies**: 会话级依赖包列表（新增）
-    - **install_timeout**: 依赖安装超时时间（秒），默认 300（新增）
-    - **fail_on_dependency_error**: 依赖安装失败时是否终止会话创建（新增）
-    - **allow_version_conflicts**: 是否允许版本冲突（新增）
+    - **template_id**: template id; without it DEFAULT_TEMPLATE_ID applies
+    - **timeout**: timeout in seconds, 300 by default, 3600 at most
+    - **cpu**: CPU cores, such as "1" or "2"
+    - **memory**: memory limit, such as "512Mi" or "1Gi"
+    - **disk**: disk limit, such as "1Gi" or "10Gi"
+    - **env_vars**: environment variables
+    - **dependencies**: session-level dependency packages
+    - **install_timeout**: dependency install timeout in seconds, 300 by default
+    - **fail_on_dependency_error**: whether a failed dependency install aborts session creation
+    - **allow_version_conflicts**: whether a version conflict is allowed
     """
     from src.domain.value_objects.resource_limit import ResourceLimit
 
@@ -96,14 +96,14 @@ async def list_sessions(
     service: SessionService = Depends(get_session_service_db),
 ):
     """
-    列出会话
+    List sessions
 
-    支持按 status 和 template_id 筛选，以及分页。
+    Filters by status and template_id, and pages.
 
-    - **status**: 会话状态筛选（可选），如 "running", "terminated"
-    - **template_id**: 模板 ID 筛选（可选）
-    - **limit**: 返回数量限制（1-200，默认 50）
-    - **offset**: 偏移量（用于分页，默认 0）
+    - **status**: filter by session status, optional, such as "running" or "terminated"
+    - **template_id**: filter by template id, optional
+    - **limit**: how many to return, 1-200, default 50
+    - **offset**: offset, for paging, default 0
     """
     result = await service.list_sessions(
         status=status, template_id=template_id, limit=limit, offset=offset
@@ -120,7 +120,7 @@ async def list_sessions(
 
 @router.get("/{session_id}", response_model=SessionResponse)
 async def get_session(session_id: str, service: SessionService = Depends(get_session_service_db)):
-    """获取会话详情"""
+    """Get the session details"""
     from src.application.queries.get_session import GetSessionQuery
 
     query = GetSessionQuery(session_id=session_id)
@@ -137,7 +137,7 @@ async def install_session_dependencies(
     request: InstallSessionDependenciesRequest,
     service: SessionService = Depends(get_session_service_db),
 ):
-    """增量安装 Python 依赖。"""
+    """Install Python dependencies incrementally."""
     try:
         command = InstallSessionDependenciesCommand(
             session_id=session_id,
@@ -160,13 +160,13 @@ async def terminate_session(
     session_id: str, service: SessionService = Depends(get_session_service_db)
 ):
     """
-    终止会话（软终止，保留记录）
+    Terminate a session: a soft stop that keeps the record
 
-    行为：
-    1. 销毁容器
-    2. 删除 S3 工作区文件
-    3. 更新会话状态为 terminated
-    4. 保留数据库记录
+    What happens:
+    1. The container is destroyed
+    2. The S3 workspace files are deleted
+    3. The session moves to terminated
+    4. The database record is kept
     """
     session_dto = await service.terminate_session(session_id)
     return _map_dto_to_response(session_dto)
@@ -177,19 +177,19 @@ async def delete_session(
     session_id: str, service: SessionService = Depends(get_session_service_db)
 ):
     """
-    删除会话（硬删除，级联删除执行记录）
+    Delete a session: a hard delete that cascades to the execution records
 
-    行为：
-    1. 执行清理（销毁容器 + 删除 S3 文件）
-    2. 硬删除 session 记录
-    3. 级联删除所有关联的 execution 记录
+    What happens:
+    1. Clean up: destroy the container and delete the S3 files
+    2. Hard-delete the session row
+    3. Cascade-delete every execution row that belongs to it
     """
     await service.delete_session(session_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 def _map_dto_to_response(dto: SessionDTO) -> SessionResponse:
-    """将 SessionDTO 映射为 SessionResponse"""
+    """Map a SessionDTO onto a SessionResponse"""
     return SessionResponse(
         id=dto.id,
         template_id=dto.template_id,

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/templates.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/api/v1/templates.py
@@ -1,7 +1,7 @@
 """
-模板 REST API 路由
+Template REST API routes
 
-定义模板相关的 HTTP 端点。
+Defines the HTTP endpoints for templates.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -24,17 +24,17 @@ async def create_template(
     request: CreateTemplateRequest, service: TemplateService = Depends(get_template_service_db)
 ):
     """
-    创建模板
+    Create a template
 
-    - **id**: 模板 ID
-    - **name**: 模板名称
-    - **image_url**: 镜像 URL
-    - **runtime_type**: 运行时类型 (python3.11, nodejs20, java17, go1.21)
-    - **default_cpu_cores**: 默认 CPU 核心数
-    - **default_memory_mb**: 默认内存（MB）
-    - **default_disk_mb**: 默认磁盘（MB）
-    - **default_timeout_sec**: 默认超时时间（秒）
-    - **default_env_vars**: 默认环境变量
+    - **id**: template id
+    - **name**: template name
+    - **image_url**: image URL
+    - **runtime_type**: runtime type (python3.11, nodejs20, java17, go1.21)
+    - **default_cpu_cores**: default CPU cores
+    - **default_memory_mb**: default memory in MB
+    - **default_disk_mb**: default disk in MB
+    - **default_timeout_sec**: default timeout in seconds
+    - **default_env_vars**: default environment variables
     """
     command = CreateTemplateCommand(
         template_id=request.id,
@@ -56,7 +56,7 @@ async def create_template(
 async def list_templates(
     limit: int = 50, offset: int = 0, service: TemplateService = Depends(get_template_service_db)
 ):
-    """列出所有模板"""
+    """List every template"""
     templates = await service.list_templates(limit=limit, offset=offset)
     return [_map_dto_to_response(t) for t in templates]
 
@@ -65,7 +65,7 @@ async def list_templates(
 async def get_template(
     template_id: str, service: TemplateService = Depends(get_template_service_db)
 ):
-    """获取模板详情"""
+    """Get the template details"""
     query = GetTemplateQuery(template_id=template_id)
     template_dto = await service.get_template(query)
     return _map_dto_to_response(template_dto)
@@ -77,7 +77,7 @@ async def update_template(
     request: UpdateTemplateRequest,
     service: TemplateService = Depends(get_template_service_db),
 ):
-    """更新模板"""
+    """Update the template"""
     command = UpdateTemplateCommand(
         template_id=template_id,
         name=request.name,
@@ -97,13 +97,13 @@ async def update_template(
 async def delete_template(
     template_id: str, service: TemplateService = Depends(get_template_service_db)
 ):
-    """删除模板"""
+    """Delete the template"""
     await service.delete_template(template_id)
     return {"message": "Template deleted successfully"}
 
 
 def _map_dto_to_response(dto: TemplateDTO) -> TemplateResponse:
-    """将 TemplateDTO 映射为 TemplateResponse"""
+    """Map a TemplateDTO onto a TemplateResponse"""
     return TemplateResponse(
         id=dto.id,
         name=dto.name,

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/main.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/main.py
@@ -1,7 +1,7 @@
 """
-FastAPI 主应用
+FastAPI application
 
-沙箱控制中心的 FastAPI 应用入口。
+Entry point of the sandbox control plane FastAPI application.
 """
 
 import time
@@ -40,34 +40,34 @@ from src.interfaces.rest.api.v1 import (
 )
 from src.interfaces.rest.schemas.response import HealthResponse
 
-# 应用启动时间
+# When the application started
 _start_time = time.time()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
-    应用生命周期管理
+    Application lifespan management
 
-    处理应用启动和关闭时的逻辑。
+    Handles what happens on start-up and on shutdown.
     """
-    # 启动时执行
+    # Start-up
     logger.info("Starting Sandbox Control Plane")
 
-    # 初始化依赖注入
+    # Wire up dependency injection
     from src.infrastructure.dependencies import initialize_dependencies, get_storage_service
 
     initialize_dependencies(app)
     logger.info("Dependencies initialized")
 
-    # 初始化 S3 storage（确保 bucket 存在）
+    # Initialize S3 storage, making sure the bucket exists
     try:
         storage_service = get_storage_service()
         await storage_service.initialize()
     except Exception as e:
         logger.warning(f"S3 storage initialization failed (continuing): {e}")
 
-    # 初始化数据库并创建表
+    # Initialize the database and create the tables
     from src.infrastructure.persistence.database import db_manager
     from src.infrastructure.config.settings import get_settings
 
@@ -79,18 +79,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     await db_manager.run_startup_schema_migrations()
     logger.info("Startup schema migrations completed")
 
-    # 根据环境决定是否自动创建表和初始化数据
+    # Whether tables and seed data are created automatically depends on the environment
     from src.infrastructure.config.settings import get_settings
 
     settings = get_settings()
     if settings.environment in ("development", "staging"):
         from src.infrastructure.persistence.seed.seeder import seed_default_data
 
-        # 创建表
+        # Create the tables
         await db_manager.create_tables()
         logger.info("Database tables created")
 
-        # 初始化默认数据
+        # Seed the default data
         seed_stats = await seed_default_data(force=False)
         logger.info(
             "Default data initialized",
@@ -98,7 +98,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             templates=seed_stats["templates"],
         )
 
-    # ============= 启动时状态同步 =============
+    # ============= State sync at start-up =============
     from src.infrastructure.dependencies import get_state_sync_service
 
     state_sync_service = get_state_sync_service()
@@ -117,22 +117,22 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     except Exception as e:
         logger.error("Failed to perform startup state sync", error=str(e), exc_info=True)
 
-    # ============= 启动后台任务管理器 =============
+    # ============= Start the background task manager =============
     from src.infrastructure.background_tasks import BackgroundTaskManager
     from src.infrastructure.dependencies import get_state_sync_service
 
     background_task_manager = BackgroundTaskManager()
 
-    # 注册定时健康检查任务（每 30 秒）
+    # Register the periodic health check, every 30 seconds
     state_sync_svc = get_state_sync_service()
     background_task_manager.register_task(
         name="health_check",
         func=state_sync_svc.periodic_health_check,
         interval_seconds=30,
-        initial_delay_seconds=30,  # 首次执行延迟 30 秒
+        initial_delay_seconds=30,  # delay the first run by 30 seconds
     )
 
-    # 注册会话清理任务（每 5 分钟）
+    # Register session cleanup, every 5 minutes
     from src.application.services.session_cleanup_service import SessionCleanupService
     from src.infrastructure.dependencies import get_docker_scheduler_service, get_storage_service
     from src.infrastructure.persistence.repositories.sql_session_repository import (
@@ -141,7 +141,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     from src.infrastructure.persistence.database import db_manager
 
     async def session_cleanup_task():
-        """会话清理任务（每次执行时创建新的 repository）"""
+        """Session cleanup task; builds a fresh repository on every run"""
         async with db_manager.get_session() as session:
             session_repo = SqlSessionRepository(session)
             scheduler = get_docker_scheduler_service(
@@ -161,15 +161,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     background_task_manager.register_task(
         name="session_cleanup",
         func=session_cleanup_task,
-        interval_seconds=300,  # 5 分钟
-        initial_delay_seconds=60,  # 首次执行延迟 1 分钟
+        interval_seconds=300,  # 5 minutes
+        initial_delay_seconds=60,  # delay the first run by 1 minute
     )
 
-    # 注册会话创建超时检测任务（每 5 分钟）
+    # Register session creation timeout detection, every 5 minutes
     from src.application.services.session_stuck_creating_service import SessionStuckCreatingService
 
     async def stuck_creating_check_task():
-        """会话创建超时检测任务（每次执行时创建新的 repository）"""
+        """Session creation timeout task; builds a fresh repository on every run"""
         async with db_manager.get_session() as session:
             session_repo = SqlSessionRepository(session)
             stuck_creating_svc = SessionStuckCreatingService(
@@ -181,28 +181,28 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     background_task_manager.register_task(
         name="stuck_creating_check",
         func=stuck_creating_check_task,
-        interval_seconds=300,  # 5 分钟，与清理任务一致
-        initial_delay_seconds=60,  # 首次执行延迟 1 分钟
+        interval_seconds=300,  # 5 minutes, matching the cleanup task
+        initial_delay_seconds=60,  # delay the first run by 1 minute
     )
 
-    # 启动所有后台任务
+    # Start every background task
     await background_task_manager.start_all()
     logger.info(f"Background tasks started: {background_task_manager.task_count} tasks")
 
-    # 将后台任务管理器存储到 app.state，以便关闭时使用
+    # Keep the background task manager on app.state, for shutdown
     app.state.background_task_manager = background_task_manager
 
     yield
 
-    # 关闭时执行
+    # Shutdown
     logger.info("Shutting down Sandbox Control Plane")
 
-    # 停止所有后台任务
+    # Stop every background task
     if hasattr(app.state, "background_task_manager"):
         await app.state.background_task_manager.stop_all()
         logger.info("Background tasks stopped")
 
-    # 清理依赖项（包括关闭数据库连接）
+    # Clean up the dependencies, closing the database connections
     from src.infrastructure.dependencies import cleanup_dependencies
 
     await cleanup_dependencies(app)
@@ -211,13 +211,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 def create_app() -> FastAPI:
     """
-    创建 FastAPI 应用
+    Create the FastAPI application
 
-    使用工厂模式创建应用，便于测试和配置。
+    A factory, which keeps it testable and configurable.
     """
     app = FastAPI(
         title="Sandbox Control Plane",
-        description="代码沙箱管理平台 API",
+        description="Code sandbox management platform API",
         version="2.1.0",
         docs_url="/docs",
         redoc_url="/redoc",
@@ -225,25 +225,25 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    # 配置 CORS
+    # Configure CORS
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # 生产环境应配置具体域名
+        allow_origins=["*"],  # production should name the actual origins
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
 
-    # 添加 Gzip 压缩
+    # Add Gzip compression
     app.add_middleware(GZipMiddleware, minimum_size=1000)
 
-    # 注册异常处理器
+    # Register the exception handlers
     _register_exception_handlers(app)
 
-    # 注册中间件
+    # Register the middleware
     _register_middleware(app)
 
-    # 注册路由
+    # Register the routes
     _register_routes(app)
 
     return app
@@ -266,12 +266,12 @@ def _apply_language_headers(response, path: str, effective_locale: str) -> None:
 
 
 def _register_exception_handlers(app: FastAPI) -> None:
-    """注册异常处理器"""
+    """Register the exception handlers"""
     from src.shared.errors.domain import NotFoundError, ValidationError
 
     @app.exception_handler(NotFoundError)
     async def not_found_exception_handler(request: Request, exc: NotFoundError) -> JSONResponse:
-        """404 异常处理"""
+        """404 handling"""
         logger.warning(
             "Resource not found",
             path=request.url.path,
@@ -289,7 +289,7 @@ def _register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(ValidationError)
     async def validation_exception_handler(request: Request, exc: ValidationError) -> JSONResponse:
-        """409 Conflict 异常处理"""
+        """409 Conflict handling"""
         logger.warning(
             "Validation error (conflict)",
             path=request.url.path,
@@ -307,7 +307,7 @@ def _register_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(Exception)
     async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
-        """全局异常处理"""
+        """Global exception handling"""
         logger.error(
             "Unhandled exception",
             path=request.url.path,
@@ -336,20 +336,20 @@ def _register_exception_handlers(app: FastAPI) -> None:
 
 
 def _register_routes(app: FastAPI) -> None:
-    """注册路由"""
+    """Register the routes"""
 
-    # 注册所有 API 路由
+    # Register every API route
     app.include_router(health.router, prefix="/api/v1")
     app.include_router(sessions.router, prefix="/api/v1")
     app.include_router(executions.router, prefix="/api/v1")
     app.include_router(templates.router, prefix="/api/v1")
     app.include_router(files.router, prefix="/api/v1")
-    app.include_router(internal.router, prefix="/api/v1")  # 内部 API
+    app.include_router(internal.router, prefix="/api/v1")  # internal API
 
-    # 根端点
+    # Root endpoint
     @app.get("/", tags=["root"])
     async def root() -> dict:
-        """根端点"""
+        """Root endpoint"""
         return {
             "name": "Sandbox Control Plane",
             "version": "2.1.0",
@@ -370,7 +370,7 @@ def _register_routes(app: FastAPI) -> None:
 
 
 def _register_middleware(app: FastAPI) -> None:
-    """注册中间件"""
+    """Register the middleware"""
 
     @app.middleware("http")
     async def locale_middleware(request: Request, call_next):
@@ -399,7 +399,7 @@ def _register_middleware(app: FastAPI) -> None:
     app.add_middleware(RequestLoggingMiddleware)
 
 
-# 创建应用实例
+# Create the application instance
 app = create_app()
 
 

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/internal.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/internal.py
@@ -1,7 +1,7 @@
 """
-内部 API 请求和响应模式
+Internal API request and response schemas
 
-定义 Executor 调用的内部 API 的 Pydantic 模型。
+The Pydantic models for the internal API the executor calls.
 """
 
 from pydantic import BaseModel, Field
@@ -9,52 +9,52 @@ from typing import Optional, Dict, Any, List
 
 
 class ExecutionMetrics(BaseModel):
-    """执行性能指标"""
+    """Execution performance metrics"""
 
-    duration_ms: float = Field(..., description="墙钟耗时（毫秒）")
-    cpu_time_ms: Optional[float] = Field(None, description="CPU 时间（毫秒）")
-    peak_memory_mb: Optional[float] = Field(None, description="内存峰值（MB）")
-    io_read_bytes: Optional[int] = Field(None, description="读取字节数")
-    io_write_bytes: Optional[int] = Field(None, description="写入字节数")
+    duration_ms: float = Field(..., description="Wall-clock duration in milliseconds")
+    cpu_time_ms: Optional[float] = Field(None, description="CPU time in milliseconds")
+    peak_memory_mb: Optional[float] = Field(None, description="Peak memory in MB")
+    io_read_bytes: Optional[int] = Field(None, description="Bytes read")
+    io_write_bytes: Optional[int] = Field(None, description="Bytes written")
 
 
 class ArtifactMetadata(BaseModel):
-    """文件元数据"""
+    """File metadata"""
 
-    path: str = Field(..., description="相对于 workspace 的文件路径")
-    size: int = Field(..., description="文件大小（字节）")
-    mime_type: str = Field(..., description="MIME 类型")
-    type: str = Field(..., description="文件类型: artifact, log, output")
-    checksum: Optional[str] = Field(None, description="SHA256 校验和")
+    path: str = Field(..., description="File path, relative to the workspace")
+    size: int = Field(..., description="File size in bytes")
+    mime_type: str = Field(..., description="MIME type")
+    type: str = Field(..., description="File type: artifact, log, or output")
+    checksum: Optional[str] = Field(None, description="SHA256 checksum")
 
 
 class ExecutionResultReport(BaseModel):
     """
-    执行结果上报请求
+    Execution result report request
 
-    由 Executor 调用，上报执行结果到控制平面。
+    The executor calls this to report a result to the control plane.
     """
 
-    status: str = Field(..., description="执行状态: success, failed, timeout, crashed")
-    stdout: str = Field("", description="标准输出")
-    stderr: str = Field("", description="标准错误")
-    exit_code: int = Field(..., description="进程退出码")
-    execution_time: float = Field(..., description="执行耗时（秒）")
-    return_value: Optional[Any] = Field(None, description="handler 函数返回值")
-    metrics: Optional[ExecutionMetrics] = Field(None, description="性能指标")
-    artifacts: List[str] = Field(default_factory=list, description="生成的文件路径列表")
+    status: str = Field(..., description="Execution status: success, failed, timeout, or crashed")
+    stdout: str = Field("", description="Standard output")
+    stderr: str = Field("", description="Standard error")
+    exit_code: int = Field(..., description="Process exit code")
+    execution_time: float = Field(..., description="Execution duration in seconds")
+    return_value: Optional[Any] = Field(None, description="Return value of the handler function")
+    metrics: Optional[ExecutionMetrics] = Field(None, description="Performance metrics")
+    artifacts: List[str] = Field(default_factory=list, description="Paths of the files that were produced")
 
 
 class InternalAPIResponse(BaseModel):
-    """内部 API 标准响应"""
+    """Standard internal API response"""
 
-    message: str = Field(..., description="响应消息")
+    message: str = Field(..., description="Response message")
 
 
 class ContainerReadyRequest(BaseModel):
-    """容器就绪请求"""
+    """Container-ready request"""
 
-    container_id: str = Field(..., description="容器 ID")
-    pod_name: Optional[str] = Field(None, description="Pod 名称（Kubernetes）")
-    executor_port: int = Field(8080, description="执行器 HTTP API 端口")
-    ready_at: Optional[str] = Field(None, description="就绪时间（ISO 8601）")
+    container_id: str = Field(..., description="Container id")
+    pod_name: Optional[str] = Field(None, description="Pod name, under Kubernetes")
+    executor_port: int = Field(8080, description="Executor HTTP API port")
+    ready_at: Optional[str] = Field(None, description="Ready timestamp, ISO 8601")

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/request.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/request.py
@@ -1,7 +1,7 @@
 """
-REST API 请求模式
+REST API request schemas
 
-定义 FastAPI 的请求 Pydantic 模型。
+Defines the Pydantic request models FastAPI uses.
 """
 
 import re
@@ -12,42 +12,42 @@ from typing import Literal, Optional, Dict, List
 
 class DependencySpec(BaseModel):
     """
-    依赖包规范
+    Dependency package specification
 
-    用于指定会话创建时需要安装的 Python 包。
-    按照 sandbox-design-v2.1.md 章节 5.3.1 设计。
+    Names a Python package to install when a session is created.
+    Follows section 5.3.1 of sandbox-design-v2.1.md.
     """
 
-    name: str = Field(..., min_length=1, max_length=100, description="包名称")
-    version: Optional[str] = Field(None, description="版本约束 (如: ==2.31.0, >=1.0)")
+    name: str = Field(..., min_length=1, max_length=100, description="Package name")
+    version: Optional[str] = Field(None, description="Version constraint, such as ==2.31.0 or >=1.0")
 
     @field_validator("name")
     @classmethod
     def validate_package_name(cls, v: str) -> str:
         """
-        验证包名格式
+        Validate the package name format
 
-        禁止：
-        - 路径穿越字符 (..)
-        - 绝对路径 (/)
+        Rejects:
+        - path traversal (..)
+        - an absolute path (/)
         - URL (://)
-        - 非法字符（仅允许字母、数字、._-）
-        - 版本号混合在包名中 (如 pandas2.3.3 应该是 name="pandas", version="==2.3.3")
+        - illegal characters; only letters, digits, and ._- are allowed
+        - a version mixed into the name, such as pandas2.3.3, which should be name="pandas", version="==2.3.3"
         """
-        # 禁止路径穿越
+        # Reject path traversal
         if ".." in v or v.startswith("/"):
             raise ValueError("Package name cannot contain path traversal characters")
-        # 禁止 URL
+        # Reject a URL
         if "://" in v:
             raise ValueError("Package name cannot contain URL")
-        # PyPI 包名规范：仅允许字母、数字、._-
+        # PyPI naming rules: letters, digits, and ._- only
         if not re.match(r"^[a-zA-Z0-9._-]+$", v):
             raise ValueError("Invalid package name format")
 
-        # 检测常见的版本号混合错误（如 pandas2.3.3, numpy1.24.0）
-        # 模式：字母开头 + 数字 + 点 + 数字（可能是版本号）
+        # Catch the common mistake of a version glued onto the name (pandas2.3.3, numpy1.24.0).
+        # The pattern is: letter, then digit, dot, digit, which looks like a version.
         if re.match(r"^[a-zA-Z]+[0-9]+\.[0-9]", v):
-            # 提取包名和版本号用于错误提示
+            # Split out the name and version for the error message
             package_name = re.sub(r"[0-9]+\.[0-9].*", "", v)
             version_num = re.sub(r"^[a-zA-Z]+", "", v)
             raise ValueError(
@@ -60,20 +60,20 @@ class DependencySpec(BaseModel):
 
     def to_pip_spec(self) -> str:
         """
-        转换为 pip 安装规范
+        Convert to a pip requirement specifier
 
-        自动为没有操作符的版本号添加 == 前缀。
-        例如：version="2.3.3" 会被转换为 "==2.3.3"
+        A version with no operator gets == in front.
+        For example version="2.3.3" becomes "==2.3.3".
 
         Returns:
-            pip 包规范字符串，如 "requests==2.31.0" 或 "pandas"
+            The pip specifier, such as "requests==2.31.0" or "pandas"
         """
         if self.version:
-            # 检查 version 是否以操作符开头
-            # pip 支持的操作符: ==, >=, <=, >, <, ~=, !=, ~, =
+            # Check whether the version already starts with an operator.
+            # pip accepts: ==, >=, <=, >, <, ~=, !=, ~, =
             version_operators = ("==", ">=", "<=", ">", "<", "~=", "!=", "~", "=")
             if not self.version.startswith(version_operators):
-                # 如果没有操作符，默认添加 ==
+                # Without an operator, default to ==
                 return f"{self.name}=={self.version}"
             return f"{self.name}{self.version}"
         return self.name
@@ -81,46 +81,47 @@ class DependencySpec(BaseModel):
 
 class CreateSessionRequest(BaseModel):
     """
-    创建会话请求
+    Create-session request
 
-    按照 sandbox-design-v2.1.md 章节 5.3.1 设计，扩展支持依赖安装。
+    Follows section 5.3.1 of sandbox-design-v2.1.md, extended for dependency installation.
     """
 
     id: Optional[str] = Field(
-        None, min_length=1, max_length=64, description="会话 ID（可选，手动指定时需确保唯一性）"
+        None, min_length=1, max_length=64, description="Session id. Optional; when given it has to be unique."
     )
     template_id: Optional[str] = Field(
-        None, min_length=1, max_length=64, description="模板 ID；未传时使用默认模板配置"
+        None, min_length=1, max_length=64, description="Template id. Without it the default template configuration applies."
     )
-    timeout: int = Field(300, ge=1, le=3600, description="超时时间（秒）")
-    cpu: str = Field("1", description="CPU 核心数")
-    memory: str = Field("512Mi", description="内存限制")
-    disk: str = Field("1Gi", description="磁盘限制")
-    env_vars: Dict[str, str] = Field(default_factory=dict, description="环境变量")
-    event: Optional[Dict] = Field(None, description="事件数据")
+    timeout: int = Field(300, ge=1, le=3600, description="Timeout in seconds")
+    cpu: str = Field("1", description="CPU cores")
+    memory: str = Field("512Mi", description="Memory limit")
+    disk: str = Field("1Gi", description="Disk limit")
+    env_vars: Dict[str, str] = Field(default_factory=dict, description="Environment variables")
+    event: Optional[Dict] = Field(None, description="Event payload")
 
-    # 依赖安装相关字段（新增）
+    # Dependency installation fields
     dependencies: List[DependencySpec] = Field(
-        default_factory=list, max_length=50, description="会话级依赖包列表"
+        default_factory=list, max_length=50, description="Session-level dependency packages"
     )
-    install_timeout: int = Field(300, ge=30, le=1800, description="依赖安装超时时间（秒）")
-    fail_on_dependency_error: bool = Field(True, description="依赖安装失败时是否终止会话创建")
+    install_timeout: int = Field(300, ge=30, le=1800, description="Dependency install timeout in seconds")
+    fail_on_dependency_error: bool = Field(True, description="Whether a failed dependency install aborts session creation")
     allow_version_conflicts: bool = Field(
-        False, description="是否允许版本冲突（Template 预装包 vs 用户请求包）"
+        False, description="Whether a version conflict is allowed between the template preinstall and the requested package"
     )
     python_package_index_url: Optional[str] = Field(
-        None, max_length=512, description="Python 软件包仓库地址，默认 https://pypi.org/simple/"
+        None, max_length=512, description="Python package index URL, https://pypi.org/simple/ by default"
     )
 
     @field_validator("id", "template_id")
     @classmethod
     def validate_identifier(cls, v: Optional[str]) -> Optional[str]:
         """
-        会话 ID / 模板 ID 只允许字母、数字、下划线、连字符。
+        A session id or template id may hold only letters, digits, underscores, and hyphens.
 
-        安全关键：id 会经 workspace_path 落入以 root 运行的 s3fs 挂载脚本
-        （k8s/docker scheduler）。放行 shell 元字符会造成 root 命令注入，放行
-        '/'、'..' 会造成前缀逃逸、绕过会话间隔离。此处严格白名单从入口拦住。
+        Security critical: the id travels through workspace_path into the s3fs mount script
+        that runs as root (the k8s and docker schedulers). Allowing a shell metacharacter
+        would be root command injection, and allowing '/' or '..' would escape the prefix
+        and break the isolation between sessions. A strict allowlist stops both at the entrance.
         """
         if v is None:
             return v
@@ -141,26 +142,26 @@ class CreateSessionRequest(BaseModel):
 
 
 class ExecuteCodeRequest(BaseModel):
-    """执行代码请求"""
+    """Execute-code request"""
 
     code: str = Field(
         ...,
         min_length=1,
         max_length=102400,
-        description="要执行的代码。language=python 时需符合 AWS Lambda handler 格式；language=shell 时表示 shell 脚本内容。",
+        description="The code to run. With language=python it has to match the AWS Lambda handler shape; with language=shell it is the shell script body.",
     )
-    language: Literal["python", "javascript", "shell"] = Field(..., description="编程语言")
-    timeout: int = Field(30, ge=1, le=3600, description="执行超时（秒）")
-    event: Optional[Dict] = Field(None, description="事件数据")
+    language: Literal["python", "javascript", "shell"] = Field(..., description="Programming language")
+    timeout: int = Field(30, ge=1, le=3600, description="Execution timeout in seconds")
+    event: Optional[Dict] = Field(None, description="Event payload")
     env_vars: Dict[str, str] = Field(
         default_factory=dict,
         description=(
-            "本次执行的环境变量，覆盖会话创建时的同名值。"
-            "会话是池化复用的，调用方身份这类随执行变化的信息必须每次下发。"
+            "Environment variables for this execution, overriding the values set when the session was created. "
+            "Sessions are pooled and reused, so anything that varies per execution, such as the caller identity, has to be sent every time."
         ),
     )
     working_directory: Optional[str] = Field(
-        None, description="可选执行目录，相对于 workspace 根目录；未传时默认使用 workspace 根目录。"
+        None, description="Optional working directory, relative to the workspace root. Without it the workspace root is used."
     )
 
     @field_validator("working_directory")
@@ -214,56 +215,56 @@ class ExecuteCodeRequest(BaseModel):
 
 
 class TerminateSessionRequest(BaseModel):
-    """终止会话请求"""
+    """Terminate-session request"""
 
-    reason: Optional[str] = Field(None, description="终止原因")
+    reason: Optional[str] = Field(None, description="Reason for terminating")
 
 
 class InstallSessionDependenciesRequest(BaseModel):
-    """增量安装 Python 依赖请求。"""
+    """Incremental Python dependency install request."""
 
     python_package_index_url: Optional[str] = Field(
         None,
         max_length=512,
-        description="Python 软件包仓库地址；未传则沿用当前 session 配置",
+        description="Python package index URL. Without it the current session setting applies.",
     )
     dependencies: List[DependencySpec] = Field(
         ...,
         min_length=1,
         max_length=50,
-        description="本次增量安装的依赖列表",
+        description="Dependencies to install in this batch",
     )
     install_timeout: int = Field(
         300,
         ge=30,
         le=1800,
-        description="本次依赖安装超时时间（秒）",
+        description="Timeout in seconds for this dependency install",
     )
 
 
 class CreateTemplateRequest(BaseModel):
-    """创建模板请求"""
+    """Create-template request"""
 
-    id: str = Field(..., min_length=1, max_length=64, description="模板 ID")
-    name: str = Field(..., min_length=1, max_length=255, description="模板名称")
-    image_url: str = Field(..., min_length=1, max_length=512, description="镜像 URL")
+    id: str = Field(..., min_length=1, max_length=64, description="Template id")
+    name: str = Field(..., min_length=1, max_length=255, description="Template name")
+    image_url: str = Field(..., min_length=1, max_length=512, description="Image URL")
     runtime_type: Literal["python3.11", "nodejs20", "java17", "go1.21"] = Field(
-        ..., description="运行时类型"
+        ..., description="Runtime type"
     )
-    default_cpu_cores: float = Field(0.5, ge=0.1, le=4.0, description="默认 CPU 核心数")
-    default_memory_mb: int = Field(512, ge=128, le=8192, description="默认内存（MB）")
-    default_disk_mb: int = Field(1024, ge=256, le=51200, description="默认磁盘（MB）")
-    default_timeout: int = Field(300, ge=60, le=3600, description="默认超时（秒）")
-    default_env_vars: Optional[Dict[str, str]] = Field(None, description="默认环境变量")
+    default_cpu_cores: float = Field(0.5, ge=0.1, le=4.0, description="Default CPU cores")
+    default_memory_mb: int = Field(512, ge=128, le=8192, description="Default memory in MB")
+    default_disk_mb: int = Field(1024, ge=256, le=51200, description="Default disk in MB")
+    default_timeout: int = Field(300, ge=60, le=3600, description="Default timeout in seconds")
+    default_env_vars: Optional[Dict[str, str]] = Field(None, description="Default environment variables")
 
 
 class UpdateTemplateRequest(BaseModel):
-    """更新模板请求"""
+    """Update-template request"""
 
-    name: Optional[str] = Field(None, min_length=1, max_length=255, description="模板名称")
-    image_url: Optional[str] = Field(None, min_length=1, max_length=512, description="镜像 URL")
-    default_cpu_cores: Optional[float] = Field(None, ge=0.1, le=4.0, description="默认 CPU 核心数")
-    default_memory_mb: Optional[int] = Field(None, ge=128, le=8192, description="默认内存（MB）")
-    default_disk_mb: Optional[int] = Field(None, ge=256, le=51200, description="默认磁盘（MB）")
-    default_timeout: Optional[int] = Field(None, ge=60, le=3600, description="默认超时（秒）")
-    default_env_vars: Optional[Dict[str, str]] = Field(None, description="默认环境变量")
+    name: Optional[str] = Field(None, min_length=1, max_length=255, description="Template name")
+    image_url: Optional[str] = Field(None, min_length=1, max_length=512, description="Image URL")
+    default_cpu_cores: Optional[float] = Field(None, ge=0.1, le=4.0, description="Default CPU cores")
+    default_memory_mb: Optional[int] = Field(None, ge=128, le=8192, description="Default memory in MB")
+    default_disk_mb: Optional[int] = Field(None, ge=256, le=51200, description="Default disk in MB")
+    default_timeout: Optional[int] = Field(None, ge=60, le=3600, description="Default timeout in seconds")
+    default_env_vars: Optional[Dict[str, str]] = Field(None, description="Default environment variables")

--- a/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/response.py
+++ b/infra/sandbox/sandbox_control_plane/src/interfaces/rest/schemas/response.py
@@ -1,7 +1,7 @@
 """
-REST API 响应模式
+REST API response schemas
 
-定义 FastAPI 的响应 Pydantic 模型。
+Defines the Pydantic response models FastAPI uses.
 """
 
 from pydantic import BaseModel, Field
@@ -10,7 +10,7 @@ from datetime import datetime
 
 
 class ResourceLimitResponse(BaseModel):
-    """资源限制响应"""
+    """Resource limit response"""
 
     cpu: str
     memory: str
@@ -19,14 +19,14 @@ class ResourceLimitResponse(BaseModel):
 
 
 class DependencyResponse(BaseModel):
-    """依赖响应。"""
+    """Dependency response."""
 
     name: str
     version: Optional[str] = None
 
 
 class InstalledDependencyResponse(BaseModel):
-    """已安装依赖响应。"""
+    """Installed dependency response."""
 
     name: str
     version: str
@@ -36,7 +36,7 @@ class InstalledDependencyResponse(BaseModel):
 
 
 class SessionResponse(BaseModel):
-    """会话响应"""
+    """Session response"""
 
     id: str
     template_id: str
@@ -64,7 +64,7 @@ class SessionResponse(BaseModel):
 
 
 class SessionListResponse(BaseModel):
-    """会话列表响应"""
+    """Session list response"""
 
     items: List[SessionResponse]
     total: int
@@ -74,7 +74,7 @@ class SessionListResponse(BaseModel):
 
 
 class ArtifactResponse(BaseModel):
-    """文件制品响应"""
+    """File artifact response"""
 
     path: str
     size: int
@@ -85,7 +85,7 @@ class ArtifactResponse(BaseModel):
 
 
 class ExecutionResponse(BaseModel):
-    """执行响应"""
+    """Execution response"""
 
     id: str
     session_id: str
@@ -108,7 +108,7 @@ class ExecutionResponse(BaseModel):
 
 
 class ExecuteCodeResponse(BaseModel):
-    """执行代码响应"""
+    """Execute-code response"""
 
     execution_id: str
     session_id: str
@@ -117,7 +117,7 @@ class ExecuteCodeResponse(BaseModel):
 
 
 class TemplateResponse(BaseModel):
-    """模板响应"""
+    """Template response"""
 
     id: str
     name: str
@@ -134,7 +134,7 @@ class TemplateResponse(BaseModel):
 
 
 class ContainerResponse(BaseModel):
-    """容器响应"""
+    """Container response"""
 
     id: str
     session_id: str
@@ -153,7 +153,7 @@ class ContainerResponse(BaseModel):
 
 
 class ErrorResponse(BaseModel):
-    """错误响应"""
+    """Error response"""
 
     error: str
     message: str
@@ -161,7 +161,7 @@ class ErrorResponse(BaseModel):
 
 
 class HealthResponse(BaseModel):
-    """健康检查响应"""
+    """Health check response"""
 
     status: str = "healthy"
     version: str = "2.1.0"

--- a/infra/sandbox/sandbox_control_plane/src/shared/errors/domain.py
+++ b/infra/sandbox/sandbox_control_plane/src/shared/errors/domain.py
@@ -1,14 +1,14 @@
 """
-领域错误
+Domain errors
 
-定义领域层的错误类型。
+The error types of the domain layer.
 """
 
 from typing import Any, Optional
 
 
 class DomainError(Exception):
-    """领域错误基类"""
+    """Base domain error"""
 
     def __init__(self, message: str, details: Optional[dict[str, Any]] = None):
         self.message = message
@@ -17,60 +17,60 @@ class DomainError(Exception):
 
 
 class NotFoundError(DomainError):
-    """未找到错误"""
+    """Not found"""
 
     pass
 
 
 class ValidationError(DomainError):
-    """验证错误"""
+    """Validation failed"""
 
     pass
 
 
 class InvalidStatusError(DomainError):
-    """无效状态错误"""
+    """Invalid state"""
 
     pass
 
 
 class ResourceLimitError(DomainError):
-    """资源限制错误"""
+    """Resource limit exceeded"""
 
     pass
 
 
 class SessionExpiredError(DomainError):
-    """会话过期错误"""
+    """Session expired"""
 
     pass
 
 
 class ExecutionTimeoutError(DomainError):
-    """执行超时错误"""
+    """Execution timed out"""
 
     pass
 
 
 class ExecutionCrashedError(DomainError):
-    """执行崩溃错误"""
+    """Execution crashed"""
 
     pass
 
 
 class TemplateNotFoundError(DomainError):
-    """模板未找到错误"""
+    """Template not found"""
 
     pass
 
 
 class NodeUnavailableError(DomainError):
-    """节点不可用错误"""
+    """Node unavailable"""
 
     pass
 
 
 class ConflictError(DomainError):
-    """资源冲突错误"""
+    """Resource conflict"""
 
     pass

--- a/infra/sandbox/sandbox_control_plane/src/shared/errors/infrastructure.py
+++ b/infra/sandbox/sandbox_control_plane/src/shared/errors/infrastructure.py
@@ -1,14 +1,14 @@
 """
-基础设施错误
+Infrastructure errors
 
-定义基础设施层的错误类型。
+The error types of the infrastructure layer.
 """
 
 from typing import Optional
 
 
 class InfrastructureError(Exception):
-    """基础设施错误基类"""
+    """Base infrastructure error"""
 
     def __init__(self, message: str, original_error: Optional[Exception] = None):
         self.message = message
@@ -17,42 +17,42 @@ class InfrastructureError(Exception):
 
 
 class DatabaseError(InfrastructureError):
-    """数据库错误"""
+    """Database error"""
 
     pass
 
 
 class ConnectionError(InfrastructureError):
-    """连接错误"""
+    """Connection error"""
 
     pass
 
 
 class StorageError(InfrastructureError):
-    """存储错误"""
+    """Storage error"""
 
     pass
 
 
 class HTTPClientError(InfrastructureError):
-    """HTTP 客户端错误"""
+    """HTTP client error"""
 
     pass
 
 
 class ContainerError(InfrastructureError):
-    """容器错误"""
+    """Container error"""
 
     pass
 
 
 class KubernetesError(InfrastructureError):
-    """Kubernetes 错误"""
+    """Kubernetes error"""
 
     pass
 
 
 class MessagingError(InfrastructureError):
-    """消息队列错误"""
+    """Message queue error"""
 
     pass

--- a/infra/sandbox/sandbox_control_plane/src/shared/utils/dependencies.py
+++ b/infra/sandbox/sandbox_control_plane/src/shared/utils/dependencies.py
@@ -1,7 +1,7 @@
 """
-依赖解析工具
+Dependency parsing helpers
 
-用于处理 Python 依赖包的格式转换和解析。
+Converts and parses Python dependency package formats.
 """
 
 import json
@@ -12,7 +12,7 @@ DEFAULT_PYTHON_PACKAGE_INDEX_URL = "https://pypi.org/simple/"
 
 
 def normalize_python_package_index_url(index_url: Optional[str]) -> str:
-    """规范化 Python 包仓库地址。"""
+    """Normalize a Python package index URL."""
     if not index_url:
         return DEFAULT_PYTHON_PACKAGE_INDEX_URL
     return index_url.strip() or DEFAULT_PYTHON_PACKAGE_INDEX_URL
@@ -20,9 +20,9 @@ def normalize_python_package_index_url(index_url: Optional[str]) -> str:
 
 def parse_pip_spec(spec: Union[str, dict]) -> dict[str, Optional[str]]:
     """
-    解析 pip requirement spec。
+    Parse a pip requirement specifier.
 
-    返回:
+    Returns:
         {"name": "requests", "version": "==2.31.0"}
     """
     if isinstance(spec, dict):
@@ -41,7 +41,7 @@ def parse_pip_spec(spec: Union[str, dict]) -> dict[str, Optional[str]]:
 
 
 def merge_pip_specs(existing: List[str], incoming: List[str]) -> List[str]:
-    """按包名合并 pip spec，同名包以后者覆盖前者。"""
+    """Merge pip specifiers by package name; a later entry wins."""
     merged: dict[str, str] = {}
 
     for spec in existing + incoming:
@@ -54,15 +54,15 @@ def merge_pip_specs(existing: List[str], incoming: List[str]) -> List[str]:
 
 def parse_dependencies_to_pip_specs(dependencies: Optional[List[Union[str, dict]]]) -> List[str]:
     """
-    将依赖列表转换为 pip 规范格式
+    Convert a dependency list into pip specifiers
 
     Args:
-        dependencies: 依赖列表，元素可以是字符串或字典
-            - 字符串格式: "requests==2.31.0" 或 "requests"
-            - 字典格式: {"name": "requests", "version": "==2.31.0"}
+        dependencies: the dependencies, each a string or a dict
+            - string form: "requests==2.31.0" or "requests"
+            - dict form: {"name": "requests", "version": "==2.31.0"}
 
     Returns:
-        pip 规范列表，如 ["requests==2.31.0", "pandas>=2.0"]
+        The pip specifiers, such as ["requests==2.31.0", "pandas>=2.0"]
     """
     if not dependencies:
         return []
@@ -83,15 +83,15 @@ def format_dependencies_for_script(
     dependencies: Optional[List[Union[str, dict]]],
 ) -> tuple[str, str]:
     """
-    格式化依赖列表用于 shell 脚本
+    Format the dependency list for a shell script
 
     Args:
-        dependencies: 依赖列表
+        dependencies: the dependencies
 
     Returns:
-        (deps_json, deps_list) 元组
-        - deps_json: JSON 字符串格式的依赖列表
-        - deps_list: 空格分隔的 pip 规范字符串，用于 shell 脚本
+        A (deps_json, deps_list) tuple
+        - deps_json: the dependency list as a JSON string
+        - deps_list: space-separated pip specifiers, for the shell script
     """
     if not dependencies:
         return "", ""
@@ -105,18 +105,18 @@ def format_dependencies_for_script(
 
 def build_dependency_install_script() -> str:
     """
-    构建通用的 Python 依赖安装脚本片段
+    Build the shared Python dependency install script fragment
 
     Returns:
-        Shell 脚本字符串，用于安装依赖到 /opt/sandbox-venv
+        The shell script that installs the dependencies into /opt/sandbox-venv
     """
     return """
-# ========== 安装 Python 依赖 ==========
+# ========== Install the Python dependencies ==========
 echo "📦 Installing dependencies: {deps_json}"
 echo "📦 Pip specs: {pip_specs}"
 
-# 将依赖安装到容器本地文件系统（而非 S3 挂载点）
-# S3 挂载点是网络文件系统，不适合作为 pip 安装目标
+# Install into the container's local filesystem rather than the S3 mount point:
+# the mount point is a network filesystem and is a poor pip target.
 VENV_DIR="/opt/sandbox-venv"
 mkdir -p $VENV_DIR
 mkdir -p /tmp/pip-cache
@@ -132,9 +132,9 @@ if pip3 install \\
     --index-url https://pypi.org/simple/ \\
     {deps_list}; then
     echo "✅ Dependencies installed successfully to $VENV_DIR"
-    # 修改属主为 sandbox 用户（gosu 切换前以 root 安装）
+    # Hand ownership to the sandbox user; the install runs as root, before gosu drops privileges
     chown -R sandbox:sandbox $VENV_DIR
-    # 清理缓存
+    # Clear the cache
     rm -rf /tmp/pip-cache
 else
     echo "❌ Failed to install dependencies"
@@ -147,13 +147,13 @@ def format_dependency_install_script_for_shell(
     dependencies: Optional[List[Union[str, dict]]],
 ) -> str:
     """
-    格式化依赖安装脚本用于 shell 执行
+    Format the dependency install script for shell execution
 
     Args:
-        dependencies: 依赖列表
+        dependencies: the dependencies
 
     Returns:
-        Shell 脚本字符串
+        The shell script as a string
     """
     if not dependencies:
         return ""
@@ -162,11 +162,11 @@ def format_dependency_install_script_for_shell(
     pip_specs_quoted = " ".join(f'"{spec}"' for spec in deps_list.split() if spec)
 
     return f"""
-# ========== 安装 Python 依赖 ==========
+# ========== Install the Python dependencies ==========
 echo "📦 Installing dependencies: {deps_json}"
 echo "📦 Pip specs: {pip_specs_quoted}"
 
-# 将依赖安装到容器本地文件系统
+# Install into the container's local filesystem
 VENV_DIR="/opt/sandbox-venv"
 mkdir -p $VENV_DIR
 mkdir -p /tmp/pip-cache
@@ -182,7 +182,7 @@ if pip3 install \\
     --index-url https://pypi.org/simple/ \\
     {deps_list}; then
     echo "✅ Dependencies installed successfully"
-    # 清理缓存
+    # Clear the cache
     rm -rf /tmp/pip-cache
 else
     echo "❌ Failed to install dependencies"


### PR DESCRIPTION
Final piece of #927 for the sandbox control plane. Comments and docstrings only — no behaviour change. Split from #1015 because it touches ~1,900 lines and would have buried that diff.

## Scope

1,908 lines across 78 files: module and class docstrings, inline comments, the comment lines inside the generated shell templates, and the Field descriptions that make up this service's OpenAPI text.

Two Chinese strings stay on purpose: the `f_description` values of the default templates in `seed/default_data.py` are business seed data, which #927 excludes from a mechanical translation.

## This nearly shipped a broken start-up script

An English comment that needed one line more than the Chinese it replaced overwrote the following line. In the Kubernetes start script that line was:

```bash
mkdir -p /mnt/s3-init
```

Without it the temporary bucket mount has no mount point, so the session prefix is never created and the workspace mount fails.

**Three layers missed it.** `py_compile` passed, because the line lives inside a string. The AST check passed, because it normalizes string constants — which is exactly what hides an edit inside an embedded script. And no test covers that script.

What caught it was a third check that reconstructs the f-string shell templates and compares only their executable lines. The same overflow bug hit `docker_scheduler.py` three times, including an assignment (`bkn_mcp_url = ...`); the AST check did catch those.

The applier was then made safe by construction: replacements go bottom-up so a longer English comment cannot shift later line numbers, and every target line is asserted to contain Chinese before it is touched. That assertion refused three more bad targets during the rest of the sweep.

## Verification

Run across the whole module against `origin/main`:

- **86 source files structurally identical** with string constants normalized — no code line moved.
- **Embedded shell templates identical line for line**, comment lines excluded — nothing executable inside a string moved.
- `pytest tests/unit` — **762 passed**, with the same **5 pre-existing failures** as before this change (2 docker-scheduler entrypoint assertions, 3 route-registration tests hitting a FastAPI `_IncludedRouter` incompatibility). Both groups fail on a clean checkout and neither touches comments.
- `python3 tools/check_i18n_catalogs.py` passes.

## Worth knowing

The 2 pre-existing docker-scheduler failures assert on an older script shape (`mount --bind "$SESSION_PATH" /workspace`) that the code no longer generates. That test drifted from the implementation before this work and is out of scope here, but it is why the s3 mount scripts have effectively no coverage — which is what let the `mkdir` deletion through in the first place.

Refs #927