### PR TITLE
refactor(mcp): resolve the locale per request instead of per session

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -61,8 +60,7 @@ const (
 	toolKeyGetSkillContent          = "get_skill_content"
 	toolKeyReadSkillFile            = "read_skill_file"
 	toolKeyExecuteSkill             = "execute_skill"
-	// Keep locale tracking aligned with the bounded lifetime of mcp-go's
-	// in-memory session state.
+	// Bounds the lifetime of mcp-go's in-memory session state.
 	mcpSessionIdleTTL = 30 * time.Minute
 )
 
@@ -83,13 +81,7 @@ func NewMCPHandlerWithLifecycle(lifecycleClient *bkntrace.LifecycleClient) http.
 }
 
 type localizedMCPHandler struct {
-	handlers       map[string]http.Handler
-	sessionLocales sync.Map // Mcp-Session-Id -> mcpSessionLocale
-}
-
-type mcpSessionLocale struct {
-	locale   string
-	lastUsed time.Time
+	handlers map[string]http.Handler
 }
 
 func newLocalizedMCPHandler(lifecycleClient *bkntrace.LifecycleClient) http.Handler {
@@ -116,48 +108,19 @@ func newMCPStreamableHTTPHandler(srv *server.MCPServer, path string) http.Handle
 }
 
 func (h *localizedMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	sessionID := r.Header.Get(server.HeaderKeySessionID)
-	now := time.Now()
-	h.cleanupExpiredSessionLocales(now)
-	locale := h.localeForRequest(r, sessionID, now)
+	// Every request carries its own language. An earlier version pinned the
+	// locale to Mcp-Session-Id, guarding against a client that changes language
+	// mid-session — which clients do not do, while the map itself became more
+	// per-replica session state to keep alive (#954).
+	locale := normalizeMCPLocale(string(sharedrest.ResolveLanguage(r.Header.Get(sharedrest.AcceptLanguageHeader))))
 	handler, ok := h.handlers[locale]
 	if !ok {
 		handler = h.handlers[defaultMCPLocale]
 	}
 
-	// All tool handlers read the effective locale from request context. Pin it
-	// to the session value so a later Accept-Language header cannot make tool
-	// results disagree with the session's initialized catalog.
+	// The tool handlers read the effective locale from the request context.
 	r = r.WithContext(common.SetLanguageToCtx(r.Context(), common.Language(locale)))
 	handler.ServeHTTP(w, r)
-	if initializedSessionID := w.Header().Get(server.HeaderKeySessionID); initializedSessionID != "" {
-		h.sessionLocales.Store(initializedSessionID, mcpSessionLocale{locale: locale, lastUsed: now})
-	}
-	if r.Method == http.MethodDelete && sessionID != "" {
-		h.sessionLocales.Delete(sessionID)
-	}
-}
-
-func (h *localizedMCPHandler) localeForRequest(r *http.Request, sessionID string, now time.Time) string {
-	if sessionID != "" {
-		if value, ok := h.sessionLocales.Load(sessionID); ok {
-			session := value.(mcpSessionLocale)
-			session.lastUsed = now
-			h.sessionLocales.Store(sessionID, session)
-			return session.locale
-		}
-	}
-	return normalizeMCPLocale(string(sharedrest.ResolveLanguage(r.Header.Get(sharedrest.AcceptLanguageHeader))))
-}
-
-func (h *localizedMCPHandler) cleanupExpiredSessionLocales(now time.Time) {
-	h.sessionLocales.Range(func(key, value any) bool {
-		session, ok := value.(mcpSessionLocale)
-		if !ok || now.Sub(session.lastUsed) >= mcpSessionIdleTTL {
-			h.sessionLocales.Delete(key)
-		}
-		return true
-	})
 }
 
 // newMCPServer assembles the tool surface. Split out of NewMCPHandler so tests

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app_locale_handler_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app_locale_handler_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/mark3labs/mcp-go/server"
 
@@ -18,38 +17,36 @@ import (
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
-func TestLocalizedMCPHandlerPinsLocaleToSession(t *testing.T) {
+func TestLocalizedMCPHandlerFollowsRequestLocale(t *testing.T) {
 	handler := &localizedMCPHandler{
 		handlers: map[string]http.Handler{
-			defaultMCPLocale: markerMCPHandler("zh-session"),
-			"en-US":          markerMCPHandler("en-session"),
+			defaultMCPLocale: markerMCPHandler("zh-handler"),
+			"en-US":          markerMCPHandler("en-handler"),
 		},
 	}
 
-	first := httptest.NewRequest(http.MethodPost, endpointPath, nil)
-	first.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
-	firstRecorder := httptest.NewRecorder()
-	handler.ServeHTTP(firstRecorder, first)
-	if got := firstRecorder.Body.String(); got != "en-session" {
-		t.Fatalf("initialize response = %q, want English handler", got)
-	}
-	if sessionID := firstRecorder.Header().Get(server.HeaderKeySessionID); sessionID != "en-session" {
-		t.Fatalf("Mcp-Session-Id = %q, want en-session", sessionID)
+	english := httptest.NewRequest(http.MethodPost, endpointPath, nil)
+	english.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
+	englishRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(englishRecorder, english)
+	if got := englishRecorder.Body.String(); got != "en-handler" {
+		t.Fatalf("en-US request = %q, want the English handler", got)
 	}
 
-	followup := httptest.NewRequest(http.MethodPost, endpointPath, nil)
-	followup.Header.Set(sharedrest.AcceptLanguageHeader, "zh-CN")
-	followup.Header.Set(server.HeaderKeySessionID, "en-session")
-	followupRecorder := httptest.NewRecorder()
-	handler.ServeHTTP(followupRecorder, followup)
-	if got := followupRecorder.Body.String(); got != "en-session" {
-		t.Fatalf("follow-up response = %q, want session-pinned English handler", got)
+	// The same session asking in another language gets that language. The
+	// handler holds no session state to contradict the header with.
+	chinese := httptest.NewRequest(http.MethodPost, endpointPath, nil)
+	chinese.Header.Set(sharedrest.AcceptLanguageHeader, "zh-CN")
+	chinese.Header.Set(server.HeaderKeySessionID, "en-handler")
+	chineseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(chineseRecorder, chinese)
+	if got := chineseRecorder.Body.String(); got != "zh-handler" {
+		t.Fatalf("zh-CN request = %q, want the Chinese handler", got)
 	}
 }
 
-func TestLocalizedMCPHandlerPinsRequestContextLocaleToSession(t *testing.T) {
+func TestLocalizedMCPHandlerPutsRequestLocaleInContext(t *testing.T) {
 	localeHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set(server.HeaderKeySessionID, "en-session")
 		_, _ = w.Write([]byte(common.GetLanguageFromCtx(r.Context())))
 	})
 	handler := &localizedMCPHandler{
@@ -59,46 +56,37 @@ func TestLocalizedMCPHandlerPinsRequestContextLocaleToSession(t *testing.T) {
 		},
 	}
 
-	initialize := httptest.NewRequest(http.MethodPost, endpointPath, nil)
-	initialize.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
-	handler.ServeHTTP(httptest.NewRecorder(), initialize)
-
-	followup := httptest.NewRequest(http.MethodPost, endpointPath, nil)
-	followup.Header.Set(sharedrest.AcceptLanguageHeader, "zh-CN")
-	followup.Header.Set(server.HeaderKeySessionID, "en-session")
+	request := httptest.NewRequest(http.MethodPost, endpointPath, nil)
+	request.Header.Set(sharedrest.AcceptLanguageHeader, "en-US")
+	request.Header.Set(server.HeaderKeySessionID, "some-session")
 	response := httptest.NewRecorder()
-	handler.ServeHTTP(response, followup)
+	handler.ServeHTTP(response, request)
 	if got := response.Body.String(); got != "en-US" {
-		t.Fatalf("request context locale = %q, want session-pinned en-US", got)
+		t.Fatalf("request context locale = %q, want en-US", got)
 	}
 }
 
-func TestLocalizedMCPHandlerReleasesAndExpiresSessionLocale(t *testing.T) {
+func TestLocalizedMCPHandlerWithoutHeaderUsesDefaultLocale(t *testing.T) {
 	handler := &localizedMCPHandler{
 		handlers: map[string]http.Handler{
-			defaultMCPLocale: markerMCPHandler("zh-session"),
-			"en-US":          markerMCPHandler("en-session"),
+			defaultMCPLocale: markerMCPHandler("zh-handler"),
+			"en-US":          markerMCPHandler("en-handler"),
 		},
 	}
-	handler.sessionLocales.Store("expired", mcpSessionLocale{
-		locale: "en-US", lastUsed: time.Now().Add(-mcpSessionIdleTTL),
-	})
 
-	request := httptest.NewRequest(http.MethodDelete, endpointPath, nil)
-	request.Header.Set(server.HeaderKeySessionID, "en-session")
+	request := httptest.NewRequest(http.MethodPost, endpointPath, nil)
+	request.Header.Set(server.HeaderKeySessionID, "some-session")
 	response := httptest.NewRecorder()
-	handler.sessionLocales.Store("en-session", mcpSessionLocale{locale: "en-US", lastUsed: time.Now()})
 	handler.ServeHTTP(response, request)
-
-	if _, ok := handler.sessionLocales.Load("en-session"); ok {
-		t.Fatal("DELETE did not release the session locale")
-	}
-	if _, ok := handler.sessionLocales.Load("expired"); ok {
-		t.Fatal("expired session locale was not pruned")
+	if got := response.Body.String(); got != "zh-handler" {
+		t.Fatalf("header-less request = %q, want the service default handler", got)
 	}
 }
 
-func TestMCPInitializeAndToolCatalogUseSessionLocale(t *testing.T) {
+// TestMCPToolCatalogFollowsRequestLocale drives the real handler end to end:
+// initialize in one language, then list tools in another, and check the catalog
+// follows each request rather than whatever the session started with.
+func TestMCPToolCatalogFollowsRequestLocale(t *testing.T) {
 	handler := NewMCPHandlerWithLifecycle(nil)
 
 	initialize := httptest.NewRequest(http.MethodPost, endpointPath, strings.NewReader(`{
@@ -135,22 +123,36 @@ func TestMCPInitializeAndToolCatalogUseSessionLocale(t *testing.T) {
 		t.Fatalf("initialize instructions = %q, want English instructions", initializeResponse.Result.Instructions)
 	}
 
-	toolsList := httptest.NewRequest(http.MethodPost, endpointPath, strings.NewReader(`{
+	englishDescription := searchSchemaDescription(t, handler, sessionID, "en-US")
+	if !strings.HasPrefix(englishDescription, "Explore schema by natural language.") {
+		t.Fatalf("en-US search_schema description = %q, want the English catalog", englishDescription)
+	}
+
+	chineseDescription := searchSchemaDescription(t, handler, sessionID, "zh-CN")
+	if !strings.HasPrefix(chineseDescription, "统一的 Schema 探索入口") {
+		t.Fatalf("zh-CN search_schema description = %q, want the default-locale catalog", chineseDescription)
+	}
+}
+
+func searchSchemaDescription(t *testing.T, handler http.Handler, sessionID, locale string) string {
+	t.Helper()
+
+	request := httptest.NewRequest(http.MethodPost, endpointPath, strings.NewReader(`{
 		"jsonrpc":"2.0",
 		"id":2,
 		"method":"tools/list",
 		"params":{}
 	}`))
-	toolsList.Header.Set("Content-Type", "application/json")
-	toolsList.Header.Set(server.HeaderKeySessionID, sessionID)
-	toolsList.Header.Set(sharedrest.AcceptLanguageHeader, "zh-CN")
-	toolsRecorder := httptest.NewRecorder()
-	handler.ServeHTTP(toolsRecorder, toolsList)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set(server.HeaderKeySessionID, sessionID)
+	request.Header.Set(sharedrest.AcceptLanguageHeader, locale)
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
 
-	if toolsRecorder.Code != http.StatusOK {
-		t.Fatalf("tools/list status = %d, body = %s", toolsRecorder.Code, toolsRecorder.Body.String())
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("tools/list status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
-	var toolsResponse struct {
+	var response struct {
 		Result struct {
 			Tools []struct {
 				Name        string `json:"name"`
@@ -158,23 +160,20 @@ func TestMCPInitializeAndToolCatalogUseSessionLocale(t *testing.T) {
 			} `json:"tools"`
 		} `json:"result"`
 	}
-	if err := json.Unmarshal(toolsRecorder.Body.Bytes(), &toolsResponse); err != nil {
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode tools/list response: %v", err)
 	}
-	for _, tool := range toolsResponse.Result.Tools {
+	for _, tool := range response.Result.Tools {
 		if tool.Name == toolKeySearchSchema {
-			if !strings.HasPrefix(tool.Description, "Explore schema by natural language.") {
-				t.Fatalf("search_schema description = %q, want English session-pinned catalog", tool.Description)
-			}
-			return
+			return tool.Description
 		}
 	}
 	t.Fatalf("tools/list did not include %q", toolKeySearchSchema)
+	return ""
 }
 
-func markerMCPHandler(sessionID string) http.Handler {
+func markerMCPHandler(marker string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(server.HeaderKeySessionID, sessionID)
-		_, _ = w.Write([]byte(sessionID))
+		_, _ = w.Write([]byte(marker))
 	})
 }


### PR DESCRIPTION
Answers #954 by removing the thing it asked to distribute. Net −32 lines.

## What the map was for

The handler kept `Mcp-Session-Id -> locale` so a later request could not change language mid-session:

```go
if sessionID != "" {
    if value, ok := h.sessionLocales.Load(sessionID); ok {
        return session.locale          // the pin wins over the header
    }
}
```

Clients do not change language mid-session. An MCP client sends the same `Accept-Language` on every request to an endpoint, so the pinned value and the header agreed in every real case.

## What it cost

A second piece of per-replica session state, plus its TTL sweep and DELETE handling — and #954, asking for it to be shared across replicas so any replica could serve a session.

That cannot work, and not because of the locale. `mcp-go v0.57.0` holds the MCP session itself in process memory:

```go
sessionRequestIDs   sync.Map   activeSessions     sync.Map
resumableStreams    sync.Map   listeningStreams   sync.Map
listeningPumpStops  sync.Map   sessionLastActive  sync.Map
sessions            sync.Map   terminated         sync.Map
```

A request routed to another replica fails at the protocol layer well before the locale is read. Sharing only the locale would have solved nothing, and would have added a Redis dependency to prove it.

## What this does

Resolve `Accept-Language` per request. The map, the sweep, and the DELETE branch go away. A request with no header falls back to the service default — the same thing that happened before whenever the session was unknown.

The cross-replica question becomes moot rather than pending: **MCP Streamable HTTP needs session affinity for reasons that have nothing to do with language**, which belongs in the deployment notes, not in a locale issue.

## Tests

The four tests that encoded session pinning are rewritten to the new contract:

| Test | Asserts |
|---|---|
| `TestLocalizedMCPHandlerFollowsRequestLocale` | the same session id asking in another language gets that language |
| `TestLocalizedMCPHandlerPutsRequestLocaleInContext` | the request context carries the per-request locale |
| `TestLocalizedMCPHandlerWithoutHeaderUsesDefaultLocale` | a header-less request falls back to the service default |
| `TestMCPToolCatalogFollowsRequestLocale` | end to end through the real handler: initialize in en-US, then `tools/list` in en-US and in zh-CN, each returning its own catalog |

`go test ./...` in agent-retrieval passes.

## What this leaves for #954

#954 asked for the locale map to survive across replicas. After this change there is no map, so that specific ask has nothing left to apply to.

The underlying constraint is unchanged and is not a locale one: MCP Streamable HTTP needs session affinity, because the session state itself is per-replica. Whether #954 is closed or rescoped to that is for its author to decide; the evidence is posted on the issue.

Refs #954
