### PR TITLE
fix(mcp): degrade on unusable locale resources instead of panicking

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale.go
@@ -195,21 +195,29 @@ func (b *mcpLocaleBundle) PTCResource(name string) string {
 }
 
 func (b *mcpLocaleBundle) PTCHints(toolName string) []string {
+	// Hints are advisory. An unreadable file costs the model a hint; it must not
+	// cost the caller their request.
 	var hints map[string][]string
 	if err := json.Unmarshal([]byte(b.PTCResource("ptc_hints.json")), &hints); err != nil {
-		panic("cannot parse PTC hints: " + err.Error())
+		log.Printf("WARN: cannot parse PTC hints for %s, continuing without them: %v", b.locale, err)
+		return nil
 	}
 	return hints[toolName]
 }
 
 func (b *mcpLocaleBundle) PTCError(key string, params ...any) string {
+	// This renders the text of an error that already happened. A missing or
+	// malformed catalog entry must degrade to something readable rather than
+	// escalate the original error into a panic on the request path.
 	var messages map[string]string
 	if err := json.Unmarshal([]byte(b.PTCResource("ptc_errors.json")), &messages); err != nil {
-		panic("cannot parse PTC errors: " + err.Error())
+		log.Printf("WARN: cannot parse PTC errors for %s: %v", b.locale, err)
+		return key
 	}
 	message, ok := messages[key]
 	if !ok {
-		panic("PTC error message not found: " + key)
+		log.Printf("WARN: PTC error message %q missing from the %s catalog", key, b.locale)
+		return key
 	}
 	return fmt.Sprintf(message, params...)
 }
@@ -281,40 +289,46 @@ func (b *mcpLocaleBundle) OverlaySchemas(
 		return input, output
 	}
 
+	// A broken overlay degrades to the baseline schema. /mcp/info rebuilds this
+	// per request through tryLoadToolSchemas, whose contract is to tolerate bad
+	// resources — panicking here would have broken that promise and turned a
+	// translation defect into a failed request.
+	wrapped, err := marshalToolSchema(input, output)
+	if err != nil {
+		log.Printf("WARN: MCP overlay for %s: cannot wrap base schema, serving baseline: %v", toolKey, err)
+		return input, output
+	}
 	var schema any
-	if err := json.Unmarshal(mustMarshalToolSchema(input, output), &schema); err != nil {
-		panic("invalid base schema for localized overlay: " + err.Error())
+	if err := json.Unmarshal(wrapped, &schema); err != nil {
+		log.Printf("WARN: MCP overlay for %s: base schema is not valid JSON, serving baseline: %v", toolKey, err)
+		return input, output
 	}
 	root, ok := schema.(map[string]any)
 	if !ok {
-		panic("invalid base schema for localized overlay: root is not object")
+		log.Printf("WARN: MCP overlay for %s: base schema root is not an object, serving baseline", toolKey)
+		return input, output
 	}
 	for path, value := range replacements {
 		setNestedString(root, strings.Split(path, "."), value)
 	}
-	wrapper := toolSchemaFile{}
-	if rawInput, err := json.Marshal(root["input_schema"]); err == nil {
-		wrapper.InputSchema = rawInput
-	} else {
-		panic("cannot marshal localized input schema: " + err.Error())
+	rawInput, err := json.Marshal(root["input_schema"])
+	if err != nil {
+		log.Printf("WARN: MCP overlay for %s: cannot marshal localized input schema, serving baseline: %v", toolKey, err)
+		return input, output
 	}
-	if rawOutput, err := json.Marshal(root["output_schema"]); err == nil {
-		wrapper.OutputSchema = rawOutput
-	} else {
-		panic("cannot marshal localized output schema: " + err.Error())
+	rawOutput, err := json.Marshal(root["output_schema"])
+	if err != nil {
+		log.Printf("WARN: MCP overlay for %s: cannot marshal localized output schema, serving baseline: %v", toolKey, err)
+		return input, output
 	}
-	return wrapper.InputSchema, wrapper.OutputSchema
+	return rawInput, rawOutput
 }
 
-func mustMarshalToolSchema(input, output json.RawMessage) []byte {
-	data, err := json.Marshal(toolSchemaFile{
+func marshalToolSchema(input, output json.RawMessage) ([]byte, error) {
+	return json.Marshal(toolSchemaFile{
 		InputSchema:  input,
 		OutputSchema: output,
 	})
-	if err != nil {
-		panic("cannot marshal tool schema wrapper: " + err.Error())
-	}
-	return data
 }
 
 func setNestedString(root map[string]any, path []string, value string) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_degradation_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_degradation_test.go
@@ -1,0 +1,75 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/smartystreets/goconvey/convey"
+)
+
+// A bad locale resource must cost the caller wording, never their request.
+// /mcp/info rebuilds the tool schemas per request through tryLoadToolSchemas,
+// so a panic in the overlay path would surface as a failed request rather than
+// as the translation defect it is.
+
+func TestOverlaySchemasDegradesOnUnusableInput(t *testing.T) {
+	convey.Convey("an overlay over an unusable base schema should serve the baseline", t, func() {
+		bundle := &mcpLocaleBundle{
+			locale: "en-US",
+			schemaDescriptions: map[string]map[string]string{
+				"probe": {"input_schema.properties.q.description": "Query."},
+			},
+		}
+
+		convey.Convey("base schema that is not valid JSON", func() {
+			input := json.RawMessage(`{"properties":`)
+			output := json.RawMessage(`{}`)
+			gotInput, gotOutput := bundle.OverlaySchemas("probe", input, output)
+			convey.So(string(gotInput), convey.ShouldEqual, string(input))
+			convey.So(string(gotOutput), convey.ShouldEqual, string(output))
+		})
+
+		convey.Convey("a tool with no overlay entry is returned untouched", func() {
+			input := json.RawMessage(`{"type":"object"}`)
+			output := json.RawMessage(`{"type":"object"}`)
+			gotInput, gotOutput := bundle.OverlaySchemas("absent", input, output)
+			convey.So(string(gotInput), convey.ShouldEqual, string(input))
+			convey.So(string(gotOutput), convey.ShouldEqual, string(output))
+		})
+
+		convey.Convey("a usable base schema is still localized", func() {
+			input := json.RawMessage(`{"type":"object","properties":{"q":{"description":"原文"}}}`)
+			output := json.RawMessage(`{"type":"object"}`)
+			gotInput, _ := bundle.OverlaySchemas("probe", input, output)
+			convey.So(string(gotInput), convey.ShouldContainSubstring, "Query.")
+		})
+	})
+}
+
+func TestPTCErrorDegradesWhenTheCatalogCannotAnswer(t *testing.T) {
+	convey.Convey("a missing PTC message should not escalate the error it describes", t, func() {
+		bundle := loadMCPLocaleBundle("en-US")
+
+		convey.Convey("a known key renders its message", func() {
+			convey.So(bundle.PTCError("code_required"), convey.ShouldNotBeBlank)
+			convey.So(bundle.PTCError("code_required"), convey.ShouldNotEqual, "code_required")
+		})
+
+		convey.Convey("an unknown key falls back to the key instead of panicking", func() {
+			convey.So(func() { bundle.PTCError("no_such_message") }, convey.ShouldNotPanic)
+			convey.So(bundle.PTCError("no_such_message"), convey.ShouldEqual, "no_such_message")
+		})
+	})
+}
+
+func TestPTCHintsDegradeToNone(t *testing.T) {
+	convey.Convey("hints are advisory and never fail a request", t, func() {
+		bundle := loadMCPLocaleBundle("en-US")
+		convey.So(func() { bundle.PTCHints("no_such_tool") }, convey.ShouldNotPanic)
+		convey.So(bundle.PTCHints("no_such_tool"), convey.ShouldBeNil)
+	})
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -46,8 +46,10 @@ func TestMCPLocaleBundle(t *testing.T) {
 
 		for toolKey, replacements := range bundle.schemaDescriptions {
 			input, output := bundle.ToolSchemas(toolKey)
+			wrapped, err := marshalToolSchema(input, output)
+			convey.So(err, convey.ShouldBeNil)
 			var schema map[string]any
-			convey.So(json.Unmarshal(mustMarshalToolSchema(input, output), &schema), convey.ShouldBeNil)
+			convey.So(json.Unmarshal(wrapped, &schema), convey.ShouldBeNil)
 
 			for path, expected := range replacements {
 				actual, ok := getNestedString(schema, strings.Split(path, "."))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_explore_subgraph_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_explore_subgraph_test.go
@@ -191,8 +191,10 @@ func TestExploreSubgraphSchema_DescriptionsAreLocalized(t *testing.T) {
 		convey.So(len(replacements), convey.ShouldBeGreaterThan, 0)
 
 		input, output := loadToolSchemas("explore_subgraph")
+		wrapped, err := marshalToolSchema(input, output)
+		convey.So(err, convey.ShouldBeNil)
 		var wrapper map[string]any
-		convey.So(json.Unmarshal(mustMarshalToolSchema(input, output), &wrapper), convey.ShouldBeNil)
+		convey.So(json.Unmarshal(wrapped, &wrapper), convey.ShouldBeNil)
 
 		// Each description in the baseline must have a corresponding coverage entry, otherwise the English client will silently fall back to Chinese.
 		for _, path := range collectDescriptionPaths(wrapper, nil) {

--- a/tools/check_i18n_catalogs.py
+++ b/tools/check_i18n_catalogs.py
@@ -52,6 +52,7 @@ JSON_CATALOGS = (
     ),
 )
 MCP_SCHEMAS_DIRECTORY = REPOSITORY_ROOT / "adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas"
+DEFAULT_MCP_LOCALE = "zh-CN"
 
 PERCENT_PLACEHOLDER = re.compile(r"(?<!%)%(?:[-+#0 ]*\d*(?:\.\d+)?[bcdeEfFgGosxXqTUv])")
 GO_TEMPLATE_PLACEHOLDER = re.compile(r"{{\s*([^{}]+?)\s*}}")
@@ -305,6 +306,54 @@ def validate_mcp_locale_resources(schemas_directory: Path, locale: str = "en-US"
     return errors
 
 
+def load_json_with_license_header(path: Path) -> Any:
+    """Parse a locale JSON file that may carry a leading /* ... */ license block."""
+    text = path.read_text(encoding="utf-8")
+    if text.lstrip().startswith("/*"):
+        end = text.find("*/")
+        if end != -1:
+            text = text[end + 2:]
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{path}: cannot parse JSON catalog: {error}") from error
+
+
+def validate_mcp_ptc_resources(schemas_directory: Path, locale: str = "en-US") -> list[str]:
+    """Every PTC catalog key present in the baseline must exist in each locale.
+
+    PTCError looks a key up at request time. Before this check nothing compared
+    the two files, so a key added to one locale only would surface as a missing
+    message while rendering an error that had already occurred.
+    """
+    errors: list[str] = []
+    for name in ("ptc_errors.json", "ptc_hints.json"):
+        baseline_path = schemas_directory / "locales" / DEFAULT_MCP_LOCALE / name
+        translated_path = schemas_directory / "locales" / locale / name
+        if not baseline_path.exists():
+            errors.append(f"mcp-ptc: {baseline_path} is missing")
+            continue
+        if not translated_path.exists():
+            # A whole missing file falls back to the baseline at runtime.
+            continue
+        try:
+            baseline = load_json_with_license_header(baseline_path)
+            translated = load_json_with_license_header(translated_path)
+        except ValueError as error:
+            errors.append(f"mcp-ptc: {error}")
+            continue
+        if not isinstance(baseline, dict) or not isinstance(translated, dict):
+            errors.append(f"mcp-ptc: {name} must contain an object")
+            continue
+        missing = sorted(set(baseline) - set(translated))
+        unexpected = sorted(set(translated) - set(baseline))
+        if missing:
+            errors.append(f"mcp-ptc: {translated_path} is missing keys: {', '.join(missing)}")
+        if unexpected:
+            errors.append(f"mcp-ptc: {translated_path} has unexpected keys: {', '.join(unexpected)}")
+    return errors
+
+
 def validate_catalog_pair(name: str, baseline_path: Path, translated_path: Path) -> list[str]:
     baseline = load_catalog(baseline_path)
     translated = load_catalog(translated_path)
@@ -356,6 +405,10 @@ def main() -> int:
             errors.append(str(error))
     try:
         errors.extend(validate_mcp_locale_resources(MCP_SCHEMAS_DIRECTORY))
+    except ValueError as error:
+        errors.append(str(error))
+    try:
+        errors.extend(validate_mcp_ptc_resources(MCP_SCHEMAS_DIRECTORY))
     except ValueError as error:
         errors.append(str(error))
     if errors:


### PR DESCRIPTION
Closes #826's *"坏 locale 资源不再打成请求路径 panic"*.

`locale.go` had twelve `panic` calls. Seven were reachable while serving a request; those degrade now. Four stay, and the reason they stay is the point of the change.

## What was reachable

| Site | Why it mattered |
|---|---|
| `OverlaySchemas` (4 panics) | `/mcp/info` rebuilds the tool schemas **per request** through `tryLoadToolSchemas`, whose own comment promises it "读不到/解析失败时返回 nil 而非 panic". It delegated straight to `OverlaySchemas`, so that promise did not hold. Now logs and serves the baseline schema. |
| `PTCError` (2 panics) | The key is a **runtime argument**, and this function renders the text of an error that *already happened*. A translation gap escalated the original error into a crash. Now falls back to the key. |
| `PTCHints` (1 panic) | Hints are advisory. An unreadable file now costs the model a hint, not the caller their request. |

## What stays, deliberately

The four remaining panics read `go:embed` resources during handler construction. `newLocalizedMCPHandler` builds a bundle for each supported locale at start-up, so they fire on a binary that shipped without its locale files.

That is a build defect, and it should be loud. Degrading it would produce a service that starts happily and answers every request in the wrong language — worse than not starting.

## The guard, not just the backstop

Runtime degradation is the backstop. The actual guard was missing: **nothing compared the PTC catalogs between locales.** `validate_mcp_locale_resources` covers `tools_meta.json` and `schema_descriptions.json` only, so a key added to `zh-CN` alone would sit there until `PTCError` asked for it.

`check_i18n_catalogs.py` now validates key parity for `ptc_errors.json` and `ptc_hints.json`. Those files carry a `/* ... */` license header that plain `json.loads` rejects — the loader strips it, the same way the Go side does.

Verified by removing one key:

```
- mcp-ptc: .../locales/en-US/ptc_errors.json is missing keys: code_required
```

## Tests

`locale_degradation_test.go` pins each degraded path: an unusable base schema serves the baseline, a tool with no overlay is untouched, a usable schema is still localized, an unknown PTC key returns the key without panicking, and unknown hints return nil.

`mustMarshalToolSchema` becomes `marshalToolSchema` returning an error; three test call sites follow.

`go test ./...` in agent-retrieval passes. `check_i18n_catalogs.py` and its unit tests pass.

Refs #826