### PR TITLE
refactor(bkn-backend): translate comments

### DIFF
--- a/adp/bkn/bkn-backend/docker/Dockerfile
+++ b/adp/bkn/bkn-backend/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY --from=builder --chown=$UID:$GID /go/src/bin /opt/bkn-backend
 ADD server/config/bkn-backend-config.yaml /opt/bkn-backend/config/
 ADD server/locale /opt/bkn-backend/locale
 
-# 指定工作目录
+# Set the working directory.
 WORKDIR /opt/bkn-backend/
 
 # Change user
@@ -46,5 +46,5 @@ USER $UID
 # Expose port
 EXPOSE 13014
 
-# 指定启动命令
+# Set the startup command.
 ENTRYPOINT [ "./bkn-backend-server" ]

--- a/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
@@ -1,7 +1,7 @@
 namespace: openbkn
 moduleName: bkn-backend
 
-# 环境变量：语言/时区
+# Environment variables: language/time zone.
 env:
   timezone: Asia/Shanghai
   language: en_US.UTF-8
@@ -15,7 +15,7 @@ bknSafe:
 
 replicaCount: 1
 
-# 节点选择器
+# Node selector.
 nodeSelector: {}
 
 image:
@@ -36,20 +36,20 @@ service:
           - /api/bkn-backend/v1
           - /api/ontology-manager/v1
 
-# 反亲和性设置
+# Anti-affinity settings.
 antiAffinity:
   enabled: true
-  rule: "soft" # 可选参数 hard, soft
+  rule: "soft" # Optional values: hard, soft.
 
-# 认证开关
+# Authentication switch.
 auth:
   enabled: true
 
-# 业务域开关
+# Business-domain switch.
 businessDomain:
   enabled: true
 
-# 微服务通信依赖配置
+# Microservice communication dependency configuration.
 depServices:
   class-443:
     ingressClass: class-443
@@ -130,28 +130,28 @@ config:
     maxAge: 100
     maxBackups: 20
     maxSize: 100
-  # OTel Collector 配置
+  # OTel Collector configuration.
   otel:
-    # 服务名称
+    # Service name.
     service_name: "bkn-backend"
-    # 运行环境
+    # Runtime environment.
     environment: "production"
-    # OTLP 上报端点
+    # OTLP reporting endpoint.
     otlp_endpoint: "otelcol-contrib:4318"
 
-    # Trace 配置
+    # Trace configuration.
     trace:
       enabled: false
-      # 采样率: 0.0 - 1.0
+      # Sampling rate: 0.0 - 1.0.
       sampling_rate: 1.0
 
-    # Log 配置
+    # Log configuration.
     log:
       enabled: false
-      # 日志级别: debug, info, warn, error
+      # Log level: debug, info, warn, error.
       level: "info"
 
-# 资源配置
+# Resource configuration.
 resources:
   requests:
     cpu: 0

--- a/adp/bkn/bkn-backend/script/delete_concept_index/readme.md
+++ b/adp/bkn/bkn-backend/script/delete_concept_index/readme.md
@@ -1,72 +1,72 @@
-# 创建概念索引删除脚本
+# Create the Concept Index Deletion Script
 
-## 概述
+## Overview
 
-创建一个 Python 脚本用于删除 OpenSearch 中的概念索引 `adp-kn_concept`。脚本将放在 `script/` 目录下。
+Create a Python script that deletes the `adp-kn_concept` concept index from OpenSearch. The script is placed under the `script/` directory.
 
-## 实现细节
+## Implementation Details
 
-### 文件结构
+### File Structure
 
-- `script/delete_concept_index.py` - 主脚本文件
+- `script/delete_concept_index.py` - Main script file
 
-### 功能特性
+### Features
 
-1. **OpenSearch 连接**
+1. **OpenSearch connection**
 
-   - 参考 `script/clean_opensearch_index/script.py` 的连接方式
-   - 支持 HTTP/HTTPS 协议
-   - 支持用户名密码认证
-   - 从环境变量或命令行参数读取配置
+   - Follows the connection pattern from `script/clean_opensearch_index/script.py`
+   - Supports HTTP/HTTPS protocols
+   - Supports username/password authentication
+   - Reads configuration from environment variables or command-line arguments
 
-2. **索引删除**
+2. **Index deletion**
 
-   - 删除概念索引 `adp-kn_concept`（定义在 `server/interfaces/common.go` 中的 `KN_CONCEPT_INDEX_NAME`）
-   - 检查索引是否存在后再删除
-   - 显示索引信息（文档数、存储大小）
+   - Deletes the `adp-kn_concept` concept index, which is defined as `KN_CONCEPT_INDEX_NAME` in `server/interfaces/common.go`
+   - Checks whether the index exists before deletion
+   - Displays index information, including document count and storage size
 
-3. **安全特性**
+3. **Safety features**
 
-   - 支持 `--dry-run` 模式，预览操作而不实际删除
-   - 删除前显示索引信息并要求确认（可选）
-   - 详细的日志输出
+   - Supports `--dry-run` mode to preview the operation without deleting the index
+   - Displays index information before deletion and optionally asks for confirmation
+   - Provides detailed log output
 
-4. **配置方式**
+4. **Configuration methods**
 
-   - 环境变量：`OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_PROTOCOL`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`
-   - 命令行参数覆盖环境变量
-   - 默认值：localhost:9200, http 协议
+   - Environment variables: `OPENSEARCH_HOST`, `OPENSEARCH_PORT`, `OPENSEARCH_PROTOCOL`, `OPENSEARCH_USER`, `OPENSEARCH_PASSWORD`
+   - Command-line arguments override environment variables
+   - Defaults: localhost:9200, http protocol
 
-## 环境要求
+## Environment Requirements
 
 - Python 3.10+
-- OpenSearch 集群
+- OpenSearch cluster
 
-## 安装依赖
+## Install Dependencies
 
 ```bash
 pip3 install -i https://pypi.tuna.tsinghua.edu.cn/simple opensearch-py
 ```
 
-### 使用示例
+### Usage Examples
 
 ```bash
-# 使用环境变量
+# Use environment variables.
 export OPENSEARCH_HOST=localhost
 export OPENSEARCH_PORT=9200
 export OPENSEARCH_USER=test
 export OPENSEARCH_PASSWORD=testpwd
 python3 script/delete_concept_index.py
 
-# 使用命令行参数
+# Use command-line arguments.
 python3 script/delete_concept_index.py --os-host localhost --os-port 9200 --os-user test --os-password testpwd
 
-# 试运行模式
+# Dry-run mode.
 python3 script/delete_concept_index.py --dry-run
 ```
 
-## 参考文件
+## References
 
-- `script/clean_opensearch_index/script.py` - OpenSearch 连接和索引删除的实现方式
-- `server/interfaces/common.go` - 概念索引名称定义 (`KN_CONCEPT_INDEX_NAME = "adp-kn_concept"`)
-- `server/common/setting.go` - OpenSearch 配置结构
+- `script/clean_opensearch_index/script.py` - OpenSearch connection and index deletion implementation
+- `server/interfaces/common.go` - Concept index name definition (`KN_CONCEPT_INDEX_NAME = "adp-kn_concept"`)
+- `server/common/setting.go` - OpenSearch configuration structure

--- a/adp/bkn/bkn-backend/script/delete_concept_index/script.py
+++ b/adp/bkn/bkn-backend/script/delete_concept_index/script.py
@@ -7,8 +7,8 @@
 # See the LICENSE file in the project root for details.
 
 """
-概念索引删除脚本
-功能：连接 OpenSearch 并删除概念索引 adp-kn_concept
+Concept index deletion script.
+Connects to OpenSearch and deletes the adp-kn_concept concept index.
 """
 
 import os
@@ -18,10 +18,10 @@ import argparse
 from typing import Dict, Optional
 from opensearchpy import OpenSearch, RequestsHttpConnection
 
-# 概念索引名称（与 server/interfaces/common.go 中的定义保持一致）
+# Concept index name, kept consistent with the definition in server/interfaces/common.go.
 CONCEPT_INDEX_NAME = "adp-kn_concept"
 
-# 配置日志
+# Configure logging.
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
@@ -31,22 +31,22 @@ logger = logging.getLogger(__name__)
 
 
 class ConceptIndexDeleter:
-    """概念索引删除器"""
+    """Concept index deleter."""
 
     def __init__(self, os_config: dict, dry_run: bool = False):
         """
-        初始化删除器
+        Initialize the deleter.
 
         Args:
-            os_config: OpenSearch配置
-            dry_run: 是否为试运行模式（不实际删除）
+            os_config: OpenSearch configuration.
+            dry_run: Whether to run in dry-run mode without deleting the index.
         """
         self.os_config = os_config
         self.dry_run = dry_run
         self.os_client: Optional[OpenSearch] = None
 
     def connect_opensearch(self) -> bool:
-        """连接OpenSearch"""
+        """Connect to OpenSearch."""
         try:
             self.os_client = OpenSearch(
                 hosts=[
@@ -63,7 +63,7 @@ class ConceptIndexDeleter:
                 timeout=30,
             )
 
-            # 测试连接
+            # Test the connection.
             if self.os_client.ping():
                 logger.info("OpenSearch连接成功")
                 return True
@@ -76,27 +76,27 @@ class ConceptIndexDeleter:
 
     def get_index_info(self, index_name: str) -> Optional[Dict[str, any]]:
         """
-        获取索引信息（文档数、存储大小等）
+        Get index information such as document count and storage size.
 
         Args:
-            index_name: 索引名称
+            index_name: Index name.
 
         Returns:
-            索引信息字典，如果索引不存在则返回 None
+            Index information, or None if the index does not exist.
         """
         try:
             if not self.os_client.indices.exists(index=index_name):
                 return None
 
-            # 获取索引统计信息
+            # Get index statistics.
             stats = self.os_client.indices.stats(index=index_name)
             index_stats = stats.get("indices", {}).get(index_name, {})
 
-            # 获取索引设置和映射信息
+            # Get index settings and mapping information.
             settings = self.os_client.indices.get_settings(index=index_name)
             index_settings = settings.get(index_name, {}).get("settings", {})
 
-            # 提取文档数和存储大小
+            # Extract document count and storage size.
             total = index_stats.get("total", {})
             docs_count = total.get("docs", {}).get("count", 0)
             store_size = total.get("store", {}).get("size_in_bytes", 0)
@@ -112,13 +112,13 @@ class ConceptIndexDeleter:
 
     def delete_index(self, index_name: str) -> bool:
         """
-        删除指定的索引
+        Delete the specified index.
 
         Args:
-            index_name: 要删除的索引名称
+            index_name: Name of the index to delete.
 
         Returns:
-            删除成功返回 True，失败返回 False
+            True if deletion succeeds; otherwise False.
         """
         try:
             if not self.os_client.indices.exists(index=index_name):
@@ -141,23 +141,23 @@ class ConceptIndexDeleter:
             return False
 
     def delete_concept_index(self) -> bool:
-        """执行概念索引删除操作"""
+        """Run the concept index deletion operation."""
         logger.info("=" * 60)
         logger.info("开始删除概念索引")
         logger.info(f"索引名称: {CONCEPT_INDEX_NAME}")
         logger.info(f"试运行模式: {'是' if self.dry_run else '否'}")
         logger.info("=" * 60)
 
-        # 连接OpenSearch
+        # Connect to OpenSearch.
         if not self.connect_opensearch():
             return False
 
-        # 检查索引是否存在
+        # Check whether the index exists.
         if not self.os_client.indices.exists(index=CONCEPT_INDEX_NAME):
             logger.warning(f"概念索引 {CONCEPT_INDEX_NAME} 不存在，无需删除")
             return True
 
-        # 获取索引信息
+        # Get index information.
         index_info = self.get_index_info(CONCEPT_INDEX_NAME)
         if index_info:
             logger.info("\n索引信息:")
@@ -169,11 +169,11 @@ class ConceptIndexDeleter:
         else:
             logger.warning("无法获取索引信息，将继续尝试删除")
 
-        # 删除索引
+        # Delete the index.
         logger.info(f"\n开始删除索引 {CONCEPT_INDEX_NAME}...")
         success = self.delete_index(CONCEPT_INDEX_NAME)
 
-        # 输出结果
+        # Output the result.
         logger.info("\n" + "=" * 60)
         if success:
             logger.info("删除操作完成")
@@ -185,13 +185,13 @@ class ConceptIndexDeleter:
 
     def _format_bytes(self, bytes_size: int) -> str:
         """
-        格式化字节大小
+        Format a byte size.
 
         Args:
-            bytes_size: 字节大小
+            bytes_size: Size in bytes.
 
         Returns:
-            格式化后的字符串
+            Formatted string.
         """
         for unit in ["B", "KB", "MB", "GB", "TB"]:
             if bytes_size < 1024.0:
@@ -200,18 +200,18 @@ class ConceptIndexDeleter:
         return f"{bytes_size:.2f} PB"
 
     def close(self):
-        """关闭连接"""
+        """Close the connection."""
         if self.os_client:
-            # OpenSearch 客户端不需要显式关闭
+            # The OpenSearch client does not require an explicit close.
             logger.info("OpenSearch连接已关闭")
 
 
 def load_config_from_env() -> dict:
     """
-    从环境变量加载配置
+    Load configuration from environment variables.
 
     Returns:
-        OpenSearch配置字典
+        OpenSearch configuration dictionary.
     """
     os_config = {
         "host": os.getenv("OPENSEARCH_HOST", "localhost"),
@@ -225,7 +225,7 @@ def load_config_from_env() -> dict:
 
 
 def main():
-    """主函数"""
+    """Main function."""
     parser = argparse.ArgumentParser(
         description="概念索引删除工具 - 删除 OpenSearch 中的概念索引 adp-kn_concept"
     )
@@ -254,10 +254,10 @@ def main():
 
     args = parser.parse_args()
 
-    # 加载配置
+    # Load configuration.
     os_config = load_config_from_env()
 
-    # 命令行参数覆盖环境变量
+    # Command-line arguments override environment variables.
     if args.os_host:
         os_config["host"] = args.os_host
     if args.os_port:
@@ -269,14 +269,14 @@ def main():
     if args.os_protocol:
         os_config["protocol"] = args.os_protocol
 
-    # 验证必需的配置
+    # Validate required configuration.
     if not os_config["password"]:
         logger.error(
             "OpenSearch密码未设置，请设置OPENSEARCH_PASSWORD环境变量或使用--os-password参数"
         )
         sys.exit(1)
 
-    # 创建删除器并执行删除
+    # Create the deleter and execute deletion.
     deleter = ConceptIndexDeleter(os_config=os_config, dry_run=args.dry_run)
 
     try:

--- a/adp/bkn/bkn-backend/server/bkn-specification/README.md
+++ b/adp/bkn/bkn-backend/server/bkn-specification/README.md
@@ -26,25 +26,25 @@ Go SDK for parsing, serializing, loading, and diffing BKN networks.
 ├── tests/
 │   └── integration_test.go
 └── tools/
-    └── regenerate_checksum.go  # 批量重新生成 examples/ 的 CHECKSUM
+    └── regenerate_checksum.go  # Regenerate CHECKSUM files for examples/ in bulk
 ```
 
 ---
 
 ## Usage
 
-### 加载网络
+### Load a Network
 
 ```go
-// 从目录加载（自动发现 network.bkn）
+// Load from a directory, automatically discovering network.bkn.
 net, err := bkn.LoadNetwork("path/to/network-dir")
 
-// 从 tar 加载
+// Load from a tar archive.
 f, _ := os.Open("network.tar")
 net, err := bkn.LoadNetworkFromTar(f)
 ```
 
-### 解析单个文件
+### Parse a Single File
 
 ```go
 content, _ := os.ReadFile("action_types/restart.bkn")
@@ -57,40 +57,40 @@ fmt.Println(at.ID)                          // "restart"
 fmt.Println(at.TriggerCondition.Operation)  // "=="
 ```
 
-### 序列化
+### Serialize
 
 ```go
-// 模型 → BKN 文本
+// Model -> BKN text.
 text := bkn.SerializeActionType(at)
 
-// 网络 → tar
+// Network -> tar.
 var buf bytes.Buffer
 err := bkn.WriteNetworkToTar(net, &buf)
 
-// 目录 → tar 文件
+// Directory -> tar file.
 err := bkn.PackDirToTar("path/to/dir", "output.tar", false)
 ```
 
-### 校验和 & Diff
+### Checksum & Diff
 
 ```go
-// 生成 CHECKSUM 文件
+// Generate a CHECKSUM file.
 checksum, err := bkn.GenerateChecksumFile("path/to/dir")
 
-// 验证 CHECKSUM 文件
+// Verify a CHECKSUM file.
 ok, errs := bkn.VerifyChecksumFile("path/to/dir")
 
-// 从 tar 验证
+// Verify from a tar archive.
 ok, errs := bkn.VerifyChecksumFromTar(tarReader)
 
-// 比较两个 tar 的差异
+// Compare differences between two tar archives.
 result, err := bkn.DiffNetworksFromTar(oldTar, newTar)
 for _, e := range result.Creates() { fmt.Println("create:", e.Key) }
 for _, e := range result.Updates() { fmt.Println("update:", e.Key) }
 for _, e := range result.Deletes() { fmt.Println("delete:", e.Key) }
 ```
 
-### 验证
+### Validate
 
 ```go
 result := bkn.ValidateNetwork(net)
@@ -107,63 +107,63 @@ if !result.OK() {
 
 ### Parser
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `ParseFrontmatter(text)` | 解析 YAML frontmatter，返回 `map[string]any` |
-| `ParseNetworkFile(text, sourcePath)` | 解析 network 文件 |
-| `ParseObjectTypeFile(text, sourcePath)` | 解析 object_type 文件 |
-| `ParseRelationTypeFile(text, sourcePath)` | 解析 relation_type 文件 |
-| `ParseActionTypeFile(text, sourcePath)` | 解析 action_type 文件（含 TriggerCondition） |
-| `ParseRiskTypeFile(text, sourcePath)` | 解析 risk_type 文件 |
-| `ParseConceptGroupFile(text, sourcePath)` | 解析 concept_group 文件 |
+| `ParseFrontmatter(text)` | Parses YAML frontmatter and returns `map[string]any` |
+| `ParseNetworkFile(text, sourcePath)` | Parses a network file |
+| `ParseObjectTypeFile(text, sourcePath)` | Parses an object_type file |
+| `ParseRelationTypeFile(text, sourcePath)` | Parses a relation_type file |
+| `ParseActionTypeFile(text, sourcePath)` | Parses an action_type file, including `TriggerCondition` |
+| `ParseRiskTypeFile(text, sourcePath)` | Parses a risk_type file |
+| `ParseConceptGroupFile(text, sourcePath)` | Parses a concept_group file |
 
 ### Loader
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `LoadNetwork(rootPath)` | 从目录加载完整网络（自动发现 network.bkn） |
-| `LoadNetworkWithFS(fsys, rootPath)` | 使用自定义 FileSystem 加载网络 |
-| `LoadNetworkFromTar(r)` | 从 tar 流加载网络 |
-| `ExtractTarToMemory(r)` | 将 tar 解压到内存文件系统 |
+| `LoadNetwork(rootPath)` | Loads a complete network from a directory, automatically discovering network.bkn |
+| `LoadNetworkWithFS(fsys, rootPath)` | Loads a network with a custom FileSystem |
+| `LoadNetworkFromTar(r)` | Loads a network from a tar stream |
+| `ExtractTarToMemory(r)` | Extracts a tar archive into an in-memory file system |
 
 ### Serializer
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `SerializeBknNetwork(doc)` | 序列化 network frontmatter |
-| `SerializeObjectType(ot)` | 序列化 object_type |
-| `SerializeRelationType(rt)` | 序列化 relation_type |
-| `SerializeActionType(at)` | 序列化 action_type |
-| `SerializeRiskType(rt)` | 序列化 risk_type |
-| `SerializeConceptGroup(cg)` | 序列化 concept_group |
-| `WriteNetworkToTar(doc, w)` | 将完整网络写入 tar 流 |
-| `PackDirToTar(sourceDir, outputPath, gzip)` | 将目录打包为 tar 文件（macOS 自动设置 `COPYFILE_DISABLE=1`） |
+| `SerializeBknNetwork(doc)` | Serializes network frontmatter |
+| `SerializeObjectType(ot)` | Serializes object_type |
+| `SerializeRelationType(rt)` | Serializes relation_type |
+| `SerializeActionType(at)` | Serializes action_type |
+| `SerializeRiskType(rt)` | Serializes risk_type |
+| `SerializeConceptGroup(cg)` | Serializes concept_group |
+| `WriteNetworkToTar(doc, w)` | Writes a complete network to a tar stream |
+| `PackDirToTar(sourceDir, outputPath, gzip)` | Packs a directory into a tar file; on macOS, sets `COPYFILE_DISABLE=1` automatically |
 
 ### Checksum & Diff
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `GenerateChecksumFile(root)` | 生成并写入 CHECKSUM 文件 |
-| `VerifyChecksumFile(root)` | 验证目录 CHECKSUM，返回 `(ok, errors)` |
-| `ComputeChecksumFromTar(r)` | 从 tar 计算各条目 checksum |
-| `GenerateChecksumFromTar(r)` | 从 tar 生成 CHECKSUM 内容字符串 |
-| `VerifyChecksumFromTar(r)` | 验证 tar 中的 CHECKSUM，返回 `(ok, errors)` |
-| `DiffNetworks(old, new)` | 比较两个 checksum map，返回 `*DiffResult` |
-| `DiffNetworksFromTar(oldTar, newTar)` | 比较两个 tar 的差异，返回 `*DiffResult` |
-| `ComputeNetworkChecksums(fsys, root)` | 计算网络目录的 checksum map |
+| `GenerateChecksumFile(root)` | Generates and writes a CHECKSUM file |
+| `VerifyChecksumFile(root)` | Verifies the directory CHECKSUM and returns `(ok, errors)` |
+| `ComputeChecksumFromTar(r)` | Computes checksums for tar entries |
+| `GenerateChecksumFromTar(r)` | Generates CHECKSUM content from a tar archive |
+| `VerifyChecksumFromTar(r)` | Verifies the CHECKSUM in a tar archive and returns `(ok, errors)` |
+| `DiffNetworks(old, new)` | Compares two checksum maps and returns `*DiffResult` |
+| `DiffNetworksFromTar(oldTar, newTar)` | Compares differences between two tar archives and returns `*DiffResult` |
+| `ComputeNetworkChecksums(fsys, root)` | Computes the checksum map for a network directory |
 
 ### Validator
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `ValidateNetwork(doc)` | 验证网络结构，返回 `*ValidationResult` |
+| `ValidateNetwork(doc)` | Validates the network structure and returns `*ValidationResult` |
 
 ### FileSystem
 
-| 函数 | 说明 |
+| Function | Description |
 |------|------|
-| `NewOSFileSystem()` | 基于 OS 的文件系统实现 |
-| `NewMemoryFileSystem()` | 内存文件系统，用于测试或 tar 解压 |
+| `NewOSFileSystem()` | OS-backed file system implementation |
+| `NewMemoryFileSystem()` | In-memory file system for tests or tar extraction |
 
 ---
 
@@ -171,22 +171,22 @@ if !result.OK() {
 
 ### regenerate_checksum.go
 
-批量重新生成 `examples/` 下所有网络的 CHECKSUM 文件。当 examples 内容发生变更（重命名、修改 .bkn 文件、更新 SKILL.md 等）后需要执行。
+Regenerates CHECKSUM files for all networks under `examples/` in bulk. Run it after example content changes, such as renaming files, modifying .bkn files, or updating SKILL.md.
 
 ```bash
-# 在 sdk/golang/ 目录下运行，传入 examples 父目录
+# Run from sdk/golang/ and pass the examples parent directory.
 go run tools/regenerate_checksum.go ../../examples
 ```
 
 ## Tests
 
 ```bash
-# 单元测试
+# Unit tests.
 go test ./bkn/... -v
 
-# 集成测试（使用 tests/testdata/ 中的真实网络）
+# Integration tests using real networks from tests/testdata/.
 go test ./tests/... -v
 
-# 全部
+# All tests.
 go test ./... -v
 ```

--- a/adp/bkn/bkn-backend/server/bkn-specification/tests/README.md
+++ b/adp/bkn/bkn-backend/server/bkn-specification/tests/README.md
@@ -1,59 +1,59 @@
-# BKN Go SDK 集成测试
+# BKN Go SDK Integration Tests
 
-集成测试验证 SDK 与文件系统、tar 归档的完整交互。
+The integration tests verify the complete interaction between the SDK, file system, and tar archives.
 
-## 测试设计原则
+## Test Design Principles
 
-- **少即是多**：6个核心工作流 + 5个边界情况
-- **严格验证**：使用深度比较确保数据一致性
-- **真实数据**：使用 `examples/` 目录下的示例网络
+- **Less is more**: 6 core workflows + 5 edge cases
+- **Strict verification**: use deep comparison to ensure data consistency
+- **Real data**: use example networks from the `examples/` directory
 
-## 核心工作流测试（6个）
+## Core Workflow Tests (6)
 
-| 测试 | 路径 | 验证方式 |
-|------|------|---------|
-| TestLoadFromFile | 文件 → Model | 严格深度比较 |
-| TestLoadFromTar | Tar → Model | 严格深度比较 |
-| TestSaveToFile | Model → 文件 | 重新加载后严格比较 |
-| TestWriteToTar | Model → Tar | 重新加载后严格比较 |
-| TestRoundTrip_FileToTar | 文件→Model→Tar→Model | 首尾严格一致 |
-| TestRoundTrip_TarToTar | Tar→Model→Tar→Model | 首尾严格一致 |
+| Test | Path | Verification |
+|------|------|--------------|
+| TestLoadFromFile | File -> Model | Strict deep comparison |
+| TestLoadFromTar | Tar -> Model | Strict deep comparison |
+| TestSaveToFile | Model -> File | Strict comparison after reloading |
+| TestWriteToTar | Model -> Tar | Strict comparison after reloading |
+| TestRoundTrip_FileToTar | File -> Model -> Tar -> Model | Strict consistency from start to end |
+| TestRoundTrip_TarToTar | Tar -> Model -> Tar -> Model | Strict consistency from start to end |
 
-## 边界情况测试（5个）
+## Edge Case Tests (5)
 
-| 测试 | 场景 | 期望行为 |
-|------|------|---------|
-| TestEmptyNetwork | 空网络 | 正常加载，返回空结构 |
-| TestMissingRootFile | 目录无 network.bkn | 返回错误：未找到根文件 |
-| TestInvalidFrontmatter | 无效 YAML | 返回错误：解析失败 |
-| TestCircularInclude | 循环包含 | 返回错误：检测到循环 |
-| TestMissingInclude | include 文件不存在 | 返回错误：文件未找到 |
+| Test | Scenario | Expected Behavior |
+|------|----------|-------------------|
+| TestEmptyNetwork | Empty network | Loads normally and returns an empty structure |
+| TestMissingRootFile | Directory without network.bkn | Returns an error: root file not found |
+| TestInvalidFrontmatter | Invalid YAML | Returns a parse failure |
+| TestCircularInclude | Circular include | Returns an error: cycle detected |
+| TestMissingInclude | Included file does not exist | Returns an error: file not found |
 
-## 运行测试
+## Running Tests
 
 ```bash
 cd sdk/golang/test
 
-# 运行所有集成测试
+# Run all integration tests.
 go test -v ./...
 
-# 只运行核心工作流
+# Run only core workflows.
 go test -v -run "TestLoad|TestSave|TestWrite|TestRoundTrip" ./...
 
-# 只运行边界情况
+# Run only edge cases.
 go test -v -run "TestEmpty|TestMissing|TestInvalid|TestCircular" ./...
 ```
 
-## 与单元测试的区别
+## Difference from Unit Tests
 
-| | 单元测试 (bkn/) | 集成测试 (test/) |
-|--|----------------|-----------------|
-| 数量 | ~30个 | 11个 |
-| 依赖 | 无外部依赖 | 依赖文件系统、示例数据 |
-| 速度 | < 1秒 | 1-3秒 |
-| 运行时机 | 每次保存 | 提交前、CI/CD |
+| | Unit tests (bkn/) | Integration tests (test/) |
+|--|-------------------|---------------------------|
+| Count | ~30 | 11 |
+| Dependencies | No external dependencies | Depends on the file system and example data |
+| Speed | < 1 second | 1-3 seconds |
+| Run timing | On every save | Before commit and in CI/CD |
 
-## 相关文档
+## Related Documentation
 
-- [BKN 设计文档](../../../design/bkn/features/bkn_docs/DESIGN.md)
-- [SDK 使用指南](../README.md)
+- [BKN design document](../../../design/bkn/features/bkn_docs/DESIGN.md)
+- [SDK usage guide](../README.md)

--- a/adp/bkn/bkn-backend/server/config/bkn-backend-config.yaml
+++ b/adp/bkn/bkn-backend/server/config/bkn-backend-config.yaml
@@ -14,25 +14,25 @@ log:
   maxAge: 100
   maxBackups: 20
   maxSize: 100
-# OTel Collector 配置
+# OTel Collector configuration.
 otel:
-  # 服务名称
+  # Service name.
   service_name: "bkn-backend"
-  # 运行环境
+  # Runtime environment.
   environment: "production"
-  # OTLP 上报端点
+  # OTLP reporting endpoint.
   otlp_endpoint: "otelcol-contrib:4318"
 
-  # Trace 配置
+  # Trace configuration.
   trace:
     enabled: false
-    # 采样率: 0.0 - 1.0
+    # Sampling rate: 0.0 - 1.0.
     sampling_rate: 1.0
 
-  # Log 配置
+  # Log configuration.
   log:
     enabled: false
-    # 日志级别: debug, info, warn, error
+    # Log level: debug, info, warn, error.
     level: "info"
 
 depServices:

--- a/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/opensearch/opensearch_access.go
@@ -280,8 +280,8 @@ func (o *openSearchAccess) InsertData(ctx context.Context, indexName string, doc
 // Example:
 //
 //	dataList := []any{
-//	  map[string]any{"id": "doc1", "title": "文档1"},
-//	  map[string]any{"id": "doc2", "title": "文档2"},
+//	  map[string]any{"id": "doc1", "title": "document 1"},
+//	  map[string]any{"id": "doc2", "title": "document 2"},
 //	}
 func (o *openSearchAccess) BulkInsertData(ctx context.Context, indexName string, dataList []any) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "BulkInsertData")
@@ -382,7 +382,7 @@ func (o *openSearchAccess) BulkInsertData(ctx context.Context, indexName string,
 //
 //	query := map[string]any{
 //	  "query": map[string]any{
-//	    "match": map[string]any{"title": "搜索关键词"},
+//	    "match": map[string]any{"title": "search keyword"},
 //	  },
 //	}
 func (o *openSearchAccess) SearchData(ctx context.Context, indexName string, query any) ([]interfaces.Hit, error) {

--- a/adp/bkn/bkn-backend/sonar-scanner.properties
+++ b/adp/bkn/bkn-backend/sonar-scanner.properties
@@ -17,5 +17,5 @@ sonar.go.tests.reportPaths=report/ut_report.xml
 
 sonar.go.coverage.reportPaths=report/ut_coverage.out
 
-# 暂时不配置，sonarqube要求golangci-lint 的out-format必须为checkstyle，这与devops要求的junit-xml冲突
+# Temporarily disabled: SonarQube requires the golangci-lint out-format to be checkstyle, which conflicts with DevOps' junit-xml requirement.
 # sonar.go.golangci-lint.reportPaths=report/lint_report.xml

--- a/adp/bkn/bkn-backend/tests/integration_tests/bkn/README.md
+++ b/adp/bkn/bkn-backend/tests/integration_tests/bkn/README.md
@@ -1,23 +1,23 @@
-# BKN 导入导出集成测试
+# BKN Import/Export Integration Tests
 
-验证 BKN 文件（tar 格式）的导入、导出及数据一致性。
+Verify BKN file import, export, and data consistency for tar-format BKN files.
 
-## 技术栈
+## Technology Stack
 
-- **语言**: Go 1.24
-- **测试框架**: [GoConvey](https://github.com/smartystreets/goconvey) (BDD 风格)
-- **配置管理**: [Viper](https://github.com/spf13/viper) (YAML + 环境变量)
+- **Language**: Go 1.24
+- **Test framework**: [GoConvey](https://github.com/smartystreets/goconvey) (BDD style)
+- **Configuration management**: [Viper](https://github.com/spf13/viper) (YAML + environment variables)
 
-## 目录结构
+## Directory Structure
 
 ```
 bkn/
-├── bkn_test.go                               # 主测试文件（10 个用例）
+├── bkn_test.go                               # Main test file (10 cases)
 ├── README.md
 └── helpers/
-    ├── bkn_helpers.go                        # 测试辅助函数
-    └── examples/                             # 测试数据
-        └── k8s-network/                      # K8s 网络拓扑示例
+    ├── bkn_helpers.go                        # Test helper functions
+    └── examples/                             # Test data
+        └── k8s-network/                      # K8s network topology example
             ├── CHECKSUM
             ├── SKILL.md
             ├── network.bkn
@@ -28,60 +28,60 @@ bkn/
             └── risk_types/                   # restart_pod_high_risk
 ```
 
-## 运行方式
+## Running Tests
 
-### 配置
+### Configuration
 
-测试配置文件位于 `../testdata/test-config.yaml`，也可通过 `BKN_TEST_` 前缀的环境变量覆盖：
+The test configuration file is located at `../testdata/test-config.yaml`. It can also be overridden with environment variables that use the `BKN_TEST_` prefix:
 
 ```bash
 export BKN_TEST_BKN_BACKEND_BASE_URL=http://my-server:8080
 ```
 
-### 执行
+### Execution
 
 ```bash
-# 从 tests 目录运行
+# Run from the tests directory.
 cd bkn/bkn-backend/tests
 go test ./integration_tests/bkn/ -v
 ```
 
-## 测试用例清单
+## Test Case List
 
-### 导入测试 (BKN101-BKN102)
+### Import Tests (BKN101-BKN102)
 
-| 编号 | 描述 | 验证点 |
-|------|------|--------|
-| BKN101 | 导入 k8s-network 示例 | tar 构建成功、上传返回 200、响应包含 kn_id |
-| BKN102 | 导入后验证各类型已创建 | 导入 k8s-network → GET object-types、relation-types、action-types、concept-groups 列表均非空 |
+| ID | Description | Verification Points |
+|----|-------------|---------------------|
+| BKN101 | Import the k8s-network example | Tar builds successfully, upload returns 200, response contains kn_id |
+| BKN102 | Verify all types are created after import | Import k8s-network, then GET object-types, relation-types, action-types, and concept-groups; each list is non-empty |
 
-### 导出测试 (BKN121-BKN122)
+### Export Tests (BKN121-BKN122)
 
-| 编号 | 描述 | 验证点 |
-|------|------|--------|
-| BKN121 | 基本导出场景 | 返回 200、响应体非空、IsValidTar 验证通过 |
-| BKN122 | 验证 Content-Disposition 包含 kn_id | Content-Disposition 头非空、包含 knID |
+| ID | Description | Verification Points |
+|----|-------------|---------------------|
+| BKN121 | Basic export scenario | Returns 200, response body is non-empty, and `IsValidTar` passes |
+| BKN122 | Verify Content-Disposition contains kn_id | Content-Disposition header is non-empty and contains knID |
 
-### 负向测试 (BKN201-BKN204)
+### Negative Tests (BKN201-BKN204)
 
-| 编号 | 描述 | 验证点 |
-|------|------|--------|
-| BKN201 | 导入无效文件格式（纯文本） | 返回 >= 400 |
-| BKN202 | 导出不存在的知识网络 | 返回 >= 400 |
-| BKN203 | 导入空文件 | 返回 >= 400 |
-| BKN204 | 导入缺少 network.bkn 的 tar 包 | 合法 tar 但缺少必要文件，返回 >= 400 |
+| ID | Description | Verification Points |
+|----|-------------|---------------------|
+| BKN201 | Import an invalid file format (plain text) | Returns >= 400 |
+| BKN202 | Export a non-existent knowledge network | Returns >= 400 |
+| BKN203 | Import an empty file | Returns >= 400 |
+| BKN204 | Import a tar archive without network.bkn | Tar is valid but lacks the required file; returns >= 400 |
 
-### 复杂数据测试 (BKN221)
+### Complex Data Test (BKN221)
 
-| 编号 | 描述 | 验证点 |
-|------|------|--------|
-| BKN221 | 导出包含复杂结构的 BKN | 导出内容包含 object_types、relation_types、action_types 字节 |
+| ID | Description | Verification Points |
+|----|-------------|---------------------|
+| BKN221 | Export a BKN with a complex structure | Exported content contains object_types, relation_types, and action_types bytes |
 
-## 测试数据说明
+## Test Data
 
 ### k8s-network
 
-Kubernetes 集群网络拓扑，包含 3 种对象、2 种关系、2 种行动、1 种风险。
+Kubernetes cluster network topology containing 3 object types, 2 relation types, 2 action types, and 1 risk type.
 
 ```
 Service ──routes──> Pod ──belongs──> Node
@@ -90,45 +90,45 @@ Service ──routes──> Pod ──belongs──> Node
               (action)           (action)
 ```
 
-## 辅助函数 (helpers/bkn_helpers.go)
+## Helper Functions (helpers/bkn_helpers.go)
 
-| 函数 | 用途 |
-|------|------|
-| `IsValidTar(data)` | 验证字节数据是否为合法 tar 格式 |
-| `GenerateUniqueName(prefix)` | 生成带时间戳的唯一名称 |
-| `BuildStringWithLength(char, length)` | 构建指定长度的字符串 |
-| `DeleteTestKN(client, knID, branch, t)` | 删除测试知识网络 |
-| `CleanupKNs(client, t)` | 清理所有测试 KN |
-| `BuildTarFromExamplesDir(exampleName)` | 从 examples 目录构建 tar 包 |
-| `BuildSimpleBKNTar(knID)` | 构建简单 tar（network.bkn + 1 个 object_type） |
-| `BuildFullBKNTar(knID)` | 构建完整 tar（2 个 object_type + 1 个 relation + 1 个 action） |
-| `BuildTarWithoutNetworkBKN()` | 构建缺少 network.bkn 的 tar（负向测试用） |
-| `GetExampleNames()` | 获取可用示例名称列表 |
-| `CreateTestObjectType(client, knID, t)` | 通过 API 创建测试对象类型 |
-| `CreateTestRelationType(...)` | 通过 API 创建测试关系类型 |
-| `CreateTestActionType(...)` | 通过 API 创建测试行动类型 |
-| `VerifyObjectTypesExist(client, knID, t)` | 验证对象类型是否存在 |
-| `VerifyRelationTypesExist(client, knID, t)` | 验证关系类型是否存在 |
-| `VerifyActionTypesExist(client, knID, t)` | 验证行动类型是否存在 |
-| `VerifyConceptGroupsExist(client, knID, t)` | 验证概念分组是否存在 |
+| Function | Purpose |
+|----------|---------|
+| `IsValidTar(data)` | Verifies whether byte data is a valid tar archive |
+| `GenerateUniqueName(prefix)` | Generates a unique timestamped name |
+| `BuildStringWithLength(char, length)` | Builds a string with the specified length |
+| `DeleteTestKN(client, knID, branch, t)` | Deletes a test knowledge network |
+| `CleanupKNs(client, t)` | Cleans up all test KNs |
+| `BuildTarFromExamplesDir(exampleName)` | Builds a tar archive from the examples directory |
+| `BuildSimpleBKNTar(knID)` | Builds a simple tar archive (network.bkn + 1 object_type) |
+| `BuildFullBKNTar(knID)` | Builds a full tar archive (2 object_types + 1 relation + 1 action) |
+| `BuildTarWithoutNetworkBKN()` | Builds a tar archive without network.bkn for negative testing |
+| `GetExampleNames()` | Gets the list of available example names |
+| `CreateTestObjectType(client, knID, t)` | Creates a test object type through the API |
+| `CreateTestRelationType(...)` | Creates a test relation type through the API |
+| `CreateTestActionType(...)` | Creates a test action type through the API |
+| `VerifyObjectTypesExist(client, knID, t)` | Verifies that object types exist |
+| `VerifyRelationTypesExist(client, knID, t)` | Verifies that relation types exist |
+| `VerifyActionTypesExist(client, knID, t)` | Verifies that action types exist |
+| `VerifyConceptGroupsExist(client, knID, t)` | Verifies that concept groups exist |
 
-## API 端点覆盖
+## API Endpoint Coverage
 
-| 端点 | 方法 | 用途 | 测试覆盖 |
-|------|------|------|----------|
-| `/api/bkn-backend/v1/bkns` | POST | 导入 BKN | BKN101-102 |
-| `/api/bkn-backend/v1/bkns/{knID}` | GET | 导出 BKN | BKN121-122, BKN221 |
-| `/api/bkn-backend/v1/knowledge-networks/{knID}/object-types` | GET | 列出对象类型 | BKN102 |
-| `/api/bkn-backend/v1/knowledge-networks/{knID}/relation-types` | GET | 列出关系类型 | BKN102 |
-| `/api/bkn-backend/v1/knowledge-networks/{knID}/action-types` | GET | 列出行动类型 | BKN102 |
-| `/api/bkn-backend/v1/knowledge-networks/{knID}/concept-groups` | GET | 列出概念分组 | BKN102 |
-| `/api/bkn-backend/v1/knowledge-networks` | GET | 列出 KN | 清理（teardown） |
-| `/api/bkn-backend/v1/knowledge-networks/{knID}` | DELETE | 删除 KN | 清理（teardown） |
+| Endpoint | Method | Purpose | Test Coverage |
+|----------|--------|---------|---------------|
+| `/api/bkn-backend/v1/bkns` | POST | Import BKN | BKN101-102 |
+| `/api/bkn-backend/v1/bkns/{knID}` | GET | Export BKN | BKN121-122, BKN221 |
+| `/api/bkn-backend/v1/knowledge-networks/{knID}/object-types` | GET | List object types | BKN102 |
+| `/api/bkn-backend/v1/knowledge-networks/{knID}/relation-types` | GET | List relation types | BKN102 |
+| `/api/bkn-backend/v1/knowledge-networks/{knID}/action-types` | GET | List action types | BKN102 |
+| `/api/bkn-backend/v1/knowledge-networks/{knID}/concept-groups` | GET | List concept groups | BKN102 |
+| `/api/bkn-backend/v1/knowledge-networks` | GET | List KNs | Cleanup (teardown) |
+| `/api/bkn-backend/v1/knowledge-networks/{knID}` | DELETE | Delete a KN | Cleanup (teardown) |
 
-## 建议补充的测试场景
+## Suggested Additional Test Scenarios
 
-| 场景 | 优先级 | 说明 |
-|------|--------|------|
-| 幂等性 | 高 | 同一 BKN 导入两次，验证无报错且不产生重复数据 |
-| 覆盖/更新语义 | 中 | 已有数据的 KN 再次导入，验证更新而非重复创建 |
-| 默认分支行为 | 中 | 不传 branch 参数时的默认行为 |
+| Scenario | Priority | Description |
+|----------|----------|-------------|
+| Idempotency | High | Import the same BKN twice and verify that no error or duplicate data is produced |
+| Overwrite/update semantics | Medium | Import an existing KN again and verify that data is updated instead of duplicated |
+| Default branch behavior | Medium | Verify default behavior when the branch parameter is omitted |

--- a/adp/bkn/bkn-backend/tests/integration_tests/bkn/bkn_test.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/bkn/bkn_test.go
@@ -19,39 +19,39 @@ import (
 	"bkn-backend-tests/testutil"
 )
 
-// TestBKNImportExport BKN导入导出集成测试
-// 测试编号前缀: BKN1xx (Import/Export)
+// TestBKNImportExport runs BKN import/export integration tests.
+// Test ID prefix: BKN1xx (Import/Export).
 func TestBKNImportExport(t *testing.T) {
 
 	Convey("BKN导入导出集成测试 - 初始化", t, func() {
 
-		// 加载测试配置
+		// Load test configuration.
 		config, err := setup.LoadTestConfig()
 		So(err, ShouldBeNil)
 		So(config, ShouldNotBeNil)
 
-		// 创建HTTP客户端
+		// Create the HTTP client.
 		client := testutil.NewHTTPClient(config.BKNBackend.BaseURL)
 
-		// 验证服务可用性
+		// Verify service availability.
 		err = client.CheckHealth()
 		So(err, ShouldBeNil)
 		t.Logf("✓ 集成测试环境就绪，BKN Backend: %s", config.BKNBackend.BaseURL)
 
-		// 清理现有测试知识网络
+		// Clean up existing test knowledge networks.
 		helpers.CleanupKNs(client, t)
 
-		// ========== BKN 导入测试（BKN101-BKN103） ==========
+		// ========== BKN import tests (BKN101-BKN103) ==========
 
 		Convey("BKN101: 导入BKN - 使用 k8s-network 示例", func() {
 
-			// 从 examples 目录构建 tar 包
+			// Build a tar archive from the examples directory.
 			tarData, err := helpers.BuildTarFromExamplesDir("k8s-network")
 			So(err, ShouldBeNil)
 			So(tarData, ShouldNotBeNil)
 			So(len(tarData), ShouldBeGreaterThan, 0)
 
-			// 上传BKN文件
+			// Upload the BKN file.
 			resp := client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
 				"file",
@@ -68,7 +68,7 @@ func TestBKNImportExport(t *testing.T) {
 		Convey("BKN102: 导入BKN后验证对象类型、关系类型、行动类型已创建", func() {
 
 			knID := "k8s-network"
-			// 导入BKN（k8s-network 包含 object_types、relation_types、action_types）
+			// Import the BKN; k8s-network contains object_types, relation_types, and action_types.
 			tarData, _ := helpers.BuildTarFromExamplesDir("k8s-network")
 			resp := client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
@@ -79,19 +79,19 @@ func TestBKNImportExport(t *testing.T) {
 			)
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 
-			// 验证对象类型已创建
+			// Verify object types were created.
 			otEntries := helpers.VerifyObjectTypesExist(client, knID, t)
 			So(len(otEntries), ShouldBeGreaterThan, 0)
 
-			// 验证关系类型已创建
+			// Verify relation types were created.
 			rtEntries := helpers.VerifyRelationTypesExist(client, knID, t)
 			So(len(rtEntries), ShouldBeGreaterThan, 0)
 
-			// 验证行动类型已创建
+			// Verify action types were created.
 			atEntries := helpers.VerifyActionTypesExist(client, knID, t)
 			So(len(atEntries), ShouldBeGreaterThan, 0)
 
-			// 验证概念分组已创建
+			// Verify concept groups were created.
 			cgEntries := helpers.VerifyConceptGroupsExist(client, knID, t)
 			So(len(cgEntries), ShouldBeGreaterThan, 0)
 		})
@@ -112,12 +112,12 @@ func TestBKNImportExport(t *testing.T) {
 			So(n, ShouldBeGreaterThanOrEqualTo, 5)
 		})
 
-		// ========== BKN 导出测试（BKN121-BKN122） ==========
+		// ========== BKN export tests (BKN121-BKN122) ==========
 
 		Convey("BKN121: 导出BKN - 基本场景", func() {
 			knID := "k8s-network"
 
-			// 先导入一些数据
+			// Import some data first.
 			tarData, _ := helpers.BuildTarFromExamplesDir("k8s-network")
 			client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
@@ -127,7 +127,7 @@ func TestBKNImportExport(t *testing.T) {
 				nil,
 			)
 
-			// 导出BKN
+			// Export the BKN.
 			resp := client.GET("/api/bkn-backend/v1/bkns/" + knID)
 
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
@@ -139,7 +139,7 @@ func TestBKNImportExport(t *testing.T) {
 		Convey("BKN122: 导出BKN - 验证Content-Disposition包含kn_id", func() {
 			knID := "k8s-network"
 
-			// 先导入数据
+			// Import data first.
 			tarData, _ := helpers.BuildTarFromExamplesDir("k8s-network")
 			client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
@@ -153,7 +153,7 @@ func TestBKNImportExport(t *testing.T) {
 
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 
-			// 验证 Content-Disposition 头包含文件下载信息
+			// Verify the Content-Disposition header contains file download information.
 			contentDisposition := resp.Headers.Get("Content-Disposition")
 			So(contentDisposition, ShouldNotBeEmpty)
 			So(strings.Contains(contentDisposition, knID), ShouldBeTrue)
@@ -176,11 +176,11 @@ func TestBKNImportExport(t *testing.T) {
 			So(bytes.Contains(resp.RawBody, []byte("pod_running_count")), ShouldBeTrue)
 		})
 
-		// ========== 负向测试（BKN201-BKN220） ==========
+		// ========== Negative tests (BKN201-BKN220) ==========
 
 		Convey("BKN201: 导入无效文件格式", func() {
 
-			// 上传非tar文件
+			// Upload a non-tar file.
 			invalidData := []byte("this is not a tar file")
 			resp := client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
@@ -190,21 +190,21 @@ func TestBKNImportExport(t *testing.T) {
 				nil,
 			)
 
-			// 应该返回错误
+			// An error should be returned.
 			So(resp.StatusCode, ShouldBeGreaterThanOrEqualTo, 400)
 		})
 
 		Convey("BKN202: 导出不存在的知识网络", func() {
-			// 尝试导出不存在的KN
+			// Try to export a non-existent KN.
 			resp := client.GET("/api/bkn-backend/v1/bkns/non-existent-kn-id")
 
-			// 应该返回错误
+			// An error should be returned.
 			So(resp.StatusCode, ShouldBeGreaterThanOrEqualTo, 400)
 		})
 
 		Convey("BKN203: 导入空文件", func() {
 
-			// 上传空文件
+			// Upload an empty file.
 			resp := client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
 				"file",
@@ -213,13 +213,13 @@ func TestBKNImportExport(t *testing.T) {
 				nil,
 			)
 
-			// 应该返回错误
+			// An error should be returned.
 			So(resp.StatusCode, ShouldBeGreaterThanOrEqualTo, 400)
 		})
 
 		Convey("BKN204: 导入缺少network.bkn的tar包", func() {
 
-			// 构建缺少 network.bkn 的 tar 包
+			// Build a tar archive without network.bkn.
 			tarData, err := helpers.BuildTarWithoutNetworkBKN()
 			So(err, ShouldBeNil)
 
@@ -231,7 +231,7 @@ func TestBKNImportExport(t *testing.T) {
 				nil,
 			)
 
-			// 应该返回错误
+			// An error should be returned.
 			So(resp.StatusCode, ShouldBeGreaterThanOrEqualTo, 400)
 		})
 
@@ -248,12 +248,12 @@ func TestBKNImportExport(t *testing.T) {
 			So(resp.StatusCode, ShouldBeGreaterThanOrEqualTo, 400)
 		})
 
-		// ========== 复杂数据测试（BKN221） ==========
+		// ========== Complex data test (BKN221) ==========
 
 		Convey("BKN221: 导出包含复杂结构的BKN", func() {
 			knID := "k8s-network"
 
-			// 先导入复杂结构（k8s-network 包含对象、关系、行动等）
+			// Import a complex structure first; k8s-network contains objects, relations, actions, and other data.
 			tarData, _ := helpers.BuildTarFromExamplesDir("k8s-network")
 			client.POSTMultipart(
 				"/api/bkn-backend/v1/bkns",
@@ -263,11 +263,11 @@ func TestBKNImportExport(t *testing.T) {
 				nil,
 			)
 
-			// 导出
+			// Export.
 			resp := client.GET("/api/bkn-backend/v1/bkns/" + knID)
 			So(resp.StatusCode, ShouldEqual, http.StatusOK)
 
-			// 验证导出内容包含所有类型
+			// Verify the exported content contains all types.
 			So(bytes.Contains(resp.RawBody, []byte("object_types")), ShouldBeTrue)
 			So(bytes.Contains(resp.RawBody, []byte("relation_types")), ShouldBeTrue)
 			So(bytes.Contains(resp.RawBody, []byte("action_types")), ShouldBeTrue)

--- a/adp/bkn/bkn-backend/tests/integration_tests/bkn/helpers/bkn_helpers.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/bkn/helpers/bkn_helpers.go
@@ -28,12 +28,12 @@ func IsValidTar(data []byte) bool {
 	reader := bytes.NewReader(data)
 	tarReader := tar.NewReader(reader)
 
-	// 尝试读取第一个文件头
+	// Try to read the first file header.
 	_, err := tarReader.Next()
 
-	// 如果 err 是 nil，说明至少有一个合法的文件头，认为是有效的 TAR
-	// 如果 err 是 io.EOF，说明是空的 TAR 包（只有结束符），通常也视为有效（取决于业务需求）
-	// 如果 err 是其他错误（如 "archive/tar: invalid tar header"），则不是合法的 TAR
+	// If err is nil, at least one valid file header exists, so treat it as a valid TAR.
+	// If err is io.EOF, it is an empty TAR package with only end markers; this is usually valid, depending on business requirements.
+	// Any other error, such as "archive/tar: invalid tar header", means the TAR is invalid.
 	if err == nil || err == io.EOF {
 		return true
 	}
@@ -42,18 +42,18 @@ func IsValidTar(data []byte) bool {
 	return false
 }
 
-// GenerateUniqueName 生成唯一的测试名称
+// GenerateUniqueName generates a unique test name.
 func GenerateUniqueName(prefix string) string {
 	timestamp := time.Now().UnixNano() / 1000000
 	return fmt.Sprintf("%s-%d", prefix, timestamp)
 }
 
-// BuildStringWithLength 构建指定长度的字符串
+// BuildStringWithLength builds a string with the specified length.
 func BuildStringWithLength(char string, length int) string {
 	return strings.Repeat(char, length)
 }
 
-// DeleteTestKN 删除测试知识网络
+// DeleteTestKN deletes a test knowledge network.
 func DeleteTestKN(client *testutil.HTTPClient, knID string, branch string, t *testing.T) {
 	resp := client.DELETE("/api/bkn-backend/v1/knowledge-networks/" + knID + "?branch=" + branch)
 	if resp.StatusCode != 200 && resp.StatusCode != 204 {
@@ -61,7 +61,7 @@ func DeleteTestKN(client *testutil.HTTPClient, knID string, branch string, t *te
 	}
 }
 
-// CreateTestObjectType 创建测试对象类型
+// CreateTestObjectType creates a test object type.
 func CreateTestObjectType(client *testutil.HTTPClient, knID string, t *testing.T) (otID string) {
 	payload := map[string]any{
 		"name":         GenerateUniqueName("test-ot"),
@@ -92,7 +92,7 @@ func CreateTestObjectType(client *testutil.HTTPClient, knID string, t *testing.T
 	return
 }
 
-// CreateTestRelationType 创建测试关系类型
+// CreateTestRelationType creates a test relation type.
 func CreateTestRelationType(client *testutil.HTTPClient, knID string, sourceOTID, targetOTID string, t *testing.T) (rtID string) {
 	payload := map[string]any{
 		"name":                  GenerateUniqueName("test-rt"),
@@ -112,7 +112,7 @@ func CreateTestRelationType(client *testutil.HTTPClient, knID string, sourceOTID
 	return
 }
 
-// CreateTestActionType 创建测试行动类型
+// CreateTestActionType creates a test action type.
 func CreateTestActionType(client *testutil.HTTPClient, knID string, objectTypeID string, t *testing.T) (atID string) {
 	payload := map[string]any{
 		"name":           GenerateUniqueName("test-at"),
@@ -131,12 +131,12 @@ func CreateTestActionType(client *testutil.HTTPClient, knID string, objectTypeID
 	return
 }
 
-// BuildSimpleBKNTar 构建简单的 BKN tar 包（用于导入测试）
+// BuildSimpleBKNTar builds a simple BKN tar package for import tests.
 func BuildSimpleBKNTar(knID string) ([]byte, error) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	// 创建 network.bkn 文件
+	// Create the network.bkn file.
 	networkContent := fmt.Sprintf(`---
 type: network
 id: %s
@@ -173,7 +173,7 @@ version: "1.0.0"
 		return nil, err
 	}
 
-	// 创建 object_types/test_object.bkn 文件
+	// Create the object_types/test_object.bkn file.
 	objectContent := `---
 type: object_type
 id: test_object
@@ -216,12 +216,12 @@ version: "1.0.0"
 	return buf.Bytes(), nil
 }
 
-// BuildFullBKNTar 构建完整的 BKN tar 包（包含对象、关系、行动）
+// BuildFullBKNTar builds a complete BKN tar package containing objects, relations, and actions.
 func BuildFullBKNTar(knID string) ([]byte, error) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	// 创建 network.bkn 文件
+	// Create the network.bkn file.
 	networkContent := fmt.Sprintf(`---
 type: network
 id: %s
@@ -244,7 +244,7 @@ version: "1.0.0"
 		return nil, err
 	}
 
-	// 创建 object_types/customer.bkn 文件
+	// Create the object_types/customer.bkn file.
 	customerContent := `---
 type: object_type
 id: customer
@@ -281,7 +281,7 @@ version: "1.0.0"
 		return nil, err
 	}
 
-	// 创建 object_types/order.bkn 文件
+	// Create the object_types/order.bkn file.
 	orderContent := `---
 type: object_type
 id: order
@@ -318,7 +318,7 @@ version: "1.0.0"
 		return nil, err
 	}
 
-	// 创建 relation_types/customer_order.bkn 文件
+	// Create the relation_types/customer_order.bkn file.
 	relationContent := `---
 type: relation_type
 id: customer_order
@@ -353,7 +353,7 @@ version: "1.0.0"
 		return nil, err
 	}
 
-	// 创建 action_types/create_order.bkn 文件
+	// Create the action_types/create_order.bkn file.
 	actionContent := `---
 type: action_type
 id: create_order
@@ -394,12 +394,12 @@ version: "1.0.0"
 	return buf.Bytes(), nil
 }
 
-// BuildTarWithoutNetworkBKN 构建缺少 network.bkn 的 tar 包（用于负向测试）
+// BuildTarWithoutNetworkBKN builds a tar package without network.bkn for negative tests.
 func BuildTarWithoutNetworkBKN() ([]byte, error) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	// 只包含 object_types，不包含 network.bkn
+	// Include only object_types, without network.bkn.
 	objectContent := `---
 type: object_type
 id: orphan_object
@@ -440,9 +440,9 @@ version: "1.0.0"
 	return buf.Bytes(), nil
 }
 
-// CleanupKNs 清理测试知识网络
+// CleanupKNs cleans up test knowledge networks.
 func CleanupKNs(client *testutil.HTTPClient, t *testing.T) {
-	// 查询所有测试知识网络
+	// Query all test knowledge networks.
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks?offset=0&limit=100")
 	if resp.StatusCode != 200 {
 		t.Logf("查询知识网络列表失败: status=%d", resp.StatusCode)
@@ -468,14 +468,14 @@ func CleanupKNs(client *testutil.HTTPClient, t *testing.T) {
 	}
 }
 
-// BuildTarFromExamplesDir 从 examples 目录构建 tar 包
-// exampleName: 示例目录名称，如 "k8s-network"
+// BuildTarFromExamplesDir builds a tar package from the examples directory.
+// exampleName: example directory name, such as "k8s-network".
 func BuildTarFromExamplesDir(exampleName string) ([]byte, error) {
 	examplesDir := filepath.Join("helpers", "examples", exampleName)
 	return buildTarFromDir(examplesDir)
 }
 
-// buildTarFromDir 从指定目录构建 tar 包
+// buildTarFromDir builds a tar package from the specified directory.
 func buildTarFromDir(dirPath string) ([]byte, error) {
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
@@ -485,21 +485,21 @@ func buildTarFromDir(dirPath string) ([]byte, error) {
 			return err
 		}
 
-		// 跳过目录
+		// Skip directories.
 		if fi.IsDir() {
 			return nil
 		}
 
-		// 计算相对路径（相对于 dirPath）
+		// Calculate the relative path from dirPath.
 		relPath, err := filepath.Rel(dirPath, file)
 		if err != nil {
 			return err
 		}
 
-		// 使用正斜杠作为 tar 包内的路径分隔符
+		// Use forward slashes as path separators inside the tar package.
 		relPath = filepath.ToSlash(relPath)
 
-		// 创建 tar 头
+		// Create the tar header.
 		header := &tar.Header{
 			Name: relPath,
 			Mode: int64(fi.Mode()),
@@ -510,7 +510,7 @@ func buildTarFromDir(dirPath string) ([]byte, error) {
 			return err
 		}
 
-		// 打开文件并写入 tar
+		// Open the file and write it to the tar package.
 		f, err := os.Open(file)
 		if err != nil {
 			return err
@@ -535,12 +535,12 @@ func buildTarFromDir(dirPath string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// GetExampleNames 获取可用的示例名称列表
+// GetExampleNames gets the list of available example names.
 func GetExampleNames() []string {
 	return []string{"k8s-network"}
 }
 
-// VerifyObjectTypesExist 验证对象类型是否存在
+// VerifyObjectTypesExist verifies that object types exist.
 func VerifyObjectTypesExist(client *testutil.HTTPClient, knID string, t *testing.T) []any {
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks/" + knID + "/object-types?offset=0&limit=100")
 	if resp.StatusCode != 200 {
@@ -553,7 +553,7 @@ func VerifyObjectTypesExist(client *testutil.HTTPClient, knID string, t *testing
 	return entries
 }
 
-// VerifyRelationTypesExist 验证关系类型是否存在
+// VerifyRelationTypesExist verifies that relation types exist.
 func VerifyRelationTypesExist(client *testutil.HTTPClient, knID string, t *testing.T) []any {
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks/" + knID + "/relation-types?offset=0&limit=100")
 	if resp.StatusCode != 200 {
@@ -566,7 +566,7 @@ func VerifyRelationTypesExist(client *testutil.HTTPClient, knID string, t *testi
 	return entries
 }
 
-// VerifyActionTypesExist 验证行动类型是否存在
+// VerifyActionTypesExist verifies that action types exist.
 func VerifyActionTypesExist(client *testutil.HTTPClient, knID string, t *testing.T) []any {
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks/" + knID + "/action-types?offset=0&limit=100")
 	if resp.StatusCode != 200 {
@@ -579,7 +579,7 @@ func VerifyActionTypesExist(client *testutil.HTTPClient, knID string, t *testing
 	return entries
 }
 
-// VerifyConceptGroupsExist 验证概念分组是否存在
+// VerifyConceptGroupsExist verifies that concept groups exist.
 func VerifyConceptGroupsExist(client *testutil.HTTPClient, knID string, t *testing.T) []any {
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks/" + knID + "/concept-groups?offset=0&limit=100")
 	if resp.StatusCode != 200 {
@@ -592,7 +592,7 @@ func VerifyConceptGroupsExist(client *testutil.HTTPClient, knID string, t *testi
 	return entries
 }
 
-// VerifyMetricsCountAtLeast 校验 GET .../metrics 返回条数不少于 minCount（用于 BKN tar 含指标的导入验收）。
+// VerifyMetricsCountAtLeast verifies that GET .../metrics returns at least minCount entries for BKN tar import acceptance with metrics.
 func VerifyMetricsCountAtLeast(client *testutil.HTTPClient, knID string, t *testing.T, minCount int) int {
 	resp := client.GET("/api/bkn-backend/v1/knowledge-networks/" + knID + "/metrics?offset=0&limit=500")
 	if resp.StatusCode != 200 {

--- a/adp/bkn/bkn-backend/tests/integration_tests/setup/config.go
+++ b/adp/bkn/bkn-backend/tests/integration_tests/setup/config.go
@@ -12,19 +12,19 @@ import (
 	"github.com/spf13/viper"
 )
 
-// TestConfig AT测试配置
+// TestConfig is the AT test configuration.
 type TestConfig struct {
 	BKNBackend BKNBackendConfig `mapstructure:"bkn_backend"`
 	MariaDB    MariaDBConfig    `mapstructure:"mariadb"`
 	OpenSearch OpenSearchConfig `mapstructure:"opensearch"`
 }
 
-// BKNBackendConfig BKN Backend服务配置
+// BKNBackendConfig is the BKN Backend service configuration.
 type BKNBackendConfig struct {
-	BaseURL string `mapstructure:"base_url"` // BKN Backend HTTP服务地址
+	BaseURL string `mapstructure:"base_url"` // BKN Backend HTTP service address.
 }
 
-// MariaDBConfig 测试目标MariaDB配置
+// MariaDBConfig is the target MariaDB configuration for tests.
 type MariaDBConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
@@ -33,7 +33,7 @@ type MariaDBConfig struct {
 	Password string `mapstructure:"password"`
 }
 
-// OpenSearchConfig 测试目标OpenSearch配置
+// OpenSearchConfig is the target OpenSearch configuration for tests.
 type OpenSearchConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
@@ -42,26 +42,26 @@ type OpenSearchConfig struct {
 	UseSSL   bool   `mapstructure:"use_ssl"`
 }
 
-// LoadTestConfig 加载测试配置
-// 优先从 testdata/test-config.yaml 读取
-// 支持环境变量覆盖 (BKN_TEST_前缀)
+// LoadTestConfig loads the test configuration.
+// It reads testdata/test-config.yaml first.
+// It supports environment variable overrides with the BKN_TEST_ prefix.
 func LoadTestConfig() (*TestConfig, error) {
 	viper.SetConfigName("test-config")
 	viper.SetConfigType("yaml")
 
-	// 添加多个可能的配置文件路径
-	viper.AddConfigPath("./testdata")                         // 从测试目录运行
-	viper.AddConfigPath("./integration_tests/testdata")       // 从tests目录运行
-	viper.AddConfigPath("./tests/integration_tests/testdata") // 从server目录运行
-	viper.AddConfigPath("../testdata")                        // 从子目录运行
-	viper.AddConfigPath("../../testdata")                     // 从深层子目录运行
-	viper.AddConfigPath("../../../testdata")                  // 从深层子目录运行
+	// Add multiple possible configuration file paths.
+	viper.AddConfigPath("./testdata")                         // Run from the test directory.
+	viper.AddConfigPath("./integration_tests/testdata")       // Run from the tests directory.
+	viper.AddConfigPath("./tests/integration_tests/testdata") // Run from the server directory.
+	viper.AddConfigPath("../testdata")                        // Run from a subdirectory.
+	viper.AddConfigPath("../../testdata")                     // Run from a deeper subdirectory.
+	viper.AddConfigPath("../../../testdata")                  // Run from a deeper subdirectory.
 
-	// 支持环境变量覆盖
+	// Support environment variable overrides.
 	viper.SetEnvPrefix("BKN_TEST")
 	viper.AutomaticEnv()
 
-	// 读取配置文件
+	// Read the configuration file.
 	if err := viper.ReadInConfig(); err != nil {
 		return nil, fmt.Errorf("读取test-config.yaml失败: %w\n提示: 请确保配置文件存在于tests/integration_tests/testdata/目录", err)
 	}
@@ -71,7 +71,7 @@ func LoadTestConfig() (*TestConfig, error) {
 		return nil, fmt.Errorf("解析配置失败: %w", err)
 	}
 
-	// 验证必填字段
+	// Validate required fields.
 	if config.BKNBackend.BaseURL == "" {
 		return nil, fmt.Errorf("配置错误: bkn_backend.base_url 不能为空")
 	}

--- a/adp/bkn/bkn-backend/tests/testutil/http_client.go
+++ b/adp/bkn/bkn-backend/tests/testutil/http_client.go
@@ -16,29 +16,29 @@ import (
 	"time"
 )
 
-// HTTPClient 封装HTTP请求的测试客户端
+// HTTPClient wraps HTTP requests for tests.
 type HTTPClient struct {
 	BaseURL string
 	Client  *http.Client
-	Headers map[string]string // 包含X-Account-ID等公共头
+	Headers map[string]string // Common headers such as X-Account-ID.
 }
 
-// HTTPResponse HTTP响应封装
+// HTTPResponse wraps an HTTP response.
 type HTTPResponse struct {
 	StatusCode int
-	Headers    http.Header    // 响应头
-	Body       map[string]any // 成功响应的JSON body
-	Error      *ErrorResponse // 错误响应
-	RawBody    []byte         // 原始响应体
+	Headers    http.Header    // Response headers.
+	Body       map[string]any // Successful response JSON body.
+	Error      *ErrorResponse // Error response.
+	RawBody    []byte         // Raw response body.
 }
 
-// ErrorResponse 错误响应结构
+// ErrorResponse is the error response structure.
 type ErrorResponse struct {
 	ErrorCode    string `json:"error_code"`
 	ErrorDetails string `json:"error_details"`
 }
 
-// NewHTTPClient 创建新的HTTP测试客户端
+// NewHTTPClient creates a new HTTP test client.
 func NewHTTPClient(baseURL string) *HTTPClient {
 	return &HTTPClient{
 		BaseURL: baseURL,
@@ -52,7 +52,7 @@ func NewHTTPClient(baseURL string) *HTTPClient {
 	}
 }
 
-// CheckHealth 检查服务健康状态
+// CheckHealth checks service health.
 func (c *HTTPClient) CheckHealth() error {
 	resp, err := c.Client.Get(c.BaseURL + "/health")
 	if err != nil {
@@ -66,32 +66,32 @@ func (c *HTTPClient) CheckHealth() error {
 	return nil
 }
 
-// POST 发送POST请求
+// POST sends a POST request.
 func (c *HTTPClient) POST(path string, payload any) HTTPResponse {
 	return c.doRequest("POST", path, payload)
 }
 
-// GET 发送GET请求
+// GET sends a GET request.
 func (c *HTTPClient) GET(path string) HTTPResponse {
 	return c.doRequest("GET", path, nil)
 }
 
-// PUT 发送PUT请求
+// PUT sends a PUT request.
 func (c *HTTPClient) PUT(path string, payload any) HTTPResponse {
 	return c.doRequest("PUT", path, payload)
 }
 
-// DELETE 发送DELETE请求
+// DELETE sends a DELETE request.
 func (c *HTTPClient) DELETE(path string) HTTPResponse {
 	return c.doRequest("DELETE", path, nil)
 }
 
-// POSTMultipart 发送 multipart/form-data POST 请求（用于文件上传）
+// POSTMultipart sends a multipart/form-data POST request for file uploads.
 func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileContent []byte, fileName string, extraParams map[string]string) HTTPResponse {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 
-	// 添加文件
+	// Add the file.
 	part, err := writer.CreateFormFile(fileFieldName, fileName)
 	if err != nil {
 		return HTTPResponse{
@@ -107,7 +107,7 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 		}
 	}
 
-	// 添加额外参数
+	// Add extra parameters.
 	for key, val := range extraParams {
 		_ = writer.WriteField(key, val)
 	}
@@ -120,10 +120,10 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 		}
 	}
 
-	// 构建完整URL
+	// Build the full URL.
 	url := c.BaseURL + path
 
-	// 创建请求
+	// Create the request.
 	req, err := http.NewRequest("POST", url, &body)
 	if err != nil {
 		return HTTPResponse{
@@ -132,13 +132,13 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 		}
 	}
 
-	// 设置 headers
+	// Set headers.
 	for key, value := range c.Headers {
 		req.Header.Set(key, value)
 	}
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 
-	// 发送请求
+	// Send the request.
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return HTTPResponse{
@@ -148,7 +148,7 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 	}
 	defer resp.Body.Close()
 
-	// 读取响应体
+	// Read the response body.
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return HTTPResponse{
@@ -157,14 +157,14 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 		}
 	}
 
-	// 解析响应
+	// Parse the response.
 	result := HTTPResponse{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header,
 		RawBody:    respBody,
 	}
 
-	// 尝试解析 JSON
+	// Try to parse JSON.
 	if len(respBody) > 0 {
 		var jsonBody map[string]any
 		if err := json.Unmarshal(respBody, &jsonBody); err == nil {
@@ -175,7 +175,7 @@ func (c *HTTPClient) POSTMultipart(path string, fileFieldName string, fileConten
 	return result
 }
 
-// doRequest 执行HTTP请求的内部方法
+// doRequest executes an HTTP request internally.
 func (c *HTTPClient) doRequest(method, path string, payload any) HTTPResponse {
 	var bodyReader io.Reader
 	if payload != nil {
@@ -189,10 +189,10 @@ func (c *HTTPClient) doRequest(method, path string, payload any) HTTPResponse {
 		bodyReader = bytes.NewBuffer(bodyBytes)
 	}
 
-	// 构建完整URL
+	// Build the full URL.
 	url := c.BaseURL + path
 
-	// 创建请求
+	// Create the request.
 	req, err := http.NewRequest(method, url, bodyReader)
 	if err != nil {
 		return HTTPResponse{
@@ -201,12 +201,12 @@ func (c *HTTPClient) doRequest(method, path string, payload any) HTTPResponse {
 		}
 	}
 
-	// 设置 headers
+	// Set headers.
 	for key, value := range c.Headers {
 		req.Header.Set(key, value)
 	}
 
-	// 发送请求
+	// Send the request.
 	resp, err := c.Client.Do(req)
 	if err != nil {
 		return HTTPResponse{
@@ -216,7 +216,7 @@ func (c *HTTPClient) doRequest(method, path string, payload any) HTTPResponse {
 	}
 	defer resp.Body.Close()
 
-	// 读取响应体
+	// Read the response body.
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return HTTPResponse{
@@ -225,20 +225,20 @@ func (c *HTTPClient) doRequest(method, path string, payload any) HTTPResponse {
 		}
 	}
 
-	// 解析响应
+	// Parse the response.
 	result := HTTPResponse{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header,
 		RawBody:    respBody,
 	}
 
-	// 尝试解析 JSON
+	// Try to parse JSON.
 	if len(respBody) > 0 {
 		var jsonBody map[string]any
 		if err := json.Unmarshal(respBody, &jsonBody); err == nil {
 			result.Body = jsonBody
 		} else {
-			// 如果不是 JSON，保留原始内容
+			// If it is not JSON, keep the original content.
 			result.Body = map[string]any{"raw": string(respBody)}
 		}
 	}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Translate ordinary comments and docstrings in dp/bkn/bkn-backend to English.
- [x] Translate in-scope README.md / eadme.md files under dp/bkn/bkn-backend.
- [x] Keep runtime logs, test output strings, CLI help, error messages, locale text, metadata, and BKN test fixture/business data unchanged.

---

## Why

- Related Issue: Part of #993
- Related Feature: N/A
- Background:
  - Issue #993 is being split by module to keep review size manageable.
  - This PR covers the dp/bkn/bkn-backend slice.
  - Scope follows the updated rule: translate comments/docstrings and README/TRACE documents only; do not translate runtime/user/contract text.

---

## How

- Key implementation points:
  - Updated Dockerfile comments, Helm/config comments, Sonar properties comments, Go comments, Python docstrings/comments, and module README files.
  - No TRACE.md file was found under dp/bkn/bkn-backend.
  - Preserved remaining Chinese in runtime strings, integration-test names/logs, BKN fixture content, README.zh.md, locale files, component metadata, and example content.
- Breaking changes (API, config, database, etc.):
  - None. This is comment/documentation-only cleanup.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran python3 -m py_compile adp/bkn/bkn-backend/script/delete_concept_index/script.py: passed.
- Parsed dp/bkn/bkn-backend/helm/bkn-backend/values.yaml and dp/bkn/bkn-backend/server/config/bkn-backend-config.yaml with Python YAML loader: passed.
- Ran git diff --check -- adp/bkn/bkn-backend: passed.
- Ran changed-file CRLF scan: no CRLF found.
- Ran I18N_MODE_UT=true go test ./drivenadapters/opensearch ./bkn-specification/... -count=1 from dp/bkn/bkn-backend/server: passed.
- Ran go test ./integration_tests/bkn/helpers ./integration_tests/setup ./testutil -count=1 from dp/bkn/bkn-backend/tests: passed.
- Ran go test ./integration_tests/bkn -run '^$' -count=1 from dp/bkn/bkn-backend/tests: passed compile-only validation.
- make test / go test ./... under dp/bkn/bkn-backend/tests was not fully runnable locally because the integration suite requires a running BKN Backend at localhost:13014; the health check failed with connection refused.

---

## Risk & Rollback

- Potential risks:
  - Low. Changes are limited to comments/docstrings and README documentation.
  - Review risk is wording accuracy for translated documentation and comments.
- Rollback plan:
  - Revert commit 9795ed8f if any translation wording is found inaccurate.

---

## Additional Notes

- This PR intentionally uses Part of #993 rather than closing #993 because the umbrella issue is being completed across multiple smaller PRs.
