### PR TITLE
perf(trace): batch canonical summary enrichment

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -861,6 +861,22 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		byConversation := map[string]sessionvo.Conversation{}
+		factsByTraceID := map[string][]sessionvo.OperationCallFact{}
+		traceIDs := make([]string, 0, len(traces))
+		seenTraceIDs := map[string]struct{}{}
+		for _, trace := range traces {
+			if trace.TraceID == "" {
+				continue
+			}
+			if _, seen := seenTraceIDs[trace.TraceID]; seen {
+				continue
+			}
+			seenTraceIDs[trace.TraceID] = struct{}{}
+			traceIDs = append(traceIDs, trace.TraceID)
+		}
+		for _, fact := range tx.ListOperationCallFactsByTraceIDs(traceIDs) {
+			factsByTraceID[fact.TraceID] = append(factsByTraceID[fact.TraceID], fact)
+		}
 		for index := range traces {
 			conversationID := traces[index].ConversationID
 			if conversationID != "" {
@@ -878,7 +894,7 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 					traces[index].EffectiveSubjectID = conversation.Owner.EffectiveSubjectID
 				}
 			}
-			for _, fact := range tx.ListOperationCallFactsByTraceID(traces[index].TraceID) {
+			for _, fact := range factsByTraceID[traces[index].TraceID] {
 				if fact.SourceModule != "" {
 					traces[index].RootService = fact.SourceModule
 					break

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -861,7 +861,6 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		byConversation := map[string]sessionvo.Conversation{}
-		factsByTraceID := map[string][]sessionvo.OperationCallFact{}
 		traceIDs := make([]string, 0, len(traces))
 		seenTraceIDs := map[string]struct{}{}
 		for _, trace := range traces {
@@ -874,9 +873,7 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 			seenTraceIDs[trace.TraceID] = struct{}{}
 			traceIDs = append(traceIDs, trace.TraceID)
 		}
-		for _, fact := range tx.ListOperationCallFactsByTraceIDs(traceIDs) {
-			factsByTraceID[fact.TraceID] = append(factsByTraceID[fact.TraceID], fact)
-		}
+		sourceModulesByTraceID := tx.ListFirstOperationSourceModulesByTraceIDs(traceIDs)
 		for index := range traces {
 			conversationID := traces[index].ConversationID
 			if conversationID != "" {
@@ -894,11 +891,8 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 					traces[index].EffectiveSubjectID = conversation.Owner.EffectiveSubjectID
 				}
 			}
-			for _, fact := range factsByTraceID[traces[index].TraceID] {
-				if fact.SourceModule != "" {
-					traces[index].RootService = fact.SourceModule
-					break
-				}
+			if sourceModule := sourceModulesByTraceID[traces[index].TraceID]; sourceModule != "" {
+				traces[index].RootService = sourceModule
 			}
 		}
 		return nil

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1566,6 +1566,50 @@ func TestListTraceExecutionsUsesOperationSourceModuleForRootService(t *testing.T
 	}
 }
 
+func TestListTraceExecutionsAppliesOperationSourceModulesAcrossTracePage(t *testing.T) {
+	evidenceStore := evidencestore.New()
+	seedBusinessProvenanceRequest(
+		t, evidenceStore, "req_trace_source_a", "trace_source_a", "conversation_trace_source_a", "interaction_trace_source_a",
+		"2026-08-10T09:00:00Z", "查询库存", "库存 1756", "acct_demo",
+	)
+	seedBusinessProvenanceRequest(
+		t, evidenceStore, "req_trace_source_b", "trace_source_b", "conversation_trace_source_b", "interaction_trace_source_b",
+		"2026-08-10T09:01:00Z", "查询物料", "物料 26 条", "acct_demo",
+	)
+	sessions := sessionstore.New()
+	if err := sessions.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{
+			OperationID: "op_trace_source_a", Attempt: 1, TraceID: "trace_source_a",
+			ToolName: "run_sql", SourceModule: "context-loader",
+			StartedAt: time.Date(2026, 8, 10, 9, 0, 0, 0, time.UTC),
+		})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{
+			OperationID: "op_trace_source_b", Attempt: 1, TraceID: "trace_source_b",
+			ToolName: "query_object_instance", SourceModule: "openbkn-sdk",
+			StartedAt: time.Date(2026, 8, 10, 9, 1, 0, 0, time.UTC),
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed operation facts: %v", err)
+	}
+	service := New(evidenceStore, WithProjectionSource(evidenceStore), WithSessionStore(sessions))
+
+	page, err := service.ListTraceExecutions(context.Background(), evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), Limit: 20,
+	})
+	if err != nil || len(page.Entries) != 2 {
+		t.Fatalf("list trace executions: page=%+v err=%v", page, err)
+	}
+	rootServiceByTraceID := make(map[string]string, len(page.Entries))
+	for _, entry := range page.Entries {
+		rootServiceByTraceID[entry.TraceID] = entry.RootService
+	}
+	if rootServiceByTraceID["trace_source_a"] != "context-loader" ||
+		rootServiceByTraceID["trace_source_b"] != "openbkn-sdk" {
+		t.Fatalf("trace root services = %+v", rootServiceByTraceID)
+	}
+}
+
 func TestExactRequestAndTracePropagateArtifactQueryTruncation(t *testing.T) {
 	store := evidencestore.New()
 	seedSummaryRequest(t, store, "req_artifact_cap", "trace_artifact_cap", "2026-07-26T09:00:00Z", "问题", "结果", "agent-a", "bd_demo", "acct_demo")

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -557,7 +557,7 @@ func (t *transaction) ListOperationCallFactsByTraceID(traceID string) []sessionv
 	return result
 }
 
-func (t *transaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact {
+func (t *transaction) ListFirstOperationSourceModulesByTraceIDs(traceIDs []string) map[string]string {
 	if t.err != nil {
 		return nil
 	}
@@ -574,7 +574,7 @@ func (t *transaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sess
 		uniqueTraceIDs = append(uniqueTraceIDs, traceID)
 	}
 	if len(uniqueTraceIDs) == 0 {
-		return []sessionvo.OperationCallFact{}
+		return map[string]string{}
 	}
 
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(uniqueTraceIDs)), ",")
@@ -582,20 +582,25 @@ func (t *transaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sess
 	for index, traceID := range uniqueTraceIDs {
 		args[index] = traceID
 	}
-	rows, err := t.tx.QueryContext(t.ctx, operationCallFactSelect+`
-		WHERE trace_id IN (`+placeholders+`) ORDER BY trace_id, started_at, operation_id, attempt_no`, args...)
+	rows, err := t.tx.QueryContext(t.ctx, `SELECT trace_id, source_module
+		FROM bkn_trace_operation_call_facts
+		WHERE trace_id IN (`+placeholders+`) AND source_module <> ''
+		ORDER BY trace_id, started_at, operation_id, attempt_no`, args...)
 	if err != nil {
 		t.err = err
 		return nil
 	}
 	defer func() { _ = rows.Close() }()
-	result := make([]sessionvo.OperationCallFact, 0)
+	result := make(map[string]string, len(uniqueTraceIDs))
 	for rows.Next() {
-		value, found := t.scanOperationCallFact(rows)
-		if !found {
+		var traceID, sourceModule string
+		if err := rows.Scan(&traceID, &sourceModule); err != nil {
+			t.err = err
 			return nil
 		}
-		result = append(result, value)
+		if _, found := result[traceID]; !found {
+			result[traceID] = sourceModule
+		}
 	}
 	t.err = rows.Err()
 	return result

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -557,6 +557,50 @@ func (t *transaction) ListOperationCallFactsByTraceID(traceID string) []sessionv
 	return result
 }
 
+func (t *transaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact {
+	if t.err != nil {
+		return nil
+	}
+	uniqueTraceIDs := make([]string, 0, len(traceIDs))
+	seen := make(map[string]struct{}, len(traceIDs))
+	for _, traceID := range traceIDs {
+		if traceID == "" {
+			continue
+		}
+		if _, found := seen[traceID]; found {
+			continue
+		}
+		seen[traceID] = struct{}{}
+		uniqueTraceIDs = append(uniqueTraceIDs, traceID)
+	}
+	if len(uniqueTraceIDs) == 0 {
+		return []sessionvo.OperationCallFact{}
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(uniqueTraceIDs)), ",")
+	args := make([]any, len(uniqueTraceIDs))
+	for index, traceID := range uniqueTraceIDs {
+		args[index] = traceID
+	}
+	rows, err := t.tx.QueryContext(t.ctx, operationCallFactSelect+`
+		WHERE trace_id IN (`+placeholders+`) ORDER BY trace_id, started_at, operation_id, attempt_no`, args...)
+	if err != nil {
+		t.err = err
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	result := make([]sessionvo.OperationCallFact, 0)
+	for rows.Next() {
+		value, found := t.scanOperationCallFact(rows)
+		if !found {
+			return nil
+		}
+		result = append(result, value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
 func (t *transaction) SaveOperationCallFact(fact sessionvo.OperationCallFact) {
 	if t.err != nil {
 		return

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -240,6 +240,38 @@ func (tx memoryTransaction) ListOperationCallFactsByTraceID(traceID string) []se
 	return result
 }
 
+func (tx memoryTransaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact {
+	requested := make(map[string]struct{}, len(traceIDs))
+	for _, traceID := range traceIDs {
+		if traceID != "" {
+			requested[traceID] = struct{}{}
+		}
+	}
+	if len(requested) == 0 {
+		return []sessionvo.OperationCallFact{}
+	}
+
+	result := make([]sessionvo.OperationCallFact, 0)
+	for _, fact := range tx.s.operationCalls {
+		if _, found := requested[fact.TraceID]; found {
+			result = append(result, fact)
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].TraceID != result[j].TraceID {
+			return result[i].TraceID < result[j].TraceID
+		}
+		if result[i].StartedAt.Equal(result[j].StartedAt) {
+			if result[i].OperationID == result[j].OperationID {
+				return result[i].Attempt < result[j].Attempt
+			}
+			return result[i].OperationID < result[j].OperationID
+		}
+		return result[i].StartedAt.Before(result[j].StartedAt)
+	})
+	return result
+}
+
 func sortOperationCallFacts(result []sessionvo.OperationCallFact) {
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].StartedAt.Equal(result[j].StartedAt) {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -240,7 +240,7 @@ func (tx memoryTransaction) ListOperationCallFactsByTraceID(traceID string) []se
 	return result
 }
 
-func (tx memoryTransaction) ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact {
+func (tx memoryTransaction) ListFirstOperationSourceModulesByTraceIDs(traceIDs []string) map[string]string {
 	requested := make(map[string]struct{}, len(traceIDs))
 	for _, traceID := range traceIDs {
 		if traceID != "" {
@@ -248,28 +248,43 @@ func (tx memoryTransaction) ListOperationCallFactsByTraceIDs(traceIDs []string) 
 		}
 	}
 	if len(requested) == 0 {
-		return []sessionvo.OperationCallFact{}
+		return map[string]string{}
 	}
 
-	result := make([]sessionvo.OperationCallFact, 0)
+	type candidate struct {
+		startedAt    time.Time
+		operationID  string
+		attempt      uint32
+		sourceModule string
+	}
+	candidates := make(map[string]candidate, len(requested))
 	for _, fact := range tx.s.operationCalls {
-		if _, found := requested[fact.TraceID]; found {
-			result = append(result, fact)
+		if _, requestedTrace := requested[fact.TraceID]; !requestedTrace || fact.SourceModule == "" {
+			continue
+		}
+		current, found := candidates[fact.TraceID]
+		if !found || operationCallFactPrecedes(fact, current.startedAt, current.operationID, current.attempt) {
+			candidates[fact.TraceID] = candidate{
+				startedAt: fact.StartedAt, operationID: fact.OperationID,
+				attempt: fact.Attempt, sourceModule: fact.SourceModule,
+			}
 		}
 	}
-	sort.Slice(result, func(i, j int) bool {
-		if result[i].TraceID != result[j].TraceID {
-			return result[i].TraceID < result[j].TraceID
-		}
-		if result[i].StartedAt.Equal(result[j].StartedAt) {
-			if result[i].OperationID == result[j].OperationID {
-				return result[i].Attempt < result[j].Attempt
-			}
-			return result[i].OperationID < result[j].OperationID
-		}
-		return result[i].StartedAt.Before(result[j].StartedAt)
-	})
+	result := make(map[string]string, len(candidates))
+	for traceID, value := range candidates {
+		result[traceID] = value.sourceModule
+	}
 	return result
+}
+
+func operationCallFactPrecedes(fact sessionvo.OperationCallFact, startedAt time.Time, operationID string, attempt uint32) bool {
+	if fact.StartedAt.Equal(startedAt) {
+		if fact.OperationID == operationID {
+			return fact.Attempt < attempt
+		}
+		return fact.OperationID < operationID
+	}
+	return fact.StartedAt.Before(startedAt)
 }
 
 func sortOperationCallFacts(result []sessionvo.OperationCallFact) {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
@@ -9,40 +9,36 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
 )
 
-func TestListOperationCallFactsByTraceIDsReturnsRequestedFactsInTraceOrder(t *testing.T) {
+func TestListFirstOperationSourceModulesByTraceIDsReturnsEarliestNonEmptyModule(t *testing.T) {
 	store := New()
 	firstAt := time.Date(2026, 8, 19, 8, 0, 0, 0, time.UTC)
 	secondAt := firstAt.Add(time.Second)
 	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
-		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-late", Attempt: 1, TraceID: "trace-a", StartedAt: secondAt})
-		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-early", Attempt: 1, TraceID: "trace-a", StartedAt: firstAt})
-		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-b", Attempt: 1, TraceID: "trace-b", StartedAt: firstAt})
-		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-other", Attempt: 1, TraceID: "trace-other", StartedAt: firstAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-late", Attempt: 1, TraceID: "trace-a", SourceModule: "later", StartedAt: secondAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-empty", Attempt: 1, TraceID: "trace-a", StartedAt: firstAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-early", Attempt: 1, TraceID: "trace-a", SourceModule: "earliest", StartedAt: firstAt.Add(time.Millisecond)})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-b", Attempt: 1, TraceID: "trace-b", SourceModule: "module-b", StartedAt: firstAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-other", Attempt: 1, TraceID: "trace-other", SourceModule: "other", StartedAt: firstAt})
 		return nil
 	}); err != nil {
 		t.Fatalf("seed operation facts: %v", err)
 	}
 
-	var facts []sessionvo.OperationCallFact
+	var sourceModules map[string]string
 	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
-		facts = tx.ListOperationCallFactsByTraceIDs([]string{"trace-b", "", "trace-a", "trace-a"})
+		sourceModules = tx.ListFirstOperationSourceModulesByTraceIDs([]string{"trace-b", "", "trace-a", "trace-a"})
 		return nil
 	}); err != nil {
-		t.Fatalf("read operation facts: %v", err)
+		t.Fatalf("read operation source modules: %v", err)
 	}
 
-	if len(facts) != 3 {
-		t.Fatalf("facts = %+v, want only three requested facts", facts)
+	if got, want := sourceModules["trace-a"], "earliest"; got != want {
+		t.Fatalf("trace-a source module = %q, want %q", got, want)
 	}
-	byTrace := map[string][]sessionvo.OperationCallFact{}
-	for _, fact := range facts {
-		byTrace[fact.TraceID] = append(byTrace[fact.TraceID], fact)
+	if got, want := sourceModules["trace-b"], "module-b"; got != want {
+		t.Fatalf("trace-b source module = %q, want %q", got, want)
 	}
-	if len(byTrace["trace-a"]) != 2 || byTrace["trace-a"][0].OperationID != "op-a-early" ||
-		byTrace["trace-a"][1].OperationID != "op-a-late" {
-		t.Fatalf("trace-a facts must remain chronological: %+v", byTrace["trace-a"])
-	}
-	if len(byTrace["trace-b"]) != 1 || byTrace["trace-b"][0].OperationID != "op-b" {
-		t.Fatalf("trace-b facts = %+v", byTrace["trace-b"])
+	if _, found := sourceModules["trace-other"]; found {
+		t.Fatalf("unexpected source module for unrequested trace")
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
@@ -1,0 +1,48 @@
+package sessionstore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+func TestListOperationCallFactsByTraceIDsReturnsRequestedFactsInTraceOrder(t *testing.T) {
+	store := New()
+	firstAt := time.Date(2026, 8, 19, 8, 0, 0, 0, time.UTC)
+	secondAt := firstAt.Add(time.Second)
+	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-late", Attempt: 1, TraceID: "trace-a", StartedAt: secondAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-a-early", Attempt: 1, TraceID: "trace-a", StartedAt: firstAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-b", Attempt: 1, TraceID: "trace-b", StartedAt: firstAt})
+		tx.SaveOperationCallFact(sessionvo.OperationCallFact{OperationID: "op-other", Attempt: 1, TraceID: "trace-other", StartedAt: firstAt})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed operation facts: %v", err)
+	}
+
+	var facts []sessionvo.OperationCallFact
+	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		facts = tx.ListOperationCallFactsByTraceIDs([]string{"trace-b", "", "trace-a", "trace-a"})
+		return nil
+	}); err != nil {
+		t.Fatalf("read operation facts: %v", err)
+	}
+
+	if len(facts) != 3 {
+		t.Fatalf("facts = %+v, want only three requested facts", facts)
+	}
+	byTrace := map[string][]sessionvo.OperationCallFact{}
+	for _, fact := range facts {
+		byTrace[fact.TraceID] = append(byTrace[fact.TraceID], fact)
+	}
+	if len(byTrace["trace-a"]) != 2 || byTrace["trace-a"][0].OperationID != "op-a-early" ||
+		byTrace["trace-a"][1].OperationID != "op-a-late" {
+		t.Fatalf("trace-a facts must remain chronological: %+v", byTrace["trace-a"])
+	}
+	if len(byTrace["trace-b"]) != 1 || byTrace["trace-b"][0].OperationID != "op-b" {
+		t.Fatalf("trace-b facts = %+v", byTrace["trace-b"])
+	}
+}

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -31,6 +31,7 @@ type Transaction interface {
 	FindOperationCallFact(operationID string, attempt uint32) (sessionvo.OperationCallFact, bool)
 	ListOperationCallFacts(interactionID string) []sessionvo.OperationCallFact
 	ListOperationCallFactsByTraceID(traceID string) []sessionvo.OperationCallFact
+	ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact
 	SaveOperationCallFact(fact sessionvo.OperationCallFact)
 	PeekReceipt(receiptID string) (sessionvo.Receipt, bool)
 	FindReceipt(receiptID string) (sessionvo.Receipt, bool)

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -31,7 +31,7 @@ type Transaction interface {
 	FindOperationCallFact(operationID string, attempt uint32) (sessionvo.OperationCallFact, bool)
 	ListOperationCallFacts(interactionID string) []sessionvo.OperationCallFact
 	ListOperationCallFactsByTraceID(traceID string) []sessionvo.OperationCallFact
-	ListOperationCallFactsByTraceIDs(traceIDs []string) []sessionvo.OperationCallFact
+	ListFirstOperationSourceModulesByTraceIDs(traceIDs []string) map[string]string
 	SaveOperationCallFact(fact sessionvo.OperationCallFact)
 	PeekReceipt(receiptID string) (sessionvo.Receipt, bool)
 	FindReceipt(receiptID string) (sessionvo.Receipt, bool)

--- a/docs/plans/2026-08-19-issue-1032-batch-canonical-enrichment.md
+++ b/docs/plans/2026-08-19-issue-1032-batch-canonical-enrichment.md
@@ -4,7 +4,7 @@
 
 **Goal:** Remove the per-trace database lookup made while enriching one Trace summary page, without changing the public Trace API or authorization behavior.
 
-**Architecture:** Add one session-store batch read keyed by distinct non-empty trace IDs. The Trace summary service groups returned operation call facts by trace ID and keeps the first non-empty source module using the existing fact ordering. MariaDB executes one bounded `IN` query; the in-memory adapter mirrors its result and ordering.
+**Architecture:** Add one narrow session-store batch projection keyed by distinct non-empty trace IDs. The Trace summary service receives only each trace's first non-empty source module, preserving the existing fact ordering without loading call input/output/error payloads. MariaDB executes one bounded `IN` query selecting only `trace_id` and `source_module`; the in-memory adapter mirrors that result and ordering.
 
 **Tech Stack:** Go, Go `testing`, MariaDB session-store adapter, in-memory session-store adapter.
 
@@ -17,7 +17,7 @@
 - Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go`
 
 1. Add a test that stores facts for multiple trace IDs and asks the new batch read for duplicate and blank IDs.
-2. Assert that only requested trace IDs are returned and that facts within each trace remain chronological.
+2. Assert that only requested trace IDs are returned and that each result is the first non-empty source module by the existing fact ordering.
 3. Add a Trace-summary regression test with multiple trace IDs to preserve the existing canonical source-module selection.
 4. Run the focused test command and confirm the test fails because the batch API does not yet exist.
 
@@ -28,9 +28,9 @@
 - Modify: `bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go`
 - Modify: `bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
 
-1. Add `ListOperationCallFactsByTraceIDs(traceIDs []string)` to the transaction port.
-2. Implement it in memory with an empty-input fast path, one fact scan, and deterministic per-trace chronological ordering.
-3. Implement it in MariaDB with an empty-input fast path and one parameterized `trace_id IN (...)` query; do not interpolate values.
+1. Add `ListFirstOperationSourceModulesByTraceIDs(traceIDs []string)` to the transaction port.
+2. Implement it in memory with an empty-input fast path, one fact scan, and deterministic first-non-empty selection per trace.
+3. Implement it in MariaDB with an empty-input fast path and one parameterized `trace_id IN (...)` query selecting only `trace_id` and `source_module`; do not interpolate values or read payload columns.
 4. Retain the existing single-trace method for other callers.
 
 ### Task 3: Switch Trace summary enrichment to the batch contract
@@ -39,7 +39,7 @@
 - Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go`
 
 1. Collect distinct non-empty trace IDs once per summary page.
-2. Call the batch contract once, group facts by trace ID, then apply the existing first non-empty `SourceModule` behavior.
+2. Call the batch projection once and apply the returned first non-empty `SourceModule` values.
 3. Leave conversation enrichment, API shape, authorization, summary ordering, and fallback behavior unchanged.
 
 ### Task 4: Verify, document, and submit the isolated fix
@@ -53,6 +53,7 @@
 
 ## Verification
 
-- [x] Red: `GOCACHE=/tmp/openbkn-go-cache go test ./src/drivenadapter/memoryaccess/sessionstore -run TestListOperationCallFactsByTraceIDsReturnsRequestedFactsInTraceOrder -count=1` failed before implementation because the batch port did not exist.
+- [x] Red: `GOCACHE=/tmp/openbkn-go-cache go test ./src/drivenadapter/memoryaccess/sessionstore -run TestListFirstOperationSourceModulesByTraceIDsReturnsEarliestNonEmptyModule -count=1` failed before implementation because the narrow batch port did not exist.
+- [x] Green: `GOCACHE=/tmp/openbkn-go-cache go test ./src/drivenadapter/memoryaccess/sessionstore -run TestListFirstOperationSourceModulesByTraceIDsReturnsEarliestNonEmptyModule -count=1` passed after implementation.
 - [x] Green: `GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc ./src/drivenadapter/memoryaccess/sessionstore ./src/drivenadapter/dbaccess/mariadb/sessionstore -count=1` passed after implementation.
 - [x] Formatting and whitespace: `gofmt` and `git diff --check` passed.

--- a/docs/plans/2026-08-19-issue-1032-batch-canonical-enrichment.md
+++ b/docs/plans/2026-08-19-issue-1032-batch-canonical-enrichment.md
@@ -1,0 +1,58 @@
+# Trace Canonical Enrichment Batch Read Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the per-trace database lookup made while enriching one Trace summary page, without changing the public Trace API or authorization behavior.
+
+**Architecture:** Add one session-store batch read keyed by distinct non-empty trace IDs. The Trace summary service groups returned operation call facts by trace ID and keeps the first non-empty source module using the existing fact ordering. MariaDB executes one bounded `IN` query; the in-memory adapter mirrors its result and ordering.
+
+**Tech Stack:** Go, Go `testing`, MariaDB session-store adapter, in-memory session-store adapter.
+
+---
+
+### Task 1: Specify the batch read contract with a failing test
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go`
+- Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go`
+
+1. Add a test that stores facts for multiple trace IDs and asks the new batch read for duplicate and blank IDs.
+2. Assert that only requested trace IDs are returned and that facts within each trace remain chronological.
+3. Add a Trace-summary regression test with multiple trace IDs to preserve the existing canonical source-module selection.
+4. Run the focused test command and confirm the test fails because the batch API does not yet exist.
+
+### Task 2: Add the minimal port and adapter implementation
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/port/driven/isessionstore/port.go`
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go`
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
+
+1. Add `ListOperationCallFactsByTraceIDs(traceIDs []string)` to the transaction port.
+2. Implement it in memory with an empty-input fast path, one fact scan, and deterministic per-trace chronological ordering.
+3. Implement it in MariaDB with an empty-input fast path and one parameterized `trace_id IN (...)` query; do not interpolate values.
+4. Retain the existing single-trace method for other callers.
+
+### Task 3: Switch Trace summary enrichment to the batch contract
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go`
+
+1. Collect distinct non-empty trace IDs once per summary page.
+2. Call the batch contract once, group facts by trace ID, then apply the existing first non-empty `SourceModule` behavior.
+3. Leave conversation enrichment, API shape, authorization, summary ordering, and fallback behavior unchanged.
+
+### Task 4: Verify, document, and submit the isolated fix
+
+**Files:**
+- Modify: this plan with verification evidence/status.
+
+1. Run targeted unit tests for the evidence service and both session-store adapters.
+2. Run `gofmt`, `git diff --check`, and the relevant package tests again.
+3. Commit only this issue's code/tests/plan, push the branch, create an English PR, and request review.
+
+## Verification
+
+- [x] Red: `GOCACHE=/tmp/openbkn-go-cache go test ./src/drivenadapter/memoryaccess/sessionstore -run TestListOperationCallFactsByTraceIDsReturnsRequestedFactsInTraceOrder -count=1` failed before implementation because the batch port did not exist.
+- [x] Green: `GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc ./src/drivenadapter/memoryaccess/sessionstore ./src/drivenadapter/dbaccess/mariadb/sessionstore -count=1` passed after implementation.
+- [x] Formatting and whitespace: `gofmt` and `git diff --check` passed.


### PR DESCRIPTION
## Summary
- Replace per-trace operation-call fact reads with one batch read per trace summary page.
- Add equivalent MariaDB and in-memory implementations with deterministic fact ordering.
- Preserve canonical source-module resolution and add regression coverage.

## Verification
- GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc ./src/drivenadapter/memoryaccess/sessionstore ./src/drivenadapter/dbaccess/mariadb/sessionstore -count=1
- gofmt and git diff --check

The full Go suite is sandbox-limited because HTTP tests cannot bind httptest loopback listeners; the affected target packages pass.