### PR TITLE
ci(review): raise the reviewed-file cap to 500

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -187,7 +187,7 @@ jobs:
           # 不用 --paginate 是给超大 PR 兜底——那种 PR 翻十几页也只会用到前 FILE_CAP 个，
           # 多出来的页是白花的 API 调用。上限本身仍然存在（单 agent 的上下文吃不下无限
           # 文件），差额照旧由 verdict 在结论里点明。
-          FILE_CAP = 150
+          FILE_CAP = 500
           PER_PAGE = 100
           paths = []
           page = 1
@@ -1163,7 +1163,7 @@ jobs:
                "reason_absent": "整个分片没跑起来或中途挂了",
                "reason_malformed": "写出的结论文件解析不了",
                "trunc": "文件清单被截断",
-               "trunc_body": "本 PR 共 %s 个改动文件，分片只拿到 %s 个（评审的文件清单上限 150），**其余 %d 个未进入任何分片、本轮未经评审**。",
+               "trunc_body": "本 PR 共 %s 个改动文件，分片只拿到 %s 个（评审的文件清单上限 500），**其余 %d 个未进入任何分片、本轮未经评审**。",
                "footer": "改完请推新提交，或回复 `/review` 要一轮复评。",
                "footer_ok": "有异议或想再评一轮，请回复 `/review`——普通回帖不会触发复评，且回帖人需为本仓 OWNER/MEMBER/COLLABORATOR。"}
 


### PR DESCRIPTION
## What

`FILE_CAP` in the automated review's plan step goes from 150 to 500, and the verdict's truncation notice quotes the new number.

## Why

The plan step stops paginating `/pulls/{n}/files` at `FILE_CAP`; everything past it enters no shard and is silently unreviewed — the verdict only reports the count. Large PRs in this repo (bulk comment translations, sweeping refactors) routinely change more than 150 files, so the cap was clipping real review coverage.

Pagination still walks 100 per page, so the ceiling costs at most 5 API pages instead of 2 on the largest PRs.

## Note

Only one agent reviews the whole list (`max_turns` 200). At 500 deep files that budget is tighter than it was at 150; if runs start ending in `error_max_turns`, the turn budget is the next dial, not the file cap.

## Testing

- Workflow file only; no local test path. Behavior visible on the first PR that changes more than 150 files after merge.
- Note: `claude-code-action` requires the workflow file to match the default branch verbatim, so the automated review will skip on this PR itself until it merges.

## Pre-Merge Checklist

- [x] No design doc needed (config constant)
- [x] CHANGELOG not applicable (CI-only change)