### PR TITLE
refactor(mcp): make the request header the only language source, and declare it

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -134,7 +134,7 @@ func (h *localizedMCPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 // from mcptool instead (Extras / DecoratorFor / Allowed), and
 // TestInfoAndToolsListAgree… pins the two answers together.
 func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer, *toolBuilder) {
-	return newMCPServerForLocale(lifecycleClient, mcpLocaleFromEnv())
+	return newMCPServerForLocale(lifecycleClient, defaultMCPLocale)
 }
 
 func newMCPServerForLocale(lifecycleClient *bkntrace.LifecycleClient, locale string) (*server.MCPServer, *toolBuilder) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -97,7 +97,7 @@ func TestCommunityToolSchemasUnchanged(t *testing.T) {
 
 	// With nothing registered the decorator path is the identity, byte for
 	// byte, or the community binary is shipping a schema the socket touched.
-	bundle := loadMCPLocaleBundle(mcpLocaleFromEnv())
+	bundle := loadMCPLocaleBundle(defaultMCPLocale)
 	srv, _ := newMCPServer(nil)
 	for _, key := range communityTools {
 		if _, isLifecycle := lifecycleToolNames[key]; isLifecycle {
@@ -158,7 +158,7 @@ func TestCommunityMCPInfoSchemasComeFromEmbeddedFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BuildMCPInfo: %v", err)
 	}
-	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
+	locale := loadMCPLocaleBundle(defaultMCPLocale)
 	for _, tool := range info.Tools {
 		want, _ := tryLoadToolSchemas(locale, tool.Name)
 		if len(want) == 0 {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -65,10 +65,10 @@ func tryLoadToolSchemas(locale *mcpLocaleBundle, toolKey string) (input, output 
 	return locale.OverlaySchemas(toolKey, wrapper.InputSchema, wrapper.OutputSchema)
 }
 
-// BuildMCPInfo builds the MCP self-description with the process default locale.
-// New request-facing callers should use BuildMCPInfoForLocale.
+// BuildMCPInfo builds the MCP self-description in the baseline locale.
+// Request-facing callers use BuildMCPInfoForLocale.
 func BuildMCPInfo(endpoint string) (*MCPInfo, error) {
-	return BuildMCPInfoForLocale(endpoint, mcpLocaleFromEnv())
+	return BuildMCPInfoForLocale(endpoint, defaultMCPLocale)
 }
 
 // BuildMCPInfoForLocale builds the MCP self-description using the requested

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/info.go
@@ -37,6 +37,8 @@ type MCPInfo struct {
 	Protocol            string          `json:"protocol"`
 	Transport           string          `json:"transport"`
 	Auth                string          `json:"auth"`
+	Language            string          `json:"language"`
+	SupportedLanguages  []string        `json:"supported_languages"`
 	ToolCount           int             `json:"tool_count"`
 	Tools               []MCPToolInfo   `json:"tools"`
 	ClientConfigExample json.RawMessage `json:"client_config_example"`
@@ -164,12 +166,16 @@ func BuildMCPInfoForLocale(endpoint, localeName string) (*MCPInfo, error) {
 		tools = append(tools, e.info)
 	}
 
+	// Accept-Language belongs in the example because this block is what an
+	// integrator copies. MCP defines no locale field, so the transport header is
+	// the only channel; omitting it falls back to the service default language.
 	cfg, _ := json.Marshal(map[string]any{
 		"mcpServers": map[string]any{
 			serverName: map[string]any{
 				"url": endpoint,
 				"headers": map[string]string{
-					"Authorization": "Bearer <access-token>",
+					"Authorization":   "Bearer <access-token>",
+					"Accept-Language": locale.locale,
 				},
 			},
 		},
@@ -181,6 +187,8 @@ func BuildMCPInfoForLocale(endpoint, localeName string) (*MCPInfo, error) {
 		Protocol:            "MCP / JSON-RPC 2.0 (initialize → tools/list → tools/call)",
 		Transport:           "Streamable HTTP",
 		Auth:                "Bearer credential via Authorization header — an OAuth access token, or a long-lived user-issued AppKey (prefix bak_). No other headers required.",
+		Language:            locale.locale,
+		SupportedLanguages:  []string{defaultMCPLocale, "en-US"},
 		ToolCount:           len(tools),
 		Tools:               tools,
 		ClientConfigExample: cfg,

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
-	"os"
 	"strings"
 	"sync"
 )
@@ -145,15 +144,6 @@ func stripMCPResourceLicenseHeader(content string) string {
 		return content
 	}
 	return strings.TrimLeft(content[end+2:], "\r\n")
-}
-
-func mcpLocaleFromEnv() string {
-	for _, key := range []string{"MCP_LOCALE", "X_LOCALE", "LANGUAGE", "LC_ALL", "LANG"} {
-		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
-			return value
-		}
-	}
-	return defaultMCPLocale
 }
 
 func normalizeMCPLocale(locale string) string {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_completeness_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_completeness_test.go
@@ -102,3 +102,35 @@ func TestEnglishCatalogHasNoHanText(t *testing.T) {
 		})
 	})
 }
+
+// TestMCPInfoDeclaresItsLanguage pins the self-description side of the language
+// contract. MCP defines no locale field, so /mcp/info is where an integrator
+// learns that the transport header decides the catalog language — and its config
+// example is the block they copy.
+func TestMCPInfoDeclaresItsLanguage(t *testing.T) {
+	convey.Convey("/mcp/info should state the language it answered in", t, func() {
+		for _, locale := range []string{defaultMCPLocale, "en-US"} {
+			info, err := BuildMCPInfoForLocale("https://example.invalid/mcp", locale)
+			convey.So(err, convey.ShouldBeNil)
+			convey.So(info.Language, convey.ShouldEqual, locale)
+			convey.So(info.SupportedLanguages, convey.ShouldContain, "en-US")
+			convey.So(info.SupportedLanguages, convey.ShouldContain, defaultMCPLocale)
+
+			var example struct {
+				MCPServers map[string]struct {
+					Headers map[string]string `json:"headers"`
+				} `json:"mcpServers"`
+			}
+			convey.So(json.Unmarshal(info.ClientConfigExample, &example), convey.ShouldBeNil)
+			for _, server := range example.MCPServers {
+				convey.So(server.Headers["Accept-Language"], convey.ShouldEqual, locale)
+			}
+		}
+	})
+
+	convey.Convey("an unsupported language should report the fallback it used", t, func() {
+		info, err := BuildMCPInfoForLocale("https://example.invalid/mcp", "kl-KL")
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(info.Language, convey.ShouldEqual, defaultMCPLocale)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
@@ -81,7 +81,7 @@ func newPTCMCPServer(
 	executor interfaces.DrivenOperatorIntegration,
 	servicePort int,
 ) (*server.MCPServer, error) {
-	return newPTCMCPServerForLocale(lifecycleClient, executor, servicePort, mcpLocaleFromEnv())
+	return newPTCMCPServerForLocale(lifecycleClient, executor, servicePort, defaultMCPLocale)
 }
 
 func newPTCMCPServerForLocale(

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit.go
@@ -454,7 +454,7 @@ func renderPTCStub(tools []MCPToolInfo) string {
 // BuildPTCToolkit renders the PTC toolkit. endpoint is consistent with BuildMCPInfo (self-describing only),
 // port is the listening port of this service and is used to derive the sandbox return address.
 func BuildPTCToolkit(endpoint string, port int) (*PTCToolkit, error) {
-	return BuildPTCToolkitForLocale(endpoint, port, mcpLocaleFromEnv())
+	return BuildPTCToolkitForLocale(endpoint, port, defaultMCPLocale)
 }
 
 // BuildPTCToolkitForLocale renders the PTC toolkit from the effective locale.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/socket_call_test.go
@@ -151,16 +151,12 @@ func TestInfoAndToolsListAgreeOnEnterpriseSchemas(t *testing.T) {
 }
 
 func TestInfoAndToolsListAgreeOnEveryToolInTheDefaultLocale(t *testing.T) {
-	// Pin locale. The core tools on the tools/list side will go through the locale overlay.
-	// (schema_descriptions.json of locale.go), the /mcp/info side always reads the embedded copy,
-	// So "both sides are literally equal" only holds true in the default locale where the overlay is empty. If not nailed,
-	// mcpLocaleFromEnv can read LANG - it is not available on CI runner, so it is green today, on the development machine.
-	// LANG=en_US.UTF-8 is the norm and will be red on a core tool that has nothing to do with this change.
-	//
-	// "/mcp/info is blind to the locale" itself is a gap that existed before this PR (even the Description.
-	// Take the default tools_meta.json, and the external documentation says that it will be localized with the deployment language), it is worth opening follow-up separately;
-	// Let’s first write down its boundaries clearly, lest this comment become the only place where it is remembered in the repo.
-	t.Setenv("MCP_LOCALE", "zh-CN")
+	// On the tools/list side the core tools pass through the locale overlay
+	// (schema_descriptions.json in locale.go), while /mcp/info always reads the
+	// embedded baseline, so "identical on both sides" holds only in the baseline
+	// locale — which is what both request-less paths now use. This test needed a
+	// t.Setenv("MCP_LOCALE", ...) before, because the locale came from LANG and
+	// an English development shell rendered a different answer than CI.
 	withSocket(t, entitlement.FixedGate(licverify.EditionEnterprise))
 	mcptool.Register(extraTool("probe_context", "probe_context"))
 	mcptool.Decorate(toolKeySearchSchema, searchSchemaDecorator())

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_meta_test.go
@@ -19,9 +19,9 @@ import (
 func TestToolsListCarriesDisplayMetadata(t *testing.T) {
 	noExtensions(t)
 
-	// Get the expected value according to the current locale of the process, instead of the Hengdu Chinese benchmark file: on the local development machine.
-	// LANG=en_US is the norm. Hard-coding the benchmark file will make this assertion falsely red.
-	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
+	// Expectations come from the baseline bundle, the same one assembledTools
+	// registers with. Neither side reads the process environment any more.
+	locale := loadMCPLocaleBundle(defaultMCPLocale)
 	for _, tool := range assembledTools(t) {
 		raw, err := json.Marshal(tool)
 		if err != nil {
@@ -155,8 +155,6 @@ func TestMCPInfoDisplayMetadataMatchesToolsList(t *testing.T) {
 // If a path is missed, it will be red.
 func TestEveryRegistrationPathHonoursTheLocale(t *testing.T) {
 	noExtensions(t)
-	t.Setenv("MCP_LOCALE", "en-US")
-
 	raw, err := schemasFS.ReadFile("schemas/locales/en-US/tools_meta.json")
 	if err != nil {
 		t.Fatalf("read localized tool metadata: %v", err)
@@ -166,7 +164,7 @@ func TestEveryRegistrationPathHonoursTheLocale(t *testing.T) {
 		t.Fatalf("decode localized tool metadata: %v", err)
 	}
 
-	for _, tool := range assembledTools(t) {
+	for _, tool := range assembledToolsForLocale(t, "en-US") {
 		want, ok := localized[tool.Name]
 		if !ok {
 			t.Errorf("tool %q has no en-US entry", tool.Name)
@@ -184,14 +182,12 @@ func TestEveryRegistrationPathHonoursTheLocale(t *testing.T) {
 // and applies the same locale as tools/list.
 func TestMCPInfoAgreesWithToolsListUnderANonDefaultLocale(t *testing.T) {
 	noExtensions(t)
-	t.Setenv("MCP_LOCALE", "en-US")
-
 	info, err := BuildMCPInfoForLocale("https://example.invalid/mcp", "en-US")
 	if err != nil {
 		t.Fatalf("BuildMCPInfo: %v", err)
 	}
 	listed := map[string]mcp.Tool{}
-	for _, tool := range assembledTools(t) {
+	for _, tool := range assembledToolsForLocale(t, "en-US") {
 		listed[tool.Name] = tool
 	}
 	if len(info.Tools) != len(listed) {
@@ -221,7 +217,12 @@ func TestMCPInfoAgreesWithToolsListUnderANonDefaultLocale(t *testing.T) {
 // assembledTools returns the tools a client would see from tools/list.
 func assembledTools(t *testing.T) []mcp.Tool {
 	t.Helper()
-	srv, b := newMCPServer(nil)
+	return assembledToolsForLocale(t, defaultMCPLocale)
+}
+
+func assembledToolsForLocale(t *testing.T, locale string) []mcp.Tool {
+	t.Helper()
+	srv, b := newMCPServerForLocale(nil, locale)
 
 	all := make([]mcp.Tool, 0, len(srv.ListTools()))
 	for _, st := range srv.ListTools() {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_skills_test.go
@@ -57,7 +57,7 @@ func TestExecuteSkillOnlyAppearsWhenEnabled(t *testing.T) {
 func TestSkillToolsAdvertiseSchemas(t *testing.T) {
 	noExtensions(t)
 
-	locale := loadMCPLocaleBundle(mcpLocaleFromEnv())
+	locale := loadMCPLocaleBundle(defaultMCPLocale)
 	for _, key := range []string{toolKeyListSkills, toolKeyGetSkillContent, toolKeyReadSkillFile, toolKeyExecuteSkill} {
 		in, out := tryLoadToolSchemas(locale, key)
 		if len(in) == 0 {

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -50,6 +50,8 @@ paths:
         - MCP
       summary: MCP 服务自描述文档
       operationId: getMCPInfo
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         一次 GET 拿到端点、协议、鉴权方式、全部工具的名称 / 描述 / 输入输出 schema，
         以及一份可直接用的客户端配置示例。给人看，也给 Agent 自举用。
@@ -86,6 +88,8 @@ paths:
       deprecated: true
       summary: PTC 工具包（旧路径，已弃用）
       operationId: getPTCToolkitLegacy
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         **已弃用，改用 `GET /mcp/ptc/toolkit`。** 响应完全相同，仅路径不同。
 
@@ -140,6 +144,8 @@ paths:
         - MCP
       summary: PTC MCP 端点（只有 run_code / run_shell）
       operationId: postPTCMCP
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         与 `/mcp` 同为 MCP Streamable HTTP，差别只在工具面：这里**只有四个工具**
 
@@ -213,6 +219,8 @@ paths:
         - MCP
       summary: PTC 工具包（自行实现 PTC 时用）
       operationId: getPTCToolkit
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         给不走 `POST /mcp/ptc`、想自己实现 PTC 的客户端（例如自建前端）用：一次返回
         全部素材，客户端自行组装工具并打执行工厂。
@@ -263,6 +271,8 @@ paths:
         - MCP
       summary: PTC MCP 端点自描述文档
       operationId: getPTCMCPInfo
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         与 `GET /mcp/info` 同构，只是 `endpoint` 指向 `/mcp/ptc`。给要接 PTC 端点的
         客户端抄连接配置用。
@@ -286,6 +296,8 @@ paths:
         - MCP
       summary: MCP Streamable HTTP 端点
       operationId: mcpStreamableHTTP
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
       description: |
         标准 MCP Streamable HTTP 入口，收发 JSON-RPC 2.0 报文。请求与响应结构由
         MCP 协议定义，本文档不再复述——用现成的 MCP 客户端接入即可，不要手写调用。
@@ -355,6 +367,23 @@ components:
       $ref: '../_shared/auth.yaml#/components/securitySchemes/OAuth2'
     AppKey:
       $ref: '../_shared/auth.yaml#/components/securitySchemes/AppKey'
+
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      schema:
+        type: string
+      description: |
+        可选的 RFC 9110 语言偏好。服务从支持的 `zh-CN`、`en-US` 中选择工具目录
+        （`title` / `description` / schema 描述）与服务端说明的语言。
+
+        MCP 协议本身不定义语言协商，`initialize` 参数里没有 locale 字段，所以这个
+        传输层请求头是唯一的通道。客户端在 MCP 连接配置的 `headers` 里设置它。
+
+        不传则使用部署配置的服务默认语言，无需客户端参与。**每个请求独立判定**，
+        不与 `Mcp-Session-Id` 绑定。
 
   schemas:
     PTCToolkit:
@@ -456,6 +485,20 @@ components:
         auth:
           type: string
           description: 鉴权说明。
+        language:
+          type: string
+          enum: [zh-CN, en-US]
+          description: |
+            本次响应实际使用的语言，即工具目录（`title` / `description` / schema
+            描述）与服务端说明的语言。由请求的 `Accept-Language` 决定；不传或不支持
+            时为部署配置的服务默认语言。
+          example: zh-CN
+        supported_languages:
+          type: array
+          items:
+            type: string
+          description: 本服务支持的语言标签。
+          example: [zh-CN, en-US]
         tool_count:
           type: integer
           description: 工具数量。


### PR DESCRIPTION
Closes #826's MCP problem 1: *"locale 来源与作用域不符合方案"*. Net −13 lines.

## What was wrong

`mcpLocaleFromEnv` read `MCP_LOCALE`, `X_LOCALE`, `LANGUAGE`, `LC_ALL`, and `LANG`, and four request-less paths resolved their locale through it.

`LANG` and `LC_ALL` are the container's character encoding and collation settings. Using them as an API language source lets the **base image** decide what language the API speaks — and nobody debugging a wrong-language response would think to look there.

## It was not sloppiness

#115 added it deliberately in July: that PR shipped *deployment-level single-language* MCP, before any request-time negotiation existed, and its own description says per-request negotiation was left for later. For a **stdio** MCP server an environment variable is genuinely the only channel — MCP has no locale field in `InitializeParams`.

#918 then added request-time negotiation for the standard endpoint but left the environment path in place, so two sources have coexisted since. This service serves MCP over **Streamable HTTP only**, so the header is always available.

## Every other service already does it this way

| Service | Fallback source |
|---|---|
| vega-backend | `rest.SetLang(appSetting.ServerSetting.Language)` |
| bkn-backend | same |
| ontology-query | same |
| operator-integration | `common.SetLang(config.Project.Language)` |
| context-loader | same — plus the environment path this PR removes |

A repo-wide grep for code reading `LANG` / `LC_ALL` / `LANGUAGE` / `MCP_LOCALE` as a language source returns **only this one place**. Eight charts inject `LANG`, and no service code reads it — that is the OS setting doing its actual job.

That also explains why this chart carries `service.language: zh-CN` next to `env.language: en_US.UTF-8`: they are unrelated knobs. The code conflated them, the values were never wrong.

## The symptom: a CI gate passing by accident

`make -C infra/sandbox bkn-tools-check` is a required gate — four build jobs `needs: bkn-tools`. It regenerates the checked-in sandbox capability surface (`_bkn_tools.py`) through `BuildPTCToolkit` and compares.

The runner's `LANG=C.UTF-8` is unrecognized by `normalizeMCPLocale`, so it fell through to the baseline and matched the committed Chinese artifact. **Green by coincidence.**

On a development machine with `LANG=en_US.UTF-8` the same target renders an English stub and reports drift — which reads as "you broke the schema". Reproduced before the change:

```
-    """获取知识网络 schema（概念组、对象类型含 data_source.id、...
+    sort: Sort field.
make: *** [bkn-tools-check] Error 1
```

And after:

```
✓ runtime/sandbox_sdk/_bkn_tools.py 与 schema 一致
```

A build artifact whose bytes depend on the operator's shell was the real defect here; the locale confusion was how it got there.

## Tests

Two tests deliberately exercise a non-default locale and `t.Setenv("MCP_LOCALE", "en-US")` was the only channel they had. `assembledTools` now takes the locale as a parameter, and they pass `"en-US"` directly — which is also what they were always trying to express.

The stale comment in `socket_call_test.go` warning that "CI is green because the runner has no LANG, a development machine will be red" is replaced, since that trap is gone.

`go test ./...` in agent-retrieval passes.

## Second half: declaring the input

Removing the wrong source leaves the right one undeclared, so the second commit declares it. **Where** matters: server instructions and tool descriptions are read by the *model*, which cannot set an HTTP header — a hint there would address the wrong party and only spend context. The audience is whoever configures the connection.

- **`docs/api/context-loader/mcp.yaml`** gains `components.parameters.AcceptLanguage`, referenced from all six operations. The shape copies what `skill.yaml`, `function.yaml`, `self-service.yaml`, and `large-model.yaml` already declare rather than inventing another. The description states the three things a client needs: supported tags, that omitting it uses the deployment default, and that resolution is per request and not bound to `Mcp-Session-Id`.
- **`/mcp/info`** now reports `language` (the one it answered in) and `supported_languages`, and its `client_config_example` carries the header. That block is what an integrator pastes, so it is the one place the header will actually be noticed.
- The `MCPInfo` schema documents both fields.

`redocly lint` on the spec is clean; the single warning it reports is pre-existing on `main`.

## Still not in this PR

`docs/api/bkn-agent/bkn-agent.yaml` mentions `Accept-Language` in prose 22 times — my own wording from #1004 — but declares no parameter. It is generated by `scripts/export_openapi.py`, so fixing it means a code change in bkn-agent and a re-export, which belongs with that service. The `bkn/*`, `agent-observability`, and `execution-factory/mcp.yaml` specs declare nothing either; that is the remaining part of #826's "OpenAPI declares the Accept-Language common header" item.

Refs #826
