### PR TITLE
fix(trace): bound projection receipt candidate queries

### DIFF
--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -116,8 +116,12 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 
 func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Query, applyScopeCandidates bool) ([]receiptDocument, bool, error) {
 	size := maxProjectionDocuments
-	if query.Limit > 0 && query.Limit*20+1 < size {
-		size = query.Limit*20 + 1
+	if query.Limit > 0 && query.Limit < size {
+		// Limit is the projection caller's candidate budget. Fetch one extra
+		// document only to preserve the existing truncation signal; expanding the
+		// budget here defeats bounded summary scans and makes a 2,000-entry request
+		// read 10,000 receipts from OpenSearch.
+		size = query.Limit + 1
 	}
 	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
 	for field, value := range map[string]string{

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -16,6 +16,40 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
 
+func TestSourceLimitsReceiptCandidatesToRequestedLimitPlusLookahead(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var query map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		if size, ok := query["size"].(float64); !ok || size != 21 {
+			t.Fatalf("receipt candidate query must request limit plus one lookahead, got %#v", query["size"])
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second),
+		"bkn-trace-core",
+		nil,
+	)
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user",
+		},
+		Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if result.Truncated {
+		t.Fatalf("an empty response must not be truncated: %#v", result)
+	}
+}
+
 func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/docs/plans/2026-08-18-issue-1010-projection-query-bounds.md
+++ b/docs/plans/2026-08-18-issue-1010-projection-query-bounds.md
@@ -11,7 +11,7 @@ The summary service intentionally caps a bounded projection scan at 2,000 entrie
 
 - `iprojectionsource.Query.Limit` is the receipt candidate budget for one Core projection query.
 - The Core adapter asks for at most `Limit + 1` documents: the single extra document preserves the existing truncation signal without fetching unrelated historical records.
-- Stable sorting, access-scope checks, artifact hydration, public cursors, totals and partial-result semantics remain unchanged.
+- Stable sorting, access-scope checks, artifact hydration, public cursors and totals remain unchanged. The existing partial-result signal remains the same, but its threshold intentionally becomes `Limit + 1` rather than the prior expanded 10,000-document read.
 - No rebuild, schema, API or UI change is included.
 
 ## Steps
@@ -27,5 +27,6 @@ The summary service intentionally caps a bounded projection scan at 2,000 entrie
 - Cursor/search-after summary materialization.
 - Batched canonical MariaDB enrichment.
 - Source timing metrics.
+- Bounding the interaction-expansion follow-up query. It needs a separate contract because one selected interaction may legitimately contain more than the list candidate budget.
 
 Those are separate Issue #1010 increments because they require new projection contracts and cannot safely be mixed with the receipt-query bound correction.

--- a/docs/plans/2026-08-18-issue-1010-projection-query-bounds.md
+++ b/docs/plans/2026-08-18-issue-1010-projection-query-bounds.md
@@ -1,0 +1,31 @@
+# Issue #1010: bound Core receipt projection reads
+
+> **Owner:** BKN Trace
+> **Scope:** First, isolated performance correction for the OpenSearch Core receipt query. Projection rebuild is already addressed by `24339bad`; canonical SQL batching and list-summary materialization remain separate follow-up changes.
+
+## Root cause
+
+The summary service intentionally caps a bounded projection scan at 2,000 entries. The OpenSearch Core adapter interprets that limit as `limit * 20 + 1`, however, and therefore asks OpenSearch for up to 10,000 receipt candidates before service-side aggregation and pagination.
+
+## Contract for this change
+
+- `iprojectionsource.Query.Limit` is the receipt candidate budget for one Core projection query.
+- The Core adapter asks for at most `Limit + 1` documents: the single extra document preserves the existing truncation signal without fetching unrelated historical records.
+- Stable sorting, access-scope checks, artifact hydration, public cursors, totals and partial-result semantics remain unchanged.
+- No rebuild, schema, API or UI change is included.
+
+## Steps
+
+1. Add an adapter regression test proving `Limit: 20` emits OpenSearch `size: 21`.
+2. Run it red against the current `limit * 20 + 1` behaviour.
+3. Replace the multiplier with the documented bounded look-ahead rule.
+4. Run the focused adapter and summary-service suites, then the module test suite.
+5. Build the affected service image before committing and opening one PR. Deployment verification remains a separate EE-image operation because this change is in the community Trace Core image.
+
+## Out of scope / follow-up
+
+- Cursor/search-after summary materialization.
+- Batched canonical MariaDB enrichment.
+- Source timing metrics.
+
+Those are separate Issue #1010 increments because they require new projection contracts and cannot safely be mixed with the receipt-query bound correction.


### PR DESCRIPTION
## Summary
- respect the projection receipt candidate budget in the OpenSearch Core adapter
- retain one lookahead document only for truncation detection
- add a regression test for the generated OpenSearch query size

This is the first isolated correction for #1010. Projection rebuild is already addressed separately; cursor materialization and canonical DB batching remain follow-up work.

## Verification
- `GOCACHE=/tmp/openbkn-go-cache go test ./src/drivenadapter/httpaccess/opensearchcoreprojection ./src/domain/service/evidencesvc -count=1`
- `GOCACHE=/tmp/openbkn-go-cache go test ./... -count=1`
- `GOCACHE=/tmp/openbkn-go-cache make lint`
- `make docker-build IMAGE=agent-observability:issue-1010-projection-query-bounds-local`