### PR TITLE
refactor(sandbox): translate comments

### DIFF
--- a/infra/sandbox/README.md
+++ b/infra/sandbox/README.md
@@ -1,6 +1,6 @@
 # Sandbox Control Plane
 
-[![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md) [![中文](https://img.shields.io/badge/lang-中文-red.svg)](README_ZH.md)
+[![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md) [![Chinese](https://img.shields.io/badge/lang-Chinese-red.svg)](README_ZH.md)
 
 A cloud-native, production-ready platform for secure code execution in isolated container environments, designed for AI agent applications.
 
@@ -14,7 +14,7 @@ The system adopts a **Control Plane + Container Scheduler** separation architect
 
 ```mermaid
 flowchart TD
-    %% 定义全局样式
+    %% Define global styles
     classDef external fill:#f9f9f9,stroke:#666,stroke-width:2px,color:#333;
     classDef control fill:#e1f5fe,stroke:#01579b,stroke-width:2px,color:#01579b;
     classDef scheduler fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#e65100;
@@ -22,38 +22,38 @@ flowchart TD
     classDef runtime fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px,color:#1b5e20;
     classDef database fill:#ede7f6,stroke:#311b92,stroke-width:2px,color:#311b92;
 
-    subgraph External ["🌐 外部系统 (External)"]
-        Client(["📱 客户端应用"])
-        Developer(["👨‍💻 开发者 SDK/API"])
+    subgraph External ["🌐 External systems (External)"]
+        Client(["📱 Client application"])
+        Developer(["👨‍💻 Developer SDK/API"])
     end
 
-    subgraph ControlPlane ["⚙️ 控制平面 (Control Plane)"]
+    subgraph ControlPlane ["⚙️ Control Plane (Control Plane)"]
         direction TB
         API[["🚀 API Gateway (FastAPI)"]]
-        Scheduler{{"📅 调度器 (Scheduler)"}}
-        SessionMgr["📂 会话管理器"]
-        TemplateMgr["📝 模板管理器"]
-        HealthProbe["🩺 健康检查"]
-        Cleanup["🧹 会话清理"]
-        StateSync["🔄 状态同步"]
+        Scheduler{{"📅 Scheduler (Scheduler)"}}
+        SessionMgr["📂 Session Manager"]
+        TemplateMgr["📝 Template Manager"]
+        HealthProbe["🩺 Health Check"]
+        Cleanup["🧹 Session Cleanup"]
+        StateSync["🔄 State Sync"]
     end
 
-    subgraph ContainerScheduler ["📦 容器编排 (Scheduler)"]
+    subgraph ContainerScheduler ["📦 Container Orchestration (Scheduler)"]
         DockerRuntime["Docker Runtime"]
         K8sRuntime["Kubernetes"]
     end
 
-    subgraph Storage ["💾 存储层 (Storage)"]
+    subgraph Storage ["💾 Storage Layer (Storage)"]
         MariaDB[("🗄️ MariaDB")]
         S3[("☁️ S3 Storage")]
     end
 
-    subgraph Runtime ["🛡️ 沙箱运行时 (Sandbox)"]
-        Executor["⚡ 执行器 (Executor)"]
-        Container["📦 容器实例"]
+    subgraph Runtime ["🛡️ Sandbox Runtime (Sandbox)"]
+        Executor["⚡ Executor (Executor)"]
+        Container["📦 Container Instance"]
     end
 
-    %% 这里的连接线逻辑
+    %% Connection line logic
     Client & Developer --> API
     API --> Scheduler
     Scheduler --> SessionMgr & ContainerScheduler
@@ -66,7 +66,7 @@ flowchart TD
     Cleanup --> SessionMgr
     API -.-> S3
 
-    %% 应用样式
+    %% Apply styles
     class Client,Developer external;
     class API,Scheduler,SessionMgr,TemplateMgr,HealthProbe,Cleanup,StateSync control;
     class DockerRuntime,K8sRuntime scheduler;
@@ -165,7 +165,7 @@ flowchart TD
 
 > Note: The above resource requirements are for the docker-compose development environment. Adjust according to actual load in production environments.
 
-### Build Images
+### build Images
 
 Before starting the services, build the versioned executor/template images:
 
@@ -189,7 +189,7 @@ This creates:
 - `sandbox-python-executor-base:python3.11-v1` - Stable Python runtime base without executor code
 - `sandbox-multi-executor-base:go1.25-python3.11-v1` - Stable Python, Go, and Bash runtime base without executor code
 
-To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Docker Buildx. The script exports `linux/amd64,linux/arm64` OCI archives and copies them to SWR:
+To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Docker buildx. The script exports `linux/amd64,linux/arm64` OCI archives and copies them to SWR:
 
 ```bash
 cd images
@@ -204,15 +204,15 @@ cd images
 If you're building images in a network environment with limited access to official repositories (e.g., mainland China), you can use mirror sources:
 
 ```bash
-# Build versioned executor/template images with mirror support
+# build versioned executor/template images with mirror support
 cd images
 USE_MIRROR=true ./build.sh
 
-# Build Control Plane with mirror from the repository root so VERSION is included
+# build Control Plane with mirror from the repository root so VERSION is included
 cd ..
 docker build -f sandbox_control_plane/Dockerfile --build-arg USE_MIRROR=true -t sandbox-control-plane .
 
-# Build Web Console with mirror
+# build Web Console with mirror
 cd ../sandbox_web
 docker build --build-arg USE_MIRROR=true -t sandbox-web .
 ```
@@ -253,7 +253,7 @@ swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:<TEMP
 
 You can also override `DEFAULT_TEMPLATE_IMAGE` and `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE` directly when different repositories or tags are required.
 
-### Kubernetes Deployment (Production)
+### Kubernetes deployment (Production)
 
 For production deployment, use Kubernetes with Helm Chart:
 
@@ -346,7 +346,7 @@ mypy sandbox_control_plane/
 
 ```
 sandbox/
-├── deploy/                   # Deployment configurations
+├── deploy/                   # deployment configurations
 │   ├── manifests/            # K8s native YAML deployment
 │   │   ├── 00-namespace.yaml
 │   │   ├── 01-configmap.yaml
@@ -387,7 +387,7 @@ sandbox/
 ├── images/                    # Container image build scripts
 │   ├── bases/                # Stable runtime base images without executor code
 │   ├── templates/            # Versioned executor/template image definitions
-│   └── build.sh              # Build runtime bases and versioned template images
+│   └── build.sh              # build runtime bases and versioned template images
 │
 ├── scripts/                  # Utility scripts
 ├── specs/                    # Implementation specifications

--- a/infra/sandbox/README.md
+++ b/infra/sandbox/README.md
@@ -1,6 +1,6 @@
 # Sandbox Control Plane
 
-[![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md) [![Chinese](https://img.shields.io/badge/lang-Chinese-red.svg)](README_ZH.md)
+[![English](https://img.shields.io/badge/lang-English-blue.svg)](README.md) [![中文](https://img.shields.io/badge/lang-中文-red.svg)](README_ZH.md)
 
 A cloud-native, production-ready platform for secure code execution in isolated container environments, designed for AI agent applications.
 
@@ -165,7 +165,7 @@ flowchart TD
 
 > Note: The above resource requirements are for the docker-compose development environment. Adjust according to actual load in production environments.
 
-### build Images
+### Build Images
 
 Before starting the services, build the versioned executor/template images:
 
@@ -189,7 +189,7 @@ This creates:
 - `sandbox-python-executor-base:python3.11-v1` - Stable Python runtime base without executor code
 - `sandbox-multi-executor-base:go1.25-python3.11-v1` - Stable Python, Go, and Bash runtime base without executor code
 
-To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Docker buildx. The script exports `linux/amd64,linux/arm64` OCI archives and copies them to SWR:
+To push multi-arch base images to Huawei Cloud SWR, install `skopeo` and use Docker Buildx. The script exports `linux/amd64,linux/arm64` OCI archives and copies them to SWR:
 
 ```bash
 cd images
@@ -204,15 +204,15 @@ cd images
 If you're building images in a network environment with limited access to official repositories (e.g., mainland China), you can use mirror sources:
 
 ```bash
-# build versioned executor/template images with mirror support
+# Build versioned executor/template images with mirror support
 cd images
 USE_MIRROR=true ./build.sh
 
-# build Control Plane with mirror from the repository root so VERSION is included
+# Build Control Plane with mirror from the repository root so VERSION is included
 cd ..
 docker build -f sandbox_control_plane/Dockerfile --build-arg USE_MIRROR=true -t sandbox-control-plane .
 
-# build Web Console with mirror
+# Build Web Console with mirror
 cd ../sandbox_web
 docker build --build-arg USE_MIRROR=true -t sandbox-web .
 ```
@@ -253,7 +253,7 @@ swr.cn-east-3.myhuaweicloud.com/openbkn-ai/sandbox-template-multi-language:<TEMP
 
 You can also override `DEFAULT_TEMPLATE_IMAGE` and `DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE` directly when different repositories or tags are required.
 
-### Kubernetes deployment (Production)
+### Kubernetes Deployment (Production)
 
 For production deployment, use Kubernetes with Helm Chart:
 
@@ -346,7 +346,7 @@ mypy sandbox_control_plane/
 
 ```
 sandbox/
-├── deploy/                   # deployment configurations
+├── deploy/                   # Deployment configurations
 │   ├── manifests/            # K8s native YAML deployment
 │   │   ├── 00-namespace.yaml
 │   │   ├── 01-configmap.yaml
@@ -387,7 +387,7 @@ sandbox/
 ├── images/                    # Container image build scripts
 │   ├── bases/                # Stable runtime base images without executor code
 │   ├── templates/            # Versioned executor/template image definitions
-│   └── build.sh              # build runtime bases and versioned template images
+│   └── build.sh              # Build runtime bases and versioned template images
 │
 ├── scripts/                  # Utility scripts
 ├── specs/                    # Implementation specifications

--- a/infra/sandbox/deploy/docker-compose/docker-compose.yml
+++ b/infra/sandbox/deploy/docker-compose/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - TEMPLATE_IMAGE_TAG
       - DEFAULT_TEMPLATE_IMAGE
       - DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE
-      # S3/MinIO configuration
+      # S3/MinIO Configuration
       - S3_ENDPOINT_URL=http://minio:9000
       - S3_ACCESS_KEY_ID=minioadmin
       - S3_SECRET_ACCESS_KEY=minioadmin

--- a/infra/sandbox/deploy/docker-compose/docker-compose.yml
+++ b/infra/sandbox/deploy/docker-compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       # Mount Docker socket for container management
       - /var/run/docker.sock:/var/run/docker.sock
-    # 资源限制（实际运行约 600MB）
+    # Resource limits (actual runtime is about 600 MB)
     deploy:
       resources:
         limits:
@@ -31,13 +31,13 @@ services:
       - DEFAULT_TIMEOUT=300
       - MAX_TIMEOUT=3600
       - WARM_POOL_ENABLED=false
-      - DISABLE_BWRAP=true # 本地开发禁用 Bubblewrap
+      - DISABLE_BWRAP=true # Disable Bubblewrap for local development
       # Default sandbox template images. If TEMPLATE_IMAGE_TAG is unset,
       # Control Plane reads /app/VERSION and uses that as the tag.
       - TEMPLATE_IMAGE_TAG
       - DEFAULT_TEMPLATE_IMAGE
       - DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE
-      # S3/MinIO Configuration
+      # S3/MinIO configuration
       - S3_ENDPOINT_URL=http://minio:9000
       - S3_ACCESS_KEY_ID=minioadmin
       - S3_SECRET_ACCESS_KEY=minioadmin
@@ -65,7 +65,7 @@ services:
       - "1101:80" # Map internal 3000 to host 1101
     networks:
       - sandbox_network
-    # 资源限制
+    # Resource limits
     deploy:
       resources:
         limits:
@@ -97,7 +97,7 @@ services:
       - "9001:9001" # MinIO Console
     networks:
       - sandbox_network
-    # 资源限制
+    # Resource limits
     deploy:
       resources:
         limits:
@@ -129,7 +129,7 @@ services:
 
     networks:
       - sandbox_network
-    # 资源限制
+    # Resource limits
     deploy:
       resources:
         limits:

--- a/infra/sandbox/deploy/helm/sandbox/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/values.yaml
@@ -96,7 +96,7 @@ controlPlane:
     PYTHONUNBUFFERED: "1"
 
   s3:
-    # Note: endpointUrl is dynamically set in secret.yaml using .Values.namespace
+    # Note: endpointUrl is dynamically set in secret.yaml using .values.namespace
     # The actual endpoint will be: http://minio.<namespace>.svc.cluster.local:9000
     endpointUrl: ""  # Dynamically generated from namespace
     bucket: "sandbox-workspace"
@@ -188,7 +188,7 @@ securityContext:
 depServices:
   class-443:
     ingressClass: class-443
-  # 数据库连接配置
+  # Database connection configuration
   rds:
     type: MariaDB
     host: mariadb-mariadb-cluster.resource

--- a/infra/sandbox/deploy/helm/sandbox/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/values.yaml
@@ -96,7 +96,7 @@ controlPlane:
     PYTHONUNBUFFERED: "1"
 
   s3:
-    # Note: endpointUrl is dynamically set in secret.yaml using .values.namespace
+    # Note: endpointUrl is dynamically set in secret.yaml using .Values.namespace
     # The actual endpoint will be: http://minio.<namespace>.svc.cluster.local:9000
     endpointUrl: ""  # Dynamically generated from namespace
     bucket: "sandbox-workspace"

--- a/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
@@ -268,7 +268,7 @@ securityContext:
 depServices:
   class-443:
     ingressClass: class-443
-  # 数据库连接配置
+  # Database connection configuration
   rds:
     type: MYSQL
     host: mariadb.sandbox-system

--- a/infra/sandbox/docs/README.md
+++ b/infra/sandbox/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-项目文档按产品、设计、API、开发、运维五类组织，避免需求文档、架构文档和操作手册混放在根目录。
+Project documents are organized into product, design, API, development, and operations categories to avoid mixing requirements, architecture, and runbooks in the root directory.
 
 ## Structure
 
@@ -30,75 +30,75 @@ docs/
 
 ### Product
 
-- [产品路线图](./product/roadmap.md)
-- [PRD 模板](./product/prd/template.md)
-- [Session Python 依赖管理 PRD](./product/prd/session-python-dependency-management.md)
-- [场景：PTC 数据分析与上下文问答](./product/use-cases/ptc-data-analysis-and-context-qa.md)
-- [背景：统一沙箱临时区](./product/use-cases/unified-sandbox-background.md)
+- [Product roadmap](./product/roadmap.md)
+- [PRD template](./product/prd/template.md)
+- [Session Python Dependency Management PRD](./product/prd/session-python-dependency-management.md)
+- [Scenario: PTC data analysis and contextual Q&A](./product/use-cases/ptc-data-analysis-and-context-qa.md)
+- [Background: unified sandbox temporary area](./product/use-cases/unified-sandbox-background.md)
 
 ### Design
 
-- [架构总览](./design/architecture/overview.md)
-- [系统上下文](./design/architecture/system-context.md)
-- [逻辑架构与流程](./design/architecture/logical-architecture.md)
-- [安全与性能](./design/architecture/security-and-performance.md)
-- [存储架构](./design/architecture/storage-architecture.md)
-- [模块设计：Control Plane](./design/modules/control-plane.md)
-- [模块设计：Container Scheduler](./design/modules/container-scheduler.md)
-- [模块设计：Executor](./design/modules/executor.md)
-- [模块设计：Python Dependencies](./design/modules/python-dependencies.md)
-- [需求设计：Session Python 依赖管理](./design/features/session-python-dependency-management.md)
-- [需求设计：MCP Server](./design/features/mcp-server-implementation.md)
-- [Design 模板](./design/features/template.md)
-- [ADR 模板](./design/decisions/template.md)
+- [Architecture overview](./design/architecture/overview.md)
+- [System context](./design/architecture/system-context.md)
+- [Logical architecture and flow](./design/architecture/logical-architecture.md)
+- [Security and performance](./design/architecture/security-and-performance.md)
+- [Storage architecture](./design/architecture/storage-architecture.md)
+- [Module design: Control Plane](./design/modules/control-plane.md)
+- [Module design: Container Scheduler](./design/modules/container-scheduler.md)
+- [Module design: Executor](./design/modules/executor.md)
+- [Module design: Python dependencies](./design/modules/python-dependencies.md)
+- [Requirement design: Session Python dependency management](./design/features/session-python-dependency-management.md)
+- [Requirement design: MCP Server](./design/features/mcp-server-implementation.md)
+- [Design template](./design/features/template.md)
+- [ADR template](./design/decisions/template.md)
 
 ### API
 
-- [API 总览](./api/README.md)
+- [API overview](./api/README.md)
 - [REST OpenAPI](./api/rest/sandbox-openapi.json)
 - [Execute Sync OpenAPI](./api/rest/execute-sync-openapi.yaml)
 
 ### Dev
 
-- [环境准备](./dev/setup.md)
-- [构建](./dev/build.md)
-- [测试](./dev/test.md)
-- [发布](./dev/release.md)
-- [贡献指南](./dev/contributing.md)
-- [项目结构](./dev/project-structure.md)
+- [Environment setup](./dev/setup.md)
+- [build](./dev/build.md)
+- [Test](./dev/test.md)
+- [Release](./dev/release.md)
+- [Contribution guide](./dev/contributing.md)
+- [Project structure](./dev/project-structure.md)
 
 ### Ops
 
-- [部署](./ops/deploy.md)
-- [配置](./ops/config.md)
-- [监控](./ops/monitoring.md)
-- [故障排查](./ops/troubleshooting.md)
-- [历史文档：监控与部署](./ops/monitoring-and-deployment.md)
-- [历史文档：Runtime Node 注册](./ops/runtime-node-registration.md)
+- [deployment](./ops/deploy.md)
+- [configuration](./ops/config.md)
+- [Monitoring](./ops/monitoring.md)
+- [Troubleshooting](./ops/troubleshooting.md)
+- [Historical document: monitoring and deployment](./ops/monitoring-and-deployment.md)
+- [Historical document: Runtime Node registration](./ops/runtime-node-registration.md)
 
 ## PRD <-> Design Linking Convention
 
-每个需求默认生成两份文档：
+Each requirement generates two documents by default:
 
 1. `docs/product/prd/<feature>.md`
 2. `docs/design/features/<feature>.md`
 
-两份文档必须使用同一个 `<feature>` slug，并互相链接。
+Both documents must use the same `<feature>` slug and link to each other.
 
-### PRD 必备区块
-
-```md
-## 关联设计
-
-- Design: [<标题>](../../design/features/<feature>.md)
-```
-
-### Design 必备区块
+### Required PRD section
 
 ```md
-## 关联需求
+## Related design
 
-- PRD: [<标题>](../../product/prd/<feature>.md)
+- Design: [<title>](../../design/features/<feature>.md)
 ```
 
-建议在文档创建时直接从模板复制，避免后补链接。
+### Required Design section
+
+```md
+## Related requirement
+
+- PRD: [<title>](../../product/prd/<feature>.md)
+```
+
+Copy directly from the template when creating documents to avoid adding links later.

--- a/infra/sandbox/runtime/executor/README.md
+++ b/infra/sandbox/runtime/executor/README.md
@@ -1,59 +1,59 @@
 # Sandbox Executor
 
-> 安全的代码执行守护进程，使用 Bubblewrap 和 macOS Seatbelt 提供进程级隔离
+> A secure code execution daemon that uses Bubblewrap and macOS Seatbelt for process-level isolation
 
 [![Python Version](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-## 概述
+## Overview
 
-Sandbox Executor 是一个高性能的代码执行服务，专为 AI Agent 应用场景设计。它提供了多层安全隔离机制，确保不受信任的代码在受控环境中安全执行。
+Sandbox Executor is a high-performance code execution service designed for AI Agent scenarios. It provides multilayer security isolation to ensure untrusted code runs safely in a controlled environment.
 
-## 核心特性
+## Key features
 
-- **多层安全隔离** - Docker 容器 + Bubblewrap/sandbox-exec 双层隔离
-- **异步高性能** - 基于 asyncio 的真正异步执行，支持高并发
-- **Lambda 兼容** - 支持 AWS Lambda handler 规范
-- **实时可观测** - 心跳上报、生命周期管理、执行指标
+- **Multilayer security isolation** - Docker container plus Bubblewrap/sandbox-exec isolation
+- **High-performance async execution** - Real async execution based on asyncio with high-concurrency support
+- **Lambda compatible** - Supports the AWS Lambda handler convention
+- **Real-time observability** - Heartbeats, lifecycle management, and execution metrics
 
-## 快速开始
+## Quick Start
 
 ```bash
-# 安装依赖
+# Install dependencies
 pip install -r requirements.txt
 
-# 启动服务
+# Start the service
 python -m executor.interfaces.http.rest
 
-# 验证服务
+# validate the service
 curl http://localhost:8080/health
 ```
 
-**详细指南**: [快速开始文档](docs/quick-start.md)
+**Detailed guide**: [Quick Start documentation](docs/quick-start.md)
 
-## 技术栈
+## Technology stack
 
-| 组件 | 技术 |
+| Component | Technology |
 |------|------|
-| HTTP 框架 | FastAPI + Uvicorn |
-| 隔离技术 | Bubblewrap (Linux) / sandbox-exec (macOS) |
-| 异步运行时 | asyncio |
-| 日志 | structlog |
-| 数据验证 | Pydantic |
+| HTTP framework | FastAPI + Uvicorn |
+| Isolation technology | Bubblewrap (Linux) / sandbox-exec (macOS) |
+| Async runtime | asyncio |
+| Logging | structlog |
+| Data validation | Pydantic |
 
-## 文档
+## Documentation
 
-| 文档 | 说明 |
+| Document | Description |
 |------|------|
-| [快速开始](docs/quick-start.md) | 安装、配置和基本使用 |
-| [架构设计](docs/architecture.md) | 六边形架构、模块结构、设计原理 |
-| [API 文档](docs/api-reference.md) | RESTful API 端点和示例 |
-| [配置说明](docs/configuration.md) | 环境变量和隔离配置 |
-| [开发指南](docs/development.md) | 开发环境设置、测试、代码规范 |
-| [部署指南](docs/deployment.md) | Docker、Docker Compose、Kubernetes 部署 |
-| [故障排查](docs/troubleshooting.md) | 常见问题和解决方案 |
+| [Quick Start](docs/quick-start.md) | installation, configuration, and basic usage |
+| [Architecture design](docs/architecture.md) | hexagonal architecture, module structure, and design principles |
+| [API documentation](docs/api-reference.md) | RESTful API endpoints and examples |
+| [configuration guide](docs/configuration.md) | environment variables and isolation configuration |
+| [Development guide](docs/development.md) | development setup, tests, and code conventions |
+| [deployment guide](docs/deployment.md) | Docker, Docker Compose, and Kubernetes deployment |
+| [Troubleshooting](docs/troubleshooting.md) | common issues and solutions |
 
-## 示例
+## Examples
 
 ### Python Handler
 
@@ -63,7 +63,7 @@ def handler(event):
     return {'message': f'Hello, {name}!'}
 ```
 
-### 执行代码
+### Execute code
 
 ```bash
 curl -X POST http://localhost:8080/execute \
@@ -77,6 +77,6 @@ curl -X POST http://localhost:8080/execute \
   }'
 ```
 
-## 许可证
+## License
 
-MIT License - 详见 [LICENSE](../../LICENSE)
+MIT License - see [LICENSE](../../LICENSE).

--- a/infra/sandbox/runtime/executor/domain/entities.py
+++ b/infra/sandbox/runtime/executor/domain/entities.py
@@ -36,7 +36,7 @@ class Execution:
     completed_at: Optional[datetime] = None
     retry_count: int = 0
     error_message: Optional[str] = None
-    # 调用方申请的超时（秒）。隔离层据此约束子进程，不再各自使用固定值。
+    # Timeout requested by the caller, in seconds. The isolation layer uses it to constrain the child process instead of each layer using fixed values.
     timeout_seconds: Optional[int] = None
 
     def mark_as_running(self) -> None:

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
@@ -95,7 +95,7 @@ class BubblewrapRunner:
 
     def _build_base_args(self, container_working_directory: str = "/workspace") -> List[str]:
         """
-        Build base Bubblewrap arguments for isolation.
+        build base Bubblewrap arguments for isolation.
 
         Returns:
             List of bwrap command arguments
@@ -168,7 +168,7 @@ class BubblewrapRunner:
         )
 
         try:
-            # Build language-specific command and environment
+            # build language-specific command and environment
             cmd, env_args = self._build_command(execution)
             if env_args:
                 cmd = self._inject_env_args(cmd, env_args)
@@ -350,7 +350,7 @@ except Exception as e:
 
     def _build_command(self, execution: Execution) -> tuple[List[str], dict]:
         """
-        Build the complete command for executing code.
+        build the complete command for executing code.
 
         Args:
             execution: Execution entity
@@ -371,7 +371,7 @@ except Exception as e:
 
     def _build_python_command(self, execution: Execution) -> tuple[List[str], dict]:
         """
-        Build command for Python execution using fileless approach.
+        build command for Python execution using fileless approach.
 
         Uses python3 -c to execute code directly in memory with Lambda-style wrapper.
         """
@@ -388,7 +388,7 @@ except Exception as e:
         return cmd, self._build_execution_env(execution)
 
     def _build_node_command(self, execution: Execution) -> tuple[List[str], dict]:
-        """Build command for Node.js execution."""
+        """build command for Node.js execution."""
         execution.context.resolve_working_directory_path()
         # Wrap user code in AWS Lambda handler pattern
         wrapper_code = f'''
@@ -415,7 +415,7 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
         return cmd, self._build_execution_env(execution)
 
     def _build_shell_command(self, execution: Execution) -> tuple[List[str], dict]:
-        """Build command for shell execution."""
+        """build command for shell execution."""
         resolved_cwd = execution.context.resolve_working_directory_path()
         normalized_code = normalize_shell_code(execution.code, resolved_cwd)
         cmd = self._build_base_args(execution.context.container_working_directory()) + [
@@ -439,13 +439,13 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
         env_args: dict[str, str] = {
             "PYTHONPATH": self._build_pythonpath(os.environ.get("PYTHONPATH")),
         }
-        # --clearenv 之后镜像上的环境变量一个都不剩，得像 PYTHONPATH 那样显式带进去。
-        # sandbox_sdk.bkn 拿不到它时会报「请由控制面设置环境变量 BKN_SANDBOX_MCP_URL」
-        # ——而运维恰恰已经设了，只是被 bwrap 挡在了外面。
+        # After --clearenv, no image-level environment variables remain, so this must be passed through explicitly like PYTHONPATH.
+        # sandbox_sdk.bkn reports that BKN_SANDBOX_MCP_URL must be set by the control plane if it cannot read this value.
+        # In that case operations has already set it, but bwrap has blocked it from the process.
         #
-        # 只有这一个需要在这里透传：它由控制面设在**容器**上，本次执行的 env 里没有。
-        # BKN_TOKEN 那些是随每次执行下发的，已经在上面的 execution.context.env_vars
-        # 里，不必也不该从容器环境去捞——容器级的值会跨调用方存活。
+        # Only this value needs to be passed through here: the control plane sets it on the **container**, and it is not present in the current execution env.
+        # values such as BKN_TOKEN are delivered with each execution and are already in execution.context.env_vars above,
+        # so they do not need to and should not be read from the container environment because container-level values can persist across callers.
         bkn_mcp_url = os.environ.get("BKN_SANDBOX_MCP_URL", "").strip()
         if bkn_mcp_url:
             env_args["BKN_SANDBOX_MCP_URL"] = bkn_mcp_url

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/bwrap.py
@@ -168,7 +168,7 @@ class BubblewrapRunner:
         )
 
         try:
-            # build language-specific command and environment
+            # Build language-specific command and environment
             cmd, env_args = self._build_command(execution)
             if env_args:
                 cmd = self._inject_env_args(cmd, env_args)
@@ -388,7 +388,7 @@ except Exception as e:
         return cmd, self._build_execution_env(execution)
 
     def _build_node_command(self, execution: Execution) -> tuple[List[str], dict]:
-        """build command for Node.js execution."""
+        """Build command for Node.js execution."""
         execution.context.resolve_working_directory_path()
         # Wrap user code in AWS Lambda handler pattern
         wrapper_code = f'''
@@ -415,7 +415,7 @@ console.log('===SANDBOX_RESULT===' + JSON.stringify(result) + '===SANDBOX_RESULT
         return cmd, self._build_execution_env(execution)
 
     def _build_shell_command(self, execution: Execution) -> tuple[List[str], dict]:
-        """build command for shell execution."""
+        """Build command for shell execution."""
         resolved_cwd = execution.context.resolve_working_directory_path()
         normalized_code = normalize_shell_code(execution.code, resolved_cwd)
         cmd = self._build_base_args(execution.context.container_working_directory()) + [

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
@@ -75,7 +75,7 @@ class SubprocessRunner:
         process = None
 
         try:
-            # build language-specific command and environment
+            # Build language-specific command and environment
             cmd, env_args = self._build_command(execution)
             cwd_path = execution.context.resolve_working_directory_path()
 
@@ -275,7 +275,7 @@ class SubprocessRunner:
         language = execution.language.lower()
         code = execution.code
 
-        # build environment variables - inherit from current process
+        # Build environment variables - inherit from current process
         env_args = os.environ.copy()
         # Override specific variables
         env_args.update({

--- a/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
+++ b/infra/sandbox/runtime/executor/infrastructure/isolation/subprocess.py
@@ -21,7 +21,7 @@ from executor.domain.value_objects import ExecutionResult, ExecutionStatus, Exec
 from executor.infrastructure.config import settings
 from executor.infrastructure.isolation.code_wrapper import defines_handler, normalize_shell_code, uses_tool_decorator
 
-# 超时后先发 SIGTERM，等这么久仍未退出就 SIGKILL
+# After timeout, send SIGTERM first; send SIGKILL if the process still has not exited after this period.
 _TERMINATE_GRACE_SECONDS = 3
 
 logger = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ class SubprocessRunner:
         process = None
 
         try:
-            # Build language-specific command and environment
+            # build language-specific command and environment
             cmd, env_args = self._build_command(execution)
             cwd_path = execution.context.resolve_working_directory_path()
 
@@ -263,7 +263,7 @@ class SubprocessRunner:
 
     def _build_command(self, execution: Execution) -> Tuple[List[str], dict]:
         """
-        Build language-specific command and environment.
+        build language-specific command and environment.
 
         Args:
             execution: Execution entity with code and context
@@ -275,7 +275,7 @@ class SubprocessRunner:
         language = execution.language.lower()
         code = execution.code
 
-        # Build environment variables - inherit from current process
+        # build environment variables - inherit from current process
         env_args = os.environ.copy()
         # Override specific variables
         env_args.update({

--- a/infra/sandbox/runtime/executor/start.sh
+++ b/infra/sandbox/runtime/executor/start.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Runtime Executor 启动脚本
+# Runtime Executor start script
 
-# 设置 PYTHONPATH
+# Set PYTHONPATH
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="$(dirname "$SCRIPT_DIR")"
 
-# 进入项目目录
+# Enter the project directory
 cd "$(dirname "$0")"
 
-# 清理端口 8080 上的旧进程
+# Clean up old processes on port 8080
 echo "检查端口 8080..."
 OLD_PIDS=$(lsof -ti:8080 2>/dev/null)
 if [ -n "$OLD_PIDS" ]; then
@@ -19,11 +19,11 @@ if [ -n "$OLD_PIDS" ]; then
     echo "旧进程已清理"
 fi
 
-# 同步依赖
+# Sync dependencies
 echo "正在同步依赖..."
 uv sync
 
-# 启动服务
+# Start the service
 echo "正在启动服务..."
 echo "提示: 使用 Ctrl+C 停止服务"
 echo ""

--- a/infra/sandbox/runtime/executor/stop.sh
+++ b/infra/sandbox/runtime/executor/stop.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Runtime Executor 停止脚本
+# Runtime Executor stop script
 
 echo "正在停止 executor 服务..."
 
-# 查找并终止占用端口 8080 的所有进程
+# Find and terminate all processes occupying port 8080
 PIDS=$(lsof -ti:8080 2>/dev/null)
 
 if [ -z "$PIDS" ]; then
@@ -14,13 +14,13 @@ fi
 echo "发现进程: $PIDS"
 echo "正在终止..."
 
-# 先尝试优雅退出（SIGTERM）
+# Try graceful shutdown first (SIGTERM)
 lsof -ti:8080 | xargs kill -15 2>/dev/null
 
-# 等待 2 秒
+# Wait 2 seconds
 sleep 2
 
-# 检查是否还有进程
+# Check whether processes are still running
 REMAINING=$(lsof -ti:8080 2>/dev/null)
 if [ -n "$REMAINING" ]; then
     echo "进程未响应，强制终止（SIGKILL）..."
@@ -28,7 +28,7 @@ if [ -n "$REMAINING" ]; then
     sleep 1
 fi
 
-# 最终检查
+# Final check
 FINAL=$(lsof -ti:8080 2>/dev/null)
 if [ -z "$FINAL" ]; then
     echo "✓ 服务已停止"

--- a/infra/sandbox/runtime/executor/tests/unit/sdk/test_bkn.py
+++ b/infra/sandbox/runtime/executor/tests/unit/sdk/test_bkn.py
@@ -1,7 +1,7 @@
-"""sandbox_sdk.bkn 的单元测试。
+"""Unit tests for sandbox_sdk.bkn.
 
-验证的是「凭据从哪来、什么时候装配、版本怎么报」这些契约，不是 BKN 那些函数本身
-——它们由 cmd/ptc-stub 从 MCP 工具目录渲染，正确性归 context-loader 那边的测试管。
+These tests validate contracts such as where credentials come from, when runtime wiring happens, and how the version is reported; they do not test the BKN functions themselves.
+Those functions are rendered by cmd/ptc-stub from the MCP tool directory, and their correctness is covered by context-loader tests.
 """
 
 import sys
@@ -24,10 +24,10 @@ def reset():
 
 @pytest.fixture
 def fake_surface(monkeypatch):
-    """替掉能力面本体，只留装配链路。
+    """Replace the capability surface itself and keep only the wiring path.
 
-    真产物有 25 个函数、35K 字符，测装配链路用不上它；而且拿它做断言，
-    schema 一改测试就跟着碎。
+    The real artifact has 25 functions and 35K characters, which is unnecessary for wiring tests; asserting against it would also
+    make these tests break whenever the schema changes.
     """
     import types
 
@@ -48,22 +48,22 @@ def fake_surface(monkeypatch):
 
 
 def test_credentials_come_from_process_env(monkeypatch):
-    """默认路径：用户代码里没有 token，执行工厂把它注入成进程级环境变量。"""
+    """Default path: user code has no token, and the execution factory injects it as a process-level environment variable."""
     monkeypatch.setenv(
         "BKN_SANDBOX_MCP_URL", "http://agent-retrieval:30779/api/x/v1/mcp/"
     )
     monkeypatch.setenv("BKN_TOKEN", "tok-from-env")
 
-    bkn.configure_runtime({})           # event 里什么都没有
+    bkn.configure_runtime({})           # there is nothing in event
     assert bkn.available() is True
     assert bkn._token() == "tok-from-env"
 
 
 def test_event_credentials_win_over_environment(monkeypatch):
-    """event 优先于 env。
+    """event takes precedence over env.
 
-    执行请求的 env 是每次现组的、随进程消亡；但建会话时的 env_vars 是容器级的，
-    会跨调用方存活。万一某个池化容器上留着旧令牌，调用方显式传的那份必须赢。
+    Execution request env is assembled per run and disappears with the process, but env_vars provided when creating the session are container-level
+    and can persist across callers. If a pooled container keeps an old token, the value explicitly provided by the caller must win.
     """
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     monkeypatch.setenv("BKN_TOKEN", "stale-from-pooled-container")
@@ -86,7 +86,7 @@ def test_missing_credentials_report_both_ways_in(monkeypatch):
 
 
 def test_business_context_falls_back_to_process_env(monkeypatch, fake_surface):
-    """会话上下文同样不必写进用户代码。"""
+    """Session context also does not need to be written into user code."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     monkeypatch.setenv("BKN_TOKEN", "tok")
     monkeypatch.setenv("BKN_CONVERSATION_ID", "conv_env")
@@ -96,7 +96,7 @@ def test_business_context_falls_back_to_process_env(monkeypatch, fake_surface):
     seen = bkn.whoami()["bkn"]
     assert seen == {"conversation_id": "conv_env", "interaction_id": "int_env"}
 
-    # 同样是 event 优先。
+    # event takes precedence here as well.
     bkn.configure_runtime({
         "mcp": "http://svc/mcp/",
         "bkn": {"conversation_id": "conv_event", "interaction_id": "int_event"},
@@ -105,9 +105,9 @@ def test_business_context_falls_back_to_process_env(monkeypatch, fake_surface):
 
 
 def test_mcp_url_may_fall_back_to_deployment_env(monkeypatch):
-    """MCP 地址是部署配置而非密钥，允许控制面注入一次。
+    """The MCP address is deployment configuration rather than a secret, so the control plane may inject it once.
 
-    定义虽然烤进了镜像，调用仍要回访 MCP —— 地址少不了。
+    Although the definitions are baked into the image, calls still need to reach MCP, so the address is required.
     """
     monkeypatch.setenv(
         "BKN_SANDBOX_MCP_URL", "http://agent-retrieval:30779/api/x/v1/mcp/"
@@ -118,42 +118,42 @@ def test_mcp_url_may_fall_back_to_deployment_env(monkeypatch):
 
 
 def test_mcp_url_always_ends_with_slash(monkeypatch):
-    """缺尾斜杠时网关 307 跳转，而 urllib 不对 POST 跟随重定向——症状是一个没有
-    报文的 400，极难排查。所以在入口补齐。"""
+    """Without the trailing slash, the gateway returns a 307 redirect and urllib does not follow redirects for POST; the symptom is a
+    400 without a response body, which is very hard to diagnose. Normalize it at the entry point."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     bkn.configure_runtime({"token": "tok", "mcp": "http://svc:1/api/x/v1/mcp"})
     assert bkn._mcp_url() == "http://svc:1/api/x/v1/mcp/"
 
 
 def test_capability_surface_is_lazily_assembled(fake_surface, monkeypatch):
-    """纯计算函数不该为 BKN 付代价：只导入不使用时不该装配。"""
+    """Pure compute functions should not pay for BKN: importing without using it should not trigger wiring."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     bkn.configure_runtime({"token": "tok", "mcp": "http://svc/mcp/"})
-    assert fake_surface == []           # 还没碰过任何能力
+    assert fake_surface == []           # no capability has been touched yet
 
     assert bkn.whoami()["token"] == "tok"
     assert len(fake_surface) == 1
 
 
 def test_runtime_is_reset_between_executions(fake_surface, monkeypatch):
-    """能力面模块是进程级单例，而沙箱会话池化复用——上一次执行的凭据不能留下。"""
+    """The capability surface module is a process-level singleton and sandbox sessions are pooled, so credentials from the previous execution must not remain."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     bkn.configure_runtime({"token": "first", "mcp": "http://svc/mcp/"})
     assert bkn.whoami()["token"] == "first"
 
     bkn.configure_runtime({"token": "second", "mcp": "http://svc/mcp/"})
     assert bkn.whoami()["token"] == "second"
-    # 换一次执行必须重新 _configure，而不是复用上一次配好的模块。
+    # Each execution must call _configure again instead of reusing the module configured by the previous execution.
     assert len(fake_surface) == 2
 
 
 def test_dispatch_hands_the_event_to_the_capability_surface(fake_surface, monkeypatch):
-    """用户函数不写 event、不接 token —— dispatch 已经替它配置好了。"""
+    """The user function neither writes event nor accepts token; dispatch has already configured these values for it."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
 
     @sandbox_sdk.tool
     def peek(kn_id: str) -> dict:
-        "看看能力面拿到了什么。"
+        "Inspect what the capability surface receives."
         return {"kn_id": kn_id, "seen": bkn.whoami()}
 
     result = sandbox_sdk.dispatch({
@@ -163,26 +163,26 @@ def test_dispatch_hands_the_event_to_the_capability_surface(fake_surface, monkey
         "bkn": {"conversation_id": "conv_1", "interaction_id": "int_1"},
     })
     assert result["kn_id"] == "worldcup"
-    # 生命周期上下文要原样传下去，脚本内的调用才挂得到同一次交互上。
+    # The lifecycle context must be passed through unchanged so in-script calls are attached to the same interaction.
     assert result["seen"]["bkn"]["conversation_id"] == "conv_1"
     assert result["seen"]["token"] == "tok"
-    # token / mcp 不该被当成业务入参喂给用户函数（它的签名里没有）。
+    # token and mcp must not be passed to the user function as business arguments because they are not in its signature.
     assert "token" not in result
 
 
 def test_toolkit_version_comes_from_the_built_artifact(fake_surface, monkeypatch):
-    """版本是构建期写进产物的，不是运行时算的。"""
+    """The version is written into the artifact at build time rather than computed at runtime."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     bkn.configure_runtime({"token": "tok", "mcp": "http://svc/mcp/"})
-    assert bkn.toolkit_version() is None         # 未装配
+    assert bkn.toolkit_version() is None         # not wired
     bkn.whoami()
     assert bkn.toolkit_version() == "sha256:fake"
-    bkn.configure_runtime({})                    # 换一次执行即重置
+    bkn.configure_runtime({})                    # reset for each execution
     assert bkn.toolkit_version() is None
 
 
 def test_missing_artifact_points_at_the_build_step(monkeypatch):
-    """产物缺失是构建事故，报错要直接给出重新生成的命令。"""
+    """A missing artifact is a build issue, and the error should directly provide the regeneration command."""
     def _boom():
         raise ImportError("no module named _bkn_tools")
 
@@ -195,7 +195,7 @@ def test_missing_artifact_points_at_the_build_step(monkeypatch):
 
 
 def test_version_check_compares_image_against_server(fake_surface, monkeypatch):
-    """镜像滞后于服务端时症状是签名对不上，而错误里看不出根因——留个能直接问的口子。"""
+    """When the image lags behind the server, the symptom is a signature mismatch and the error does not reveal the root cause, so expose a directly queryable version."""
     monkeypatch.delenv("BKN_SANDBOX_MCP_URL", raising=False)
     bkn.configure_runtime({"token": "tok", "mcp": "http://svc/mcp/"})
 
@@ -210,16 +210,16 @@ def test_version_check_compares_image_against_server(fake_surface, monkeypatch):
 
 
 def test_shipped_artifact_is_importable_and_versioned():
-    """镜像里那份产物本身要能 import，且带着构建期写入的版本。
+    """The artifact in the image must be importable and include the version written at build time.
 
-    上面的用例都把能力面替掉了，这里是唯一碰真产物的地方——它若坏了，
-    整条离线路径就是坏的。
+    The tests above replace the capability surface; this is the only one that touches the real artifact, so if it is broken,
+    the whole offline path is broken.
     """
     from sandbox_sdk import _bkn_tools
 
     assert _bkn_tools.__toolkit_version__.startswith("sha256:")
     assert callable(_bkn_tools._configure)
-    # 抽查几个能力：签名清单变了不该悄悄少函数。
+    # Spot-check several capabilities: changes to the signature manifest must not silently remove functions.
     for name in ("list_knowledge_networks", "query_object_instance",
                  "run_sql", "list_resources"):
         assert callable(getattr(_bkn_tools, name)), name

--- a/infra/sandbox/sandbox_control_plane/README.md
+++ b/infra/sandbox/sandbox_control_plane/README.md
@@ -1,116 +1,116 @@
-# 沙箱平台控制中心
+# Sandbox Control Plane
 
-基于六边形架构的代码沙箱管理平台。
+A code sandbox management platform based on hexagonal architecture.
 
-## 架构
+## Architecture
 
-本项目采用**六边形架构**（Hexagonal Architecture），确保核心业务逻辑独立于技术实现。
+This project uses **Hexagonal Architecture** to keep core business logic independent from technical implementations.
 
-### 依赖方向
+### Dependency direction
 
 ```
 Interfaces → Application → Domain ← Infrastructure
 ```
 
-- **Domain（领域层）**: 核心业务逻辑，无外部依赖
-- **Application（应用层）**: 用例编排，依赖 Domain
-- **Infrastructure（基础设施层）**: 技术实现，实现 Domain 定义的接口
-- **Interfaces（接口层）**: 对外接口，依赖 Application
+- **Domain**: Core business logic without external dependencies
+- **Application**: Use-case orchestration; depends on Domain
+- **Infrastructure**: Technical implementations for interfaces defined by Domain
+- **Interfaces**: External interfaces that depend on Application
 
-## 快速开始
+## Quick Start
 
-### 安装
+### Installation
 
 ```bash
-# 克隆仓库
+# Clone the repository
 git clone https://github.com/sandbox/sandbox-control-plane
 cd sandbox-control-plane
 
-# 使用 uv 管理项目
-# 安装 uv（如果尚未安装）
+# Use uv to manage the project
+# Install uv if it is not installed yet
 # curl -LsSf https://astral.sh/uv/install.sh | sh  # Linux/macOS
 # powershell -c "irm https://astral.sh/uv/install.ps1"  # Windows
 
-# 同步依赖
+# Sync dependencies
 uv sync
 
-# 激活虚拟环境
+# Activate the virtual environment
 source .venv/bin/activate  # Linux/macOS
 .venv\Scripts\activate     # Windows
 ```
 
-### 配置
+### configuration
 
 ```bash
-# 复制环境变量模板
+# Copy the environment variable template
 cp .env.example .env
 
-# 编辑配置
+# Edit configuration
 vim .env
 ```
 
-### 数据库迁移
+### Database migration
 
 ```bash
-# 初始化数据库
+# Initialize the database
 alembic upgrade head
 ```
 
-### 运行
+### Run
 
 ```bash
-# 开发模式
+# Development mode
 uvicorn src.interfaces.rest.main:app --reload --port 8000
 
-# 生产模式
+# Production mode
 uvicorn src.interfaces.rest.main:app --host 0.0.0.0 --port 8000 --workers 4
 ```
 
-## 项目结构
+## Project structure
 
 ```
 src/
-├── domain/           # 领域层（核心）
-├── application/      # 应用层（用例）
-├── infrastructure/   # 基础设施层（适配器）
-└── interfaces/       # 接口层（API）
+├── domain/           # Domain layer (core)
+├── application/      # Application layer (use cases)
+├── infrastructure/   # Infrastructure layer (adapters)
+└── interfaces/       # Interface layer (API)
 ```
 
-详见 [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)。
+See [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md).
 
-## API 文档
+## API documentation
 
-启动服务后访问：
+After starting the service, visit:
 
 - Swagger UI: http://localhost:8000/docs
 - ReDoc: http://localhost:8000/redoc
 
-## 测试
+## Test
 
 ```bash
-# 使用 uv 运行所有测试
+# Run all tests with uv
 uv run pytest
 
-# 运行单元测试
+# Run unit tests
 uv run pytest tests/unit
 
-# 运行集成测试
+# Run integration tests
 uv run pytest tests/integration
 
-# 生成覆盖率报告
+# Generate a coverage report
 uv run pytest --cov=src --cov-report=html
 ```
 
-## 开发
+## Development
 
 ```bash
-# 使用 uv 运行代码格式化
+# Run code formatting with uv
 uv run black src tests
 
-# 代码检查
+# Code linting
 uv run ruff check src tests
 
-# 类型检查
+# Type checking
 uv run mypy src
 ```
 

--- a/infra/sandbox/sandbox_control_plane/scripts/migrations/add_execution_metrics.py
+++ b/infra/sandbox/sandbox_control_plane/scripts/migrations/add_execution_metrics.py
@@ -1,13 +1,13 @@
 """
-Alembic 迁移脚本模板
+Alembic migration script template
 
-添加 execution 表的 return_value 和 metrics 字段
+Add return_value and metrics fields to the execution table
 
-使用方法：
-1. 确保 Alembic 已初始化：`alembic init alembic`
-2. 将此文件复制到 `alembic/versions/` 目录
-3. 根据实际生成的修订版本号重命名文件
-4. 运行迁移：`alembic upgrade head`
+Usage:
+1. Ensure Alembic is initialized：`alembic init alembic`
+2. Copy this file to the Alembic versions directory
+3. Rename the file according to the generated revision number
+4. Run the migration:`alembic upgrade head`
 """
 from alembic import op
 import sqlalchemy as sa
@@ -20,7 +20,7 @@ depends_on = None
 
 
 def upgrade():
-    """添加 return_value 和 metrics 字段"""
+    """Add return_value and metrics fields."""
     op.add_column(
         'executions',
         sa.Column('return_value', sa.JSON(), nullable=True)
@@ -32,6 +32,6 @@ def upgrade():
 
 
 def downgrade():
-    """移除 return_value 和 metrics 字段"""
+    """Remove return_value and metrics fields"""
     op.drop_column('executions', 'metrics')
     op.drop_column('executions', 'return_value')

--- a/infra/sandbox/sandbox_control_plane/start.sh
+++ b/infra/sandbox/sandbox_control_plane/start.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# Sandbox Control Plane 启动脚本
+# Sandbox Control Plane start script
 
-# 设置项目根目录
+# Set the project root directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONPATH="$SCRIPT_DIR"
 
-# 进入项目目录
+# Enter the project directory
 cd "$SCRIPT_DIR"
 
-# 清理端口 8000 上的旧进程
+# Clean up old processes on port 8000
 echo "检查端口 8000..."
 OLD_PIDS=$(lsof -ti:8000 2>/dev/null)
 if [ -n "$OLD_PIDS" ]; then
@@ -19,7 +19,7 @@ if [ -n "$OLD_PIDS" ]; then
     echo "旧进程已清理"
 fi
 
-# 检查 .env 文件
+# Check the .env file
 if [ ! -f .env ]; then
     echo "警告: .env 文件不存在"
     echo "正在从 .env.example 创建 .env..."
@@ -27,7 +27,7 @@ if [ ! -f .env ]; then
     echo "请根据需要编辑 .env 文件"
 fi
 
-# 同步依赖
+# Sync dependencies
 echo "正在同步依赖..."
 if command -v uv &> /dev/null; then
     uv sync
@@ -36,7 +36,7 @@ else
     pip install -e ".[dev]"
 fi
 
-# 启动服务
+# Start the service
 echo "正在启动 Sandbox Control Plane..."
 echo "提示: 使用 Ctrl+C 停止服务"
 echo ""
@@ -46,7 +46,7 @@ echo "  - API 文档: http://localhost:8000/docs"
 echo "  - ReDoc: http://localhost:8000/redoc"
 echo ""
 
-# 使用 uv 或直接运行
+# Use uv or run directly
 if command -v uv &> /dev/null; then
     uv run uvicorn src.interfaces.rest.main:app --host 0.0.0.0 --port 8000 --reload
 else

--- a/infra/sandbox/sandbox_control_plane/stop.sh
+++ b/infra/sandbox/sandbox_control_plane/stop.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Sandbox Control Plane 停止脚本
+# Sandbox Control Plane stop script
 
 echo "正在停止 Sandbox Control Plane..."
 
-# 查找并终止占用端口 8000 的进程
+# Find and terminate the process occupying port 8000
 PIDS=$(lsof -ti:8000 2>/dev/null)
 
 if [ -z "$PIDS" ]; then
@@ -17,13 +17,13 @@ ps -p $PIDS -o pid,ppid,cmd 2>/dev/null || echo "PID: $PIDS"
 echo ""
 echo "正在终止进程..."
 
-# 尝试优雅终止
+# Try graceful termination
 for PID in $PIDS; do
     echo "发送 SIGTERM 到进程 $PID..."
     kill -TERM $PID 2>/dev/null
 done
 
-# 等待进程结束
+# Wait for the process to exit
 echo "等待进程结束..."
 for i in {1..10}; do
     sleep 1
@@ -35,7 +35,7 @@ for i in {1..10}; do
     echo "等待中... ($i/10)"
 done
 
-# 强制终止剩余进程
+# Force-terminate remaining processes
 REMAINING=$(lsof -ti:8000 2>/dev/null)
 if [ -n "$REMAINING" ]; then
     echo "强制终止剩余进程..."
@@ -43,7 +43,7 @@ if [ -n "$REMAINING" ]; then
     sleep 1
 fi
 
-# 验证
+# validate
 REMAINING=$(lsof -ti:8000 2>/dev/null)
 if [ -z "$REMAINING" ]; then
     echo "Sandbox Control Plane 已停止"

--- a/infra/sandbox/sandbox_control_plane/tests/conftest.py
+++ b/infra/sandbox/sandbox_control_plane/tests/conftest.py
@@ -1,31 +1,27 @@
-"""
-Pytest 配置文件
-
-确保测试按顺序执行，并在测试之间添加延迟以避免系统过载。
-"""
+"""Unit tests for conftest."""
 import asyncio
 import time
 
 
 def pytest_configure(config):
-    """Pytest 配置钩子"""
-    # 禁用并行测试
+    """Create pytest configure."""
+    # Test setup.
     config.pluginmanager.set_blocked("pytest-xdist")
 
 
 def pytest_runtest_setup(item):
-    """在每个测试开始前执行"""
-    # 添加延迟，避免同时启动多个容器
+    """Create pytest runtest setup."""
+    # Test setup.
     time.sleep(0.5)
 
 
 def pytest_runtest_teardown(item, nextitem):
-    """在每个测试结束后执行"""
-    # 确保异步资源被清理
+    """Create pytest runtest teardown."""
+    # Test setup.
     try:
         loop = asyncio.get_event_loop()
         if loop and not loop.is_closed():
-            # 运行所有待处理的任务
+            # Test setup.
             pending = asyncio.all_tasks(loop)
             if pending:
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))

--- a/infra/sandbox/sandbox_control_plane/tests/conftest.py
+++ b/infra/sandbox/sandbox_control_plane/tests/conftest.py
@@ -5,23 +5,23 @@ import time
 
 def pytest_configure(config):
     """Create pytest configure."""
-    # Test setup.
+    # Disable parallel tests.
     config.pluginmanager.set_blocked("pytest-xdist")
 
 
 def pytest_runtest_setup(item):
     """Create pytest runtest setup."""
-    # Test setup.
+    # Add a delay to avoid starting multiple containers simultaneously.
     time.sleep(0.5)
 
 
 def pytest_runtest_teardown(item, nextitem):
     """Create pytest runtest teardown."""
-    # Test setup.
+    # Ensure async resources are cleaned up.
     try:
         loop = asyncio.get_event_loop()
         if loop and not loop.is_closed():
-            # Test setup.
+            # Run all pending tasks.
             pending = asyncio.all_tasks(loop)
             if pending:
                 loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))

--- a/infra/sandbox/sandbox_control_plane/tests/helpers.py
+++ b/infra/sandbox/sandbox_control_plane/tests/helpers.py
@@ -1,8 +1,4 @@
-"""
-共享测试工具
-
-提供通用的测试 fixture 和 mock 工具，减少测试代码重复。
-"""
+"""Unit tests for helpers."""
 from unittest.mock import Mock, AsyncMock
 from datetime import datetime
 
@@ -20,18 +16,7 @@ def create_mock_template(
     image: str = "python:3.11",
     default_timeout_sec: int = 300
 ) -> Template:
-    """
-    创建测试用模板实体
-
-    Args:
-        template_id: 模板 ID
-        name: 模板名称
-        image: 镜像名称
-        default_timeout_sec: 默认超时时间（秒）
-
-    Returns:
-        Template 实体
-    """
+    """Create mock template."""
     return Template(
         id=template_id,
         name=name,
@@ -54,17 +39,7 @@ def create_mock_session(
     template_id: str = "python-test",
     status: str = "running"
 ) -> Session:
-    """
-    创建测试用会话实体
-
-    Args:
-        session_id: 会话 ID
-        template_id: 模板 ID
-        status: 会话状态
-
-    Returns:
-        Session 实体
-    """
+    """Create mock session."""
     return Session(
         id=session_id,
         template_id=template_id,
@@ -88,17 +63,7 @@ def create_mock_execution(
     session_id: str = "test-session-123",
     status: str = "pending"
 ) -> Execution:
-    """
-    创建测试用执行实体
-
-    Args:
-        execution_id: 执行 ID
-        session_id: 会话 ID
-        status: 执行状态
-
-    Returns:
-        Execution 实体
-    """
+    """Create mock execution."""
     return Execution(
         id=execution_id,
         session_id=session_id,
@@ -113,16 +78,7 @@ def create_mock_runtime_node(
     node_id: str = "node-1",
     node_type: str = "docker"
 ) -> RuntimeNode:
-    """
-    创建测试用运行时节点
-
-    Args:
-        node_id: 节点 ID
-        node_type: 节点类型
-
-    Returns:
-        RuntimeNode 对象
-    """
+    """Create mock runtime node."""
     return RuntimeNode(
         id=node_id,
         type=node_type,
@@ -141,17 +97,7 @@ def create_mock_repository(
     save_return=None,
     find_all_return=None
 ) -> Mock:
-    """
-    创建模拟仓储
-
-    Args:
-        find_by_id_return: find_by_id 方法的返回值
-        save_return: save 方法的返回值
-        find_all_return: find_all 方法的返回值
-
-    Returns:
-        Mock 对象
-    """
+    """Create mock repository."""
     repo = Mock()
     repo.save = AsyncMock(return_value=save_return)
     repo.find_by_id = AsyncMock(return_value=find_by_id_return)
@@ -165,17 +111,7 @@ def create_mock_scheduler(
     create_container_return="container-123",
     destroy_container_return=None
 ) -> Mock:
-    """
-    创建模拟调度器
-
-    Args:
-        schedule_return: schedule 方法的返回值
-        create_container_return: create_container_for_session 方法的返回值
-        destroy_container_return: destroy_container 方法的返回值
-
-    Returns:
-        Mock 对象
-    """
+    """Create mock scheduler."""
     scheduler = Mock()
     scheduler.schedule = AsyncMock(return_value=schedule_return)
     scheduler.create_container_for_session = AsyncMock(

--- a/infra/sandbox/sandbox_control_plane/tests/integration/api/test_execute_sync_api.py
+++ b/infra/sandbox/sandbox_control_plane/tests/integration/api/test_execute_sync_api.py
@@ -1,9 +1,4 @@
-"""
-Execute-Sync API Integration Tests
-
-Tests for synchronous code execution endpoint.
-覆盖正确传参、异常传参、代码正确执行、代码抛出异常、代码输出标准错误、代码正确返回结果、代码执行使用标准库、代码执行使用第三方库等情况。
-"""
+"""Unit tests for execute sync API."""
 import pytest
 import asyncio
 from httpx import AsyncClient
@@ -13,7 +8,7 @@ from httpx import AsyncClient
 class TestExecuteSyncAPI:
     """Execute-Sync API integration tests."""
 
-    # ==================== 正确传参测试 ====================
+    # ==================== Valid parameter tests ====================
 
     async def test_execute_sync_valid_parameters(
         self,
@@ -57,7 +52,7 @@ def handler(event):
             "timeout": 10
         }
 
-        # 使用默认的 poll_interval 和 sync_timeout
+        # Test setup.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data
@@ -269,7 +264,7 @@ def handler(event):
             "timeout": 10
         }
 
-        # 测试最小 poll_interval
+        # Test setup.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
@@ -277,7 +272,7 @@ def handler(event):
         )
         assert response.status_code == 200
 
-        # 测试最大 poll_interval
+        # Test setup.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
@@ -285,7 +280,7 @@ def handler(event):
         )
         assert response.status_code == 200
 
-    # ==================== 异常传参测试 ====================
+    # ==================== Valid parameter tests ====================
 
     async def test_execute_sync_invalid_poll_interval_too_low(
         self,
@@ -302,7 +297,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"poll_interval": 0.05}  # 低于最小值 0.1
+            params={"poll_interval": 0.05}  # Test setup.
         )
 
         assert response.status_code == 422
@@ -322,7 +317,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"poll_interval": 15.0}  # 高于最大值 10.0
+            params={"poll_interval": 15.0}  # Test setup.
         )
 
         assert response.status_code == 422
@@ -342,7 +337,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"sync_timeout": 5}  # 低于最小值 10
+            params={"sync_timeout": 5}  # Test setup.
         )
 
         assert response.status_code == 422
@@ -362,7 +357,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"sync_timeout": 4000}  # 高于最大值 3600
+            params={"sync_timeout": 4000}  # Test setup.
         )
 
         assert response.status_code == 422
@@ -431,7 +426,7 @@ def handler(event):
         request_data = {
             "code": "print('test')",
             "language": "python",
-            "timeout": 0  # 低于最小值 1
+            "timeout": 0  # Test setup.
         }
 
         response = await http_client.post(
@@ -450,7 +445,7 @@ def handler(event):
         request_data = {
             "code": "print('test')",
             "language": "python",
-            "timeout": 4000  # 高于最大值 3600
+            "timeout": 4000  # Test setup.
         }
 
         response = await http_client.post(
@@ -478,7 +473,7 @@ def handler(event):
 
         assert response.status_code in (400, 404)
 
-    # ==================== 代码正确执行测试 ====================
+    # ==================== Test group ====================
 
     async def test_execute_sync_simple_execution(
         self,
@@ -536,7 +531,7 @@ def handler(event):
         assert data["status"] in ("success", "completed")
         assert data["exit_code"] == 0
 
-    # ==================== 代码抛出异常测试 ====================
+    # ==================== Test group ====================
 
     async def test_execute_sync_runtime_exception(
         self,
@@ -650,7 +645,7 @@ def handler(event):
         assert "CustomError" in data["stderr"]
         assert "custom error" in data["stderr"].lower()
 
-    # ==================== 代码输出标准错误测试 ====================
+    # ==================== Test group ====================
 
     async def test_execute_sync_stderr_output(
         self,
@@ -709,10 +704,10 @@ def handler(event):
         assert response.status_code == 200
         data = response.json()
         assert data["status"] in ("success", "completed")
-        # 警告信息通常输出到 stderr
+        # Test setup.
         assert "stderr" in data
 
-    # ==================== 代码正确返回结果测试 ====================
+    # ==================== Test group ====================
 
     async def test_execute_sync_return_dict(
         self,
@@ -860,7 +855,7 @@ def handler(event):
         assert data["return_value"]["user"]["tags"] == ["admin", "tester"]
         assert data["return_value"]["items"][0]["value"] == "first"
 
-    # ==================== 代码执行使用标准库测试 ====================
+    # ==================== standard library execution tests ====================
 
     async def test_execute_sync_use_json_stdlib(
         self,
@@ -1031,19 +1026,15 @@ def handler(event):
         assert 3.14 < data["return_value"]["pi"] < 3.15
         assert data["return_value"]["sqrt_2"] == 2 ** 0.5
 
-    # ==================== 代码执行使用第三方库测试 ====================
+    # ==================== third-party dependency execution tests ====================
 
     async def test_execute_sync_use_requests_third_party(
         self,
         http_client: AsyncClient,
         test_template_id: str
     ):
-        """Test execute-sync using requests third-party library.
-
-        This test creates a session with requests dependency pre-installed,
-        then executes code that uses the requests library.
-        """
-        # Step 1: 创建会话时传入 dependencies 参数安装 requests 库
+        """Test execute sync use requests third party."""
+        # Create test data.
         session_data = {
             "template_id": test_template_id,
             "timeout": 300,
@@ -1069,7 +1060,7 @@ def handler(event):
         track_session(session_id)
 
         try:
-            # Step 2: 等待会话就绪（包括依赖安装完成）
+            # Test setup.
             max_wait = 120
             for i in range(max_wait):
                 response = await http_client.get(f"/sessions/{session_id}")
@@ -1085,13 +1076,13 @@ def handler(event):
             else:
                 pytest.fail(f"Session did not become ready with dependencies in {max_wait} seconds")
 
-            # Step 3: 使用已安装 requests 库的会话执行代码
+            # Test setup.
             request_data = {
                 "code": '''
 import requests
 
 def handler(event):
-    # 测试 requests 库可导入且核心对象可用，不依赖外网
+    # Verify that the requests library is importable and usable without external network access.
     request = requests.Request("GET", "https://example.com/api", params={"q": "sandbox"})
     prepared = request.prepare()
     return {
@@ -1126,13 +1117,8 @@ def handler(event):
         http_client: AsyncClient,
         test_template_id: str
     ):
-        """Test execute-sync using click third-party library.
-
-        This test creates a session with click dependency pre-installed,
-        then executes code that uses the click library.
-        Note: Using click instead of numpy as it's much lighter (<2MB vs >100MB).
-        """
-        # Step 1: 创建会话时传入 dependencies 参数安装 click 库
+        """Test execute sync use click third party."""
+        # Create test data.
         session_data = {
             "template_id": test_template_id,
             "timeout": 300,
@@ -1143,7 +1129,7 @@ def handler(event):
             "dependencies": [
                 {"name": "click"}
             ],
-            "install_timeout": 60  # click 安装很快
+            "install_timeout": 60  # Test setup.
         }
 
         create_response = await http_client.post("/sessions", json=session_data)
@@ -1158,7 +1144,7 @@ def handler(event):
         track_session(session_id)
 
         try:
-            # Step 2: 等待会话就绪（包括依赖安装完成）
+            # Test setup.
             max_wait = 60
             for i in range(max_wait):
                 response = await http_client.get(f"/sessions/{session_id}")
@@ -1174,7 +1160,7 @@ def handler(event):
             else:
                 pytest.fail(f"Session did not become ready with dependencies in {max_wait} seconds")
 
-            # Step 3: 使用已安装 click 库的会话执行代码
+            # Test setup.
             request_data = {
                 "code": '''
 import click
@@ -1207,7 +1193,7 @@ def handler(event):
             from tests.integration.conftest import untrack_session
             untrack_session(session_id)
 
-    # ==================== 其他边界情况测试 ====================
+    # ==================== Test group ====================
 
     async def test_execute_sync_execution_timeout(
         self,
@@ -1220,11 +1206,11 @@ def handler(event):
 import time
 
 def handler(event):
-    time.sleep(15)  # 超过 timeout 设置
+    time.sleep(15)  # Timing-related test setup.
     return {"should_not_reach": "here"}
 ''',
             "language": "python",
-            "timeout": 5  # 5秒超时
+            "timeout": 5  # Test setup.
         }
 
         response = await http_client.post(
@@ -1248,7 +1234,7 @@ def handler(event):
         request_data = {
             "code": '''
 def handler(event):
-    # 返回一个较大的数据结构（限制在TEXT列范围内）
+    # Return a large data structure within the TEXT column limit.
     return {
         "items": [{"id": i, "data": "x" * 100} for i in range(400)],
         "metadata": {

--- a/infra/sandbox/sandbox_control_plane/tests/integration/api/test_execute_sync_api.py
+++ b/infra/sandbox/sandbox_control_plane/tests/integration/api/test_execute_sync_api.py
@@ -1,4 +1,10 @@
-"""Unit tests for execute sync API."""
+"""
+Execute-Sync API Integration Tests
+
+Tests for synchronous code execution endpoint.
+Covers valid parameters, invalid parameters, successful code execution, runtime exceptions,
+stderr output, return values, standard library usage, and third-party library usage.
+"""
 import pytest
 import asyncio
 from httpx import AsyncClient
@@ -52,7 +58,7 @@ def handler(event):
             "timeout": 10
         }
 
-        # Test setup.
+        # Use the default poll_interval and sync_timeout.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data
@@ -264,7 +270,7 @@ def handler(event):
             "timeout": 10
         }
 
-        # Test setup.
+        # Test the minimum poll_interval.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
@@ -272,7 +278,7 @@ def handler(event):
         )
         assert response.status_code == 200
 
-        # Test setup.
+        # Test the maximum poll_interval.
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
@@ -280,7 +286,7 @@ def handler(event):
         )
         assert response.status_code == 200
 
-    # ==================== Valid parameter tests ====================
+    # ==================== Invalid parameter tests ====================
 
     async def test_execute_sync_invalid_poll_interval_too_low(
         self,
@@ -297,7 +303,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"poll_interval": 0.05}  # Test setup.
+            params={"poll_interval": 0.05}  # Below the minimum value 0.1.
         )
 
         assert response.status_code == 422
@@ -317,7 +323,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"poll_interval": 15.0}  # Test setup.
+            params={"poll_interval": 15.0}  # Above the maximum value 10.0.
         )
 
         assert response.status_code == 422
@@ -337,7 +343,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"sync_timeout": 5}  # Test setup.
+            params={"sync_timeout": 5}  # Below the minimum value 10.
         )
 
         assert response.status_code == 422
@@ -357,7 +363,7 @@ def handler(event):
         response = await http_client.post(
             f"/executions/sessions/{test_session_id}/execute-sync",
             json=request_data,
-            params={"sync_timeout": 4000}  # Test setup.
+            params={"sync_timeout": 4000}  # Above the maximum value 3600.
         )
 
         assert response.status_code == 422
@@ -426,7 +432,7 @@ def handler(event):
         request_data = {
             "code": "print('test')",
             "language": "python",
-            "timeout": 0  # Test setup.
+            "timeout": 0  # Below the minimum value 1.
         }
 
         response = await http_client.post(
@@ -445,7 +451,7 @@ def handler(event):
         request_data = {
             "code": "print('test')",
             "language": "python",
-            "timeout": 4000  # Test setup.
+            "timeout": 4000  # Above the maximum value 3600.
         }
 
         response = await http_client.post(
@@ -473,7 +479,7 @@ def handler(event):
 
         assert response.status_code in (400, 404)
 
-    # ==================== Test group ====================
+    # ==================== Successful code execution tests ====================
 
     async def test_execute_sync_simple_execution(
         self,
@@ -531,7 +537,7 @@ def handler(event):
         assert data["status"] in ("success", "completed")
         assert data["exit_code"] == 0
 
-    # ==================== Test group ====================
+    # ==================== Runtime exception tests ====================
 
     async def test_execute_sync_runtime_exception(
         self,
@@ -645,7 +651,7 @@ def handler(event):
         assert "CustomError" in data["stderr"]
         assert "custom error" in data["stderr"].lower()
 
-    # ==================== Test group ====================
+    # ==================== stderr output tests ====================
 
     async def test_execute_sync_stderr_output(
         self,
@@ -704,10 +710,10 @@ def handler(event):
         assert response.status_code == 200
         data = response.json()
         assert data["status"] in ("success", "completed")
-        # Test setup.
+        # Warning messages are usually written to stderr.
         assert "stderr" in data
 
-    # ==================== Test group ====================
+    # ==================== Return value tests ====================
 
     async def test_execute_sync_return_dict(
         self,
@@ -855,7 +861,7 @@ def handler(event):
         assert data["return_value"]["user"]["tags"] == ["admin", "tester"]
         assert data["return_value"]["items"][0]["value"] == "first"
 
-    # ==================== standard library execution tests ====================
+    # ==================== Standard library execution tests ====================
 
     async def test_execute_sync_use_json_stdlib(
         self,
@@ -1026,15 +1032,19 @@ def handler(event):
         assert 3.14 < data["return_value"]["pi"] < 3.15
         assert data["return_value"]["sqrt_2"] == 2 ** 0.5
 
-    # ==================== third-party dependency execution tests ====================
+    # ==================== Third-party dependency execution tests ====================
 
     async def test_execute_sync_use_requests_third_party(
         self,
         http_client: AsyncClient,
         test_template_id: str
     ):
-        """Test execute sync use requests third party."""
-        # Create test data.
+        """Test execute-sync using requests third-party library.
+
+        This test creates a session with requests dependency pre-installed,
+        then executes code that uses the requests library.
+        """
+        # Step 1: create a session with the requests dependency.
         session_data = {
             "template_id": test_template_id,
             "timeout": 300,
@@ -1060,7 +1070,7 @@ def handler(event):
         track_session(session_id)
 
         try:
-            # Test setup.
+            # Step 2: wait for the session to become ready, including dependency installation.
             max_wait = 120
             for i in range(max_wait):
                 response = await http_client.get(f"/sessions/{session_id}")
@@ -1076,7 +1086,7 @@ def handler(event):
             else:
                 pytest.fail(f"Session did not become ready with dependencies in {max_wait} seconds")
 
-            # Test setup.
+            # Step 3: execute code in the session with requests installed.
             request_data = {
                 "code": '''
 import requests
@@ -1117,8 +1127,13 @@ def handler(event):
         http_client: AsyncClient,
         test_template_id: str
     ):
-        """Test execute sync use click third party."""
-        # Create test data.
+        """Test execute-sync using click third-party library.
+
+        This test creates a session with click dependency pre-installed,
+        then executes code that uses the click library.
+        Note: Using click instead of numpy as it's much lighter (<2MB vs >100MB).
+        """
+        # Step 1: create a session with the click dependency.
         session_data = {
             "template_id": test_template_id,
             "timeout": 300,
@@ -1129,7 +1144,7 @@ def handler(event):
             "dependencies": [
                 {"name": "click"}
             ],
-            "install_timeout": 60  # Test setup.
+            "install_timeout": 60  # click installs quickly.
         }
 
         create_response = await http_client.post("/sessions", json=session_data)
@@ -1144,7 +1159,7 @@ def handler(event):
         track_session(session_id)
 
         try:
-            # Test setup.
+            # Step 2: wait for the session to become ready, including dependency installation.
             max_wait = 60
             for i in range(max_wait):
                 response = await http_client.get(f"/sessions/{session_id}")
@@ -1160,7 +1175,7 @@ def handler(event):
             else:
                 pytest.fail(f"Session did not become ready with dependencies in {max_wait} seconds")
 
-            # Test setup.
+            # Step 3: execute code in the session with click installed.
             request_data = {
                 "code": '''
 import click
@@ -1193,7 +1208,7 @@ def handler(event):
             from tests.integration.conftest import untrack_session
             untrack_session(session_id)
 
-    # ==================== Test group ====================
+    # ==================== Additional edge-case tests ====================
 
     async def test_execute_sync_execution_timeout(
         self,
@@ -1206,11 +1221,11 @@ def handler(event):
 import time
 
 def handler(event):
-    time.sleep(15)  # Timing-related test setup.
+    time.sleep(15)  # Exceed the timeout setting.
     return {"should_not_reach": "here"}
 ''',
             "language": "python",
-            "timeout": 5  # Test setup.
+            "timeout": 5  # 5-second timeout.
         }
 
         response = await http_client.post(

--- a/infra/sandbox/sandbox_control_plane/tests/integration/api/test_session_dependency_installation_api.py
+++ b/infra/sandbox/sandbox_control_plane/tests/integration/api/test_session_dependency_installation_api.py
@@ -1,15 +1,4 @@
-"""
-Session dependency installation integration tests.
-
-完整验证链路：
-1. 创建 session
-2. 等待 session 进入 running
-3. 调用依赖安装接口安装指定仓库源和依赖
-4. 校验 session 中的依赖安装状态与结果
-5. 调用同步执行接口运行依赖相关代码
-6. 校验执行成功并返回预期结果
-7. 删除 session
-"""
+"""Unit tests for session dependency installation API."""
 import asyncio
 
 import pytest

--- a/infra/sandbox/sandbox_control_plane/tests/integration/conftest.py
+++ b/infra/sandbox/sandbox_control_plane/tests/integration/conftest.py
@@ -1,9 +1,4 @@
-"""
-Integration Test Configuration
-
-Shared fixtures and configuration for integration tests.
-These tests run against a live docker-compose stack.
-"""
+"""Unit tests for conftest."""
 import asyncio
 import os
 import pytest
@@ -117,12 +112,7 @@ def untrack_session(session_id: str) -> None:
 
 
 async def _list_session_ids(http_client: httpx.AsyncClient) -> Optional[Set[str]]:
-    """
-    Return all visible session IDs, or None if the control plane is unavailable.
-
-    Use absolute URLs so this cleanup still works for modules that override
-    the http_client fixture without a base_url.
-    """
+    """Create list session ids."""
     session_ids: Set[str] = set()
     limit = 200
     offset = 0
@@ -187,11 +177,7 @@ async def _delete_sessions(http_client: httpx.AsyncClient, session_ids: Set[str]
 
 @pytest.fixture(scope="session")
 def event_loop_policy():
-    """
-    为整个测试会话创建一个事件循环策略。
-
-    这有助于避免异步测试中的事件循环问题。
-    """
+    """Create event loop policy."""
     import asyncio
     policy = asyncio.get_event_loop_policy()
     yield policy
@@ -199,17 +185,13 @@ def event_loop_policy():
 
 @pytest.fixture(scope="function", autouse=True)
 async def auto_cleanup_sessions(http_client: httpx.AsyncClient, request):
-    """
-    每个测试函数完成后自动清理所有测试 session。
-
-    autouse=True 确保此 fixture 在每个测试函数后自动运行。
-    """
-    # 记录测试开始前已存在的 sessions。清理时只删除本测试新增的
-    # sessions，避免误删运行环境中已有的手工 session。
+    """Create auto cleanup sessions."""
+    # Record sessions that existed before the test starts. During cleanup, delete only sessions created by this test.
+    # sessions to avoid deleting manual sessions that already existed in the runtime environment.
     sessions_before_test = await _list_session_ids(http_client)
     tracked_before_test = set(_created_sessions)
 
-    yield  # 测试运行
+    yield  # Test setup.
 
     tracked_new_sessions = _created_sessions - tracked_before_test
 
@@ -224,16 +206,7 @@ async def auto_cleanup_sessions(http_client: httpx.AsyncClient, request):
 
 @pytest.fixture(scope="function")
 async def http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
-    """
-    Create HTTP client for API calls.
-
-    This client is used for all integration tests to communicate
-    with the control plane API.
-
-    Note: trust_env=False is set to bypass macOS system proxy
-    that would otherwise cause 502 errors. localhost resolves to IPv6
-    on this system, which is required for connectivity.
-    """
+    """Create HTTP client."""
     async with httpx.AsyncClient(
         base_url=API_BASE_URL,
         timeout=httpx.Timeout(30.0, connect=10.0),
@@ -244,14 +217,7 @@ async def http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
 
 @pytest.fixture(scope="function")
 async def cleanup_test_data(http_client: httpx.AsyncClient) -> None:
-    """
-    Cleanup test data after each test.
-
-    This fixture runs after each test to clean up:
-    - Test sessions
-    - Test executions
-    - Test templates (if created during test)
-    """
+    """Create cleanup test data."""
     yield  # Run the test first
 
     # Cleanup: Delete test sessions
@@ -270,12 +236,8 @@ async def cleanup_test_data(http_client: httpx.AsyncClient) -> None:
 
 @pytest.fixture(scope="function")
 async def test_template_id(http_client: httpx.AsyncClient) -> str:
-    """
-    Create or get test template.
-
-    Returns the template ID for testing.
-    """
-    # Try to get existing template
+    """Test template ID."""
+    # Test setup.
     response = await http_client.get(f"/templates/{TEST_TEMPLATE_ID}")
     if response.status_code == 200:
         return TEST_TEMPLATE_ID
@@ -310,11 +272,7 @@ async def _create_session_and_track(
     template_id: str,
     mode: str = None
 ) -> str:
-    """
-    Helper function to create a session and track it for cleanup.
-
-    This ensures all created sessions are tracked for automatic cleanup.
-    """
+    """Create create session and track."""
     session_data = {
         "template_id": template_id,
         "timeout": 300,
@@ -360,11 +318,7 @@ async def test_session_id(
     http_client: httpx.AsyncClient,
     test_template_id: str
 ) -> str:
-    """
-    Create a test session and return its ID.
-
-    The session is automatically tracked for cleanup after the test.
-    """
+    """Test session ID."""
     return await _create_session_and_track(http_client, test_template_id)
 
 
@@ -373,13 +327,7 @@ async def persistent_session_id(
     http_client: httpx.AsyncClient,
     test_template_id: str
 ) -> str:
-    """
-    Create a persistent test session for multiple executions.
-
-    Persistent sessions can accept multiple execution requests and
-    maintain state between executions. The session is automatically
-    tracked for cleanup after the test.
-    """
+    """Create persistent session ID."""
     return await _create_session_and_track(http_client, test_template_id, mode="persistent")
 
 
@@ -388,11 +336,7 @@ async def test_execution_id(
     http_client: httpx.AsyncClient,
     test_session_id: str
 ) -> str:
-    """
-    Create a test execution and return its ID.
-
-    Executes simple Python code that prints "Hello, World!".
-    """
+    """Test execution ID."""
     execution_data = {
         "code": 'print("Hello, World!")',
         "language": "python",
@@ -418,13 +362,7 @@ async def test_execution_id(
 async def wait_for_execution_completion(
     http_client: httpx.AsyncClient
 ):
-    """
-    Return a function that waits for execution completion.
-
-    Usage:
-        execution_id = await test_execution_id(http_client, test_session_id)
-        result = await wait_for_execution_completion(http_client, execution_id)
-    """
+    """Create wait for execution completion."""
     async def _wait(execution_id: str, timeout: int = 60) -> Dict[str, Any]:
         """Wait for execution to complete and return result."""
         for _ in range(timeout):
@@ -448,15 +386,7 @@ async def wait_for_execution_completion(
 # ============== Helpers ==============
 
 def generate_test_id(prefix: str = "test") -> str:
-    """
-    Generate a unique test ID.
-
-    Args:
-        prefix: Prefix for the ID (default: "test")
-
-    Returns:
-        Unique ID string
-    """
+    """Create generate test ID."""
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
     return f"{prefix}_{timestamp}"
 
@@ -466,17 +396,7 @@ async def wait_for_container_ready(
     session_id: str,
     timeout: int = 30
 ) -> bool:
-    """
-    Wait for container to be ready.
-
-    Args:
-        http_client: HTTP client for API calls
-        session_id: Session ID to check
-        timeout: Maximum wait time in seconds
-
-    Returns:
-        True if container is ready, False otherwise
-    """
+    """Create wait for container ready."""
     for _ in range(timeout):
         response = await http_client.get(f"/sessions/{session_id}")
         if response.status_code == 200:

--- a/infra/sandbox/sandbox_control_plane/tests/integration/conftest.py
+++ b/infra/sandbox/sandbox_control_plane/tests/integration/conftest.py
@@ -1,4 +1,9 @@
-"""Unit tests for conftest."""
+"""
+Integration Test Configuration
+
+Shared fixtures and configuration for integration tests.
+These tests run against a live docker-compose stack.
+"""
 import asyncio
 import os
 import pytest
@@ -112,7 +117,12 @@ def untrack_session(session_id: str) -> None:
 
 
 async def _list_session_ids(http_client: httpx.AsyncClient) -> Optional[Set[str]]:
-    """Create list session ids."""
+    """
+    Return all visible session IDs, or None if the control plane is unavailable.
+
+    Use absolute URLs so this cleanup still works for modules that override
+    the http_client fixture without a base_url.
+    """
     session_ids: Set[str] = set()
     limit = 200
     offset = 0
@@ -177,7 +187,11 @@ async def _delete_sessions(http_client: httpx.AsyncClient, session_ids: Set[str]
 
 @pytest.fixture(scope="session")
 def event_loop_policy():
-    """Create event loop policy."""
+    """
+    Create an event loop policy for the entire test session.
+
+    This helps avoid event loop issues in async tests.
+    """
     import asyncio
     policy = asyncio.get_event_loop_policy()
     yield policy
@@ -185,13 +199,18 @@ def event_loop_policy():
 
 @pytest.fixture(scope="function", autouse=True)
 async def auto_cleanup_sessions(http_client: httpx.AsyncClient, request):
-    """Create auto cleanup sessions."""
-    # Record sessions that existed before the test starts. During cleanup, delete only sessions created by this test.
-    # sessions to avoid deleting manual sessions that already existed in the runtime environment.
+    """
+    Automatically clean up test sessions after each test function.
+
+    autouse=True ensures this fixture runs automatically after each test function.
+    """
+    # Record sessions that existed before the test starts. During cleanup, delete only
+    # sessions created by this test to avoid deleting manual sessions that already existed
+    # in the runtime environment.
     sessions_before_test = await _list_session_ids(http_client)
     tracked_before_test = set(_created_sessions)
 
-    yield  # Test setup.
+    yield  # Run the test.
 
     tracked_new_sessions = _created_sessions - tracked_before_test
 
@@ -206,7 +225,16 @@ async def auto_cleanup_sessions(http_client: httpx.AsyncClient, request):
 
 @pytest.fixture(scope="function")
 async def http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
-    """Create HTTP client."""
+    """
+    Create HTTP client for API calls.
+
+    This client is used for all integration tests to communicate
+    with the control plane API.
+
+    Note: trust_env=False is set to bypass macOS system proxy
+    that would otherwise cause 502 errors. localhost resolves to IPv6
+    on this system, which is required for connectivity.
+    """
     async with httpx.AsyncClient(
         base_url=API_BASE_URL,
         timeout=httpx.Timeout(30.0, connect=10.0),
@@ -217,7 +245,14 @@ async def http_client() -> AsyncGenerator[httpx.AsyncClient, None]:
 
 @pytest.fixture(scope="function")
 async def cleanup_test_data(http_client: httpx.AsyncClient) -> None:
-    """Create cleanup test data."""
+    """
+    Cleanup test data after each test.
+
+    This fixture runs after each test to clean up:
+    - Test sessions
+    - Test executions
+    - Test templates (if created during test)
+    """
     yield  # Run the test first
 
     # Cleanup: Delete test sessions
@@ -236,8 +271,12 @@ async def cleanup_test_data(http_client: httpx.AsyncClient) -> None:
 
 @pytest.fixture(scope="function")
 async def test_template_id(http_client: httpx.AsyncClient) -> str:
-    """Test template ID."""
-    # Test setup.
+    """
+    Create or get test template.
+
+    Returns the template ID for testing.
+    """
+    # Try to get existing template.
     response = await http_client.get(f"/templates/{TEST_TEMPLATE_ID}")
     if response.status_code == 200:
         return TEST_TEMPLATE_ID
@@ -272,7 +311,11 @@ async def _create_session_and_track(
     template_id: str,
     mode: str = None
 ) -> str:
-    """Create create session and track."""
+    """
+    Helper function to create a session and track it for cleanup.
+
+    This ensures all created sessions are tracked for automatic cleanup.
+    """
     session_data = {
         "template_id": template_id,
         "timeout": 300,
@@ -318,7 +361,11 @@ async def test_session_id(
     http_client: httpx.AsyncClient,
     test_template_id: str
 ) -> str:
-    """Test session ID."""
+    """
+    Create a test session and return its ID.
+
+    The session is automatically tracked for cleanup after the test.
+    """
     return await _create_session_and_track(http_client, test_template_id)
 
 
@@ -327,7 +374,13 @@ async def persistent_session_id(
     http_client: httpx.AsyncClient,
     test_template_id: str
 ) -> str:
-    """Create persistent session ID."""
+    """
+    Create a persistent test session for multiple executions.
+
+    Persistent sessions can accept multiple execution requests and
+    maintain state between executions. The session is automatically
+    tracked for cleanup after the test.
+    """
     return await _create_session_and_track(http_client, test_template_id, mode="persistent")
 
 
@@ -336,7 +389,11 @@ async def test_execution_id(
     http_client: httpx.AsyncClient,
     test_session_id: str
 ) -> str:
-    """Test execution ID."""
+    """
+    Create a test execution and return its ID.
+
+    Executes simple Python code that prints "Hello, World!".
+    """
     execution_data = {
         "code": 'print("Hello, World!")',
         "language": "python",
@@ -362,7 +419,13 @@ async def test_execution_id(
 async def wait_for_execution_completion(
     http_client: httpx.AsyncClient
 ):
-    """Create wait for execution completion."""
+    """
+    Return a function that waits for execution completion.
+
+    Usage:
+        execution_id = await test_execution_id(http_client, test_session_id)
+        result = await wait_for_execution_completion(http_client, execution_id)
+    """
     async def _wait(execution_id: str, timeout: int = 60) -> Dict[str, Any]:
         """Wait for execution to complete and return result."""
         for _ in range(timeout):
@@ -386,7 +449,15 @@ async def wait_for_execution_completion(
 # ============== Helpers ==============
 
 def generate_test_id(prefix: str = "test") -> str:
-    """Create generate test ID."""
+    """
+    Generate a unique test ID.
+
+    Args:
+        prefix: Prefix for the ID (default: "test")
+
+    Returns:
+        Unique ID string
+    """
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
     return f"{prefix}_{timestamp}"
 
@@ -396,7 +467,17 @@ async def wait_for_container_ready(
     session_id: str,
     timeout: int = 30
 ) -> bool:
-    """Create wait for container ready."""
+    """
+    Wait for container to be ready.
+
+    Args:
+        http_client: HTTP client for API calls
+        session_id: Session ID to check
+        timeout: Maximum wait time in seconds
+
+    Returns:
+        True if container is ready, False otherwise
+    """
     for _ in range(timeout):
         response = await http_client.get(f"/sessions/{session_id}")
         if response.status_code == 200:

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
@@ -21,8 +21,8 @@ class TestCreateSessionCommandValidation:
         ],
     )
     def test_rejects_unsafe_id(self, bad_id):
-        # Test setup.
-        # Test setup.
+        # Fallback layer: even without request schema validation, IDs containing shell metacharacters, `..`, or `/` must
+        # be rejected because they flow into the s3fs mount script running as root; otherwise they could cause command injection or prefix escape.
         with pytest.raises(ValueError):
             CreateSessionCommand(id=bad_id)
         with pytest.raises(ValueError):

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_create_session.py
@@ -1,4 +1,4 @@
-"""CreateSessionCommand 校验测试（id / template_id 安全白名单兜底层）。"""
+"""Unit tests for create session."""
 
 import pytest
 
@@ -21,8 +21,8 @@ class TestCreateSessionCommandValidation:
         ],
     )
     def test_rejects_unsafe_id(self, bad_id):
-        # 兜底层：即使不经 request schema，含 shell 元字符 / '..' / '/' 的 id 也必须
-        # 被拒——它会落入以 root 运行的 s3fs 挂载脚本，否则造成命令注入 / 前缀逃逸。
+        # Test setup.
+        # Test setup.
         with pytest.raises(ValueError):
             CreateSessionCommand(id=bad_id)
         with pytest.raises(ValueError):
@@ -34,7 +34,7 @@ class TestCreateSessionCommandValidation:
         assert cmd.template_id == "python-basic"
 
     def test_allows_none(self):
-        # id/template_id 可选；None 走自动生成 / 默认模板，不应被校验拦下。
+        # Verify expected behavior.
         cmd = CreateSessionCommand()
         assert cmd.id is None
         assert cmd.template_id is None

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_execute_code.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/commands/test_execute_code.py
@@ -1,18 +1,14 @@
-"""
-执行代码命令单元测试
-
-测试 ExecuteCodeCommand 的功能。
-"""
+"""Unit tests for execute code."""
 import pytest
 
 from src.application.commands.execute_code import ExecuteCodeCommand
 
 
 class TestExecuteCodeCommand:
-    """执行代码命令测试"""
+    """Tests for TestExecuteCodeCommand."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -28,7 +24,7 @@ class TestExecuteCodeCommand:
         assert command.event_data is None  # default
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -50,7 +46,7 @@ class TestExecuteCodeCommand:
         assert command.working_directory == "src/jobs"
 
     def test_language_python(self):
-        """测试 Python 语言"""
+        """Test language python."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -60,7 +56,7 @@ class TestExecuteCodeCommand:
         assert command.language == "python"
 
     def test_language_javascript(self):
-        """测试 JavaScript 语言"""
+        """Test language javascript."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="console.log('hello')",
@@ -70,7 +66,7 @@ class TestExecuteCodeCommand:
         assert command.language == "javascript"
 
     def test_language_shell(self):
-        """测试 Shell 语言"""
+        """Test language shell."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="echo hello",
@@ -80,7 +76,7 @@ class TestExecuteCodeCommand:
         assert command.language == "shell"
 
     def test_empty_code_raises_error(self):
-        """测试空代码抛出错误"""
+        """Test empty code raises error."""
         with pytest.raises(ValueError, match="code cannot be empty"):
             ExecuteCodeCommand(
                 session_id="sess-123",
@@ -89,7 +85,7 @@ class TestExecuteCodeCommand:
             )
 
     def test_zero_timeout_raises_error(self):
-        """测试零超时抛出错误"""
+        """Test zero timeout raises error."""
         with pytest.raises(ValueError, match="timeout must be positive"):
             ExecuteCodeCommand(
                 session_id="sess-123",
@@ -99,7 +95,7 @@ class TestExecuteCodeCommand:
             )
 
     def test_negative_timeout_raises_error(self):
-        """测试负超时抛出错误"""
+        """Test negative timeout raises error."""
         with pytest.raises(ValueError, match="timeout must be positive"):
             ExecuteCodeCommand(
                 session_id="sess-123",
@@ -109,7 +105,7 @@ class TestExecuteCodeCommand:
             )
 
     def test_unsupported_language_raises_error(self):
-        """测试不支持的语言抛出错误"""
+        """Test unsupported language raises error."""
         with pytest.raises(ValueError, match="Unsupported language"):
             ExecuteCodeCommand(
                 session_id="sess-123",
@@ -118,7 +114,7 @@ class TestExecuteCodeCommand:
             )
 
     def test_async_mode_true(self):
-        """测试异步模式为 True"""
+        """Test async mode true."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -129,7 +125,7 @@ class TestExecuteCodeCommand:
         assert command.async_mode is True
 
     def test_async_mode_false(self):
-        """测试异步模式为 False"""
+        """Test async mode false."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -140,7 +136,7 @@ class TestExecuteCodeCommand:
         assert command.async_mode is False
 
     def test_with_stdin(self):
-        """测试带标准输入"""
+        """Test with stdin."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="name = input()",
@@ -151,7 +147,7 @@ class TestExecuteCodeCommand:
         assert command.stdin == "World"
 
     def test_with_event_data(self):
-        """测试带事件数据"""
+        """Test with event data."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print(event['name'])",
@@ -162,7 +158,7 @@ class TestExecuteCodeCommand:
         assert command.event_data == {"name": "World", "count": 42}
 
     def test_with_working_directory_normalized(self):
-        """测试工作目录归一化"""
+        """Test with working directory normalized."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="echo hello",
@@ -173,7 +169,7 @@ class TestExecuteCodeCommand:
         assert command.working_directory == "skill/mini-wiki"
 
     def test_invalid_working_directory_raises_error(self):
-        """测试非法工作目录抛出错误"""
+        """Test invalid working directory raises error."""
         with pytest.raises(ValueError, match="working_directory must be a relative workspace path"):
             ExecuteCodeCommand(
                 session_id="sess-123",
@@ -183,7 +179,7 @@ class TestExecuteCodeCommand:
             )
 
     def test_timeout_boundary_minimum(self):
-        """测试超时边界值（最小有效值）"""
+        """Test timeout boundary minimum."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -194,7 +190,7 @@ class TestExecuteCodeCommand:
         assert command.timeout == 1
 
     def test_timeout_boundary_large(self):
-        """测试超时边界值（较大值）"""
+        """Test timeout boundary large."""
         command = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -205,13 +201,13 @@ class TestExecuteCodeCommand:
         assert command.timeout == 3600
 
     def test_is_dataclass(self):
-        """测试是数据类"""
+        """Test is dataclass."""
         from dataclasses import is_dataclass
 
         assert is_dataclass(ExecuteCodeCommand)
 
     def test_dataclass_equality(self):
-        """测试数据类相等性"""
+        """Test dataclass equality."""
         command1 = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -227,7 +223,7 @@ class TestExecuteCodeCommand:
         assert command1 == command2
 
     def test_dataclass_inequality(self):
-        """测试数据类不等性"""
+        """Test dataclass inequality."""
         command1 = ExecuteCodeCommand(
             session_id="sess-123",
             code="print('hello')",
@@ -243,7 +239,7 @@ class TestExecuteCodeCommand:
         assert command1 != command2
 
     def test_multiline_code(self):
-        """测试多行代码"""
+        """Test multiline code."""
         code = '''
 def greet(name):
     return f"Hello, {name}!"
@@ -260,7 +256,7 @@ print(greet("World"))
         assert "Hello" in command.code
 
     def test_whitespace_only_code_raises_error(self):
-        """测试仅空白字符的代码抛出错误"""
+        """Test whitespace only code raises error."""
         # Note: The validation checks `if not self.code`, which evaluates to True for empty string
         # but False for whitespace-only strings. This test verifies the current behavior.
         command = ExecuteCodeCommand(

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/dtos/test_session_dto.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/dtos/test_session_dto.py
@@ -1,8 +1,4 @@
-"""
-会话 DTO 单元测试
-
-测试 SessionDTO 的功能。
-"""
+"""Unit tests for session DTO."""
 import pytest
 from datetime import datetime
 
@@ -13,10 +9,10 @@ from src.domain.value_objects.execution_status import SessionStatus
 
 
 class TestSessionDTO:
-    """会话 DTO 测试"""
+    """Tests for TestSessionDTO."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         dto = SessionDTO(
             id="test-session",
             template_id="python-test",
@@ -47,7 +43,7 @@ class TestSessionDTO:
         assert dto.last_activity_at is not None  # Default from __post_init__
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         now = datetime.now()
         dto = SessionDTO(
             id="test-session",
@@ -81,7 +77,7 @@ class TestSessionDTO:
         assert dto.completed_at == now
 
     def test_post_init_defaults(self):
-        """测试 __post_init__ 默认值"""
+        """Test post init defaults."""
         dto = SessionDTO(
             id="test-session",
             template_id="python-test",
@@ -104,7 +100,7 @@ class TestSessionDTO:
         assert dto.installed_dependencies == []
 
     def test_from_entity(self):
-        """测试从领域实体创建 DTO"""
+        """Test from entity."""
         session = Session(
             id="test-session",
             template_id="python-test",
@@ -138,7 +134,7 @@ class TestSessionDTO:
         ]
 
     def test_from_entity_with_all_fields(self):
-        """测试从领域实体创建 DTO（所有字段）"""
+        """Test from entity with all fields."""
         now = datetime.now()
         session = Session(
             id="test-session",
@@ -176,7 +172,7 @@ class TestSessionDTO:
         assert dto.completed_at == now
 
     def test_is_dataclass(self):
-        """测试是数据类"""
+        """Test is dataclass."""
         from dataclasses import is_dataclass
 
         assert is_dataclass(SessionDTO)

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/dtos/test_template_dto.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/dtos/test_template_dto.py
@@ -1,8 +1,4 @@
-"""
-模板 DTO 单元测试
-
-测试 TemplateDTO 的功能。
-"""
+"""Unit tests for template DTO."""
 import pytest
 from datetime import datetime
 
@@ -12,10 +8,10 @@ from src.domain.value_objects.resource_limit import ResourceLimit
 
 
 class TestTemplateDTO:
-    """模板 DTO 测试"""
+    """Tests for TestTemplateDTO."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         dto = TemplateDTO(
             id="python-test",
             name="Python Test",
@@ -39,7 +35,7 @@ class TestTemplateDTO:
         assert dto.is_active is True
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         now = datetime.now()
         dto = TemplateDTO(
             id="python-test",
@@ -62,7 +58,7 @@ class TestTemplateDTO:
         assert dto.updated_at == now
 
     def test_from_entity(self):
-        """测试从领域实体创建 DTO"""
+        """Test from entity."""
         template = Template(
             id="python-test",
             name="Python Test",
@@ -87,7 +83,7 @@ class TestTemplateDTO:
         assert dto.default_timeout_sec == 300
 
     def test_from_entity_with_gi_memory(self):
-        """测试从领域实体创建 DTO（Gi 内存单位）"""
+        """Test from entity with gi memory."""
         template = Template(
             id="python-test",
             name="Python Test",
@@ -106,7 +102,7 @@ class TestTemplateDTO:
         assert dto.default_disk_mb == 10240  # 10Gi = 10240MB
 
     def test_from_entity_with_large_resources(self):
-        """测试从领域实体创建 DTO（大资源）"""
+        """Test from entity with large resources."""
         template = Template(
             id="python-test",
             name="Python Test",
@@ -126,7 +122,7 @@ class TestTemplateDTO:
         assert dto.default_disk_mb == 51200  # 50Gi = 51200MB
 
     def test_from_entity_with_default_resources(self):
-        """测试从领域实体创建 DTO（使用默认资源）"""
+        """Test from entity with default resources."""
         template = Template(
             id="python-test",
             name="Python Test",
@@ -142,7 +138,7 @@ class TestTemplateDTO:
         assert dto.default_disk_mb == 1024
 
     def test_to_dict(self):
-        """测试转换为字典"""
+        """Test to dict."""
         now = datetime.now()
         dto = TemplateDTO(
             id="python-test",
@@ -175,7 +171,7 @@ class TestTemplateDTO:
         assert result["updated_at"] == now.isoformat()
 
     def test_to_dict_without_dates(self):
-        """测试转换为字典（无日期）"""
+        """Test to dict without dates."""
         dto = TemplateDTO(
             id="python-test",
             name="Python Test",
@@ -193,7 +189,7 @@ class TestTemplateDTO:
         assert result["updated_at"] is None
 
     def test_is_dataclass(self):
-        """测试是数据类"""
+        """Test is dataclass."""
         from dataclasses import is_dataclass
 
         assert is_dataclass(TemplateDTO)

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_file_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_file_service.py
@@ -109,7 +109,7 @@ class TestFileService:
         """Test upload file invalid path."""
         session_repo.find_by_id.return_value = active_session
 
-        # Test setup.
+        # Absolute path.
         with pytest.raises(ValidationError, match="Invalid file path"):
             await service.upload_file(
                 session_id="sess_123",
@@ -460,7 +460,7 @@ class TestFileService:
         storage_service.file_exists.return_value = True
         storage_service.get_file_info.return_value = {
             "size": 1024
-            # Test setup.
+            # Missing content_type.
         }
         storage_service.download_file.return_value = b"content"
 
@@ -469,7 +469,7 @@ class TestFileService:
             path="test.txt"
         )
 
-        # Test setup.
+        # Should use the default content_type.
         assert result["content_type"] == "application/octet-stream"
 
     @pytest.mark.asyncio

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_file_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_file_service.py
@@ -1,8 +1,4 @@
-"""
-文件应用服务单元测试
-
-测试 FileService 的用例编排逻辑。
-"""
+"""Unit tests for file service."""
 import io
 import stat
 import zipfile
@@ -19,18 +15,18 @@ from src.shared.errors.domain import NotFoundError, ValidationError
 
 
 class TestFileService:
-    """文件应用服务测试"""
+    """Tests for TestFileService."""
 
     @pytest.fixture
     def session_repo(self):
-        """模拟会话仓储"""
+        """Create session repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         return repo
 
     @pytest.fixture
     def storage_service(self):
-        """模拟存储服务"""
+        """Create storage service."""
         service = Mock()
         service.upload_file = AsyncMock()
         service.download_file = AsyncMock()
@@ -42,7 +38,7 @@ class TestFileService:
 
     @pytest.fixture
     def service(self, session_repo, storage_service):
-        """创建文件服务"""
+        """Create service."""
         return FileService(
             session_repo=session_repo,
             storage_service=storage_service
@@ -50,7 +46,7 @@ class TestFileService:
 
     @pytest.fixture
     def active_session(self):
-        """活跃会话"""
+        """Create active session."""
         return Session(
             id="sess_123",
             template_id="python-basic",
@@ -62,7 +58,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_file_success(self, service, session_repo, storage_service, active_session):
-        """测试成功上传文件"""
+        """Test upload file success."""
         session_repo.find_by_id.return_value = active_session
 
         content = b"hello world"
@@ -78,7 +74,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_file_session_not_found(self, service, session_repo):
-        """测试上传文件到不存在的会话"""
+        """Test upload file session not found."""
         session_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Session not found"):
@@ -90,7 +86,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_file_session_not_active(self, service, session_repo):
-        """测试上传文件到非活跃会话"""
+        """Test upload file session not active."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -110,10 +106,10 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_file_invalid_path(self, service, session_repo, active_session):
-        """测试上传文件到无效路径"""
+        """Test upload file invalid path."""
         session_repo.find_by_id.return_value = active_session
 
-        # 绝对路径
+        # Test setup.
         with pytest.raises(ValidationError, match="Invalid file path"):
             await service.upload_file(
                 session_id="sess_123",
@@ -121,7 +117,7 @@ class TestFileService:
                 content=b"hello"
             )
 
-        # 空路径
+        # Invalid input case.
         with pytest.raises(ValidationError, match="Invalid file path"):
             await service.upload_file(
                 session_id="sess_123",
@@ -138,7 +134,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_file_with_default_content_type(self, service, session_repo, storage_service, active_session):
-        """测试使用默认内容类型上传文件"""
+        """Test upload file with default content type."""
         session_repo.find_by_id.return_value = active_session
 
         await service.upload_file(
@@ -147,13 +143,13 @@ class TestFileService:
             content=b"\x00\x01\x02"
         )
 
-        # 验证使用了默认的 content_type
+        # Verify expected behavior.
         call_args = storage_service.upload_file.call_args
         assert call_args[1]["content_type"] == "application/octet-stream"
 
     @pytest.mark.asyncio
     async def test_upload_file_with_custom_content_type(self, service, session_repo, storage_service, active_session):
-        """测试使用自定义内容类型上传文件"""
+        """Test upload file with custom content type."""
         session_repo.find_by_id.return_value = active_session
 
         await service.upload_file(
@@ -163,13 +159,13 @@ class TestFileService:
             content_type="application/json"
         )
 
-        # 验证使用了自定义的 content_type
+        # Verify expected behavior.
         call_args = storage_service.upload_file.call_args
         assert call_args[1]["content_type"] == "application/json"
 
     @pytest.mark.asyncio
     async def test_upload_file_s3_path_construction(self, service, session_repo, storage_service, active_session):
-        """测试 S3 路径构造"""
+        """Test upload file S3 path construction."""
         session_repo.find_by_id.return_value = active_session
 
         await service.upload_file(
@@ -178,7 +174,7 @@ class TestFileService:
             content=b"id,name\n1,test"
         )
 
-        # 验证 S3 路径包含 workspace_path
+        # S3-related assertion.
         call_args = storage_service.upload_file.call_args
         if call_args[0]:
             s3_path = call_args[0][0]
@@ -189,7 +185,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_and_extract_zip_success(self, service, session_repo, storage_service, active_session):
-        """测试成功解压 ZIP 并上传多个文件"""
+        """Test upload and extract ZIP success."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = False
 
@@ -213,7 +209,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_and_extract_zip_skips_conflicts(self, service, session_repo, storage_service, active_session):
-        """测试 ZIP 解压时跳过已存在文件"""
+        """Test upload and extract ZIP skips conflicts."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.side_effect = [True, False]
 
@@ -235,7 +231,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_and_extract_zip_invalid_entry_path(self, service, session_repo, active_session):
-        """测试 ZIP 含非法路径时拒绝解压"""
+        """Test upload and extract ZIP invalid entry path."""
         session_repo.find_by_id.return_value = active_session
 
         archive_buffer = io.BytesIO()
@@ -257,7 +253,7 @@ class TestFileService:
         session_repo,
         active_session,
     ):
-        """测试 ZIP 含符号链接 entry 时拒绝解压"""
+        """Test upload and extract ZIP rejects symlink entry."""
         session_repo.find_by_id.return_value = active_session
 
         archive_buffer = io.BytesIO()
@@ -281,7 +277,7 @@ class TestFileService:
         storage_service,
         active_session,
     ):
-        """测试 ZIP 文件数量超过限制时拒绝解压"""
+        """Test upload and extract ZIP rejects too many files."""
         service = FileService(
             session_repo=session_repo,
             storage_service=storage_service,
@@ -311,7 +307,7 @@ class TestFileService:
         storage_service,
         active_session,
     ):
-        """测试 ZIP 解压后总大小超过限制时拒绝解压"""
+        """Test upload and extract ZIP rejects uncompressed size limit."""
         service = FileService(
             session_repo=session_repo,
             storage_service=storage_service,
@@ -335,7 +331,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_upload_and_extract_zip_invalid_archive(self, service, session_repo, active_session):
-        """测试非法 ZIP 内容"""
+        """Test upload and extract ZIP invalid archive."""
         session_repo.find_by_id.return_value = active_session
 
         with pytest.raises(ValidationError, match="Invalid ZIP archive"):
@@ -348,7 +344,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_small_file(self, service, session_repo, storage_service, active_session):
-        """测试下载小文件（直接返回内容）"""
+        """Test download file small file."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = True
         storage_service.get_file_info.return_value = {
@@ -368,7 +364,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_large_file(self, service, session_repo, storage_service, active_session):
-        """测试下载大文件（返回预签名 URL）"""
+        """Test download file large file."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = True
         storage_service.get_file_info.return_value = {
@@ -388,7 +384,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_session_not_found(self, service, session_repo):
-        """测试从不存在会话下载文件"""
+        """Test download file session not found."""
         session_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Session not found"):
@@ -399,7 +395,7 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_not_found(self, service, session_repo, storage_service, active_session):
-        """测试下载不存在的文件"""
+        """Test download file not found."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = False
 
@@ -411,11 +407,11 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_10mb_boundary(self, service, session_repo, storage_service, active_session):
-        """测试 10MB 边界情况"""
+        """Test download file 10mb boundary."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = True
 
-        # 正好 10MB
+        # 10 MB boundary case.
         storage_service.get_file_info.return_value = {
             "size": 10 * 1024 * 1024,
             "content_type": "application/octet-stream"
@@ -427,14 +423,14 @@ class TestFileService:
             path="boundary.bin"
         )
 
-        # 小于 10MB（等于也是小于），应返回内容
-        # 但如果 result 是 Mock，需要检查其属性
+        # 10 MB boundary case.
+        # Mock test dependency.
         if hasattr(result, "__getitem__"):
             assert "content" in result or "presigned_url" in result
 
     @pytest.mark.asyncio
     async def test_download_file_s3_path_construction(self, service, session_repo, storage_service, active_session):
-        """测试下载文件 S3 路径构造"""
+        """Test download file S3 path construction."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = True
         storage_service.get_file_info.return_value = {
@@ -448,7 +444,7 @@ class TestFileService:
             path="data/test.csv"
         )
 
-        # 验证所有文件操作都使用正确的 S3 路径
+        # S3-related test setup.
         file_exists_path = storage_service.file_exists.call_args[0][0]
         file_info_path = storage_service.get_file_info.call_args[0][0]
         download_path = storage_service.download_file.call_args[0][0]
@@ -459,12 +455,12 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_download_file_with_missing_content_type(self, service, session_repo, storage_service, active_session):
-        """测试缺少 content_type 的文件信息"""
+        """Test download file with missing content type."""
         session_repo.find_by_id.return_value = active_session
         storage_service.file_exists.return_value = True
         storage_service.get_file_info.return_value = {
             "size": 1024
-            # 缺少 content_type
+            # Test setup.
         }
         storage_service.download_file.return_value = b"content"
 
@@ -473,12 +469,12 @@ class TestFileService:
             path="test.txt"
         )
 
-        # 应使用默认 content_type
+        # Test setup.
         assert result["content_type"] == "application/octet-stream"
 
     @pytest.mark.asyncio
     async def test_list_files_all(self, service, session_repo, storage_service, active_session):
-        """测试列出所有文件"""
+        """Test list files all."""
         session_repo.find_by_id.return_value = active_session
         storage_service.list_files.return_value = [
             {
@@ -504,13 +500,13 @@ class TestFileService:
         assert result[1]["name"] == "src/main.py"
         assert result[1]["container_path"] == "/workspace/src/main.py"
         assert result[1]["size"] == 2048
-        # 验证调用时使用了正确的 workspace 前缀
+        # Verify expected behavior.
         call_prefix = storage_service.list_files.call_args[0][0]
         assert "sessions/sess_123" in call_prefix
 
     @pytest.mark.asyncio
     async def test_list_files_with_path(self, service, session_repo, storage_service, active_session):
-        """测试列出指定目录下的文件"""
+        """Test list files with path."""
         session_repo.find_by_id.return_value = active_session
         storage_service.list_files.return_value = [
             {
@@ -527,13 +523,13 @@ class TestFileService:
         assert result[0]["name"] == "src/utils/helper.py"
         assert result[0]["container_path"] == "/workspace/src/utils/helper.py"
         assert result[0]["size"] == 512
-        # 验证调用时使用了正确的前缀（包含子目录）
+        # Verify expected behavior.
         call_prefix = storage_service.list_files.call_args[0][0]
         assert "sessions/sess_123/src/utils" in call_prefix
 
     @pytest.mark.asyncio
     async def test_list_files_with_trailing_slash_path(self, service, session_repo, storage_service, active_session):
-        """测试列出指定目录下的文件（带尾部斜杠）"""
+        """Test list files with trailing slash path."""
         session_repo.find_by_id.return_value = active_session
         storage_service.list_files.return_value = [
             {
@@ -549,13 +545,13 @@ class TestFileService:
         assert len(result) == 1
         assert result[0]["name"] == "src/app.py"
         assert result[0]["container_path"] == "/workspace/src/app.py"
-        # 验证路径被正确规范化
+        # Verify expected behavior.
         call_prefix = storage_service.list_files.call_args[0][0]
         assert "sessions/sess_123/src" in call_prefix
 
     @pytest.mark.asyncio
     async def test_list_files_session_not_found(self, service, session_repo):
-        """测试列出不存在会话的文件"""
+        """Test list files session not found."""
         session_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Session not found"):
@@ -563,21 +559,21 @@ class TestFileService:
 
     @pytest.mark.asyncio
     async def test_list_files_with_limit(self, service, session_repo, storage_service, active_session):
-        """测试列出文件（带限制）"""
+        """Test list files with limit."""
         session_repo.find_by_id.return_value = active_session
         storage_service.list_files.return_value = []
 
         await service.list_files(session_id="sess_123", limit=100)
 
-        # 验证 limit 参数被正确传递（通过位置参数）
+        # Verify expected behavior.
         call_args = storage_service.list_files.call_args[0]
         assert call_args[1] == 100
 
     @pytest.mark.asyncio
     async def test_list_files_empty_directory(self, service, session_repo, storage_service, active_session):
-        """测试列出空目录（S3 返回目录本身作为 0 大小对象）"""
+        """Test list files empty directory."""
         session_repo.find_by_id.return_value = active_session
-        # S3 返回目录标记本身（以 / 结尾，size=0）
+        # S3-related test setup.
         storage_service.list_files.return_value = [
             {
                 "key": "s3://sandbox-workspace/sessions/sess_123/",
@@ -589,6 +585,6 @@ class TestFileService:
 
         result = await service.list_files(session_id="sess_123")
 
-        # 应该过滤掉目录标记，返回空数组
+        # Expected return value.
         assert len(result) == 0
         assert result == []

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_cleanup_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_cleanup_service.py
@@ -103,7 +103,7 @@ class TestSessionCleanupService:
 
         assert result["idle_cleaned"] == 1
         assert idle_session.status == SessionStatus.TERMINATED
-        # Test setup.
+        # destroy_container may use container_id as the argument name.
         assert scheduler.destroy_container.called
         storage_service.delete_prefix.assert_called_once()
         session_repo.save.assert_called_once()
@@ -118,7 +118,7 @@ class TestSessionCleanupService:
 
         assert result["expired_cleaned"] == 1
         assert expired_session.status == SessionStatus.TERMINATED
-        # Test setup.
+        # destroy_container may use container_id as the argument name.
         assert scheduler.destroy_container.called
 
     @pytest.mark.asyncio
@@ -144,7 +144,7 @@ class TestSessionCleanupService:
                 workspace_path="s3://sandbox-workspace/sessions/sess_1",
                 runtime_type="docker",
                 container_id="container-1",
-                last_activity_at=datetime.now()  # Test setup.
+                last_activity_at=datetime.now()  # Active session.
             ),
             Session(
                 id="sess_2",
@@ -154,7 +154,7 @@ class TestSessionCleanupService:
                 workspace_path="s3://sandbox-workspace/sessions/sess_2",
                 runtime_type="docker",
                 container_id="container-2",
-                last_activity_at=datetime.now() - timedelta(minutes=40)  # Test setup.
+                last_activity_at=datetime.now() - timedelta(minutes=40)  # Idle session.
             ),
         ]
         storage_service.delete_prefix.return_value = 2
@@ -170,7 +170,7 @@ class TestSessionCleanupService:
         service = SessionCleanupService(
             session_repo=session_repo,
             scheduler=scheduler,
-            idle_timeout_minutes=-1,  # Test setup.
+            idle_timeout_minutes=-1,  # Disable idle timeout cleanup.
             max_lifetime_hours=6,
             storage_service=storage_service
         )
@@ -183,7 +183,7 @@ class TestSessionCleanupService:
             workspace_path="s3://sandbox-workspace/sessions/sess_idle",
             runtime_type="docker",
             container_id="container-idle",
-            last_activity_at=datetime.now() - timedelta(hours=10)  # Test setup.
+            last_activity_at=datetime.now() - timedelta(hours=10)  # Exceeds the idle threshold.
         )
         session_repo.find_by_status.return_value = [idle_session]
 
@@ -200,7 +200,7 @@ class TestSessionCleanupService:
             session_repo=session_repo,
             scheduler=scheduler,
             idle_timeout_minutes=30,
-            max_lifetime_hours=-1,  # Test setup.
+            max_lifetime_hours=-1,  # Disable max lifetime cleanup.
             storage_service=storage_service
         )
 
@@ -212,14 +212,14 @@ class TestSessionCleanupService:
             workspace_path="s3://sandbox-workspace/sessions/sess_expired",
             runtime_type="docker",
             container_id="container-expired",
-            created_at=datetime.now() - timedelta(days=1),  # Test setup.
+            created_at=datetime.now() - timedelta(days=1),  # Exceeds the lifetime threshold.
             last_activity_at=datetime.now()
         )
         session_repo.find_by_status.return_value = [expired_session]
 
         result = await service.cleanup_idle_sessions()
 
-        # Verify expected behavior.
+        # The expired session should not be cleaned up.
         assert result["expired_cleaned"] == 0
         assert expired_session.status == SessionStatus.RUNNING
 
@@ -235,10 +235,10 @@ class TestSessionCleanupService:
             runtime_type="docker",
             container_id="container-failed"
         )
-        # Expected return value.
+        # Use side_effect to distinguish return values for different status queries.
         session_repo.find_by_status.side_effect = [
-            [failed_session],  # Status-specific test setup.
-            []  # Status-specific test setup.
+            [failed_session],  # failed status query.
+            []  # timeout status query.
         ]
 
         result = await service.cleanup_orphaned_sessions()
@@ -258,10 +258,10 @@ class TestSessionCleanupService:
             runtime_type="docker",
             container_id="container-timeout"
         )
-        # Expected return value.
+        # Use side_effect to distinguish return values for different status queries.
         session_repo.find_by_status.side_effect = [
-            [],  # Status-specific test setup.
-            [timeout_session]  # Status-specific test setup.
+            [],  # failed status query.
+            [timeout_session]  # timeout status query.
         ]
 
         result = await service.cleanup_orphaned_sessions()
@@ -278,7 +278,7 @@ class TestSessionCleanupService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_failed",
             runtime_type="docker",
-            container_id=None  # Test setup.
+            container_id=None  # No container to clean up.
         )
         session_repo.find_by_status.return_value = [failed_session]
 
@@ -309,23 +309,23 @@ class TestSessionCleanupService:
     @pytest.mark.asyncio
     async def test_cleanup_session_without_workspace(self, service, storage_service):
         """Test cleanup session without workspace."""
-        # Verify expected behavior.
-        # S3-related test setup.
+        # Session entity validates that workspace_path is not empty.
+        # Use a non-S3 path here.
         session = Session(
             id="sess_123",
             template_id="python-basic",
             status=SessionStatus.RUNNING,
             resource_limit=ResourceLimit.default(),
-            workspace_path="local:/tmp/sess_123",  # S3-related test setup.
+            workspace_path="local:/tmp/sess_123",  # Non-S3 path, so S3 cleanup is not executed.
             runtime_type="docker"
         )
 
-        # Expected return value.
+        # Mock delete_prefix to return 0.
         storage_service.delete_prefix.return_value = 0
 
         deleted_count = await service.cleanup_session_files(session, "test_cleanup")
 
-        # S3-related test setup.
+        # Non-S3 paths may still run through cleanup, but the result should be 0.
         assert deleted_count == 0
 
     @pytest.mark.asyncio
@@ -378,7 +378,7 @@ class TestSessionCleanupService:
 
         result = await service.cleanup_idle_sessions()
 
-        # Status-specific test setup.
+        # Cleanup should continue even if container destruction fails.
         assert result["idle_cleaned"] == 1
         assert idle_session.status == SessionStatus.TERMINATED
         storage_service.delete_prefix.assert_called_once()

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_cleanup_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_cleanup_service.py
@@ -1,8 +1,4 @@
-"""
-会话清理服务单元测试
-
-测试 SessionCleanupService 的清理逻辑。
-"""
+"""Unit tests for session cleanup service."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime, timedelta
@@ -16,11 +12,11 @@ from src.domain.services.scheduler import IScheduler
 
 
 class TestSessionCleanupService:
-    """会话清理服务测试"""
+    """Tests for TestSessionCleanupService."""
 
     @pytest.fixture
     def session_repo(self):
-        """模拟会话仓储"""
+        """Create session repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -29,21 +25,21 @@ class TestSessionCleanupService:
 
     @pytest.fixture
     def scheduler(self):
-        """模拟调度器"""
+        """Create scheduler."""
         sched = Mock()
         sched.destroy_container = AsyncMock()
         return sched
 
     @pytest.fixture
     def storage_service(self):
-        """模拟存储服务"""
+        """Create storage service."""
         storage = Mock()
         storage.delete_prefix = AsyncMock()
         return storage
 
     @pytest.fixture
     def service(self, session_repo, scheduler, storage_service):
-        """创建会话清理服务"""
+        """Create service."""
         return SessionCleanupService(
             session_repo=session_repo,
             scheduler=scheduler,
@@ -54,7 +50,7 @@ class TestSessionCleanupService:
 
     @pytest.fixture
     def active_session(self):
-        """创建活跃会话"""
+        """Create active session."""
         return Session(
             id="sess_active",
             template_id="python-basic",
@@ -68,7 +64,7 @@ class TestSessionCleanupService:
 
     @pytest.fixture
     def idle_session(self):
-        """创建空闲会话"""
+        """Create idle session."""
         old_time = datetime.now() - timedelta(minutes=35)
         return Session(
             id="sess_idle",
@@ -83,7 +79,7 @@ class TestSessionCleanupService:
 
     @pytest.fixture
     def expired_session(self):
-        """创建过期会话"""
+        """Create expired session."""
         old_time = datetime.now() - timedelta(hours=7)
         return Session(
             id="sess_expired",
@@ -99,7 +95,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_idle_sessions(self, service, session_repo, scheduler, storage_service, idle_session):
-        """测试清理空闲会话"""
+        """Test cleanup idle sessions."""
         session_repo.find_by_status.return_value = [idle_session]
         storage_service.delete_prefix.return_value = 5
 
@@ -107,14 +103,14 @@ class TestSessionCleanupService:
 
         assert result["idle_cleaned"] == 1
         assert idle_session.status == SessionStatus.TERMINATED
-        # destroy_container 可能使用 container_id 参数名
+        # Test setup.
         assert scheduler.destroy_container.called
         storage_service.delete_prefix.assert_called_once()
         session_repo.save.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cleanup_expired_sessions(self, service, session_repo, scheduler, storage_service, expired_session):
-        """测试清理过期会话"""
+        """Test cleanup expired sessions."""
         session_repo.find_by_status.return_value = [expired_session]
         storage_service.delete_prefix.return_value = 3
 
@@ -122,12 +118,12 @@ class TestSessionCleanupService:
 
         assert result["expired_cleaned"] == 1
         assert expired_session.status == SessionStatus.TERMINATED
-        # destroy_container 可能使用 container_id 参数名
+        # Test setup.
         assert scheduler.destroy_container.called
 
     @pytest.mark.asyncio
     async def test_no_cleanup_for_active_sessions(self, service, session_repo, active_session):
-        """测试不清理活跃会话"""
+        """Test no cleanup for active sessions."""
         session_repo.find_by_status.return_value = [active_session]
 
         result = await service.cleanup_idle_sessions()
@@ -138,7 +134,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_mixed_sessions(self, service, session_repo, scheduler, storage_service):
-        """测试清理混合状态的会话"""
+        """Test cleanup mixed sessions."""
         session_repo.find_by_status.return_value = [
             Session(
                 id="sess_1",
@@ -148,7 +144,7 @@ class TestSessionCleanupService:
                 workspace_path="s3://sandbox-workspace/sessions/sess_1",
                 runtime_type="docker",
                 container_id="container-1",
-                last_activity_at=datetime.now()  # 活跃
+                last_activity_at=datetime.now()  # Test setup.
             ),
             Session(
                 id="sess_2",
@@ -158,7 +154,7 @@ class TestSessionCleanupService:
                 workspace_path="s3://sandbox-workspace/sessions/sess_2",
                 runtime_type="docker",
                 container_id="container-2",
-                last_activity_at=datetime.now() - timedelta(minutes=40)  # 空闲
+                last_activity_at=datetime.now() - timedelta(minutes=40)  # Test setup.
             ),
         ]
         storage_service.delete_prefix.return_value = 2
@@ -170,11 +166,11 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_disabled_idle_timeout(self, session_repo, scheduler, storage_service):
-        """测试禁用空闲超时清理"""
+        """Test cleanup disabled idle timeout."""
         service = SessionCleanupService(
             session_repo=session_repo,
             scheduler=scheduler,
-            idle_timeout_minutes=-1,  # 禁用
+            idle_timeout_minutes=-1,  # Test setup.
             max_lifetime_hours=6,
             storage_service=storage_service
         )
@@ -187,24 +183,24 @@ class TestSessionCleanupService:
             workspace_path="s3://sandbox-workspace/sessions/sess_idle",
             runtime_type="docker",
             container_id="container-idle",
-            last_activity_at=datetime.now() - timedelta(hours=10)  # 超过空闲阈值
+            last_activity_at=datetime.now() - timedelta(hours=10)  # Test setup.
         )
         session_repo.find_by_status.return_value = [idle_session]
 
         result = await service.cleanup_idle_sessions()
 
-        # 空闲会话不应被清理
+        # Verify expected behavior.
         assert result["idle_cleaned"] == 0
         assert idle_session.status == SessionStatus.RUNNING
 
     @pytest.mark.asyncio
     async def test_cleanup_disabled_max_lifetime(self, session_repo, scheduler, storage_service):
-        """测试禁用最大生命周期清理"""
+        """Test cleanup disabled max lifetime."""
         service = SessionCleanupService(
             session_repo=session_repo,
             scheduler=scheduler,
             idle_timeout_minutes=30,
-            max_lifetime_hours=-1,  # 禁用
+            max_lifetime_hours=-1,  # Test setup.
             storage_service=storage_service
         )
 
@@ -216,20 +212,20 @@ class TestSessionCleanupService:
             workspace_path="s3://sandbox-workspace/sessions/sess_expired",
             runtime_type="docker",
             container_id="container-expired",
-            created_at=datetime.now() - timedelta(days=1),  # 超过生命周期
+            created_at=datetime.now() - timedelta(days=1),  # Test setup.
             last_activity_at=datetime.now()
         )
         session_repo.find_by_status.return_value = [expired_session]
 
         result = await service.cleanup_idle_sessions()
 
-        # 过期会话不应被清理
+        # Verify expected behavior.
         assert result["expired_cleaned"] == 0
         assert expired_session.status == SessionStatus.RUNNING
 
     @pytest.mark.asyncio
     async def test_cleanup_orphaned_failed_sessions(self, service, session_repo):
-        """测试清理孤立的失败会话"""
+        """Test cleanup orphaned failed sessions."""
         failed_session = Session(
             id="sess_failed",
             template_id="python-basic",
@@ -239,10 +235,10 @@ class TestSessionCleanupService:
             runtime_type="docker",
             container_id="container-failed"
         )
-        # 使用 side_effect 区分不同参数的返回值
+        # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [failed_session],  # failed 状态查询
-            []  # timeout 状态查询
+            [failed_session],  # Status-specific test setup.
+            []  # Status-specific test setup.
         ]
 
         result = await service.cleanup_orphaned_sessions()
@@ -252,7 +248,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_orphaned_timeout_sessions(self, service, session_repo):
-        """测试清理孤立超时会话"""
+        """Test cleanup orphaned timeout sessions."""
         timeout_session = Session(
             id="sess_timeout",
             template_id="python-basic",
@@ -262,10 +258,10 @@ class TestSessionCleanupService:
             runtime_type="docker",
             container_id="container-timeout"
         )
-        # 使用 side_effect 区分不同参数的返回值
+        # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [],  # failed 状态查询
-            [timeout_session]  # timeout 状态查询
+            [],  # Status-specific test setup.
+            [timeout_session]  # Status-specific test setup.
         ]
 
         result = await service.cleanup_orphaned_sessions()
@@ -274,7 +270,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_orphaned_without_container(self, service, session_repo):
-        """测试不清理没有容器的孤立会话"""
+        """Test cleanup orphaned without container."""
         failed_session = Session(
             id="sess_failed",
             template_id="python-basic",
@@ -282,7 +278,7 @@ class TestSessionCleanupService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_failed",
             runtime_type="docker",
-            container_id=None  # 没有容器
+            container_id=None  # Test setup.
         )
         session_repo.find_by_status.return_value = [failed_session]
 
@@ -292,7 +288,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_session_files(self, service, storage_service):
-        """测试清理会话文件"""
+        """Test cleanup session files."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -312,29 +308,29 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_session_without_workspace(self, service, storage_service):
-        """测试清理没有 workspace 的会话"""
-        # 注意：Session 实体会验证 workspace_path 不能为空
-        # 所以这里使用非 S3 路径
+        """Test cleanup session without workspace."""
+        # Verify expected behavior.
+        # S3-related test setup.
         session = Session(
             id="sess_123",
             template_id="python-basic",
             status=SessionStatus.RUNNING,
             resource_limit=ResourceLimit.default(),
-            workspace_path="local:/tmp/sess_123",  # 非 S3 路径，不会执行 S3 清理
+            workspace_path="local:/tmp/sess_123",  # S3-related test setup.
             runtime_type="docker"
         )
 
-        # 模拟 delete_prefix 返回 0
+        # Expected return value.
         storage_service.delete_prefix.return_value = 0
 
         deleted_count = await service.cleanup_session_files(session, "test_cleanup")
 
-        # 非 S3 路径可能仍会执行清理，但结果应为 0
+        # S3-related test setup.
         assert deleted_count == 0
 
     @pytest.mark.asyncio
     async def test_cleanup_by_ids(self, service, session_repo):
-        """测试按 ID 清理会话"""
+        """Test cleanup by ids."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -353,7 +349,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_by_ids_not_found(self, service, session_repo):
-        """测试按 ID 清理不存在的会话"""
+        """Test cleanup by ids not found."""
         session_repo.find_by_id.return_value = None
 
         result = await service.cleanup_by_ids(["non-existent"])
@@ -363,7 +359,7 @@ class TestSessionCleanupService:
 
     @pytest.mark.asyncio
     async def test_cleanup_container_destruction_failure(self, service, session_repo, scheduler, storage_service):
-        """测试容器销毁失败时的处理"""
+        """Test cleanup container destruction failure."""
         idle_session = Session(
             id="sess_idle",
             template_id="python-basic",
@@ -376,20 +372,20 @@ class TestSessionCleanupService:
         )
         session_repo.find_by_status.return_value = [idle_session]
 
-        # 模拟容器销毁失败
+        # Mock test dependency.
         scheduler.destroy_container.side_effect = Exception("Docker error")
         storage_service.delete_prefix.return_value = 2
 
         result = await service.cleanup_idle_sessions()
 
-        # 应继续执行文件清理和状态更新
+        # Status-specific test setup.
         assert result["idle_cleaned"] == 1
         assert idle_session.status == SessionStatus.TERMINATED
         storage_service.delete_prefix.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cleanup_error_handling(self, service, session_repo):
-        """测试清理过程中的错误处理"""
+        """Test cleanup error handling."""
         session_repo.find_by_status.side_effect = Exception("Database error")
 
         result = await service.cleanup_idle_sessions()

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_service.py
@@ -117,7 +117,7 @@ class TestSessionService:
         )
         scheduler.schedule.return_value = runtime_node
 
-        # Test setup.
+        # Execute the command.
         command = CreateSessionCommand(
             template_id="python-datascience", timeout=300, resource_limit=ResourceLimit.default()
         )
@@ -126,9 +126,9 @@ class TestSessionService:
 
         # Verify expected behavior.
         assert result.template_id == "python-datascience"
-        # Status-specific test setup.
+        # Status may be CREATING or RUNNING depending on the implementation.
         assert result.status in (SessionStatus.CREATING.value, SessionStatus.RUNNING.value)
-        assert session_repo.save.call_count >= 1  # Test setup.
+        assert session_repo.save.call_count >= 1  # Save at least once.
 
     @pytest.mark.asyncio
     async def test_create_session_template_not_found(self, service, template_repo):
@@ -643,7 +643,7 @@ class TestSessionService:
         self, service, session_repo, execution_repo
     ):
         """Test get session executions session not found."""
-        # Test setup.
+        # list_executions does not check whether the session exists; it queries execution records directly.
         execution_repo.find_by_session_id.return_value = []
 
         result = await service.list_executions("non-existent")

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_service.py
@@ -1,8 +1,4 @@
-"""
-会话应用服务单元测试
-
-测试 SessionService 的用例编排逻辑。
-"""
+"""Unit tests for session service."""
 
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -30,11 +26,11 @@ from src.shared.errors.domain import ConflictError, NotFoundError, ValidationErr
 
 
 class TestSessionService:
-    """会话应用服务测试"""
+    """Tests for TestSessionService."""
 
     @pytest.fixture
     def session_repo(self):
-        """模拟会话仓储"""
+        """Create session repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -42,14 +38,14 @@ class TestSessionService:
 
     @pytest.fixture
     def template_repo(self):
-        """模拟模板仓储"""
+        """Create template repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         return repo
 
     @pytest.fixture
     def scheduler(self):
-        """模拟调度器"""
+        """Create scheduler."""
         scheduler = Mock()
         scheduler.schedule = AsyncMock()
         scheduler.create_container_for_session = AsyncMock(return_value="container-123")
@@ -59,7 +55,7 @@ class TestSessionService:
 
     @pytest.fixture
     def execution_repo(self):
-        """模拟执行仓储"""
+        """Create execution repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -86,7 +82,7 @@ class TestSessionService:
         executor_client,
         initial_dependency_sync_scheduler,
     ):
-        """创建会话服务"""
+        """Create service."""
         return SessionService(
             session_repo=session_repo,
             execution_repo=execution_repo,
@@ -98,8 +94,8 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_create_session_success(self, service, template_repo, scheduler, session_repo):
-        """测试成功创建会话"""
-        # 设置模拟返回值
+        """Test create session success."""
+        # Expected return value.
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -121,22 +117,22 @@ class TestSessionService:
         )
         scheduler.schedule.return_value = runtime_node
 
-        # 执行命令
+        # Test setup.
         command = CreateSessionCommand(
             template_id="python-datascience", timeout=300, resource_limit=ResourceLimit.default()
         )
 
         result = await service.create_session(command)
 
-        # 验证
+        # Verify expected behavior.
         assert result.template_id == "python-datascience"
-        # 状态可能是 CREATING 或 RUNNING，取决于具体实现
+        # Status-specific test setup.
         assert result.status in (SessionStatus.CREATING.value, SessionStatus.RUNNING.value)
-        assert session_repo.save.call_count >= 1  # 至少保存一次
+        assert session_repo.save.call_count >= 1  # Test setup.
 
     @pytest.mark.asyncio
     async def test_create_session_template_not_found(self, service, template_repo):
-        """测试模板不存在"""
+        """Test create session template not found."""
         template_repo.find_by_id.return_value = None
 
         command = CreateSessionCommand(template_id="non-existent", timeout=300)
@@ -153,7 +149,7 @@ class TestSessionService:
         session_repo,
         monkeypatch,
     ):
-        """测试未指定模板时使用默认模板配置"""
+        """Test create session uses default template when omitted."""
         monkeypatch.setattr(
             "src.application.services.session_service.get_settings",
             lambda: SimpleNamespace(
@@ -191,7 +187,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_get_session_success(self, service, session_repo):
-        """测试成功获取会话"""
+        """Test get session success."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -213,7 +209,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_get_session_not_found(self, service, session_repo):
-        """测试会话不存在"""
+        """Test get session not found."""
         session_repo.find_by_id.return_value = None
 
         from src.application.queries.get_session import GetSessionQuery
@@ -225,7 +221,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_terminate_session_success(self, service, session_repo):
-        """测试成功终止会话"""
+        """Test terminate session success."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -243,7 +239,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_terminate_already_terminated(self, service, session_repo):
-        """测试终止已终止的会话"""
+        """Test terminate already terminated."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -257,12 +253,12 @@ class TestSessionService:
         result = await service.terminate_session("sess_20240115_abc123")
 
         assert result.status == SessionStatus.TERMINATED.value
-        # 不应该再次调用 save
+        # Verify expected behavior.
         session_repo.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_session_success(self, service, session_repo, execution_repo):
-        """测试成功删除会话（硬删除，级联删除执行记录）"""
+        """Test delete session success."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -286,7 +282,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_delete_session_not_found(self, service, session_repo):
-        """测试删除不存在的会话"""
+        """Test delete session not found."""
         session_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Session not found"):
@@ -299,7 +295,7 @@ class TestSessionService:
     async def test_create_session_with_manual_id(
         self, service, template_repo, scheduler, session_repo
     ):
-        """测试使用手动指定 ID 创建会话"""
+        """Test create session with manual ID."""
         template = Template(
             id="python-test", name="Python Test", image="python:3.11", base_image="python:3.11-slim"
         )
@@ -318,7 +314,7 @@ class TestSessionService:
         )
         scheduler.schedule.return_value = runtime_node
 
-        # 第一个调用返回 None（检查 ID 是否存在），后续调用返回会话
+        # Expected return value.
         session_repo.find_by_id.side_effect = [None, None]
 
         command = CreateSessionCommand(
@@ -465,7 +461,7 @@ class TestSessionService:
     async def test_create_session_with_duplicate_id(
         self, service, template_repo, scheduler, session_repo
     ):
-        """测试使用重复 ID 创建会话"""
+        """Test create session with duplicate ID."""
         template = Template(
             id="python-test", name="Python Test", image="python:3.11", base_image="python:3.11-slim"
         )
@@ -499,7 +495,7 @@ class TestSessionService:
         session_repo,
         initial_dependency_sync_scheduler,
     ):
-        """测试创建带依赖的会话"""
+        """Test create session with dependencies."""
         template = Template(
             id="python-test", name="Python Test", image="python:3.11", base_image="python:3.11-slim"
         )
@@ -534,7 +530,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_list_sessions(self, service, session_repo):
-        """测试列出会话"""
+        """Test list sessions."""
         sessions = [
             Session(
                 id="sess_1",
@@ -563,7 +559,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_list_sessions_by_status(self, service, session_repo):
-        """测试按状态列出会话"""
+        """Test list sessions by status."""
         sessions = [
             Session(
                 id="sess_1",
@@ -584,7 +580,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_terminate_session_not_found(self, service, session_repo):
-        """测试终止不存在的会话"""
+        """Test terminate session not found."""
         session_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Session not found"):
@@ -592,7 +588,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_terminate_session_with_container(self, service, session_repo, scheduler):
-        """测试终止带容器的会话"""
+        """Test terminate session with container."""
         session = Session(
             id="sess_123",
             template_id="python-test",
@@ -611,7 +607,7 @@ class TestSessionService:
 
     @pytest.mark.asyncio
     async def test_get_session_executions(self, service, session_repo, execution_repo):
-        """测试获取会话的执行记录"""
+        """Test get session executions."""
         session = Session(
             id="sess_123",
             template_id="python-test",
@@ -646,20 +642,20 @@ class TestSessionService:
     async def test_get_session_executions_session_not_found(
         self, service, session_repo, execution_repo
     ):
-        """测试获取不存在会话的执行记录"""
-        # list_executions 不检查会话是否存在，直接查询执行记录
+        """Test get session executions session not found."""
+        # Test setup.
         execution_repo.find_by_session_id.return_value = []
 
         result = await service.list_executions("non-existent")
 
-        # 应该返回空列表
+        # Invalid input case.
         assert result == []
 
     @pytest.mark.asyncio
     async def test_create_session_without_container_creation_support(
         self, session_repo, template_repo, scheduler
     ):
-        """调度器不支持容器创建时保留创建中的会话记录。"""
+        """Test create session without container creation support."""
         scheduler_without_container_create = SimpleNamespace(schedule=scheduler.schedule)
         service = SessionService(
             session_repo=session_repo,

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_stuck_creating_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_stuck_creating_service.py
@@ -1,8 +1,4 @@
-"""
-会话创建超时检测服务单元测试
-
-测试 SessionStuckCreatingService 的超时检测逻辑。
-"""
+"""Unit tests for session stuck creating service."""
 import pytest
 from unittest.mock import Mock, AsyncMock
 from datetime import datetime, timedelta
@@ -15,11 +11,11 @@ from src.domain.repositories.session_repository import ISessionRepository
 
 
 class TestSessionStuckCreatingService:
-    """会话创建超时检测服务测试"""
+    """Tests for TestSessionStuckCreatingService."""
 
     @pytest.fixture
     def session_repo(self):
-        """模拟会话仓储"""
+        """Create session repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -28,16 +24,16 @@ class TestSessionStuckCreatingService:
 
     @pytest.fixture
     def service(self, session_repo):
-        """创建会话创建超时检测服务"""
+        """Create service."""
         return SessionStuckCreatingService(
             session_repo=session_repo,
-            creating_timeout_seconds=300,  # 5 分钟
+            creating_timeout_seconds=300,  # Timing-related test setup.
         )
 
     @pytest.fixture
     def creating_session_stuck(self):
-        """创建卡在 creating 状态的超时会话"""
-        old_time = datetime.now() - timedelta(minutes=6)  # 超过 5 分钟阈值
+        """Create creating session stuck."""
+        old_time = datetime.now() - timedelta(minutes=6)  # Timing-related test setup.
         return Session(
             id="sess_stuck",
             template_id="python-basic",
@@ -50,8 +46,8 @@ class TestSessionStuckCreatingService:
 
     @pytest.fixture
     def creating_session_recent(self):
-        """创建最近创建的 creating 状态会话（未超时）"""
-        recent_time = datetime.now() - timedelta(minutes=2)  # 未超过 5 分钟阈值
+        """Create creating session recent."""
+        recent_time = datetime.now() - timedelta(minutes=2)  # Timing-related test setup.
         return Session(
             id="sess_recent",
             template_id="python-basic",
@@ -64,7 +60,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_mark_stuck_session_as_failed(self, service, session_repo, creating_session_stuck):
-        """测试标记超时的 creating 会话为 failed"""
+        """Test mark stuck session as failed."""
         session_repo.find_by_status.return_value = [creating_session_stuck]
 
         result = await service.check_and_mark_stuck_sessions()
@@ -76,7 +72,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_keep_recent_creating_session(self, service, session_repo, creating_session_recent):
-        """测试不标记未超时的 creating 会话"""
+        """Test keep recent creating session."""
         session_repo.find_by_status.return_value = [creating_session_recent]
 
         result = await service.check_and_mark_stuck_sessions()
@@ -88,7 +84,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_check_mixed_creating_sessions(self, service, session_repo):
-        """测试检查混合状态的 creating 会话"""
+        """Test check mixed creating sessions."""
         stuck_time = datetime.now() - timedelta(minutes=6)
         recent_time = datetime.now() - timedelta(minutes=2)
 
@@ -100,7 +96,7 @@ class TestSessionStuckCreatingService:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_1",
                 runtime_type="docker",
-                created_at=stuck_time,  # 超时
+                created_at=stuck_time,  # Timing-related test setup.
             ),
             Session(
                 id="sess_2",
@@ -109,7 +105,7 @@ class TestSessionStuckCreatingService:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_2",
                 runtime_type="docker",
-                created_at=recent_time,  # 未超时
+                created_at=recent_time,  # Test setup.
             ),
         ]
 
@@ -120,7 +116,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_no_creating_sessions(self, service, session_repo):
-        """测试没有 creating 会话时的情况"""
+        """Test no creating sessions."""
         session_repo.find_by_status.return_value = []
 
         result = await service.check_and_mark_stuck_sessions()
@@ -130,13 +126,13 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_custom_timeout_threshold(self, session_repo):
-        """测试自定义超时阈值"""
+        """Test custom timeout threshold."""
         service = SessionStuckCreatingService(
             session_repo=session_repo,
-            creating_timeout_seconds=60,  # 1 分钟
+            creating_timeout_seconds=60,  # Timing-related test setup.
         )
 
-        # 创建 2 分钟前创建的会话（超过自定义阈值）
+        # Timing-related test setup.
         old_time = datetime.now() - timedelta(minutes=2)
         stuck_session = Session(
             id="sess_stuck",
@@ -156,7 +152,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_error_handling(self, service, session_repo):
-        """测试错误处理"""
+        """Test error handling."""
         session_repo.find_by_status.side_effect = Exception("Database error")
 
         result = await service.check_and_mark_stuck_sessions()
@@ -167,7 +163,7 @@ class TestSessionStuckCreatingService:
 
     @pytest.mark.asyncio
     async def test_session_without_created_at(self, service, session_repo):
-        """测试没有 created_at 的会话（边界情况）"""
+        """Test session without created at."""
         session = Session(
             id="sess_no_created_at",
             template_id="python-basic",
@@ -175,20 +171,20 @@ class TestSessionStuckCreatingService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_no_created_at",
             runtime_type="docker",
-            created_at=None,  # 没有 created_at
+            created_at=None,  # Create test data.
         )
         session_repo.find_by_status.return_value = [session]
 
         result = await service.check_and_mark_stuck_sessions()
 
-        # 没有 created_at 的会话不应被标记为失败（无法判断是否超时）
+        # Verify expected behavior.
         assert result["marked_failed"] == 0
         assert session.status == SessionStatus.CREATING
 
     @pytest.mark.asyncio
     async def test_exactly_at_threshold(self, service, session_repo):
-        """测试恰好等于阈值的情况"""
-        # 创建恰好 5 分钟前的会话
+        """Test exactly at threshold."""
+        # Timing-related test setup.
         exact_threshold_time = datetime.now() - timedelta(seconds=300)
         session = Session(
             id="sess_exact",
@@ -203,5 +199,5 @@ class TestSessionStuckCreatingService:
 
         result = await service.check_and_mark_stuck_sessions()
 
-        # 恰好等于阈值应被标记为失败（因为检查时间略有延迟）
+        # Test setup.
         assert result["marked_failed"] == 1

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_stuck_creating_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_session_stuck_creating_service.py
@@ -27,13 +27,13 @@ class TestSessionStuckCreatingService:
         """Create service."""
         return SessionStuckCreatingService(
             session_repo=session_repo,
-            creating_timeout_seconds=300,  # Timing-related test setup.
+            creating_timeout_seconds=300,  # 5 minutes.
         )
 
     @pytest.fixture
     def creating_session_stuck(self):
         """Create creating session stuck."""
-        old_time = datetime.now() - timedelta(minutes=6)  # Timing-related test setup.
+        old_time = datetime.now() - timedelta(minutes=6)  # Exceeds the 5-minute threshold.
         return Session(
             id="sess_stuck",
             template_id="python-basic",
@@ -47,7 +47,7 @@ class TestSessionStuckCreatingService:
     @pytest.fixture
     def creating_session_recent(self):
         """Create creating session recent."""
-        recent_time = datetime.now() - timedelta(minutes=2)  # Timing-related test setup.
+        recent_time = datetime.now() - timedelta(minutes=2)  # Does not exceed the 5-minute threshold.
         return Session(
             id="sess_recent",
             template_id="python-basic",
@@ -96,7 +96,7 @@ class TestSessionStuckCreatingService:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_1",
                 runtime_type="docker",
-                created_at=stuck_time,  # Timing-related test setup.
+                created_at=stuck_time,  # Timed out.
             ),
             Session(
                 id="sess_2",
@@ -105,7 +105,7 @@ class TestSessionStuckCreatingService:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_2",
                 runtime_type="docker",
-                created_at=recent_time,  # Test setup.
+                created_at=recent_time,  # Not timed out.
             ),
         ]
 
@@ -129,10 +129,10 @@ class TestSessionStuckCreatingService:
         """Test custom timeout threshold."""
         service = SessionStuckCreatingService(
             session_repo=session_repo,
-            creating_timeout_seconds=60,  # Timing-related test setup.
+            creating_timeout_seconds=60,  # 1 minute.
         )
 
-        # Timing-related test setup.
+        # Create a session created 2 minutes ago, exceeding the custom threshold.
         old_time = datetime.now() - timedelta(minutes=2)
         stuck_session = Session(
             id="sess_stuck",
@@ -171,7 +171,7 @@ class TestSessionStuckCreatingService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_no_created_at",
             runtime_type="docker",
-            created_at=None,  # Create test data.
+            created_at=None,  # No created_at value.
         )
         session_repo.find_by_status.return_value = [session]
 
@@ -184,7 +184,7 @@ class TestSessionStuckCreatingService:
     @pytest.mark.asyncio
     async def test_exactly_at_threshold(self, service, session_repo):
         """Test exactly at threshold."""
-        # Timing-related test setup.
+        # Create a session from exactly 5 minutes ago.
         exact_threshold_time = datetime.now() - timedelta(seconds=300)
         session = Session(
             id="sess_exact",
@@ -199,5 +199,5 @@ class TestSessionStuckCreatingService:
 
         result = await service.check_and_mark_stuck_sessions()
 
-        # Test setup.
+        # Exactly meeting the threshold should be marked as failed because the check time is slightly later.
         assert result["marked_failed"] == 1

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_state_sync_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_state_sync_service.py
@@ -130,8 +130,8 @@ class TestStateSyncService:
 
         # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [session1],  # Status-specific test setup.
-            [session2]   # Status-specific test setup.
+            [session1],  # running status query.
+            [session2]   # creating status query.
         ]
         container_scheduler.is_container_running.return_value = True
 
@@ -168,12 +168,12 @@ class TestStateSyncService:
 
         session_repo.find_by_status.return_value = [session1, session2]
 
-        # Test setup.
+        # The first container is healthy and the second is unhealthy.
         container_scheduler.is_container_running.side_effect = [True, False]
 
         result = await service.sync_on_startup()
 
-        # Status-specific test setup.
+        # find_by_status may be called multiple times for running and creating sessions.
         assert result["total"] >= 2
         assert result["healthy"] >= 1
         assert result["unhealthy"] >= 1
@@ -188,13 +188,13 @@ class TestStateSyncService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_no_container",
             runtime_type="docker",
-            container_id=None  # Test setup.
+            container_id=None  # No container.
         )
 
         # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [session],  # Status-specific test setup.
-            []         # Status-specific test setup.
+            [session],  # running status query.
+            []         # creating status query.
         ]
 
         result = await service.sync_on_startup()
@@ -524,7 +524,7 @@ class TestStateSyncService:
             container_id="container-creating"
         )
 
-        # Status-specific test setup.
+        # Only call find_by_status("running"), not "creating".
         session_repo.find_by_status.return_value = []
 
         result = await service.periodic_health_check()
@@ -630,7 +630,7 @@ class TestStateSyncService:
         container_scheduler.create_container.return_value = "new-container"
         template_repo.find_by_id.return_value = python_template
 
-        # Create test data.
+        # Do not pass scheduler; recovery will try to create a new container.
         result = await service._attempt_recovery(session)
 
         assert result is True

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_state_sync_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_state_sync_service.py
@@ -1,8 +1,4 @@
-"""
-状态同步服务单元测试
-
-测试 StateSyncService 的状态同步逻辑。
-"""
+"""Unit tests for state sync service."""
 import pytest
 from unittest.mock import Mock, AsyncMock
 from datetime import datetime, timedelta
@@ -18,11 +14,11 @@ from src.infrastructure.container_scheduler.base import IContainerScheduler
 
 
 class TestStateSyncService:
-    """状态同步服务测试"""
+    """Tests for TestStateSyncService."""
 
     @pytest.fixture
     def session_repo(self):
-        """模拟会话仓储"""
+        """Create session repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -33,7 +29,7 @@ class TestStateSyncService:
 
     @pytest.fixture
     def container_scheduler(self):
-        """模拟容器调度器"""
+        """Create container scheduler."""
         scheduler = Mock()
         scheduler.is_container_running = AsyncMock()
         scheduler.create_container = AsyncMock()
@@ -44,14 +40,14 @@ class TestStateSyncService:
 
     @pytest.fixture
     def template_repo(self):
-        """模拟模板仓储"""
+        """Create template repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         return repo
 
     @pytest.fixture
     def execution_repo(self):
-        """模拟执行仓储"""
+        """Create execution repo."""
         repo = Mock()
         repo.find_by_session_id = AsyncMock(return_value=[])
         repo.save = AsyncMock()
@@ -60,7 +56,7 @@ class TestStateSyncService:
 
     @pytest.fixture
     def service(self, session_repo, container_scheduler, template_repo, execution_repo):
-        """创建状态同步服务"""
+        """Create service."""
         return StateSyncService(
             session_repo=session_repo,
             container_scheduler=container_scheduler,
@@ -70,7 +66,7 @@ class TestStateSyncService:
 
     @pytest.fixture
     def python_template(self):
-        """创建测试模板"""
+        """Create python template."""
         return Template(
             id="python-basic",
             name="Python Basic",
@@ -84,7 +80,7 @@ class TestStateSyncService:
 
     @pytest.fixture
     def running_session(self):
-        """创建运行中的会话"""
+        """Create running session."""
         return Session(
             id="sess_running",
             template_id="python-basic",
@@ -98,7 +94,7 @@ class TestStateSyncService:
 
     @pytest.fixture
     def creating_session(self):
-        """创建创建中的会话"""
+        """Create creating session."""
         return Session(
             id="sess_creating",
             template_id="python-basic",
@@ -112,7 +108,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_sync_on_startup_all_healthy(self, service, session_repo, container_scheduler):
-        """测试启动同步时所有容器健康"""
+        """Test sync on startup all healthy."""
         session1 = Session(
             id="sess_1",
             template_id="python-basic",
@@ -132,23 +128,23 @@ class TestStateSyncService:
             container_id="container-2"
         )
 
-        # 使用 side_effect 区分不同参数的返回值
+        # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [session1],  # running 状态查询
-            [session2]   # creating 状态查询
+            [session1],  # Status-specific test setup.
+            [session2]   # Status-specific test setup.
         ]
         container_scheduler.is_container_running.return_value = True
 
         result = await service.sync_on_startup()
 
-        # 验证结果
+        # Verify expected behavior.
         assert result["total"] == 2
         assert result["healthy"] == 2
         assert result["unhealthy"] == 0
 
     @pytest.mark.asyncio
     async def test_sync_on_startup_with_unhealthy(self, service, session_repo, container_scheduler):
-        """测试启动同步时有不健康容器"""
+        """Test sync on startup with unhealthy."""
         session1 = Session(
             id="sess_1",
             template_id="python-basic",
@@ -172,19 +168,19 @@ class TestStateSyncService:
 
         session_repo.find_by_status.return_value = [session1, session2]
 
-        # 第一个健康，第二个不健康
+        # Test setup.
         container_scheduler.is_container_running.side_effect = [True, False]
 
         result = await service.sync_on_startup()
 
-        # find_by_status 可能被调用多次（running 和 creating）
+        # Status-specific test setup.
         assert result["total"] >= 2
         assert result["healthy"] >= 1
         assert result["unhealthy"] >= 1
 
     @pytest.mark.asyncio
     async def test_sync_on_startup_skip_no_container(self, service, session_repo):
-        """测试跳过没有 container_id 的会话"""
+        """Test sync on startup skip no container."""
         session = Session(
             id="sess_no_container",
             template_id="python-basic",
@@ -192,18 +188,18 @@ class TestStateSyncService:
             resource_limit=ResourceLimit.default(),
             workspace_path="s3://sandbox-workspace/sessions/sess_no_container",
             runtime_type="docker",
-            container_id=None  # 没有容器
+            container_id=None  # Test setup.
         )
 
-        # 使用 side_effect 区分不同参数的返回值
+        # Expected return value.
         session_repo.find_by_status.side_effect = [
-            [session],  # running 状态查询
-            []         # creating 状态查询
+            [session],  # Status-specific test setup.
+            []         # Status-specific test setup.
         ]
 
         result = await service.sync_on_startup()
 
-        # 验证不检查容器状态（因为会话没有 container_id）
+        # Verify expected behavior.
         assert result["total"] == 1
 
     @pytest.mark.asyncio
@@ -215,7 +211,7 @@ class TestStateSyncService:
         execution_repo,
         python_template,
     ):
-        """测试 K8s 启动接管时缺失 Pod 会直接重建，并标记中断执行。"""
+        """Test sync on startup K8s takeover recreates missing Pod."""
         service = StateSyncService(
             session_repo=session_repo,
             container_scheduler=container_scheduler,
@@ -267,7 +263,7 @@ class TestStateSyncService:
         template_repo,
         execution_repo,
     ):
-        """测试当前 owner 且健康的 Pod 会被保留。"""
+        """Test sync on startup K8s takeover keeps healthy current owner."""
         service = StateSyncService(
             session_repo=session_repo,
             container_scheduler=container_scheduler,
@@ -313,7 +309,7 @@ class TestStateSyncService:
         execution_repo,
         python_template,
     ):
-        """测试当前 owner 但不健康的 Pod 会先删除再重建，并标记中断执行。"""
+        """Test sync on startup K8s takeover recreates unhealthy current owner and marks execution failed."""
         scheduler = Mock(
             _cluster_node=Mock(type="kubernetes", id="k8s-cluster"),
             _owner_context=Mock(pod_name="cp-new", pod_uid="uid-new"),
@@ -376,7 +372,7 @@ class TestStateSyncService:
         execution_repo,
         python_template,
     ):
-        """测试仅 annotation 匹配而无 Pod ownerReference 时仍会接管重建。"""
+        """Test sync on startup K8s takeover recreates when only annotations match current owner."""
         scheduler = Mock(
             _cluster_node=Mock(type="kubernetes", id="k8s-cluster"),
             _owner_context=Mock(pod_name="cp-new", pod_uid="uid-new"),
@@ -427,7 +423,7 @@ class TestStateSyncService:
         execution_repo,
         python_template,
     ):
-        """测试 takeover 删除旧 Pod 并将未完成执行标记为失败。"""
+        """Test sync on startup K8s takeover recreates old owner and marks execution failed."""
         scheduler = Mock(
             _cluster_node=Mock(type="kubernetes", id="k8s-cluster"),
             _owner_context=Mock(pod_name="cp-new", pod_uid="uid-new"),
@@ -484,7 +480,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_periodic_health_check(self, service, session_repo, container_scheduler):
-        """测试定期健康检查"""
+        """Test periodic health check."""
         session1 = Session(
             id="sess_1",
             template_id="python-basic",
@@ -517,7 +513,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_periodic_health_check_only_running(self, service, session_repo):
-        """测试定期健康检查只检查 RUNNING 状态"""
+        """Test periodic health check only running."""
         creating_session = Session(
             id="sess_creating",
             template_id="python-basic",
@@ -528,7 +524,7 @@ class TestStateSyncService:
             container_id="container-creating"
         )
 
-        # 只调用 find_by_status("running")，不调用 "creating"
+        # Status-specific test setup.
         session_repo.find_by_status.return_value = []
 
         result = await service.periodic_health_check()
@@ -537,7 +533,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_check_session_health_success(self, service, session_repo, container_scheduler):
-        """测试检查单个会话健康状态"""
+        """Test check session health success."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -560,7 +556,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_check_session_health_not_found(self, service, session_repo):
-        """测试检查不存在的会话"""
+        """Test check session health not found."""
         session_repo.find_by_id.return_value = None
 
         result = await service.check_session_health("non-existent")
@@ -570,7 +566,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_check_session_health_no_container(self, service, session_repo):
-        """测试检查没有容器的会话"""
+        """Test check session health no container."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -590,7 +586,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_check_session_health_unhealthy(self, service, session_repo, container_scheduler):
-        """测试检查不健康的会话"""
+        """Test check session health unhealthy."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -618,7 +614,7 @@ class TestStateSyncService:
         template_repo,
         python_template,
     ):
-        """测试成功恢复会话"""
+        """Test recovery success."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -634,7 +630,7 @@ class TestStateSyncService:
         container_scheduler.create_container.return_value = "new-container"
         template_repo.find_by_id.return_value = python_template
 
-        # 不传入 scheduler 参数，恢复功能会尝试创建新容器
+        # Create test data.
         result = await service._attempt_recovery(session)
 
         assert result is True
@@ -653,7 +649,7 @@ class TestStateSyncService:
         template_repo,
         python_template,
     ):
-        """测试恢复成功后会刷新 last_activity_at，避免被空闲清理立即回收。"""
+        """Test recovery success refreshes last activity."""
         stale_last_activity = datetime.now() - timedelta(minutes=45)
         session = Session(
             id="sess_recovery_refresh",
@@ -685,7 +681,7 @@ class TestStateSyncService:
         template_repo,
         python_template,
     ):
-        """测试恢复失败时标记会话为失败"""
+        """Test recovery failure marks failed."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -713,7 +709,7 @@ class TestStateSyncService:
         container_scheduler,
         template_repo,
     ):
-        """测试恢复时模板不存在会标记失败且不创建容器"""
+        """Test recovery fails when template missing."""
         session = Session(
             id="sess_123",
             template_id="python-basic",
@@ -740,7 +736,7 @@ class TestStateSyncService:
         template_repo,
         execution_repo,
     ):
-        """测试启动同步会分页加载全部 active sessions，而不是受默认 limit 截断。"""
+        """Test sync on startup loads all active sessions via pagination."""
         class PaginatedSessionRepo:
             def __init__(self, pages):
                 self.pages = pages
@@ -813,7 +809,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_sync_error_handling(self, service, session_repo):
-        """测试同步过程中的错误处理"""
+        """Test sync error handling."""
         session_repo.find_by_status.side_effect = Exception("Database error")
 
         result = await service.sync_on_startup()
@@ -824,7 +820,7 @@ class TestStateSyncService:
 
     @pytest.mark.asyncio
     async def test_sync_empty_sessions(self, service, session_repo):
-        """测试没有会话需要同步"""
+        """Test sync empty sessions."""
         session_repo.find_by_status.return_value = []
 
         result = await service.sync_on_startup()

--- a/infra/sandbox/sandbox_control_plane/tests/unit/application/test_template_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/application/test_template_service.py
@@ -1,8 +1,4 @@
-"""
-模板应用服务单元测试
-
-测试 TemplateService 的用例编排逻辑。
-"""
+"""Unit tests for template service."""
 import pytest
 from unittest.mock import Mock, AsyncMock
 
@@ -17,11 +13,11 @@ from tests.helpers import create_mock_template
 
 
 class TestTemplateService:
-    """模板应用服务测试"""
+    """Tests for TestTemplateService."""
 
     @pytest.fixture
     def template_repo(self):
-        """模拟模板仓储"""
+        """Create template repo."""
         repo = Mock()
         repo.save = AsyncMock()
         repo.find_by_id = AsyncMock()
@@ -32,12 +28,12 @@ class TestTemplateService:
 
     @pytest.fixture
     def service(self, template_repo):
-        """创建模板服务"""
+        """Create service."""
         return TemplateService(template_repo=template_repo)
 
     @pytest.mark.asyncio
     async def test_create_template_success(self, service, template_repo):
-        """测试成功创建模板"""
+        """Test create template success."""
         template_repo.find_by_id.return_value = None
         template_repo.find_by_name.return_value = None
 
@@ -60,7 +56,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_create_template_duplicate_name(self, service, template_repo):
-        """测试创建重名模板"""
+        """Test create template duplicate name."""
         existing_template = create_mock_template(
             template_id="existing-id",
             name="Python Data Science"
@@ -84,7 +80,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_get_template_success(self, service, template_repo):
-        """测试成功获取模板"""
+        """Test get template success."""
         template = create_mock_template(
             template_id="python-datascience",
             name="Python Data Science",
@@ -100,7 +96,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_get_template_not_found(self, service, template_repo):
-        """测试获取不存在的模板"""
+        """Test get template not found."""
         template_repo.find_by_id.return_value = None
 
         query = GetTemplateQuery(template_id="non-existent")
@@ -110,7 +106,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_list_templates(self, service, template_repo):
-        """测试列出所有模板"""
+        """Test list templates."""
         templates = [
             create_mock_template("python-basic", "Python Basic", "python:3.11"),
             create_mock_template("python-datascience", "Python Data Science", "python:3.11-datascience"),
@@ -125,7 +121,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_list_templates_with_pagination(self, service, template_repo):
-        """测试分页列出模板"""
+        """Test list templates with pagination."""
         all_templates = [
             create_mock_template(f"template-{i}", f"Template {i}", "python:3.11")
             for i in range(5, 10)
@@ -139,7 +135,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_success(self, service, template_repo):
-        """测试成功更新模板"""
+        """Test update template success."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
         template_repo.find_by_name.return_value = None
@@ -157,7 +153,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_not_found(self, service, template_repo):
-        """测试更新不存在的模板"""
+        """Test update template not found."""
         template_repo.find_by_id.return_value = None
 
         command = UpdateTemplateCommand(
@@ -170,7 +166,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_duplicate_name(self, service, template_repo):
-        """测试更新模板为重名"""
+        """Test update template duplicate name."""
         template = create_mock_template("template-1", "Template 1")
         other_template = create_mock_template("template-2", "Template 2")
         template_repo.find_by_id.return_value = template
@@ -186,7 +182,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_resources(self, service, template_repo):
-        """测试更新模板资源"""
+        """Test update template resources."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
         template_repo.find_by_name.return_value = None
@@ -206,7 +202,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_delete_template_success(self, service, template_repo):
-        """测试成功删除模板"""
+        """Test delete template success."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
 
@@ -216,7 +212,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_delete_template_not_found(self, service, template_repo):
-        """测试删除不存在的模板"""
+        """Test delete template not found."""
         template_repo.find_by_id.return_value = None
 
         with pytest.raises(NotFoundError, match="Template not found"):
@@ -224,7 +220,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_same_name(self, service, template_repo):
-        """测试更新模板为相同名称（不应报错）"""
+        """Test update template same name."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
         template_repo.find_by_name.return_value = template
@@ -239,7 +235,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_name_to_new_value(self, service, template_repo):
-        """测试成功更新模板名称为新值"""
+        """Test update template name to new value."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
         template_repo.find_by_name.return_value = None  # No collision with new name
@@ -259,7 +255,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_timeout_to_new_value(self, service, template_repo):
-        """测试成功更新模板超时时间为新值"""
+        """Test update template timeout to new value."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
 
@@ -278,7 +274,7 @@ class TestTemplateService:
 
     @pytest.mark.asyncio
     async def test_update_template_timeout_to_zero(self, service, template_repo):
-        """测试更新模板超时时间为0（边界情况）"""
+        """Test update template timeout to zero."""
         template = create_mock_template("python-basic", "Python Basic", "python:3.11")
         template_repo.find_by_id.return_value = template
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_artifact.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_artifact.py
@@ -121,7 +121,7 @@ class TestArtifact:
             mime_type="text/plain"
         )
 
-        # Test setup.
+        # frozen=True means the object cannot be modified.
         with pytest.raises(Exception):  # FrozenInstanceError from dataclasses
             artifact.size = 2048
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_artifact.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_artifact.py
@@ -1,8 +1,4 @@
-"""
-文件制品值对象单元测试
-
-测试 Artifact 值对象的行为。
-"""
+"""Unit tests for artifact."""
 import pytest
 from datetime import datetime
 
@@ -10,20 +6,20 @@ from src.domain.value_objects.artifact import Artifact, ArtifactType
 
 
 class TestArtifactType:
-    """制品类型枚举测试"""
+    """Tests for TestArtifactType."""
 
     def test_artifact_values(self):
-        """测试制品类型枚举值"""
+        """Test artifact values."""
         assert ArtifactType.ARTIFACT == "artifact"
         assert ArtifactType.LOG == "log"
         assert ArtifactType.OUTPUT == "output"
 
 
 class TestArtifact:
-    """制品值对象测试"""
+    """Tests for TestArtifact."""
 
     def test_create_artifact_success(self):
-        """测试成功创建制品"""
+        """Test create artifact success."""
         artifact = Artifact(
             path="output/result.csv",
             size=1024,
@@ -38,7 +34,7 @@ class TestArtifact:
         assert artifact.type == ArtifactType.ARTIFACT
 
     def test_create_artifact_factory_method(self):
-        """测试使用工厂方法创建制品"""
+        """Test create artifact factory method."""
         artifact = Artifact.create(
             path="logs/execution.log",
             size=2048,
@@ -52,7 +48,7 @@ class TestArtifact:
         assert artifact.type == ArtifactType.LOG
 
     def test_create_artifact_with_checksum(self):
-        """测试创建带校验和的制品"""
+        """Test create artifact with checksum."""
         artifact = Artifact.create(
             path="output/data.json",
             size=4096,
@@ -64,7 +60,7 @@ class TestArtifact:
         assert artifact.checksum == "a1b2c3d4e5f6"
 
     def test_create_artifact_invalid_size(self):
-        """测试无效的文件大小"""
+        """Test create artifact invalid size."""
         with pytest.raises(ValueError, match="size cannot be negative"):
             Artifact.create(
                 path="output/file.txt",
@@ -73,7 +69,7 @@ class TestArtifact:
             )
 
     def test_create_artifact_empty_path(self):
-        """测试空路径"""
+        """Test create artifact empty path."""
         with pytest.raises(ValueError, match="path cannot be empty"):
             Artifact.create(
                 path="",
@@ -82,7 +78,7 @@ class TestArtifact:
             )
 
     def test_is_log(self):
-        """测试是否为日志文件"""
+        """Test is log."""
         log_artifact = Artifact.create(
             path="logs/output.log",
             size=1024,
@@ -100,7 +96,7 @@ class TestArtifact:
         assert data_artifact.is_log() is False
 
     def test_is_output(self):
-        """测试是否为输出文件"""
+        """Test is output."""
         output_artifact = Artifact.create(
             path="output/stdout.txt",
             size=2048,
@@ -118,19 +114,19 @@ class TestArtifact:
         assert log_artifact.is_output() is False
 
     def test_immutability(self):
-        """测试不可变性"""
+        """Test immutability."""
         artifact = Artifact.create(
             path="output/file.txt",
             size=1024,
             mime_type="text/plain"
         )
 
-        # frozen=True 意味着不可修改
+        # Test setup.
         with pytest.raises(Exception):  # FrozenInstanceError from dataclasses
             artifact.size = 2048
 
     def test_different_mime_types(self):
-        """测试不同的 MIME 类型"""
+        """Test different mime types."""
         csv_artifact = Artifact.create(
             path="data.csv",
             size=1024,
@@ -156,7 +152,7 @@ class TestArtifact:
         assert png_artifact.mime_type == "image/png"
 
     def test_zero_size_artifact(self):
-        """测试零大小制品"""
+        """Test zero size artifact."""
         artifact = Artifact.create(
             path="output/empty.txt",
             size=0,
@@ -165,7 +161,7 @@ class TestArtifact:
         assert artifact.size == 0
 
     def test_artifact_equality(self):
-        """测试制品相等性"""
+        """Test artifact equality."""
         dt = datetime.now()
         artifact1 = Artifact(
             path="output/file.txt",

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution.py
@@ -1,8 +1,4 @@
-"""
-执行实体单元测试
-
-测试 Execution 实体的领域行为。
-"""
+"""Unit tests for execution."""
 import pytest
 from datetime import datetime, timedelta
 
@@ -12,10 +8,10 @@ from src.domain.value_objects.artifact import Artifact, ArtifactType
 
 
 class TestExecution:
-    """执行实体测试"""
+    """Tests for TestExecution."""
 
     def test_create_execution(self):
-        """测试创建执行"""
+        """Test create execution."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -30,7 +26,7 @@ class TestExecution:
         assert execution.is_running() is False
 
     def test_mark_running(self):
-        """测试标记为运行中"""
+        """Test mark running."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -45,7 +41,7 @@ class TestExecution:
         assert execution.last_heartbeat_at is not None
 
     def test_mark_completed(self):
-        """测试标记为已完成"""
+        """Test mark completed."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -76,7 +72,7 @@ class TestExecution:
         assert len(execution.artifacts) == 1
 
     def test_mark_failed(self):
-        """测试标记为失败"""
+        """Test mark failed."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -95,7 +91,7 @@ class TestExecution:
         assert execution.state.exit_code == 1
 
     def test_mark_timeout(self):
-        """测试标记为超时"""
+        """Test mark timeout."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -109,7 +105,7 @@ class TestExecution:
         assert execution.state.status == ExecutionStatus.TIMEOUT
 
     def test_mark_crashed(self):
-        """测试标记为崩溃"""
+        """Test mark crashed."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -124,7 +120,7 @@ class TestExecution:
         assert execution.can_retry() is True
 
     def test_increment_retry_count(self):
-        """测试增加重试计数"""
+        """Test increment retry count."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -139,7 +135,7 @@ class TestExecution:
         assert execution.retry_count == 1
 
     def test_can_retry(self):
-        """测试是否可以重试"""
+        """Test can retry."""
         execution = Execution(
             id="exec_20240115_abc123",
             session_id="sess_20240115_xyz789",
@@ -153,7 +149,7 @@ class TestExecution:
         assert execution.can_retry(max_retries=2) is False
 
     def test_is_heartbeat_timeout(self):
-        """测试心跳超时检查"""
+        """Test is heartbeat timeout."""
         import time
 
         execution = Execution(
@@ -169,23 +165,23 @@ class TestExecution:
         assert execution.is_heartbeat_timeout(timeout_seconds=30) is False
 
     def test_invalid_empty_code(self):
-        """测试空代码"""
+        """Test invalid empty code."""
         with pytest.raises(ValueError, match="code cannot be empty"):
             Execution(
                 id="exec_20240115_abc123",
                 session_id="sess_20240115_xyz789",
-                code="",  # 无效值
+                code="",  # Test setup.
                 language="python",
                 state=ExecutionState(status=ExecutionStatus.PENDING)
             )
 
     def test_invalid_empty_language(self):
-        """测试空语言"""
+        """Test invalid empty language."""
         with pytest.raises(ValueError, match="language cannot be empty"):
             Execution(
                 id="exec_20240115_abc123",
                 session_id="sess_20240115_xyz789",
                 code="print('hello')",
-                language="",  # 无效值
+                language="",  # Test setup.
                 state=ExecutionState(status=ExecutionStatus.PENDING)
             )

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution.py
@@ -170,7 +170,7 @@ class TestExecution:
             Execution(
                 id="exec_20240115_abc123",
                 session_id="sess_20240115_xyz789",
-                code="",  # Test setup.
+                code="",  # Invalid value.
                 language="python",
                 state=ExecutionState(status=ExecutionStatus.PENDING)
             )
@@ -182,6 +182,6 @@ class TestExecution:
                 id="exec_20240115_abc123",
                 session_id="sess_20240115_xyz789",
                 code="print('hello')",
-                language="",  # Test setup.
+                language="",  # Invalid value.
                 state=ExecutionState(status=ExecutionStatus.PENDING)
             )

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_request.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_request.py
@@ -1,18 +1,14 @@
-"""
-执行请求值对象单元测试
-
-测试 ExecutionRequest 的功能。
-"""
+"""Unit tests for execution request."""
 import pytest
 
 from src.domain.value_objects.execution_request import ExecutionRequest
 
 
 class TestExecutionRequest:
-    """执行请求测试"""
+    """Tests for TestExecutionRequest."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -30,7 +26,7 @@ class TestExecutionRequest:
         assert request.session_id is None
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -47,7 +43,7 @@ class TestExecutionRequest:
         assert request.working_directory == "src/tasks"
 
     def test_language_python(self):
-        """测试 Python 语言"""
+        """Test language python."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -58,7 +54,7 @@ class TestExecutionRequest:
         assert request.language == "python"
 
     def test_language_javascript(self):
-        """测试 JavaScript 语言"""
+        """Test language javascript."""
         request = ExecutionRequest(
             code="console.log('hello')",
             language="javascript",
@@ -69,7 +65,7 @@ class TestExecutionRequest:
         assert request.language == "javascript"
 
     def test_language_shell(self):
-        """测试 Shell 语言"""
+        """Test language shell."""
         request = ExecutionRequest(
             code="echo hello",
             language="shell",
@@ -80,7 +76,7 @@ class TestExecutionRequest:
         assert request.language == "shell"
 
     def test_empty_code_raises_error(self):
-        """测试空代码抛出错误"""
+        """Test empty code raises error."""
         with pytest.raises(ValueError, match="code cannot be empty"):
             ExecutionRequest(
                 code="",
@@ -91,7 +87,7 @@ class TestExecutionRequest:
             )
 
     def test_empty_language_raises_error(self):
-        """测试空语言抛出错误"""
+        """Test empty language raises error."""
         with pytest.raises(ValueError, match="language cannot be empty"):
             ExecutionRequest(
                 code="print('hello')",
@@ -102,7 +98,7 @@ class TestExecutionRequest:
             )
 
     def test_timeout_below_minimum_raises_error(self):
-        """测试超时低于最小值抛出错误"""
+        """Test timeout below minimum raises error."""
         with pytest.raises(ValueError, match="timeout must be between 1 and 3600"):
             ExecutionRequest(
                 code="print('hello')",
@@ -113,7 +109,7 @@ class TestExecutionRequest:
             )
 
     def test_timeout_above_maximum_raises_error(self):
-        """测试超时高于最大值抛出错误"""
+        """Test timeout above maximum raises error."""
         with pytest.raises(ValueError, match="timeout must be between 1 and 3600"):
             ExecutionRequest(
                 code="print('hello')",
@@ -124,7 +120,7 @@ class TestExecutionRequest:
             )
 
     def test_timeout_negative_raises_error(self):
-        """测试负超时抛出错误"""
+        """Test timeout negative raises error."""
         with pytest.raises(ValueError, match="timeout must be between 1 and 3600"):
             ExecutionRequest(
                 code="print('hello')",
@@ -135,7 +131,7 @@ class TestExecutionRequest:
             )
 
     def test_unsupported_language_raises_error(self):
-        """测试不支持的语言抛出错误"""
+        """Test unsupported language raises error."""
         with pytest.raises(ValueError, match="unsupported language"):
             ExecutionRequest(
                 code="print('hello')",
@@ -146,7 +142,7 @@ class TestExecutionRequest:
             )
 
     def test_timeout_boundary_minimum(self):
-        """测试超时边界值（最小有效值）"""
+        """Test timeout boundary minimum."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -157,7 +153,7 @@ class TestExecutionRequest:
         assert request.timeout == 1
 
     def test_timeout_boundary_maximum(self):
-        """测试超时边界值（最大有效值）"""
+        """Test timeout boundary maximum."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -168,7 +164,7 @@ class TestExecutionRequest:
         assert request.timeout == 3600
 
     def test_env_vars_empty(self):
-        """测试空环境变量"""
+        """Test env vars empty."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -179,7 +175,7 @@ class TestExecutionRequest:
         assert request.env_vars == {}
 
     def test_env_vars_with_values(self):
-        """测试带值的环境变量"""
+        """Test env vars with values."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -190,7 +186,7 @@ class TestExecutionRequest:
         assert request.env_vars == {"DEBUG": "true", "API_KEY": "secret"}
 
     def test_event_empty(self):
-        """测试空事件"""
+        """Test event empty."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -201,7 +197,7 @@ class TestExecutionRequest:
         assert request.event == {}
 
     def test_event_with_nested_data(self):
-        """测试带嵌套数据的事件"""
+        """Test event with nested data."""
         event = {
             "name": "World",
             "data": {"key": "value"},
@@ -217,7 +213,7 @@ class TestExecutionRequest:
         assert request.event == event
 
     def test_working_directory_normalized(self):
-        """测试工作目录归一化"""
+        """Test working directory normalized."""
         request = ExecutionRequest(
             code="echo hello",
             language="shell",
@@ -230,7 +226,7 @@ class TestExecutionRequest:
         assert request.working_directory == "skill/mini-wiki"
 
     def test_invalid_working_directory_raises_error(self):
-        """测试非法工作目录抛出错误"""
+        """Test invalid working directory raises error."""
         with pytest.raises(ValueError, match="working_directory must be a relative workspace path"):
             ExecutionRequest(
                 code="echo hello",
@@ -242,12 +238,12 @@ class TestExecutionRequest:
             )
 
     def test_is_dataclass(self):
-        """测试是数据类"""
+        """Test is dataclass."""
         from dataclasses import is_dataclass
         assert is_dataclass(ExecutionRequest)
 
     def test_dataclass_equality(self):
-        """测试数据类相等性"""
+        """Test dataclass equality."""
         request1 = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -265,7 +261,7 @@ class TestExecutionRequest:
         assert request1 == request2
 
     def test_dataclass_inequality(self):
-        """测试数据类不等性"""
+        """Test dataclass inequality."""
         request1 = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -283,7 +279,7 @@ class TestExecutionRequest:
         assert request1 != request2
 
     def test_multiline_code(self):
-        """测试多行代码"""
+        """Test multiline code."""
         code = '''
 def greet(name):
     return f"Hello, {name}!"
@@ -300,7 +296,7 @@ print(greet("World"))
         assert "def greet" in request.code
 
     def test_optional_execution_id(self):
-        """测试可选执行 ID"""
+        """Test optional execution ID."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",
@@ -312,7 +308,7 @@ print(greet("World"))
         assert request.execution_id == "exec-123"
 
     def test_optional_session_id(self):
-        """测试可选会话 ID"""
+        """Test optional session ID."""
         request = ExecutionRequest(
             code="print('hello')",
             language="python",

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_state.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_state.py
@@ -172,7 +172,7 @@ class TestExecutionState:
             error_message="test"
         )
 
-        # Test setup.
+        # frozen=True means the object cannot be modified.
         with pytest.raises(Exception):  # FrozenInstanceError
             state.exit_code = 1
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_state.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_execution_state.py
@@ -1,8 +1,4 @@
-"""
-执行状态值对象单元测试
-
-测试 ExecutionState 值对象的行为。
-"""
+"""Unit tests for execution state."""
 import pytest
 
 from src.domain.value_objects.execution_status import (
@@ -13,10 +9,10 @@ from src.domain.value_objects.execution_status import (
 
 
 class TestSessionStatus:
-    """会话状态枚举测试"""
+    """Tests for TestSessionStatus."""
 
     def test_session_status_values(self):
-        """测试会话状态枚举值"""
+        """Test session status values."""
         assert SessionStatus.CREATING == "creating"
         assert SessionStatus.RUNNING == "running"
         assert SessionStatus.COMPLETED == "completed"
@@ -25,15 +21,15 @@ class TestSessionStatus:
         assert SessionStatus.TERMINATED == "terminated"
 
     def test_session_status_is_string(self):
-        """测试会话状态是字符串类型"""
+        """Test session status is string."""
         assert isinstance(SessionStatus.RUNNING, str)
 
 
 class TestExecutionStatus:
-    """执行状态枚举测试"""
+    """Tests for TestExecutionStatus."""
 
     def test_execution_status_values(self):
-        """测试执行状态枚举值"""
+        """Test execution status values."""
         assert ExecutionStatus.PENDING == "pending"
         assert ExecutionStatus.RUNNING == "running"
         assert ExecutionStatus.COMPLETED == "completed"
@@ -42,15 +38,15 @@ class TestExecutionStatus:
         assert ExecutionStatus.CRASHED == "crashed"
 
     def test_execution_status_is_string(self):
-        """测试执行状态是字符串类型"""
+        """Test execution status is string."""
         assert isinstance(ExecutionStatus.RUNNING, str)
 
 
 class TestExecutionState:
-    """执行状态值对象测试"""
+    """Tests for TestExecutionState."""
 
     def test_create_pending_state(self):
-        """测试创建等待状态"""
+        """Test create pending state."""
         state = ExecutionState(status=ExecutionStatus.PENDING)
 
         assert state.status == ExecutionStatus.PENDING
@@ -58,14 +54,14 @@ class TestExecutionState:
         assert state.error_message is None
 
     def test_create_running_state(self):
-        """测试创建运行中状态"""
+        """Test create running state."""
         state = ExecutionState(status=ExecutionStatus.RUNNING)
 
         assert state.status == ExecutionStatus.RUNNING
         assert state.is_terminal() is False
 
     def test_create_completed_state(self):
-        """测试创建完成状态"""
+        """Test create completed state."""
         state = ExecutionState(
             status=ExecutionStatus.COMPLETED,
             exit_code=0
@@ -77,7 +73,7 @@ class TestExecutionState:
         assert state.can_retry() is False
 
     def test_create_failed_state_with_error(self):
-        """测试创建失败状态（带错误信息）"""
+        """Test create failed state with error."""
         state = ExecutionState(
             status=ExecutionStatus.FAILED,
             exit_code=1,
@@ -91,7 +87,7 @@ class TestExecutionState:
         assert state.can_retry() is False
 
     def test_create_failed_state_without_error(self):
-        """测试创建失败状态（不带错误信息）"""
+        """Test create failed state without error."""
         state = ExecutionState(
             status=ExecutionStatus.FAILED,
             exit_code=1
@@ -103,7 +99,7 @@ class TestExecutionState:
         assert state.is_terminal() is True
 
     def test_create_timeout_state(self):
-        """测试创建超时状态"""
+        """Test create timeout state."""
         state = ExecutionState(
             status=ExecutionStatus.TIMEOUT,
             exit_code=124
@@ -114,7 +110,7 @@ class TestExecutionState:
         assert state.can_retry() is False
 
     def test_create_crashed_state(self):
-        """测试创建崩溃状态"""
+        """Test create crashed state."""
         state = ExecutionState(
             status=ExecutionStatus.CRASHED
         )
@@ -124,64 +120,64 @@ class TestExecutionState:
         assert state.can_retry() is True
 
     def test_is_terminal_for_pending(self):
-        """测试等待状态不是终态"""
+        """Test is terminal for pending."""
         state = ExecutionState(status=ExecutionStatus.PENDING)
         assert state.is_terminal() is False
 
     def test_is_terminal_for_running(self):
-        """测试运行中状态不是终态"""
+        """Test is terminal for running."""
         state = ExecutionState(status=ExecutionStatus.RUNNING)
         assert state.is_terminal() is False
 
     def test_is_terminal_for_completed(self):
-        """测试完成状态是终态"""
+        """Test is terminal for completed."""
         state = ExecutionState(status=ExecutionStatus.COMPLETED)
         assert state.is_terminal() is True
 
     def test_is_terminal_for_failed(self):
-        """测试失败状态是终态"""
+        """Test is terminal for failed."""
         state = ExecutionState(status=ExecutionStatus.FAILED)
         assert state.is_terminal() is True
 
     def test_is_terminal_for_timeout(self):
-        """测试超时状态是终态"""
+        """Test is terminal for timeout."""
         state = ExecutionState(status=ExecutionStatus.TIMEOUT)
         assert state.is_terminal() is True
 
     def test_can_retry_for_crashed(self):
-        """测试崩溃状态可以重试"""
+        """Test can retry for crashed."""
         state = ExecutionState(status=ExecutionStatus.CRASHED)
         assert state.can_retry() is True
 
     def test_can_retry_for_completed(self):
-        """测试完成状态不能重试"""
+        """Test can retry for completed."""
         state = ExecutionState(status=ExecutionStatus.COMPLETED)
         assert state.can_retry() is False
 
     def test_can_retry_for_failed(self):
-        """测试失败状态不能重试"""
+        """Test can retry for failed."""
         state = ExecutionState(status=ExecutionStatus.FAILED)
         assert state.can_retry() is False
 
     def test_can_retry_for_timeout(self):
-        """测试超时状态不能重试"""
+        """Test can retry for timeout."""
         state = ExecutionState(status=ExecutionStatus.TIMEOUT)
         assert state.can_retry() is False
 
     def test_immutability(self):
-        """测试不可变性"""
+        """Test immutability."""
         state = ExecutionState(
             status=ExecutionStatus.PENDING,
             exit_code=0,
             error_message="test"
         )
 
-        # frozen=True 意味着不可修改
+        # Test setup.
         with pytest.raises(Exception):  # FrozenInstanceError
             state.exit_code = 1
 
     def test_state_equality(self):
-        """测试状态相等性"""
+        """Test state equality."""
         state1 = ExecutionState(
             status=ExecutionStatus.COMPLETED,
             exit_code=0
@@ -199,7 +195,7 @@ class TestExecutionState:
         assert state1 != state3
 
     def test_all_terminal_statuses(self):
-        """测试所有终态状态"""
+        """Test all terminal statuses."""
         terminal_states = [
             ExecutionStatus.COMPLETED,
             ExecutionStatus.FAILED,
@@ -211,7 +207,7 @@ class TestExecutionState:
             assert state.is_terminal() is True
 
     def test_non_terminal_statuses(self):
-        """测试所有非终态状态"""
+        """Test non terminal statuses."""
         non_terminal_states = [
             ExecutionStatus.PENDING,
             ExecutionStatus.RUNNING,

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_resource_limit.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_resource_limit.py
@@ -1,18 +1,14 @@
-"""
-资源限制值对象单元测试
-
-测试 ResourceLimit 值对象的行为。
-"""
+"""Unit tests for resource limit."""
 import pytest
 
 from src.domain.value_objects.resource_limit import ResourceLimit
 
 
 class TestResourceLimit:
-    """资源限制值对象测试"""
+    """Tests for TestResourceLimit."""
 
     def test_create_default(self):
-        """测试创建默认资源限制"""
+        """Test create default."""
         limit = ResourceLimit.default()
 
         assert limit.cpu == "1"
@@ -21,7 +17,7 @@ class TestResourceLimit:
         assert limit.max_processes == 128
 
     def test_create_custom(self):
-        """测试创建自定义资源限制"""
+        """Test create custom."""
         limit = ResourceLimit(
             cpu="2",
             memory="1Gi",
@@ -35,7 +31,7 @@ class TestResourceLimit:
         assert limit.max_processes == 256
 
     def test_invalid_cpu(self):
-        """测试无效的 CPU 值"""
+        """Test invalid CPU."""
         with pytest.raises(ValueError, match="Invalid cpu format"):
             ResourceLimit(
                 cpu="invalid",
@@ -44,7 +40,7 @@ class TestResourceLimit:
             )
 
     def test_negative_cpu(self):
-        """测试负数 CPU"""
+        """Test negative CPU."""
         with pytest.raises(ValueError, match="cpu must be positive"):
             ResourceLimit(
                 cpu="-1",
@@ -53,7 +49,7 @@ class TestResourceLimit:
             )
 
     def test_invalid_memory_format(self):
-        """测试无效的内存格式"""
+        """Test invalid memory format."""
         with pytest.raises(ValueError, match="Invalid memory format"):
             ResourceLimit(
                 cpu="1",
@@ -62,7 +58,7 @@ class TestResourceLimit:
             )
 
     def test_invalid_disk_format(self):
-        """测试无效的磁盘格式"""
+        """Test invalid disk format."""
         with pytest.raises(ValueError, match="Invalid disk format"):
             ResourceLimit(
                 cpu="1",
@@ -71,7 +67,7 @@ class TestResourceLimit:
             )
 
     def test_negative_max_processes(self):
-        """测试负数最大进程数"""
+        """Test negative max processes."""
         with pytest.raises(ValueError, match="max_processes must be positive"):
             ResourceLimit(
                 cpu="1",
@@ -81,38 +77,38 @@ class TestResourceLimit:
             )
 
     def test_with_cpu(self):
-        """测试创建新的 CPU 限制"""
+        """Test with CPU."""
         limit = ResourceLimit.default()
         new_limit = limit.with_cpu("2")
 
-        # 原对象不变
+        # Test setup.
         assert limit.cpu == "1"
 
-        # 新对象有新值
+        # Test setup.
         assert new_limit.cpu == "2"
         assert new_limit.memory == limit.memory
 
     def test_with_memory(self):
-        """测试创建新的内存限制"""
+        """Test with memory."""
         limit = ResourceLimit.default()
         new_limit = limit.with_memory("1Gi")
 
-        # 原对象不变
+        # Test setup.
         assert limit.memory == "512Mi"
 
-        # 新对象有新值
+        # Test setup.
         assert new_limit.memory == "1Gi"
         assert new_limit.cpu == limit.cpu
 
     def test_frozen(self):
-        """测试值对象不可变"""
+        """Test frozen."""
         limit = ResourceLimit.default()
 
-        with pytest.raises(Exception):  # frozen.dataclass 会抛出异常
+        with pytest.raises(Exception):  # Test setup.
             limit.cpu = "2"
 
     def test_valid_size_formats(self):
-        """测试有效的大小格式"""
+        """Test valid size formats."""
         valid_formats = [
             ("512Mi", True),
             ("1Gi", True),

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_resource_limit.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_resource_limit.py
@@ -81,10 +81,10 @@ class TestResourceLimit:
         limit = ResourceLimit.default()
         new_limit = limit.with_cpu("2")
 
-        # Test setup.
+        # Original object is unchanged.
         assert limit.cpu == "1"
 
-        # Test setup.
+        # New object has the new value.
         assert new_limit.cpu == "2"
         assert new_limit.memory == limit.memory
 
@@ -93,10 +93,10 @@ class TestResourceLimit:
         limit = ResourceLimit.default()
         new_limit = limit.with_memory("1Gi")
 
-        # Test setup.
+        # Original object is unchanged.
         assert limit.memory == "512Mi"
 
-        # Test setup.
+        # New object has the new value.
         assert new_limit.memory == "1Gi"
         assert new_limit.cpu == limit.cpu
 
@@ -104,7 +104,7 @@ class TestResourceLimit:
         """Test frozen."""
         limit = ResourceLimit.default()
 
-        with pytest.raises(Exception):  # Test setup.
+        with pytest.raises(Exception):  # frozen.dataclass raises an exception.
             limit.cpu = "2"
 
     def test_valid_size_formats(self):

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_session.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_session.py
@@ -79,7 +79,7 @@ class TestSession:
 
     def test_is_idle(self):
         """Test is idle."""
-        # Create test data.
+        # Create a session that has been inactive for more than 30 minutes.
         old_time = datetime.now() - timedelta(minutes=35)
 
         session = Session(
@@ -96,7 +96,7 @@ class TestSession:
 
     def test_should_cleanup(self):
         """Test should cleanup."""
-        # Test setup.
+        # Idle session.
         old_time = datetime.now() - timedelta(minutes=35)
 
         session = Session(
@@ -154,7 +154,7 @@ class TestSession:
 
         execution = Execution(
             id="exec_20240115_xyz789",
-            session_id="different_session_id",  # Test setup.
+            session_id="different_session_id",  # Wrong session ID.
             code="print('hello')",
             language="python",
             state=ExecutionState(status=ExecutionStatus.PENDING),
@@ -173,7 +173,7 @@ class TestSession:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_20240115_abc123",
                 runtime_type="docker",
-                timeout=-1,  # Test setup.
+                timeout=-1,  # Invalid value.
             )
 
     def test_invalid_workspace_path(self):
@@ -184,7 +184,7 @@ class TestSession:
                 template_id="python-datascience",
                 status=SessionStatus.CREATING,
                 resource_limit=ResourceLimit.default(),
-                workspace_path="",  # Test setup.
+                workspace_path="",  # Invalid value.
                 runtime_type="docker",
             )
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_session.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_session.py
@@ -1,8 +1,4 @@
-"""
-会话实体单元测试
-
-测试 Session 实体的领域行为。
-"""
+"""Unit tests for session."""
 import pytest
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
@@ -13,10 +9,10 @@ from src.domain.value_objects.execution_status import SessionStatus
 
 
 class TestSession:
-    """会话实体测试"""
+    """Tests for TestSession."""
 
     def test_create_session(self):
-        """测试创建会话"""
+        """Test create session."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -32,7 +28,7 @@ class TestSession:
         assert session.is_active() is True
 
     def test_mark_as_running(self):
-        """测试标记会话为运行中"""
+        """Test mark as running."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -52,7 +48,7 @@ class TestSession:
         assert session.container_id == "container-123"
 
     def test_mark_as_running_invalid_transition(self):
-        """测试无效状态转换"""
+        """Test mark as running invalid transition."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -66,7 +62,7 @@ class TestSession:
             session.mark_as_running("node-1", "container-123")
 
     def test_mark_as_terminated(self):
-        """测试终止会话"""
+        """Test mark as terminated."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -82,8 +78,8 @@ class TestSession:
         assert session.is_active() is False
 
     def test_is_idle(self):
-        """测试空闲检查"""
-        # 创建一个超过 30 分钟未活动的会话
+        """Test is idle."""
+        # Create test data.
         old_time = datetime.now() - timedelta(minutes=35)
 
         session = Session(
@@ -99,8 +95,8 @@ class TestSession:
         assert session.is_idle(threshold_minutes=30) is True
 
     def test_should_cleanup(self):
-        """测试是否应该清理"""
-        # 空闲会话
+        """Test should cleanup."""
+        # Test setup.
         old_time = datetime.now() - timedelta(minutes=35)
 
         session = Session(
@@ -116,7 +112,7 @@ class TestSession:
         assert session.should_cleanup() is True
 
     def test_add_execution(self):
-        """测试添加执行记录"""
+        """Test add execution."""
         from src.domain.entities.execution import Execution
         from src.domain.value_objects.execution_status import ExecutionStatus, ExecutionState
 
@@ -143,7 +139,7 @@ class TestSession:
         assert session.get_executions()[0].id == "exec_20240115_xyz789"
 
     def test_add_execution_wrong_session(self):
-        """测试添加错误会话的执行记录"""
+        """Test add execution wrong session."""
         from src.domain.entities.execution import Execution
         from src.domain.value_objects.execution_status import ExecutionStatus, ExecutionState
 
@@ -158,7 +154,7 @@ class TestSession:
 
         execution = Execution(
             id="exec_20240115_xyz789",
-            session_id="different_session_id",  # 错误的会话 ID
+            session_id="different_session_id",  # Test setup.
             code="print('hello')",
             language="python",
             state=ExecutionState(status=ExecutionStatus.PENDING),
@@ -168,7 +164,7 @@ class TestSession:
             session.add_execution(execution)
 
     def test_invalid_timeout(self):
-        """测试无效的超时值"""
+        """Test invalid timeout."""
         with pytest.raises(ValueError, match="timeout must be positive"):
             Session(
                 id="sess_20240115_abc123",
@@ -177,23 +173,23 @@ class TestSession:
                 resource_limit=ResourceLimit.default(),
                 workspace_path="s3://sandbox-workspace/sessions/sess_20240115_abc123",
                 runtime_type="docker",
-                timeout=-1,  # 无效值
+                timeout=-1,  # Test setup.
             )
 
     def test_invalid_workspace_path(self):
-        """测试无效的 workspace 路径"""
+        """Test invalid workspace path."""
         with pytest.raises(ValueError, match="workspace_path cannot be empty"):
             Session(
                 id="sess_20240115_abc123",
                 template_id="python-datascience",
                 status=SessionStatus.CREATING,
                 resource_limit=ResourceLimit.default(),
-                workspace_path="",  # 无效值
+                workspace_path="",  # Test setup.
                 runtime_type="docker",
             )
 
     def test_mark_as_completed(self):
-        """测试标记会话为已完成"""
+        """Test mark as completed."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -209,7 +205,7 @@ class TestSession:
         assert session.completed_at is not None
 
     def test_mark_as_completed_invalid_transition(self):
-        """测试标记完成时无效状态转换"""
+        """Test mark as completed invalid transition."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -223,7 +219,7 @@ class TestSession:
             session.mark_as_completed()
 
     def test_mark_as_failed(self):
-        """测试标记会话为失败"""
+        """Test mark as failed."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -239,7 +235,7 @@ class TestSession:
         assert session.completed_at is not None
 
     def test_mark_as_failed_from_creating(self):
-        """测试从 CREATING 状态标记为失败"""
+        """Test mark as failed from creating."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -254,7 +250,7 @@ class TestSession:
         assert session.status == SessionStatus.FAILED
 
     def test_mark_as_failed_invalid_transition(self):
-        """测试标记失败时无效状态转换"""
+        """Test mark as failed invalid transition."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -268,7 +264,7 @@ class TestSession:
             session.mark_as_failed()
 
     def test_mark_as_terminated_idempotent(self):
-        """测试终止会话幂等性"""
+        """Test mark as terminated idempotent."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -278,13 +274,13 @@ class TestSession:
             runtime_type="docker",
         )
 
-        # 再次终止应该不报错
+        # Verify expected behavior.
         session.mark_as_terminated()
 
         assert session.status == SessionStatus.TERMINATED
 
     def test_is_expired(self):
-        """测试过期检查"""
+        """Test is expired."""
         old_time = datetime.now() - timedelta(hours=7)
 
         session = Session(
@@ -300,7 +296,7 @@ class TestSession:
         assert session.is_expired(max_hours=6) is True
 
     def test_is_not_expired(self):
-        """测试未过期"""
+        """Test is not expired."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -313,7 +309,7 @@ class TestSession:
         assert session.is_expired(max_hours=6) is False
 
     def test_is_idle_not_active(self):
-        """测试非活跃会话不判断空闲"""
+        """Test is idle not active."""
         session = Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -326,7 +322,7 @@ class TestSession:
         assert session.is_idle() is False
 
     def test_update_last_activity(self):
-        """测试更新最后活动时间"""
+        """Test update last activity."""
         old_time = datetime.now() - timedelta(minutes=10)
         session = Session(
             id="sess_20240115_abc123",
@@ -343,7 +339,7 @@ class TestSession:
         assert session.last_activity_at > old_time
 
     def test_get_running_executions(self):
-        """测试获取运行中的执行"""
+        """Test get running executions."""
         from src.domain.entities.execution import Execution
         from src.domain.value_objects.execution_status import ExecutionStatus, ExecutionState
 
@@ -382,10 +378,10 @@ class TestSession:
 
 
 class TestInstalledDependency:
-    """已安装依赖测试"""
+    """Tests for TestInstalledDependency."""
 
     def test_create_installed_dependency(self):
-        """测试创建已安装依赖"""
+        """Test create installed dependency."""
         from src.domain.entities.session import InstalledDependency
 
         dep = InstalledDependency(
@@ -403,11 +399,11 @@ class TestInstalledDependency:
 
 
 class TestSessionDependencies:
-    """会话依赖管理测试"""
+    """Tests for TestSessionDependencies."""
 
     @pytest.fixture
     def session(self):
-        """创建测试会话"""
+        """Create session."""
         return Session(
             id="sess_20240115_abc123",
             template_id="python-datascience",
@@ -418,13 +414,13 @@ class TestSessionDependencies:
         )
 
     def test_set_dependencies_installing(self, session):
-        """测试标记依赖安装中"""
+        """Test set dependencies installing."""
         session.set_dependencies_installing()
 
         assert session.dependency_install_status == "installing"
 
     def test_set_dependencies_completed(self, session):
-        """测试标记依赖安装完成"""
+        """Test set dependencies completed."""
         from src.domain.entities.session import InstalledDependency
 
         installed = [
@@ -443,24 +439,24 @@ class TestSessionDependencies:
         assert len(session.installed_dependencies) == 1
 
     def test_set_dependencies_failed(self, session):
-        """测试标记依赖安装失败"""
+        """Test set dependencies failed."""
         session.set_dependencies_failed("pip install failed")
 
         assert session.dependency_install_status == "failed"
         assert session.dependency_install_error == "pip install failed"
 
     def test_has_dependencies_true(self, session):
-        """测试有依赖需要安装"""
+        """Test has dependencies true."""
         session.requested_dependencies = ["requests", "pandas"]
 
         assert session.has_dependencies() is True
 
     def test_has_dependencies_false(self, session):
-        """测试没有依赖需要安装"""
+        """Test has dependencies false."""
         assert session.has_dependencies() is False
 
     def test_is_dependency_install_pending(self, session):
-        """测试依赖是否待安装"""
+        """Test is dependency install pending."""
         assert session.is_dependency_install_pending() is True  # default "pending"
 
         session.set_dependencies_installing()
@@ -470,13 +466,13 @@ class TestSessionDependencies:
         assert session.is_dependency_install_pending() is False
 
     def test_is_dependency_install_successful(self, session):
-        """测试依赖是否安装成功"""
+        """Test is dependency install successful."""
         session.set_dependencies_completed([])
 
         assert session.is_dependency_install_successful() is True
 
     def test_is_dependency_install_successful_false(self, session):
-        """测试依赖安装失败"""
+        """Test is dependency install successful false."""
         session.set_dependencies_failed("error")
 
         assert session.is_dependency_install_successful() is False

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_template.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_template.py
@@ -140,7 +140,7 @@ class TestTemplate:
         )
 
         original_updated_at = template.updated_at
-        template.add_package("numpy")  # Test setup.
+        template.add_package("numpy")  # Add an existing package.
 
         # Verify expected behavior.
         assert template.pre_installed_packages.count("numpy") == 1
@@ -172,7 +172,7 @@ class TestTemplate:
         )
 
         original_updated_at = template.updated_at
-        template.remove_package("pandas")  # Test setup.
+        template.remove_package("pandas")  # Remove a nonexistent package.
 
         # Verify expected behavior.
         assert template.updated_at == original_updated_at

--- a/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_template.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/domain/test_template.py
@@ -1,8 +1,4 @@
-"""
-模板实体单元测试
-
-测试 Template 实体的领域行为。
-"""
+"""Unit tests for template."""
 import pytest
 from datetime import datetime
 
@@ -11,10 +7,10 @@ from src.domain.value_objects.resource_limit import ResourceLimit
 
 
 class TestTemplate:
-    """模板实体测试"""
+    """Tests for TestTemplate."""
 
     def test_create_template_success(self):
-        """测试成功创建模板"""
+        """Test create template success."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -28,7 +24,7 @@ class TestTemplate:
         assert template.base_image == "python:3.11-slim"
 
     def test_create_template_with_default_resources(self):
-        """测试使用默认资源配置创建模板"""
+        """Test create template with default resources."""
         template = Template(
             id="python-basic",
             name="Python Basic",
@@ -41,7 +37,7 @@ class TestTemplate:
         assert template.default_resources.disk == "1Gi"
 
     def test_create_template_with_custom_resources(self):
-        """测试使用自定义资源配置创建模板"""
+        """Test create template with custom resources."""
         resources = ResourceLimit(
             cpu="2",
             memory="1Gi",
@@ -62,7 +58,7 @@ class TestTemplate:
         assert template.default_resources.max_processes == 256
 
     def test_create_template_invalid_name(self):
-        """测试无效的模板名称"""
+        """Test create template invalid name."""
         with pytest.raises(ValueError, match="name cannot be empty"):
             Template(
                 id="test",
@@ -72,7 +68,7 @@ class TestTemplate:
             )
 
     def test_create_template_invalid_image(self):
-        """测试无效的镜像"""
+        """Test create template invalid image."""
         with pytest.raises(ValueError, match="image cannot be empty"):
             Template(
                 id="test",
@@ -82,7 +78,7 @@ class TestTemplate:
             )
 
     def test_create_template_invalid_base_image(self):
-        """测试无效的基础镜像"""
+        """Test create template invalid base image."""
         with pytest.raises(ValueError, match="base_image cannot be empty"):
             Template(
                 id="test",
@@ -92,7 +88,7 @@ class TestTemplate:
             )
 
     def test_update_image(self):
-        """测试更新镜像"""
+        """Test update image."""
         template = Template(
             id="python-basic",
             name="Python Basic",
@@ -107,7 +103,7 @@ class TestTemplate:
         assert template.updated_at > original_updated_at
 
     def test_update_image_invalid(self):
-        """测试更新为无效镜像"""
+        """Test update image invalid."""
         template = Template(
             id="python-basic",
             name="Python Basic",
@@ -119,7 +115,7 @@ class TestTemplate:
             template.update_image("")
 
     def test_add_package(self):
-        """测试添加预装包"""
+        """Test add package."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -134,7 +130,7 @@ class TestTemplate:
         assert "numpy" in template.pre_installed_packages
 
     def test_add_duplicate_package(self):
-        """测试添加重复的包"""
+        """Test add duplicate package."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -144,14 +140,14 @@ class TestTemplate:
         )
 
         original_updated_at = template.updated_at
-        template.add_package("numpy")  # 添加已存在的包
+        template.add_package("numpy")  # Test setup.
 
-        # 不应该重复添加，也不应该更新 updated_at
+        # Verify expected behavior.
         assert template.pre_installed_packages.count("numpy") == 1
         assert template.updated_at == original_updated_at
 
     def test_remove_package(self):
-        """测试移除预装包"""
+        """Test remove package."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -166,7 +162,7 @@ class TestTemplate:
         assert "pandas" not in template.pre_installed_packages
 
     def test_remove_nonexistent_package(self):
-        """测试移除不存在的包"""
+        """Test remove nonexistent package."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -176,13 +172,13 @@ class TestTemplate:
         )
 
         original_updated_at = template.updated_at
-        template.remove_package("pandas")  # 移除不存在的包
+        template.remove_package("pandas")  # Test setup.
 
-        # 不应该更新 updated_at
+        # Verify expected behavior.
         assert template.updated_at == original_updated_at
 
     def test_update_default_resources(self):
-        """测试更新默认资源配置"""
+        """Test update default resources."""
         template = Template(
             id="python-basic",
             name="Python Basic",
@@ -206,7 +202,7 @@ class TestTemplate:
         assert template.updated_at > original_updated_at
 
     def test_has_package(self):
-        """测试检查是否包含指定包"""
+        """Test has package."""
         template = Template(
             id="python-datascience",
             name="Python Data Science",
@@ -220,7 +216,7 @@ class TestTemplate:
         assert template.has_package("scikit-learn") is False
 
     def test_get_image_name(self):
-        """测试获取镜像名称"""
+        """Test get image name."""
         template1 = Template(
             id="python-basic",
             name="Python Basic",
@@ -246,7 +242,7 @@ class TestTemplate:
         assert template3.get_image_name() == "python"
 
     def test_security_context(self):
-        """测试安全上下文"""
+        """Test security context."""
         security_context = {
             "readonly_rootfs": True,
             "capabilities": ["CAP_NET_RAW"],

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/config/test_settings.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/config/test_settings.py
@@ -9,7 +9,7 @@ from src.infrastructure.config.settings import Settings, get_settings
 
 def create_settings_with_defaults(**kwargs):
     """Create settings with defaults."""
-    # Test setup.
+    # Use _env_file=None to skip loading the .env file.
     return Settings(_env_file=None, **kwargs)
 
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/config/test_settings.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/config/test_settings.py
@@ -1,8 +1,4 @@
-"""
-应用配置单元测试
-
-测试 Settings 类的功能。
-"""
+"""Unit tests for settings."""
 import os
 import pytest
 from unittest.mock import patch
@@ -12,16 +8,16 @@ from src.infrastructure.config.settings import Settings, get_settings
 
 
 def create_settings_with_defaults(**kwargs):
-    """创建使用默认值的 Settings 实例（不读取 .env 文件）"""
-    # 使用 _env_file=None 来跳过 .env 文件加载
+    """Create settings with defaults."""
+    # Test setup.
     return Settings(_env_file=None, **kwargs)
 
 
 class TestSettings:
-    """应用配置测试"""
+    """Tests for TestSettings."""
 
     def test_default_values(self):
-        """测试默认值"""
+        """Test default values."""
         settings = create_settings_with_defaults()
 
         assert settings.app_name == "Sandbox Control Plane"
@@ -33,7 +29,7 @@ class TestSettings:
         assert settings.workers == 4
 
     def test_default_database_config(self):
-        """测试默认数据库配置"""
+        """Test default database config."""
         settings = create_settings_with_defaults()
 
         assert settings.database_url == "mysql+aiomysql://sandbox:password@localhost:3308/openbkn"
@@ -42,7 +38,7 @@ class TestSettings:
         assert settings.db_pool_recycle == 3600
 
     def test_default_s3_config(self):
-        """测试默认 S3 配置"""
+        """Test default S3 config."""
         settings = create_settings_with_defaults()
 
         assert settings.s3_bucket == "sandbox-workspace"
@@ -51,20 +47,20 @@ class TestSettings:
         assert settings.s3_secret_access_key == ""
 
     def test_default_docker_config(self):
-        """测试默认 Docker 配置"""
+        """Test default docker config."""
         settings = create_settings_with_defaults()
 
         assert settings.docker_host == "unix:///var/run/docker.sock"
         assert settings.docker_tls_verify is False
 
     def test_default_kubernetes_config(self):
-        """测试默认 Kubernetes 配置"""
+        """Test default kubernetes config."""
         settings = create_settings_with_defaults()
 
         assert settings.kubernetes_namespace == "sandbox-runtime"
 
     def test_default_execution_config(self):
-        """测试默认执行配置"""
+        """Test default execution config."""
         settings = create_settings_with_defaults()
 
         assert settings.default_timeout == 300
@@ -75,7 +71,7 @@ class TestSettings:
         assert settings.disable_bwrap is False
 
     def test_default_cleanup_config(self):
-        """测试默认清理配置"""
+        """Test default cleanup config."""
         settings = create_settings_with_defaults()
 
         assert settings.idle_threshold_minutes == -1
@@ -84,7 +80,7 @@ class TestSettings:
         assert settings.creating_timeout_seconds == 300
 
     def test_default_retry_config(self):
-        """测试默认重试配置"""
+        """Test default retry config."""
         settings = create_settings_with_defaults()
 
         assert settings.max_retry_attempts == 3
@@ -92,7 +88,7 @@ class TestSettings:
         assert settings.retry_backoff_factor == 2.0
 
     def test_default_health_check_config(self):
-        """测试默认健康检查配置"""
+        """Test default health check config."""
         settings = create_settings_with_defaults()
 
         assert settings.health_check_interval_seconds == 10
@@ -100,59 +96,59 @@ class TestSettings:
         assert settings.heartbeat_timeout_seconds == 15
 
     def test_default_log_config(self):
-        """测试默认日志配置"""
+        """Test default log config."""
         settings = create_settings_with_defaults()
 
         assert settings.log_level == "INFO"
         assert settings.log_format == "text"
 
     def test_validate_log_level_valid(self):
-        """测试验证有效的日志级别"""
+        """Test validate log level valid."""
         for level in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
             settings = create_settings_with_defaults(log_level=level)
             assert settings.log_level == level
 
     def test_validate_log_level_lowercase(self):
-        """测试验证小写日志级别（自动转大写）"""
+        """Test validate log level lowercase."""
         settings = create_settings_with_defaults(log_level="debug")
         assert settings.log_level == "DEBUG"
 
     def test_validate_log_level_invalid(self):
-        """测试验证无效的日志级别"""
+        """Test validate log level invalid."""
         with pytest.raises(ValidationError, match="log_level must be one of"):
             create_settings_with_defaults(log_level="INVALID")
 
     def test_validate_log_format_valid(self):
-        """测试验证有效的日志格式"""
+        """Test validate log format valid."""
         for fmt in ["json", "text"]:
             settings = create_settings_with_defaults(log_format=fmt)
             assert settings.log_format == fmt
 
     def test_validate_log_format_invalid(self):
-        """测试验证无效的日志格式"""
+        """Test validate log format invalid."""
         with pytest.raises(ValidationError, match="log_format must be one of"):
             create_settings_with_defaults(log_format="xml")
 
     def test_validate_environment_valid(self):
-        """测试验证有效的环境"""
+        """Test validate environment valid."""
         for env in ["development", "staging", "production"]:
             settings = create_settings_with_defaults(environment=env)
             assert settings.environment == env
 
     def test_validate_environment_invalid(self):
-        """测试验证无效的环境"""
+        """Test validate environment invalid."""
         with pytest.raises(ValidationError, match="environment must be one of"):
             create_settings_with_defaults(environment="testing")
 
     def test_effective_database_url_default(self):
-        """测试有效的数据库 URL（默认值）"""
+        """Test effective database URL default."""
         settings = create_settings_with_defaults()
 
         # When RDS fields are not set, use default database_url
         assert settings.effective_database_url == settings.database_url
 
     def test_effective_database_url_with_rds_config(self):
-        """测试有效的数据库 URL（使用 RDS 配置）"""
+        """Test effective database URL with RDS config."""
         settings = create_settings_with_defaults(
             db_type="MYSQL",
             db_host="localhost",
@@ -169,7 +165,7 @@ class TestSettings:
         assert "sandbox" in settings.effective_database_url
 
     def test_effective_database_url_with_charset(self):
-        """测试有效的数据库 URL（带字符集）"""
+        """Test effective database URL with charset."""
         settings = create_settings_with_defaults(
             db_type="MYSQL",
             db_host="localhost",
@@ -183,7 +179,7 @@ class TestSettings:
         assert "charset=utf8mb4" in settings.effective_database_url
 
     def test_effective_database_url_partial_rds_config(self):
-        """测试有效的数据库 URL（部分 RDS 配置）"""
+        """Test effective database URL partial RDS config."""
         settings = create_settings_with_defaults(
             db_host="localhost",
             db_port=3306,
@@ -194,7 +190,7 @@ class TestSettings:
         assert settings.effective_database_url == settings.database_url
 
     def test_default_security_config(self):
-        """测试默认安全配置"""
+        """Test default security config."""
         settings = create_settings_with_defaults()
 
         assert settings.secret_key == "change-this-in-production"
@@ -202,21 +198,21 @@ class TestSettings:
         assert settings.cors_origins == ["http://localhost:3000"]
 
     def test_default_rate_limit_config(self):
-        """测试默认限流配置"""
+        """Test default rate limit config."""
         settings = create_settings_with_defaults()
 
         assert settings.rate_limit_enabled is True
         assert settings.rate_limit_per_minute == 60
 
     def test_default_metrics_config(self):
-        """测试默认监控配置"""
+        """Test default metrics config."""
         settings = create_settings_with_defaults()
 
         assert settings.metrics_enabled is True
         assert settings.metrics_port == 9090
 
     def test_custom_values(self):
-        """测试自定义值"""
+        """Test custom values."""
         settings = create_settings_with_defaults(
             app_name="Custom App",
             environment="production",
@@ -230,7 +226,7 @@ class TestSettings:
         assert settings.debug is True
 
     def test_get_settings_returns_singleton(self):
-        """测试获取配置单例"""
+        """Test get settings returns singleton."""
         # Clear cache first
         get_settings.cache_clear()
 
@@ -241,10 +237,10 @@ class TestSettings:
 
 
 class TestSettingsValidation:
-    """配置验证测试"""
+    """Tests for TestSettingsValidation."""
 
     def test_cleanup_interval_validation(self):
-        """测试清理间隔验证"""
+        """Test cleanup interval validation."""
         # Valid value
         settings = create_settings_with_defaults(cleanup_interval_seconds=60)
         assert settings.cleanup_interval_seconds == 60
@@ -254,7 +250,7 @@ class TestSettingsValidation:
             create_settings_with_defaults(cleanup_interval_seconds=0)
 
     def test_creating_timeout_validation(self):
-        """测试创建超时验证"""
+        """Test creating timeout validation."""
         # Valid value
         settings = create_settings_with_defaults(creating_timeout_seconds=60)
         assert settings.creating_timeout_seconds == 60
@@ -264,7 +260,7 @@ class TestSettingsValidation:
             create_settings_with_defaults(creating_timeout_seconds=10)
 
     def test_idle_threshold_validation(self):
-        """测试空闲阈值验证"""
+        """Test idle threshold validation."""
         # Valid value
         settings = create_settings_with_defaults(idle_threshold_minutes=30)
         assert settings.idle_threshold_minutes == 30
@@ -274,7 +270,7 @@ class TestSettingsValidation:
         assert settings.idle_threshold_minutes == -1
 
     def test_max_lifetime_validation(self):
-        """测试最大生命周期验证"""
+        """Test max lifetime validation."""
         # Valid value
         settings = create_settings_with_defaults(max_lifetime_hours=6)
         assert settings.max_lifetime_hours == 6

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_docker_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_docker_scheduler.py
@@ -15,7 +15,7 @@ class TestDockerScheduler:
     def mock_docker(self):
         """Create docker."""
         docker = Mock()
-        # Test setup.
+        # Version info is a synchronous call.
         docker.version.return_value = {"Version": "20.10.0"}
         images_mock = Mock()
         images_mock.inspect = AsyncMock(return_value={})
@@ -380,7 +380,7 @@ class TestDockerScheduler:
         """Test build dependency install entrypoint no deps."""
         script = scheduler._build_dependency_install_entrypoint(None)
 
-        # Test setup.
+        # Should not contain pip install.
         assert "pip3 install" not in script
 
     @pytest.mark.asyncio
@@ -519,7 +519,7 @@ class TestDockerScheduler:
         """Test parse memory to bytes plain number."""
         result = scheduler._parse_memory_to_bytes("2048")
 
-        # Test setup.
+        # Default unit is MB.
         assert result == 2048 * 1024 * 1024
 
     @pytest.mark.asyncio

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_docker_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_docker_scheduler.py
@@ -1,8 +1,4 @@
-"""
-Docker 容器调度器单元测试
-
-测试 DockerScheduler 类的功能。
-"""
+"""Unit tests for docker scheduler."""
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -13,13 +9,13 @@ from src.infrastructure.container_scheduler.docker_scheduler import DockerSchedu
 
 
 class TestDockerScheduler:
-    """Docker 容器调度器测试"""
+    """Tests for TestDockerScheduler."""
 
     @pytest.fixture
     def mock_docker(self):
-        """模拟 Docker 客户端"""
+        """Create docker."""
         docker = Mock()
-        # 版本信息同步调用
+        # Test setup.
         docker.version.return_value = {"Version": "20.10.0"}
         images_mock = Mock()
         images_mock.inspect = AsyncMock(return_value={})
@@ -29,7 +25,7 @@ class TestDockerScheduler:
 
     @pytest.fixture
     def scheduler(self, mock_docker):
-        """创建 Docker 调度器"""
+        """Create scheduler."""
         sched = DockerScheduler()
         sched._docker = mock_docker
         sched._initialized = True
@@ -37,7 +33,7 @@ class TestDockerScheduler:
 
     @pytest.fixture
     def basic_config(self):
-        """基础容器配置"""
+        """Create basic config."""
         return ContainerConfig(
             image="python:3.11",
             name="test-container",
@@ -51,7 +47,7 @@ class TestDockerScheduler:
         )
 
     def test_parse_s3_workspace_valid(self, scheduler):
-        """测试解析有效的 S3 workspace 路径"""
+        """Test parse S3 workspace valid."""
         result = scheduler._parse_s3_workspace("s3://my-bucket/sessions/sess_123/")
 
         assert result is not None
@@ -59,48 +55,48 @@ class TestDockerScheduler:
         assert result["prefix"] == "sessions/sess_123/"
 
     def test_parse_s3_workspace_invalid(self, scheduler):
-        """测试解析无效的 S3 workspace 路径"""
+        """Test parse S3 workspace invalid."""
         result = scheduler._parse_s3_workspace("/local/path/workspace")
 
         assert result is None
 
     def test_parse_memory_to_bytes_gi(self, scheduler):
-        """测试解析内存限制（Gi）"""
+        """Test parse memory to bytes gi."""
         result = scheduler._parse_memory_to_bytes("1Gi")
 
         assert result == 1024 * 1024 * 1024
 
     def test_parse_memory_to_bytes_mi(self, scheduler):
-        """测试解析内存限制（Mi）"""
+        """Test parse memory to bytes mi."""
         result = scheduler._parse_memory_to_bytes("512Mi")
 
         assert result == 512 * 1024 * 1024
 
     def test_parse_memory_to_bytes_ki(self, scheduler):
-        """测试解析内存限制（Ki）"""
+        """Test parse memory to bytes ki."""
         result = scheduler._parse_memory_to_bytes("256Ki")
 
         assert result == 256 * 1024
 
     def test_parse_memory_to_bytes_default(self, scheduler):
-        """测试解析内存限制（默认单位为 MB）"""
+        """Test parse memory to bytes default."""
         result = scheduler._parse_memory_to_bytes("1024")
 
         assert result == 1024 * 1024 * 1024
 
     def test_parse_disk_to_bytes(self, scheduler):
-        """测试解析磁盘限制"""
+        """Test parse disk to bytes."""
         result = scheduler._parse_disk_to_bytes("10Gi")
 
         assert result == 10 * 1024 * 1024 * 1024
 
     @pytest.mark.asyncio
     async def test_create_container_basic(self, scheduler, mock_docker, basic_config):
-        """测试创建基本容器"""
+        """Test create container basic."""
         mock_container = Mock()
         mock_container.id = "container-123"
 
-        # 创建 containers mock
+        # Mock test dependency.
         containers_mock = Mock()
         containers_mock.create = AsyncMock(return_value=mock_container)
         mock_docker.containers = containers_mock
@@ -114,7 +110,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_create_container_pulls_missing_image(self, scheduler, mock_docker, basic_config):
-        """测试本地镜像缺失时会先拉取远端镜像。"""
+        """Test create container pulls missing image."""
         mock_container = Mock()
         mock_container.id = "container-123"
 
@@ -134,7 +130,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_create_container_with_s3_workspace(self, scheduler, mock_docker):
-        """测试创建带 S3 workspace 的容器"""
+        """Test create container with S3 workspace."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-container",
@@ -158,15 +154,15 @@ class TestDockerScheduler:
 
         assert container_id == "container-123"
 
-        # 验证容器配置包含 S3 相关配置
+        # S3-related test setup.
         call_args = containers_mock.create.call_args
         container_config = call_args[0][0]
-        assert container_config["User"] == "root"  # S3 模式需要 root
+        assert container_config["User"] == "root"  # S3-related test setup.
         assert "SYS_ADMIN" in container_config["HostConfig"]["CapAdd"]
 
     @pytest.mark.asyncio
     async def test_start_container(self, scheduler, mock_docker):
-        """测试启动容器"""
+        """Test start container."""
         mock_container = Mock()
         mock_container.start = AsyncMock()
 
@@ -181,7 +177,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_stop_container(self, scheduler, mock_docker):
-        """测试停止容器"""
+        """Test stop container."""
         mock_container = Mock()
         mock_container.stop = AsyncMock()
 
@@ -195,7 +191,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_remove_container(self, scheduler, mock_docker):
-        """测试删除容器"""
+        """Test remove container."""
         mock_container = Mock()
         mock_container.delete = AsyncMock()
 
@@ -209,7 +205,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_status_running(self, scheduler, mock_docker):
-        """测试获取运行中容器状态"""
+        """Test get container status running."""
         mock_container = Mock()
         mock_container.show = AsyncMock(return_value={
             "Id": "container-123",
@@ -243,7 +239,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_is_container_running_true(self, scheduler, mock_docker):
-        """测试检查容器是否运行中（运行中）"""
+        """Test is container running true."""
         mock_container = Mock()
         mock_container.show = AsyncMock(return_value={
             "Id": "container-123",
@@ -275,7 +271,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_logs(self, scheduler, mock_docker):
-        """测试获取容器日志"""
+        """Test get container logs."""
         mock_container = Mock()
         mock_container.log = AsyncMock(return_value=["log line 1\n", "log line 2\n"])
 
@@ -290,7 +286,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_wait_container_success(self, scheduler, mock_docker):
-        """测试等待容器完成（成功）"""
+        """Test wait container success."""
         mock_container = Mock()
         mock_container.wait = AsyncMock(return_value={"StatusCode": 0})
         mock_container.log = AsyncMock(return_value=["output\n"])
@@ -307,7 +303,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_wait_container_timeout(self, scheduler, mock_docker):
-        """测试等待容器完成（超时）"""
+        """Test wait container timeout."""
         mock_container = Mock()
         mock_container.wait = AsyncMock(side_effect=TimeoutError())
 
@@ -322,14 +318,14 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_ping_success(self, scheduler, mock_docker):
-        """测试 ping 成功"""
+        """Test ping success."""
         mock_docker.version = AsyncMock(return_value={"Version": "20.10.0"})
         result = await scheduler.ping()
         assert result is True
 
     @pytest.mark.asyncio
     async def test_close(self, scheduler, mock_docker):
-        """测试关闭连接"""
+        """Test close."""
         mock_docker.close = AsyncMock()
 
         await scheduler.close()
@@ -338,7 +334,7 @@ class TestDockerScheduler:
         assert scheduler._initialized is False
 
     def test_build_s3_mount_entrypoint(self, scheduler):
-        """测试构建 S3 挂载入口脚本"""
+        """Test build S3 mount entrypoint."""
         script = scheduler._build_s3_mount_entrypoint(
             s3_bucket="test-bucket",
             s3_prefix="sessions/sess_123",
@@ -357,7 +353,7 @@ class TestDockerScheduler:
         assert "ln -s" not in script
 
     def test_build_s3_mount_entrypoint_with_dependencies(self, scheduler):
-        """测试构建带依赖的 S3 挂载入口脚本"""
+        """Test build S3 mount entrypoint with dependencies."""
         dependencies = [{"name": "requests", "version": "==2.31.0"}]
         script = scheduler._build_s3_mount_entrypoint(
             s3_bucket="test-bucket",
@@ -373,7 +369,7 @@ class TestDockerScheduler:
         assert 'mount --bind "$SESSION_PATH" /workspace' in script
 
     def test_build_dependency_install_entrypoint(self, scheduler):
-        """测试构建依赖安装入口脚本"""
+        """Test build dependency install entrypoint."""
         dependencies = [{"name": "pandas", "version": ">=2.0"}]
         script = scheduler._build_dependency_install_entrypoint(dependencies)
 
@@ -381,15 +377,15 @@ class TestDockerScheduler:
         assert "pandas>=2.0" in script
 
     def test_build_dependency_install_entrypoint_no_deps(self, scheduler):
-        """测试构建无依赖的入口脚本"""
+        """Test build dependency install entrypoint no deps."""
         script = scheduler._build_dependency_install_entrypoint(None)
 
-        # 应不包含 pip install
+        # Test setup.
         assert "pip3 install" not in script
 
     @pytest.mark.asyncio
     async def test_is_container_running_false(self, scheduler, mock_docker):
-        """测试检查容器是否运行中（未运行）"""
+        """Test is container running false."""
         mock_container = Mock()
         mock_container.show = AsyncMock(return_value={
             "Id": "container-123",
@@ -421,7 +417,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_status_stopped(self, scheduler, mock_docker):
-        """测试获取已停止容器状态"""
+        """Test get container status stopped."""
         mock_container = Mock()
         mock_container.show = AsyncMock(return_value={
             "Id": "container-123",
@@ -454,7 +450,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_wait_container_failure(self, scheduler, mock_docker):
-        """测试等待容器完成（失败）"""
+        """Test wait container failure."""
         mock_container = Mock()
         mock_container.wait = AsyncMock(return_value={"StatusCode": 1})
         mock_container.log = AsyncMock(return_value=["error output\n"])
@@ -470,14 +466,14 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_ping_failure(self, scheduler, mock_docker):
-        """测试 ping 失败"""
+        """Test ping failure."""
         mock_docker.version = AsyncMock(side_effect=Exception("Connection failed"))
         result = await scheduler.ping()
         assert result is False
 
     @pytest.mark.asyncio
     async def test_ensure_docker_initialization(self, mock_docker):
-        """测试 Docker 客户端初始化"""
+        """Test ensure docker initialization."""
         scheduler = DockerScheduler()
         scheduler._initialized = False
 
@@ -490,45 +486,45 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_ensure_docker_already_initialized(self, scheduler, mock_docker):
-        """测试 Docker 客户端已初始化"""
+        """Test ensure docker already initialized."""
         result = await scheduler._ensure_docker()
 
         assert result is mock_docker
 
     def test_parse_s3_workspace_empty(self, scheduler):
-        """测试解析空 S3 workspace 路径"""
+        """Test parse S3 workspace empty."""
         result = scheduler._parse_s3_workspace("")
 
         assert result is None
 
     def test_parse_s3_workspace_none(self, scheduler):
-        """测试解析 None S3 workspace 路径"""
+        """Test parse S3 workspace none."""
         result = scheduler._parse_s3_workspace(None)
 
         assert result is None
 
     def test_parse_disk_to_bytes_mb(self, scheduler):
-        """测试解析磁盘限制（MB）"""
+        """Test parse disk to bytes mb."""
         result = scheduler._parse_disk_to_bytes("512Mi")
 
         assert result == 512 * 1024 * 1024
 
     def test_parse_memory_to_bytes_gib(self, scheduler):
-        """测试解析内存限制（GiB）"""
+        """Test parse memory to bytes gib."""
         result = scheduler._parse_memory_to_bytes("2Gi")
 
         assert result == 2 * 1024 * 1024 * 1024
 
     def test_parse_memory_to_bytes_plain_number(self, scheduler):
-        """测试解析内存限制（纯数字）"""
+        """Test parse memory to bytes plain number."""
         result = scheduler._parse_memory_to_bytes("2048")
 
-        # 默认单位为 MB
+        # Test setup.
         assert result == 2048 * 1024 * 1024
 
     @pytest.mark.asyncio
     async def test_create_container_with_labels(self, scheduler, mock_docker):
-        """测试创建带标签的容器"""
+        """Test create container with labels."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-container",
@@ -552,7 +548,7 @@ class TestDockerScheduler:
 
         assert container_id == "container-123"
 
-        # 验证标签被传递
+        # Verify expected behavior.
         call_args = containers_mock.create.call_args
         container_config = call_args[0][0]
         assert container_config["Labels"]["session_id"] == "sess-123"
@@ -560,7 +556,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_status_with_name(self, scheduler, mock_docker):
-        """测试获取容器状态（带名称）"""
+        """Test get container status with name."""
         mock_container = Mock()
         mock_container.show = AsyncMock(return_value={
             "Id": "container-123",
@@ -592,7 +588,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_logs_with_stderr(self, scheduler, mock_docker):
-        """测试获取容器日志（包含 stderr）"""
+        """Test get container logs with stderr."""
         mock_container = Mock()
         mock_container.log = AsyncMock(return_value=["stdout\n", "stderr\n"])
 
@@ -607,7 +603,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_stop_container_default_timeout(self, scheduler, mock_docker):
-        """测试停止容器（默认超时）"""
+        """Test stop container default timeout."""
         mock_container = Mock()
         mock_container.stop = AsyncMock()
 
@@ -621,7 +617,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_remove_container_no_force(self, scheduler, mock_docker):
-        """测试删除容器（不强制）"""
+        """Test remove container no force."""
         mock_container = Mock()
         mock_container.delete = AsyncMock()
 
@@ -635,7 +631,7 @@ class TestDockerScheduler:
 
     @pytest.mark.asyncio
     async def test_create_container_with_env_vars(self, scheduler, mock_docker):
-        """测试创建带环境变量的容器"""
+        """Test create container with env vars."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-container",
@@ -659,7 +655,7 @@ class TestDockerScheduler:
 
         assert container_id == "container-123"
 
-        # 验证环境变量被传递
+        # Verify expected behavior.
         call_args = containers_mock.create.call_args
         container_config = call_args[0][0]
         assert "DEBUG=true" in container_config["Env"]

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_k8s_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_k8s_scheduler.py
@@ -555,7 +555,7 @@ class TestK8sSchedulerExtended:
         """Test parse memory to bytes plain number."""
         result = scheduler._parse_memory_to_bytes("1024")
 
-        # Test setup.
+        # Default unit is MB.
         assert result == 1024 * 1024 * 1024
 
     def test_parse_disk_to_bytes_mb(self, scheduler):
@@ -636,7 +636,7 @@ class TestK8sSchedulerExtended:
     @pytest.mark.asyncio
     async def test_start_container(self, scheduler, mock_core_v1):
         """Test start container."""
-        # Test setup.
+        # In K8s, start_container usually does not need extra operations.
         await scheduler.start_container("test-pod")
         # Verify expected behavior.
 

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_k8s_scheduler.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/container_scheduler/test_k8s_scheduler.py
@@ -1,8 +1,4 @@
-"""
-Kubernetes 容器调度器单元测试
-
-测试 K8sScheduler 类的功能。
-"""
+"""Unit tests for K8s scheduler."""
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -15,17 +11,17 @@ from src.infrastructure.container_scheduler.k8s_scheduler import K8sScheduler
 
 
 class TestK8sScheduler:
-    """K8s 容器调度器测试"""
+    """Tests for TestK8sScheduler."""
 
     @pytest.fixture
     def mock_core_v1(self):
-        """模拟 Kubernetes CoreV1Api"""
+        """Create core v1."""
         api = Mock()
         return api
 
     @pytest.fixture
     def scheduler(self, mock_core_v1):
-        """创建 K8s 调度器"""
+        """Create scheduler."""
         sched = K8sScheduler(namespace="test-namespace")
         sched._core_v1 = mock_core_v1
         sched._initialized = True
@@ -33,7 +29,7 @@ class TestK8sScheduler:
 
     @pytest.fixture
     def basic_config(self):
-        """基础容器配置"""
+        """Create basic config."""
         return ContainerConfig(
             image="python:3.11",
             name="test-session-abc123",
@@ -47,7 +43,7 @@ class TestK8sScheduler:
         )
 
     def test_build_pod_name(self, scheduler):
-        """测试生成 Pod 名称"""
+        """Test build Pod name."""
         pod_name = scheduler._build_pod_name("sess_abc123")
 
         assert "sandbox" in pod_name
@@ -55,15 +51,15 @@ class TestK8sScheduler:
         assert len(pod_name) <= 253
 
     def test_build_pod_name_with_uppercase(self, scheduler):
-        """测试大写会话 ID 转换"""
+        """Test build Pod name with uppercase."""
         pod_name = scheduler._build_pod_name("Sess_ABC123")
 
         assert "sess" in pod_name.lower()
-        # 应该不包含大写字母
+        # Verify expected behavior.
         assert pod_name == pod_name.lower()
 
     def test_parse_s3_workspace_valid(self, scheduler):
-        """测试解析有效的 S3 workspace 路径"""
+        """Test parse S3 workspace valid."""
         result = scheduler._parse_s3_workspace("s3://my-bucket/sessions/sess_123/")
 
         assert result is not None
@@ -71,32 +67,32 @@ class TestK8sScheduler:
         assert result["prefix"] == "sessions/sess_123/"
 
     def test_parse_s3_workspace_invalid(self, scheduler):
-        """测试解析无效的 S3 workspace 路径"""
+        """Test parse S3 workspace invalid."""
         result = scheduler._parse_s3_workspace("/local/path/workspace")
 
         assert result is None
 
     def test_parse_memory_to_bytes_gi(self, scheduler):
-        """测试解析内存限制（Gi）"""
+        """Test parse memory to bytes gi."""
         result = scheduler._parse_memory_to_bytes("1Gi")
 
         assert result == 1024 * 1024 * 1024
 
     def test_parse_memory_to_bytes_mi(self, scheduler):
-        """测试解析内存限制（Mi）"""
+        """Test parse memory to bytes mi."""
         result = scheduler._parse_memory_to_bytes("512Mi")
 
         assert result == 512 * 1024 * 1024
 
     def test_parse_disk_to_bytes(self, scheduler):
-        """测试解析磁盘限制"""
+        """Test parse disk to bytes."""
         result = scheduler._parse_disk_to_bytes("10Gi")
 
         assert result == 10 * 1024 * 1024 * 1024
 
     @pytest.mark.asyncio
     async def test_ping_success(self, scheduler, mock_core_v1):
-        """测试 ping 成功"""
+        """Test ping success."""
         mock_core_v1.list_namespace.return_value = Mock(items=[])
 
         result = await scheduler.ping()
@@ -105,7 +101,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_ping_failure(self, scheduler, mock_core_v1):
-        """测试 ping 失败"""
+        """Test ping failure."""
         mock_core_v1.list_namespace.side_effect = Exception("Connection error")
 
         result = await scheduler.ping()
@@ -114,7 +110,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_create_pod_basic(self, scheduler, mock_core_v1, basic_config):
-        """测试创建基本 Pod"""
+        """Test create Pod basic."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "sandbox-test-session-abc123"
@@ -125,7 +121,7 @@ class TestK8sScheduler:
         assert pod_name == "sandbox-test-session-abc123"
         mock_core_v1.create_namespaced_pod.assert_called_once()
 
-        # 验证参数
+        # Verify expected behavior.
         call_args = mock_core_v1.create_namespaced_pod.call_args
         assert call_args[1]["namespace"] == "test-namespace"
 
@@ -137,7 +133,7 @@ class TestK8sScheduler:
         basic_config,
         monkeypatch,
     ):
-        """测试 executor Pod 使用配置化镜像拉取策略和 imagePullSecrets。"""
+        """Test create Pod uses configured image pull settings."""
         monkeypatch.setenv("EXECUTOR_IMAGE_PULL_POLICY", "Always")
         monkeypatch.setenv("EXECUTOR_IMAGE_PULL_SECRETS", "swr-secret, backup-secret")
         get_settings.cache_clear()
@@ -162,7 +158,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_create_pod_sets_owner_references_and_annotations(self, scheduler, mock_core_v1):
-        """测试创建 Pod 时写入 ownerReferences 和 control plane annotations。"""
+        """Test create Pod sets owner references and annotations."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -201,7 +197,7 @@ class TestK8sScheduler:
         mock_core_v1,
         basic_config,
     ):
-        """测试旧 Pod 正在删除时会等待并重试同名创建。"""
+        """Test create Pod retries after terminating Pod conflict."""
         stale_pod = Mock()
         stale_pod.metadata = Mock()
         stale_pod.metadata.deletion_timestamp = datetime.now(UTC)
@@ -224,7 +220,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_create_pod_with_s3_workspace(self, scheduler, mock_core_v1):
-        """测试创建带 S3 workspace 的 Pod"""
+        """Test create Pod with S3 workspace."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -246,7 +242,7 @@ class TestK8sScheduler:
 
         assert pod_name == "sandbox-test-session"
 
-        # 验证 Pod 配置包含单个 executor 容器（s3fs 在容器内挂载）
+        # Verify expected behavior.
         call_args = mock_core_v1.create_namespaced_pod.call_args
         pod_spec = call_args[1]["body"]
         assert len(pod_spec.spec.containers) == 1
@@ -254,7 +250,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_create_pod_with_dependencies(self, scheduler, mock_core_v1):
-        """测试创建带依赖安装的 Pod"""
+        """Test create Pod with dependencies."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -276,7 +272,7 @@ class TestK8sScheduler:
 
         assert pod_name == "sandbox-test-session"
 
-        # 验证 executor 容器有启动脚本
+        # Verify expected behavior.
         call_args = mock_core_v1.create_namespaced_pod.call_args
         pod_spec = call_args[1]["body"]
         executor_container = next(c for c in pod_spec.spec.containers if c.name == "executor")
@@ -285,7 +281,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_stop_container(self, scheduler, mock_core_v1):
-        """测试停止 Pod"""
+        """Test stop container."""
         mock_core_v1.delete_namespaced_pod.return_value = None
 
         await scheduler.stop_container("test-pod", timeout=30)
@@ -297,7 +293,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_remove_container_force(self, scheduler, mock_core_v1):
-        """测试强制删除 Pod"""
+        """Test remove container force."""
         mock_core_v1.delete_namespaced_pod.return_value = None
 
         await scheduler.remove_container("test-pod", force=True)
@@ -307,7 +303,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_status_running(self, scheduler, mock_core_v1):
-        """测试获取运行中 Pod 状态"""
+        """Test get container status running."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "test-pod"
@@ -338,7 +334,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_is_container_running_true(self, scheduler, mock_core_v1):
-        """测试检查 Pod 是否运行中（运行中）"""
+        """Test is container running true."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "test-pod"
@@ -367,7 +363,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_is_container_running_false(self, scheduler, mock_core_v1):
-        """测试检查 Pod 是否运行中（未运行）"""
+        """Test is container running false."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "test-pod"
@@ -384,7 +380,7 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_get_container_logs(self, scheduler, mock_core_v1):
-        """测试获取 Pod 日志"""
+        """Test get container logs."""
         mock_core_v1.read_namespaced_pod_log.return_value = "log line 1\nlog line 2\n"
 
         logs = await scheduler.get_container_logs("test-pod", tail=100)
@@ -394,8 +390,8 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_wait_container_success(self, scheduler, mock_core_v1):
-        """测试等待 Pod 完成（成功）"""
-        # 第一次调用返回运行中，第二次返回完成
+        """Test wait container success."""
+        # Expected return value.
         running_pod = Mock()
         running_pod.status.phase = "Running"
         running_pod.status.container_statuses = [
@@ -423,8 +419,8 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_wait_container_timeout(self, scheduler, mock_core_v1):
-        """测试等待 Pod 完成（超时）"""
-        # 始终返回运行中
+        """Test wait container timeout."""
+        # Expected return value.
         running_pod = Mock()
         running_pod.status.phase = "Running"
         running_pod.status.container_statuses = [
@@ -446,12 +442,12 @@ class TestK8sScheduler:
 
     @pytest.mark.asyncio
     async def test_close(self, scheduler):
-        """测试关闭连接"""
+        """Test close."""
         await scheduler.close()
         assert scheduler._initialized is False
 
     def test_build_executor_container(self, scheduler, basic_config):
-        """测试构建 executor 容器"""
+        """Test build executor container."""
         container = scheduler._build_executor_container(
             config=basic_config,
             use_s3_mount=False,
@@ -462,7 +458,7 @@ class TestK8sScheduler:
         assert container.image == "python:3.11"
 
     def test_build_executor_container_with_s3_mount(self, scheduler):
-        """测试构建带 S3 挂载的 executor 容器"""
+        """Test build executor container with S3 mount."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -481,7 +477,7 @@ class TestK8sScheduler:
             has_dependencies=False,
         )
 
-        # 验证 S3 相关环境变量
+        # S3-related test setup.
         env_names = [env.name for env in container.env]
         assert "WORKSPACE_PATH" in env_names
         assert "S3_BUCKET" in env_names
@@ -489,31 +485,31 @@ class TestK8sScheduler:
 
 
 class TestS3PrefixHelper:
-    """测试 S3 路径前缀辅助函数"""
+    """Tests for TestS3PrefixHelper."""
 
     def test_s3_prefix_from_path_session_format(self):
-        """测试从会话格式路径提取会话 ID"""
+        """Test S3 prefix from path session format."""
         from src.infrastructure.container_scheduler.k8s_scheduler import s3_prefix_from_path
 
         session_id = s3_prefix_from_path("sessions/test-001/workspace")
         assert session_id == "test-001"
 
     def test_s3_prefix_from_path_session_format_without_workspace(self):
-        """测试从会话格式路径提取会话 ID（无 workspace 后缀）"""
+        """Test S3 prefix from path session format without workspace."""
         from src.infrastructure.container_scheduler.k8s_scheduler import s3_prefix_from_path
 
         session_id = s3_prefix_from_path("sessions/test-001")
         assert session_id == "test-001"
 
     def test_s3_prefix_from_path_non_session_format(self):
-        """测试非会话格式路径返回原路径"""
+        """Test S3 prefix from path non session format."""
         from src.infrastructure.container_scheduler.k8s_scheduler import s3_prefix_from_path
 
         result = s3_prefix_from_path("custom/path/to/files")
         assert result == "custom/path/to/files"
 
     def test_s3_prefix_from_path_with_trailing_slash(self):
-        """测试带尾部斜杠的路径"""
+        """Test S3 prefix from path with trailing slash."""
         from src.infrastructure.container_scheduler.k8s_scheduler import s3_prefix_from_path
 
         session_id = s3_prefix_from_path("sessions/test-001/")
@@ -521,56 +517,56 @@ class TestS3PrefixHelper:
 
 
 class TestK8sSchedulerExtended:
-    """K8s 调度器扩展测试"""
+    """Tests for TestK8sSchedulerExtended."""
 
     @pytest.fixture
     def mock_core_v1(self):
-        """模拟 Kubernetes CoreV1Api"""
+        """Create core v1."""
         api = Mock()
         return api
 
     @pytest.fixture
     def scheduler(self, mock_core_v1):
-        """创建 K8s 调度器"""
+        """Create scheduler."""
         sched = K8sScheduler(namespace="test-namespace")
         sched._core_v1 = mock_core_v1
         sched._initialized = True
         return sched
 
     def test_parse_s3_workspace_empty(self, scheduler):
-        """测试解析空 S3 workspace 路径"""
+        """Test parse S3 workspace empty."""
         result = scheduler._parse_s3_workspace("")
 
         assert result is None
 
     def test_parse_s3_workspace_none(self, scheduler):
-        """测试解析 None S3 workspace 路径"""
+        """Test parse S3 workspace none."""
         result = scheduler._parse_s3_workspace(None)
 
         assert result is None
 
     def test_parse_memory_to_bytes_ki(self, scheduler):
-        """测试解析内存限制（Ki）"""
+        """Test parse memory to bytes ki."""
         result = scheduler._parse_memory_to_bytes("256Ki")
 
         assert result == 256 * 1024
 
     def test_parse_memory_to_bytes_plain_number(self, scheduler):
-        """测试解析内存限制（纯数字）"""
+        """Test parse memory to bytes plain number."""
         result = scheduler._parse_memory_to_bytes("1024")
 
-        # 默认单位为 MB
+        # Test setup.
         assert result == 1024 * 1024 * 1024
 
     def test_parse_disk_to_bytes_mb(self, scheduler):
-        """测试解析磁盘限制（MB）"""
+        """Test parse disk to bytes mb."""
         result = scheduler._parse_disk_to_bytes("512Mi")
 
         assert result == 512 * 1024 * 1024
 
     @pytest.mark.asyncio
     async def test_get_container_status_pending(self, scheduler, mock_core_v1):
-        """测试获取等待中 Pod 状态"""
+        """Test get container status pending."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "test-pod"
@@ -589,7 +585,7 @@ class TestK8sSchedulerExtended:
 
     @pytest.mark.asyncio
     async def test_get_container_status_failed(self, scheduler, mock_core_v1):
-        """测试获取失败 Pod 状态"""
+        """Test get container status failed."""
         mock_pod = Mock()
         mock_pod.metadata = Mock()
         mock_pod.metadata.name = "test-pod"
@@ -617,7 +613,7 @@ class TestK8sSchedulerExtended:
 
     @pytest.mark.asyncio
     async def test_wait_container_failure(self, scheduler, mock_core_v1):
-        """测试等待 Pod 完成（失败）"""
+        """Test wait container failure."""
         failed_pod = Mock()
         failed_pod.status.phase = "Failed"
         failed_pod.status.container_statuses = [
@@ -639,14 +635,14 @@ class TestK8sSchedulerExtended:
 
     @pytest.mark.asyncio
     async def test_start_container(self, scheduler, mock_core_v1):
-        """测试启动 Pod（K8s 中 Pod 创建即启动）"""
-        # K8s 中 start_container 通常不需要额外操作
+        """Test start container."""
+        # Test setup.
         await scheduler.start_container("test-pod")
-        # 不应该有异常
+        # Verify expected behavior.
 
     @pytest.mark.asyncio
     async def test_get_container_logs_with_tail(self, scheduler, mock_core_v1):
-        """测试获取 Pod 日志（带 tail 参数）"""
+        """Test get container logs with tail."""
         mock_core_v1.read_namespaced_pod_log.return_value = "log output"
 
         logs = await scheduler.get_container_logs("test-pod", tail=50)
@@ -657,7 +653,7 @@ class TestK8sSchedulerExtended:
 
     @pytest.mark.asyncio
     async def test_remove_container_no_force(self, scheduler, mock_core_v1):
-        """测试删除 Pod（不强制）"""
+        """Test remove container no force."""
         mock_core_v1.delete_namespaced_pod.return_value = None
 
         await scheduler.remove_container("test-pod", force=False)
@@ -666,23 +662,23 @@ class TestK8sSchedulerExtended:
         assert call_args[1]["grace_period_seconds"] == 30
 
     def test_build_pod_name_long_id(self, scheduler):
-        """测试生成 Pod 名称（长 ID）"""
+        """Test build Pod name long ID."""
         long_id = "a" * 300
         pod_name = scheduler._build_pod_name(long_id)
 
         assert len(pod_name) <= 253
 
     def test_build_pod_name_special_chars(self, scheduler):
-        """测试生成 Pod 名称（特殊字符）"""
+        """Test build Pod name special chars."""
         session_id = "session_ABC-123.test"
         pod_name = scheduler._build_pod_name(session_id)
 
-        # 应该只包含小写字母、数字和连字符
+        # Verify expected behavior.
         assert pod_name == pod_name.lower()
         assert "_" not in pod_name or "." not in pod_name
 
     def test_build_executor_container_with_resources(self, scheduler):
-        """测试构建带资源限制的 executor 容器"""
+        """Test build executor container with resources."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -711,7 +707,7 @@ class TestK8sSchedulerExtended:
         assert container.resources.limits["ephemeral-storage"] == "10Gi"
 
     def test_build_executor_container_with_dependencies(self, scheduler):
-        """测试构建带依赖安装的 executor 容器"""
+        """Test build executor container with dependencies."""
         config = ContainerConfig(
             image="python:3.11",
             name="test-session",
@@ -730,6 +726,6 @@ class TestK8sSchedulerExtended:
             has_dependencies=True,
         )
 
-        # 应该有启动命令
+        # Verify expected behavior.
         assert container.command is not None
         assert "pip3 install" in container.command[2]

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_client.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_client.py
@@ -1,8 +1,4 @@
-"""
-执行器 HTTP 客户端单元测试
-
-测试 ExecutorClient 的功能。
-"""
+"""Unit tests for client."""
 
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
@@ -19,16 +15,16 @@ from src.infrastructure.executors.errors import (
 
 
 class TestExecutorClient:
-    """执行器客户端测试"""
+    """Tests for TestExecutorClient."""
 
     @pytest.fixture
     def client(self):
-        """创建执行器客户端"""
+        """Create client."""
         return ExecutorClient(timeout=30.0, max_retries=3, retry_delay=0.1)
 
     @pytest.fixture
     def mock_httpx_client(self):
-        """创建模拟 httpx 客户端"""
+        """Create httpx client."""
         mock = Mock()
         mock.post = AsyncMock()
         mock.get = AsyncMock()
@@ -36,7 +32,7 @@ class TestExecutorClient:
         return mock
 
     def test_init_default_params(self):
-        """测试默认参数初始化"""
+        """Test init default params."""
         client = ExecutorClient()
 
         assert client._timeout == 30.0
@@ -44,7 +40,7 @@ class TestExecutorClient:
         assert client._retry_delay == 0.5
 
     def test_init_custom_params(self):
-        """测试自定义参数初始化"""
+        """Test init custom params."""
         client = ExecutorClient(timeout=60.0, max_retries=5, retry_delay=1.0)
 
         assert client._timeout == 60.0
@@ -53,7 +49,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_context_manager(self):
-        """测试上下文管理器"""
+        """Test context manager."""
         async with ExecutorClient() as client:
             assert client._client is not None
 
@@ -62,7 +58,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_context_manager_creates_client(self):
-        """测试上下文管理器创建客户端"""
+        """Test context manager creates client."""
         client = ExecutorClient()
         assert client._client is None
 
@@ -71,7 +67,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_close(self, client):
-        """测试关闭客户端"""
+        """Test close."""
         # First, get a client instance
         client._get_client()
         assert client._client is not None
@@ -81,13 +77,13 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_close_when_no_client(self, client):
-        """测试关闭不存在的客户端"""
+        """Test close when no client."""
         # Should not raise error
         await client.close()
 
     @pytest.mark.asyncio
     async def test_submit_execution_success(self, client, mock_httpx_client):
-        """测试成功提交执行请求"""
+        """Test submit execution success."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -115,7 +111,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_validation_error(self, client, mock_httpx_client):
-        """测试验证错误（不重试）"""
+        """Test submit execution validation error."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -141,7 +137,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_5xx_retry_then_success(self, client, mock_httpx_client):
-        """测试 5xx 错误后重试成功"""
+        """Test submit execution 5xx retry then success."""
         client._client = mock_httpx_client
 
         # First call: 500 error
@@ -176,7 +172,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_5xx_max_retries(self, client, mock_httpx_client):
-        """测试 5xx 错误达到最大重试次数"""
+        """Test submit execution 5xx max retries."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -201,7 +197,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_connection_error_retry(self, client, mock_httpx_client):
-        """测试连接错误重试"""
+        """Test submit execution connection error retry."""
         client._client = mock_httpx_client
 
         # First two calls: connection error
@@ -236,7 +232,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_connection_error_max_retries(self, client, mock_httpx_client):
-        """测试连接错误达到最大重试次数"""
+        """Test submit execution connection error max retries."""
         client._client = mock_httpx_client
 
         mock_httpx_client.post.side_effect = httpx.ConnectError("Connection refused")
@@ -257,7 +253,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_timeout_error(self, client, mock_httpx_client):
-        """测试超时错误"""
+        """Test submit execution timeout error."""
         client._client = mock_httpx_client
 
         mock_httpx_client.post.side_effect = httpx.TimeoutException("Timeout")
@@ -276,7 +272,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_submit_execution_other_error_response(self, client, mock_httpx_client):
-        """测试其他错误响应（如 404）"""
+        """Test submit execution other error response."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -300,7 +296,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_health_check_success(self, client, mock_httpx_client):
-        """测试健康检查成功"""
+        """Test health check success."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -315,7 +311,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_health_check_unhealthy(self, client, mock_httpx_client):
-        """测试健康检查不健康"""
+        """Test health check unhealthy."""
         client._client = mock_httpx_client
 
         mock_response = Mock()
@@ -327,7 +323,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_health_check_connection_error(self, client, mock_httpx_client):
-        """测试健康检查连接错误"""
+        """Test health check connection error."""
         client._client = mock_httpx_client
 
         mock_httpx_client.get.side_effect = httpx.ConnectError("Connection refused")
@@ -337,7 +333,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_health_check_timeout(self, client, mock_httpx_client):
-        """测试健康检查超时"""
+        """Test health check timeout."""
         client._client = mock_httpx_client
 
         mock_httpx_client.get.side_effect = httpx.TimeoutException("Timeout")
@@ -347,7 +343,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_get_client_creates_if_none(self, client):
-        """测试获取客户端时自动创建"""
+        """Test get client creates if none."""
         assert client._client is None
 
         c = client._get_client()
@@ -357,7 +353,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_get_client_returns_existing(self, client, mock_httpx_client):
-        """测试获取客户端时返回现有实例"""
+        """Test get client returns existing."""
         client._client = mock_httpx_client
 
         c = client._get_client()
@@ -366,7 +362,7 @@ class TestExecutorClient:
 
     @pytest.mark.asyncio
     async def test_sync_session_config_uses_request_timeout(self, client, mock_httpx_client):
-        """测试同步依赖配置时使用本次请求超时。"""
+        """Test sync session config uses request timeout."""
         client._client = mock_httpx_client
 
         mock_response = Mock()

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_dto.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_dto.py
@@ -1,8 +1,4 @@
-"""
-执行器 DTO 单元测试
-
-测试执行器数据传输对象。
-"""
+"""Unit tests for DTO."""
 import pytest
 from pydantic import ValidationError
 
@@ -15,10 +11,10 @@ from src.infrastructure.executors.dto import (
 
 
 class TestExecutorExecuteRequest:
-    """执行器执行请求测试"""
+    """Tests for TestExecutorExecuteRequest."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -36,7 +32,7 @@ class TestExecutorExecuteRequest:
         assert request.working_directory is None
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -58,7 +54,7 @@ class TestExecutorExecuteRequest:
         assert request.working_directory == "src/jobs"
 
     def test_timeout_minimum(self):
-        """测试超时最小值"""
+        """Test timeout minimum."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -69,7 +65,7 @@ class TestExecutorExecuteRequest:
         assert request.timeout == 1
 
     def test_timeout_maximum(self):
-        """测试超时最大值"""
+        """Test timeout maximum."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -80,7 +76,7 @@ class TestExecutorExecuteRequest:
         assert request.timeout == 3600
 
     def test_timeout_below_minimum(self):
-        """测试超时低于最小值"""
+        """Test timeout below minimum."""
         with pytest.raises(ValidationError):
             ExecutorExecuteRequest(
                 execution_id="exec-123",
@@ -91,7 +87,7 @@ class TestExecutorExecuteRequest:
             )
 
     def test_timeout_above_maximum(self):
-        """测试超时高于最大值"""
+        """Test timeout above maximum."""
         with pytest.raises(ValidationError):
             ExecutorExecuteRequest(
                 execution_id="exec-123",
@@ -102,7 +98,7 @@ class TestExecutorExecuteRequest:
             )
 
     def test_missing_required_fields(self):
-        """测试缺少必填字段"""
+        """Test missing required fields."""
         with pytest.raises(ValidationError):
             ExecutorExecuteRequest(
                 execution_id="exec-123",
@@ -112,7 +108,7 @@ class TestExecutorExecuteRequest:
             )
 
     def test_model_dump(self):
-        """测试序列化为字典"""
+        """Test model dump."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -132,7 +128,7 @@ class TestExecutorExecuteRequest:
         assert data["timeout"] == 60
 
     def test_model_dump_includes_working_directory(self):
-        """测试序列化包含工作目录"""
+        """Test model dump includes working directory."""
         request = ExecutorExecuteRequest(
             execution_id="exec-123",
             session_id="sess-456",
@@ -146,16 +142,16 @@ class TestExecutorExecuteRequest:
         assert data["working_directory"] == "skill/mini-wiki"
 
     def test_json_schema_examples(self):
-        """测试 JSON schema 示例"""
+        """Test JSON schema examples."""
         # Should have examples defined
         assert "examples" in ExecutorExecuteRequest.model_config.get("json_schema_extra", {})
 
 
 class TestExecutorExecuteResponse:
-    """执行器执行响应测试"""
+    """Tests for TestExecutorExecuteResponse."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         response = ExecutorExecuteResponse(
             execution_id="exec-123",
             status="submitted"
@@ -166,7 +162,7 @@ class TestExecutorExecuteResponse:
         assert response.message == ""  # default
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         response = ExecutorExecuteResponse(
             execution_id="exec-123",
             status="completed",
@@ -178,7 +174,7 @@ class TestExecutorExecuteResponse:
         assert response.message == "Execution finished successfully"
 
     def test_missing_required_fields(self):
-        """测试缺少必填字段"""
+        """Test missing required fields."""
         with pytest.raises(ValidationError):
             ExecutorExecuteResponse(
                 execution_id="exec-123"
@@ -186,7 +182,7 @@ class TestExecutorExecuteResponse:
             )
 
     def test_from_json(self):
-        """测试从 JSON 创建"""
+        """Test from JSON."""
         response = ExecutorExecuteResponse(**{
             "execution_id": "exec-123",
             "status": "completed",
@@ -199,10 +195,10 @@ class TestExecutorExecuteResponse:
 
 
 class TestExecutorHealthResponse:
-    """执行器健康检查响应测试"""
+    """Tests for TestExecutorHealthResponse."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         response = ExecutorHealthResponse(
             status="healthy"
         )
@@ -213,7 +209,7 @@ class TestExecutorHealthResponse:
         assert response.active_executions is None
 
     def test_create_with_all_fields(self):
-        """测试使用所有字段创建"""
+        """Test create with all fields."""
         response = ExecutorHealthResponse(
             status="healthy",
             version="2.0.0",
@@ -227,7 +223,7 @@ class TestExecutorHealthResponse:
         assert response.active_executions == 5
 
     def test_unhealthy_status(self):
-        """测试不健康状态"""
+        """Test unhealthy status."""
         response = ExecutorHealthResponse(
             status="unhealthy"
         )
@@ -235,7 +231,7 @@ class TestExecutorHealthResponse:
         assert response.status == "unhealthy"
 
     def test_from_json(self):
-        """测试从 JSON 创建"""
+        """Test from JSON."""
         response = ExecutorHealthResponse(**{
             "status": "healthy",
             "version": "1.5.0",
@@ -249,7 +245,7 @@ class TestExecutorHealthResponse:
         assert response.active_executions == 3
 
     def test_from_json_minimal(self):
-        """测试从最小 JSON 创建"""
+        """Test from JSON minimal."""
         response = ExecutorHealthResponse(**{
             "status": "healthy"
         })
@@ -259,10 +255,10 @@ class TestExecutorHealthResponse:
 
 
 class TestExecutorContainerInfo:
-    """执行器容器信息测试"""
+    """Tests for TestExecutorContainerInfo."""
 
     def test_create_with_required_fields(self):
-        """测试使用必填字段创建"""
+        """Test create with required fields."""
         info = ExecutorContainerInfo(
             container_id="container-123",
             container_name="sandbox-sess-123"
@@ -273,7 +269,7 @@ class TestExecutorContainerInfo:
         assert info.executor_port == 8080  # default
 
     def test_create_with_custom_port(self):
-        """测试使用自定义端口创建"""
+        """Test create with custom port."""
         info = ExecutorContainerInfo(
             container_id="container-123",
             container_name="sandbox-sess-123",
@@ -283,7 +279,7 @@ class TestExecutorContainerInfo:
         assert info.executor_port == 9090
 
     def test_executor_url_default_port(self):
-        """测试执行器 URL（默认端口）"""
+        """Test executor URL default port."""
         info = ExecutorContainerInfo(
             container_id="container-123",
             container_name="sandbox-sess-123"
@@ -292,7 +288,7 @@ class TestExecutorContainerInfo:
         assert info.executor_url == "http://sandbox-sess-123:8080"
 
     def test_executor_url_custom_port(self):
-        """测试执行器 URL（自定义端口）"""
+        """Test executor URL custom port."""
         info = ExecutorContainerInfo(
             container_id="container-123",
             container_name="sandbox-sess-123",
@@ -302,7 +298,7 @@ class TestExecutorContainerInfo:
         assert info.executor_url == "http://sandbox-sess-123:9090"
 
     def test_executor_url_with_underscored_name(self):
-        """测试执行器 URL（带下划线的名称）"""
+        """Test executor URL with underscored name."""
         info = ExecutorContainerInfo(
             container_id="container-123",
             container_name="sandbox_session_test"
@@ -311,7 +307,7 @@ class TestExecutorContainerInfo:
         assert info.executor_url == "http://sandbox_session_test:8080"
 
     def test_is_dataclass(self):
-        """测试是数据类"""
+        """Test is dataclass."""
         from dataclasses import is_dataclass
 
         assert is_dataclass(ExecutorContainerInfo)

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_errors.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/executors/test_errors.py
@@ -1,8 +1,4 @@
-"""
-执行器错误单元测试
-
-测试执行器相关错误类。
-"""
+"""Unit tests for errors."""
 import pytest
 
 from src.infrastructure.executors.errors import (
@@ -16,24 +12,24 @@ from src.infrastructure.executors.errors import (
 
 
 class TestExecutorError:
-    """执行器错误基类测试"""
+    """Tests for TestExecutorError."""
 
     def test_is_exception(self):
-        """测试继承自 Exception"""
+        """Test is exception."""
         error = ExecutorError("Test error")
         assert isinstance(error, Exception)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = ExecutorError("Test error message")
         assert str(error) == "Test error message"
 
 
 class TestExecutorConnectionError:
-    """执行器连接错误测试"""
+    """Tests for TestExecutorConnectionError."""
 
     def test_init(self):
-        """测试初始化"""
+        """Test init."""
         error = ExecutorConnectionError(
             executor_url="http://localhost:8080",
             reason="Connection refused"
@@ -43,7 +39,7 @@ class TestExecutorConnectionError:
         assert error.reason == "Connection refused"
 
     def test_message_format(self):
-        """测试消息格式"""
+        """Test message format."""
         error = ExecutorConnectionError(
             executor_url="http://localhost:8080",
             reason="Connection refused"
@@ -53,12 +49,12 @@ class TestExecutorConnectionError:
         assert "Connection refused" in str(error)
 
     def test_inherits_from_executor_error(self):
-        """测试继承自 ExecutorError"""
+        """Test inherits from executor error."""
         error = ExecutorConnectionError("http://localhost:8080", "test")
         assert isinstance(error, ExecutorError)
 
     def test_empty_reason(self):
-        """测试空原因"""
+        """Test empty reason."""
         error = ExecutorConnectionError("http://localhost:8080")
 
         assert error.executor_url == "http://localhost:8080"
@@ -67,10 +63,10 @@ class TestExecutorConnectionError:
 
 
 class TestExecutorTimeoutError:
-    """执行器超时错误测试"""
+    """Tests for TestExecutorTimeoutError."""
 
     def test_init(self):
-        """测试初始化"""
+        """Test init."""
         error = ExecutorTimeoutError(
             executor_url="http://localhost:8080",
             timeout=30.0
@@ -80,7 +76,7 @@ class TestExecutorTimeoutError:
         assert error.timeout == 30.0
 
     def test_message_format(self):
-        """测试消息格式"""
+        """Test message format."""
         error = ExecutorTimeoutError(
             executor_url="http://localhost:8080",
             timeout=30.0
@@ -91,16 +87,16 @@ class TestExecutorTimeoutError:
         assert "timed out" in str(error).lower()
 
     def test_inherits_from_executor_error(self):
-        """测试继承自 ExecutorError"""
+        """Test inherits from executor error."""
         error = ExecutorTimeoutError("http://localhost:8080", 30.0)
         assert isinstance(error, ExecutorError)
 
 
 class TestExecutorUnavailableError:
-    """执行器不可用错误测试"""
+    """Tests for TestExecutorUnavailableError."""
 
     def test_init(self):
-        """测试初始化"""
+        """Test init."""
         error = ExecutorUnavailableError(
             executor_url="http://localhost:8080",
             status="unhealthy"
@@ -110,7 +106,7 @@ class TestExecutorUnavailableError:
         assert error.status == "unhealthy"
 
     def test_message_format(self):
-        """测试消息格式"""
+        """Test message format."""
         error = ExecutorUnavailableError(
             executor_url="http://localhost:8080",
             status="unhealthy"
@@ -121,23 +117,23 @@ class TestExecutorUnavailableError:
         assert "unhealthy" in str(error)
 
     def test_empty_status(self):
-        """测试空状态"""
+        """Test empty status."""
         error = ExecutorUnavailableError("http://localhost:8080")
 
         assert error.executor_url == "http://localhost:8080"
         assert error.status == ""
 
     def test_inherits_from_executor_error(self):
-        """测试继承自 ExecutorError"""
+        """Test inherits from executor error."""
         error = ExecutorUnavailableError("http://localhost:8080", "test")
         assert isinstance(error, ExecutorError)
 
 
 class TestExecutorResponseError:
-    """执行器响应错误测试"""
+    """Tests for TestExecutorResponseError."""
 
     def test_init(self):
-        """测试初始化"""
+        """Test init."""
         error = ExecutorResponseError(
             executor_url="http://localhost:8080",
             status_code=500,
@@ -149,7 +145,7 @@ class TestExecutorResponseError:
         assert error.message == "Internal Server Error"
 
     def test_message_format(self):
-        """测试消息格式"""
+        """Test message format."""
         error = ExecutorResponseError(
             executor_url="http://localhost:8080",
             status_code=500,
@@ -161,7 +157,7 @@ class TestExecutorResponseError:
         assert "Internal Server Error" in str(error)
 
     def test_empty_message(self):
-        """测试空消息"""
+        """Test empty message."""
         error = ExecutorResponseError(
             executor_url="http://localhost:8080",
             status_code=404
@@ -172,16 +168,16 @@ class TestExecutorResponseError:
         assert error.message == ""
 
     def test_inherits_from_executor_error(self):
-        """测试继承自 ExecutorError"""
+        """Test inherits from executor error."""
         error = ExecutorResponseError("http://localhost:8080", 500, "test")
         assert isinstance(error, ExecutorError)
 
 
 class TestExecutorValidationError:
-    """执行器验证错误测试"""
+    """Tests for TestExecutorValidationError."""
 
     def test_init(self):
-        """测试初始化"""
+        """Test init."""
         error = ExecutorValidationError(
             executor_url="http://localhost:8080",
             validation_errors=["Missing field: code", "Invalid timeout"]
@@ -191,7 +187,7 @@ class TestExecutorValidationError:
         assert error.validation_errors == ["Missing field: code", "Invalid timeout"]
 
     def test_message_format(self):
-        """测试消息格式"""
+        """Test message format."""
         error = ExecutorValidationError(
             executor_url="http://localhost:8080",
             validation_errors=["Missing field: code"]
@@ -202,7 +198,7 @@ class TestExecutorValidationError:
         assert "Missing field: code" in str(error)
 
     def test_empty_validation_errors(self):
-        """测试空验证错误列表"""
+        """Test empty validation errors."""
         error = ExecutorValidationError(
             executor_url="http://localhost:8080",
             validation_errors=[]
@@ -212,6 +208,6 @@ class TestExecutorValidationError:
         assert error.validation_errors == []
 
     def test_inherits_from_executor_error(self):
-        """测试继承自 ExecutorError"""
+        """Test inherits from executor error."""
         error = ExecutorValidationError("http://localhost:8080", [])
         assert isinstance(error, ExecutorError)

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/persistence/test_database.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/persistence/test_database.py
@@ -1,8 +1,4 @@
-"""
-数据库管理器单元测试
-
-测试 DatabaseManager 的功能。
-"""
+"""Unit tests for database."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 
@@ -15,11 +11,11 @@ from src.infrastructure.persistence.database import (
 
 
 class TestDatabaseManager:
-    """数据库管理器测试"""
+    """Tests for TestDatabaseManager."""
 
     @pytest.fixture
     def mock_settings(self):
-        """模拟设置"""
+        """Create settings."""
         settings = Mock()
         settings.effective_database_url = "mysql+aiomysql://root:password@localhost:3306/openbkn"
         settings.log_level = "INFO"
@@ -30,16 +26,16 @@ class TestDatabaseManager:
 
     @pytest.fixture
     def db_manager(self):
-        """创建数据库管理器"""
+        """Create db manager."""
         return DatabaseManager()
 
     def test_init(self, db_manager):
-        """测试初始化"""
+        """Test init."""
         assert db_manager._engine is None
         assert db_manager._session_factory is None
 
     def test_get_runtime_database_url_normalizes_legacy_database_name(self, db_manager, mock_settings):
-        """测试运行期数据库 URL 会将旧库名规范化到新库名。"""
+        """Test get runtime database URL normalizes legacy database name."""
         mock_settings.effective_database_url = "mysql+aiomysql://root:password@localhost:3306/adp"
 
         with patch("src.infrastructure.persistence.database.get_settings", return_value=mock_settings):
@@ -48,7 +44,7 @@ class TestDatabaseManager:
         assert runtime_url == "mysql+aiomysql://root:password@localhost:3306/openbkn"
 
     def test_get_managed_sandbox_table_names(self, db_manager):
-        """测试只返回受管的沙箱表。"""
+        """Test get managed sandbox table names."""
         assert db_manager._get_managed_sandbox_table_names() == {
             "t_sandbox_execution",
             "t_sandbox_runtime_node",
@@ -58,33 +54,33 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_ensure_database_exists_integration(self, db_manager):
-        """测试确保数据库存在（集成测试，需要实际连接）"""
+        """Test ensure database exists integration."""
         # This test requires actual database connection
         # Skip in unit tests
         pass
 
     @pytest.mark.asyncio
     async def test_initialize_integration(self, db_manager):
-        """测试初始化数据库引擎（集成测试）"""
+        """Test initialize integration."""
         # This test requires actual database connection
         # Skip in unit tests
         pass
 
     @pytest.mark.asyncio
     async def test_create_tables_not_initialized(self, db_manager):
-        """测试未初始化时创建表"""
+        """Test create tables not initialized."""
         with pytest.raises(RuntimeError, match="not initialized"):
             await db_manager.create_tables()
 
     @pytest.mark.asyncio
     async def test_run_startup_schema_migrations_not_initialized(self, db_manager):
-        """测试未初始化时执行启动迁移。"""
+        """Test run startup schema migrations not initialized."""
         with pytest.raises(RuntimeError, match="not initialized"):
             await db_manager.run_startup_schema_migrations()
 
     @pytest.mark.asyncio
     async def test_initialize_with_seed_no_tables_no_seed(self, db_manager):
-        """测试初始化不创建表和种子数据"""
+        """Test initialize with seed no tables no seed."""
         result = await db_manager.initialize_with_seed(
             create_tables=False,
             seed_data=False
@@ -96,7 +92,7 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_initialize_with_seed_create_tables(self, db_manager):
-        """测试初始化创建表"""
+        """Test initialize with seed create tables."""
         with patch.object(db_manager, 'create_tables', new_callable=AsyncMock):
             result = await db_manager.initialize_with_seed(
                 create_tables=True,
@@ -108,7 +104,7 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_initialize_with_seed_with_seed(self, db_manager):
-        """测试初始化带种子数据"""
+        """Test initialize with seed with seed."""
         with patch.object(db_manager, 'create_tables', new_callable=AsyncMock):
             with patch('src.infrastructure.persistence.seed.seeder.seed_default_data',
                       new_callable=AsyncMock, return_value={"templates": 1, "runtime_nodes": 1}):
@@ -123,20 +119,20 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_get_session_not_initialized(self, db_manager):
-        """测试未初始化时获取会话"""
+        """Test get session not initialized."""
         with pytest.raises(RuntimeError, match="not initialized"):
             async with db_manager.get_session():
                 pass
 
     @pytest.mark.asyncio
     async def test_close_no_engine(self, db_manager):
-        """测试没有引擎时关闭"""
+        """Test close no engine."""
         # Should not raise error
         await db_manager.close()
 
     @pytest.mark.asyncio
     async def test_close_with_engine(self, db_manager):
-        """测试有引擎时关闭"""
+        """Test close with engine."""
         mock_engine = Mock()
         mock_engine.dispose = AsyncMock()
         db_manager._engine = mock_engine
@@ -151,7 +147,7 @@ class TestDatabaseManager:
         db_manager,
         mock_settings,
     ):
-        """测试旧数据库名会迁移受管表，但不会删除旧库。"""
+        """Test upgrade legacy database name migrates managed tables without dropping legacy database."""
         mock_cursor = AsyncMock()
         mock_cursor.fetchone = AsyncMock(side_effect=[(1,), (0,)])
         mock_cursor.fetchall = AsyncMock(
@@ -205,7 +201,7 @@ class TestDatabaseManager:
         db_manager,
         mock_settings,
     ):
-        """测试新数据库已存在但缺表时会迁移缺失表且保留旧库。"""
+        """Test upgrade legacy database name migrates missing tables when target exists."""
         mock_cursor = AsyncMock()
         mock_cursor.fetchone = AsyncMock(side_effect=[(1,), (1,)])
         mock_cursor.fetchall = AsyncMock(
@@ -254,7 +250,7 @@ class TestDatabaseManager:
         db_manager,
         mock_settings,
     ):
-        """测试目标库已有同名表时保留旧库剩余表，避免覆盖数据。"""
+        """Test upgrade legacy database name keeps legacy database when tables remain."""
         mock_cursor = AsyncMock()
         mock_cursor.fetchone = AsyncMock(side_effect=[(1,), (1,)])
         mock_cursor.fetchall = AsyncMock(
@@ -298,7 +294,7 @@ class TestDatabaseManager:
         db_manager,
         mock_settings,
     ):
-        """测试只迁移受管的沙箱表，不处理其他业务表。"""
+        """Test upgrade legacy database name ignores non sandbox tables."""
         mock_cursor = AsyncMock()
         mock_cursor.fetchone = AsyncMock(side_effect=[(1,), (1,)])
         mock_cursor.fetchall = AsyncMock(
@@ -342,7 +338,7 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_run_startup_schema_migrations_adds_missing_column(self, db_manager):
-        """测试启动迁移会补齐缺失字段。"""
+        """Test run startup schema migrations adds missing column."""
         mock_conn = AsyncMock()
         table_exists_result = Mock()
         table_exists_result.scalar.return_value = 1
@@ -371,7 +367,7 @@ class TestDatabaseManager:
 
     @pytest.mark.asyncio
     async def test_run_startup_schema_migrations_skips_existing_column(self, db_manager):
-        """测试启动迁移在字段已存在时跳过。"""
+        """Test run startup schema migrations skips existing column."""
         mock_conn = AsyncMock()
         table_exists_result = Mock()
         table_exists_result.scalar.return_value = 1
@@ -396,9 +392,9 @@ class TestDatabaseManager:
 
 
 class TestBase:
-    """SQLAlchemy 基类测试"""
+    """Tests for TestBase."""
 
     def test_base_is_declarative_base(self):
-        """测试 Base 是 DeclarativeBase"""
+        """Test base is declarative base."""
         from sqlalchemy.orm import DeclarativeBase
         assert issubclass(Base, DeclarativeBase)

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_docker_scheduler_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_docker_scheduler_service.py
@@ -1,8 +1,4 @@
-"""
-Docker 调度服务单元测试
-
-测试 DockerSchedulerService 的功能。
-"""
+"""Unit tests for docker scheduler service."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 
@@ -13,11 +9,11 @@ from tests.helpers import create_mock_template, create_mock_runtime_node
 
 
 class TestDockerSchedulerService:
-    """Docker 调度服务测试"""
+    """Tests for TestDockerSchedulerService."""
 
     @pytest.fixture
     def runtime_node_repo(self):
-        """模拟运行时节点仓储"""
+        """Create runtime node repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         repo.find_by_status = AsyncMock(return_value=[])
@@ -26,7 +22,7 @@ class TestDockerSchedulerService:
 
     @pytest.fixture
     def container_scheduler(self):
-        """模拟容器调度器"""
+        """Create container scheduler."""
         scheduler = Mock()
         scheduler.create_container = AsyncMock(return_value="container-123")
         scheduler.start_container = AsyncMock()
@@ -37,14 +33,14 @@ class TestDockerSchedulerService:
 
     @pytest.fixture
     def template_repo(self):
-        """模拟模板仓储"""
+        """Create template repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         return repo
 
     @pytest.fixture
     def executor_client(self):
-        """模拟执行器客户端"""
+        """Create executor client."""
         client = Mock()
         client.submit_execution = AsyncMock(return_value="exec-123")
         client.health_check = AsyncMock()
@@ -52,7 +48,7 @@ class TestDockerSchedulerService:
 
     @pytest.fixture
     def service(self, runtime_node_repo, container_scheduler, template_repo, executor_client):
-        """创建 Docker 调度服务"""
+        """Create service."""
         return DockerSchedulerService(
             runtime_node_repo=runtime_node_repo,
             container_scheduler=container_scheduler,
@@ -65,12 +61,12 @@ class TestDockerSchedulerService:
 
     @pytest.fixture
     def healthy_node(self):
-        """创建健康节点"""
+        """Create healthy node."""
         return create_mock_runtime_node(node_id="node-1", node_type="docker")
 
     @pytest.fixture
     def schedule_request(self):
-        """创建调度请求"""
+        """Create schedule request."""
         return ScheduleRequest(
             session_id="sess-123",
             template_id="python-test",
@@ -81,8 +77,8 @@ class TestDockerSchedulerService:
     async def test_schedule_with_affinity(
         self, service, runtime_node_repo, healthy_node, schedule_request
     ):
-        """测试有模板亲和性的调度"""
-        # 节点有模板缓存
+        """Test schedule with affinity."""
+        # Test setup.
         healthy_node._cached_templates = ["python-test"]
         runtime_node_repo.find_by_status.return_value = [
             healthy_node.to_runtime_node() if hasattr(healthy_node, 'to_runtime_node') else healthy_node
@@ -103,7 +99,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_schedule_no_healthy_nodes(self, service, runtime_node_repo, schedule_request):
-        """测试没有健康节点"""
+        """Test schedule no healthy nodes."""
         runtime_node_repo.find_by_status.return_value = []
 
         with pytest.raises(RuntimeError, match="No healthy runtime nodes available"):
@@ -113,8 +109,8 @@ class TestDockerSchedulerService:
     async def test_schedule_load_balanced(
         self, service, runtime_node_repo, schedule_request
     ):
-        """测试负载均衡调度"""
-        # 创建多个节点，都没有模板缓存
+        """Test schedule load balanced."""
+        # Create test data.
         node1 = create_mock_runtime_node(node_id="node-1")
         node1.cached_templates = []
         node1.session_count = 10
@@ -123,7 +119,7 @@ class TestDockerSchedulerService:
 
         node2 = create_mock_runtime_node(node_id="node-2")
         node2.cached_templates = []
-        node2.session_count = 5  # 更少会话
+        node2.session_count = 5  # Test setup.
         node2._cpu_usage = 0.3
         node2._mem_usage = 0.4
 
@@ -135,12 +131,12 @@ class TestDockerSchedulerService:
 
         result = await service.schedule(schedule_request)
 
-        # 应选择负载较低的节点
+        # Test setup.
         assert result is not None
 
     @pytest.mark.asyncio
     async def test_get_node_found(self, service, runtime_node_repo, healthy_node):
-        """测试获取存在的节点"""
+        """Test get node found."""
         node_model = Mock()
         node_model.to_runtime_node = Mock(return_value=healthy_node)
         runtime_node_repo.find_by_id.return_value = node_model
@@ -152,7 +148,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_node_not_found(self, service, runtime_node_repo):
-        """测试获取不存在的节点"""
+        """Test get node not found."""
         runtime_node_repo.find_by_id.return_value = None
 
         result = await service.get_node("non-existent")
@@ -161,7 +157,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_healthy_nodes(self, service, runtime_node_repo, healthy_node):
-        """测试获取健康节点列表"""
+        """Test get healthy nodes."""
         node_model = Mock()
         node_model.to_runtime_node = Mock(return_value=healthy_node)
         runtime_node_repo.find_by_status.return_value = [node_model]
@@ -173,7 +169,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_mark_node_unhealthy(self, service, runtime_node_repo):
-        """测试标记节点为不健康"""
+        """Test mark node unhealthy."""
         await service.mark_node_unhealthy("node-1")
 
         runtime_node_repo.update_status.assert_called_once_with("node-1", "offline")
@@ -182,7 +178,7 @@ class TestDockerSchedulerService:
     async def test_create_container_for_session_success(
         self, service, runtime_node_repo, container_scheduler, healthy_node
     ):
-        """测试成功创建容器"""
+        """Test create container for session success."""
         node_model = Mock()
         node_model.to_runtime_node = Mock(return_value=healthy_node)
         runtime_node_repo.find_by_id.return_value = node_model
@@ -210,7 +206,7 @@ class TestDockerSchedulerService:
     async def test_create_container_node_not_found(
         self, service, runtime_node_repo
     ):
-        """测试节点不存在时创建容器失败"""
+        """Test create container node not found."""
         runtime_node_repo.find_by_id.return_value = None
 
         with pytest.raises(RuntimeError, match="Node not found"):
@@ -228,7 +224,7 @@ class TestDockerSchedulerService:
     async def test_create_container_with_dependencies(
         self, service, runtime_node_repo, container_scheduler, healthy_node
     ):
-        """测试创建带依赖的容器"""
+        """Test create container with dependencies."""
         node_model = Mock()
         node_model.to_runtime_node = Mock(return_value=healthy_node)
         runtime_node_repo.find_by_id.return_value = node_model
@@ -253,7 +249,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_destroy_container_success(self, service, container_scheduler):
-        """测试成功销毁容器"""
+        """Test destroy container success."""
         await service.destroy_container("container-123")
 
         container_scheduler.stop_container.assert_called_once()
@@ -261,7 +257,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_destroy_container_with_error(self, service, container_scheduler):
-        """测试销毁容器时出错"""
+        """Test destroy container with error."""
         container_scheduler.stop_container.side_effect = RuntimeError("Stop failed")
 
         with pytest.raises(RuntimeError):
@@ -269,7 +265,7 @@ class TestDockerSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_container_info(self, service, container_scheduler):
-        """测试获取容器信息"""
+        """Test get container info."""
         container_info = Mock()
         container_scheduler.get_container_status.return_value = container_info
 
@@ -282,7 +278,7 @@ class TestDockerSchedulerService:
     async def test_execute_success(
         self, service, container_scheduler, executor_client
     ):
-        """测试成功执行代码"""
+        """Test execute success."""
         container_info = Mock()
         container_info.name = "sandbox-sess-123"
         container_scheduler.get_container_status.return_value = container_info
@@ -308,7 +304,7 @@ class TestDockerSchedulerService:
         assert executor_client.submit_execution.call_args.kwargs["working_directory"] == "src/jobs"
 
     def test_select_least_loaded(self, service):
-        """测试选择负载最低的节点"""
+        """Test select least loaded."""
         node1 = create_mock_runtime_node(node_id="node-1")
         node1.session_count = 10
         node1._cpu_usage = 0.8

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_docker_scheduler_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_docker_scheduler_service.py
@@ -78,7 +78,7 @@ class TestDockerSchedulerService:
         self, service, runtime_node_repo, healthy_node, schedule_request
     ):
         """Test schedule with affinity."""
-        # Test setup.
+        # Node has a template cache.
         healthy_node._cached_templates = ["python-test"]
         runtime_node_repo.find_by_status.return_value = [
             healthy_node.to_runtime_node() if hasattr(healthy_node, 'to_runtime_node') else healthy_node
@@ -110,7 +110,7 @@ class TestDockerSchedulerService:
         self, service, runtime_node_repo, schedule_request
     ):
         """Test schedule load balanced."""
-        # Create test data.
+        # Create multiple nodes with no template cache.
         node1 = create_mock_runtime_node(node_id="node-1")
         node1.cached_templates = []
         node1.session_count = 10
@@ -119,7 +119,7 @@ class TestDockerSchedulerService:
 
         node2 = create_mock_runtime_node(node_id="node-2")
         node2.cached_templates = []
-        node2.session_count = 5  # Test setup.
+        node2.session_count = 5  # Fewer sessions.
         node2._cpu_usage = 0.3
         node2._mem_usage = 0.4
 
@@ -131,7 +131,7 @@ class TestDockerSchedulerService:
 
         result = await service.schedule(schedule_request)
 
-        # Test setup.
+        # Should select the node with lower load.
         assert result is not None
 
     @pytest.mark.asyncio

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_k8s_scheduler_service.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/schedulers/test_k8s_scheduler_service.py
@@ -1,8 +1,4 @@
-"""
-Kubernetes 调度服务单元测试
-
-测试 K8sSchedulerService 的功能。
-"""
+"""Unit tests for K8s scheduler service."""
 import os
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
@@ -14,11 +10,11 @@ from tests.helpers import create_mock_template
 
 
 class TestK8sSchedulerService:
-    """Kubernetes 调度服务测试"""
+    """Tests for TestK8sSchedulerService."""
 
     @pytest.fixture
     def container_scheduler(self):
-        """模拟容器调度器"""
+        """Create container scheduler."""
         scheduler = Mock()
         scheduler.create_container = AsyncMock(return_value="sandbox-sess-123")
         scheduler.start_container = AsyncMock()
@@ -31,14 +27,14 @@ class TestK8sSchedulerService:
 
     @pytest.fixture
     def template_repo(self):
-        """模拟模板仓储"""
+        """Create template repo."""
         repo = Mock()
         repo.find_by_id = AsyncMock()
         return repo
 
     @pytest.fixture
     def executor_client(self):
-        """模拟执行器客户端"""
+        """Create executor client."""
         client = Mock()
         client.submit_execution = AsyncMock(return_value="exec-123")
         client.health_check = AsyncMock()
@@ -46,7 +42,7 @@ class TestK8sSchedulerService:
 
     @pytest.fixture
     def service(self, container_scheduler, template_repo, executor_client):
-        """创建 K8s 调度服务"""
+        """Create service."""
         with patch.dict(os.environ, {"POD_NAME": "cp-0", "POD_UID": "uid-0"}, clear=False):
             return K8sSchedulerService(
                 container_scheduler=container_scheduler,
@@ -59,7 +55,7 @@ class TestK8sSchedulerService:
 
     @pytest.fixture
     def schedule_request(self):
-        """创建调度请求"""
+        """Create schedule request."""
         return ScheduleRequest(
             session_id="sess-123",
             template_id="python-test",
@@ -68,12 +64,12 @@ class TestK8sSchedulerService:
 
     @pytest.fixture
     def template(self):
-        """创建模板"""
+        """Create template."""
         return create_mock_template(template_id="python-test")
 
     @pytest.mark.asyncio
     async def test_schedule_returns_cluster_node(self, service, schedule_request):
-        """测试调度返回集群节点"""
+        """Test schedule returns cluster node."""
         result = await service.schedule(schedule_request)
 
         assert result is not None
@@ -82,7 +78,7 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_node_cluster_node(self, service):
-        """测试获取集群节点"""
+        """Test get node cluster node."""
         result = await service.get_node("k8s-cluster")
 
         assert result is not None
@@ -90,14 +86,14 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_node_not_found(self, service):
-        """测试获取不存在的节点"""
+        """Test get node not found."""
         result = await service.get_node("non-existent")
 
         assert result is None
 
     @pytest.mark.asyncio
     async def test_get_healthy_nodes(self, service):
-        """测试获取健康节点列表"""
+        """Test get healthy nodes."""
         result = await service.get_healthy_nodes()
 
         # K8s always returns the single cluster node
@@ -106,7 +102,7 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_mark_node_unhealthy(self, service):
-        """测试标记节点为不健康（K8s 环境下不执行操作）"""
+        """Test mark node unhealthy."""
         # Should not raise error
         await service.mark_node_unhealthy("any-node")
 
@@ -114,7 +110,7 @@ class TestK8sSchedulerService:
     async def test_create_container_for_session_success(
         self, service, container_scheduler, template_repo, template
     ):
-        """测试成功创建 Pod"""
+        """Test create container for session success."""
         template_repo.find_by_id.return_value = template
 
         result = await service.create_container_for_session(
@@ -138,7 +134,7 @@ class TestK8sSchedulerService:
     async def test_create_container_template_not_found(
         self, service, template_repo
     ):
-        """测试模板不存在时创建 Pod 失败"""
+        """Test create container template not found."""
         template_repo.find_by_id.return_value = None
 
         with pytest.raises(RuntimeError, match="Template not found"):
@@ -156,7 +152,7 @@ class TestK8sSchedulerService:
     async def test_create_container_with_dependencies(
         self, service, container_scheduler, template_repo, template
     ):
-        """测试创建带依赖的 Pod"""
+        """Test create container with dependencies."""
         template_repo.find_by_id.return_value = template
 
         result = await service.create_container_for_session(
@@ -176,7 +172,7 @@ class TestK8sSchedulerService:
     async def test_create_container_with_error(
         self, service, container_scheduler, template_repo, template
     ):
-        """测试创建 Pod 失败"""
+        """Test create container with error."""
         template_repo.find_by_id.return_value = template
         container_scheduler.create_container.side_effect = RuntimeError("Create failed")
 
@@ -192,7 +188,7 @@ class TestK8sSchedulerService:
             )
 
     def test_init_fails_without_owner_context(self, container_scheduler, template_repo, executor_client):
-        """测试缺少 POD_NAME/POD_UID 时初始化失败。"""
+        """Test init fails without owner context."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(RuntimeError, match="POD_NAME and POD_UID"):
                 K8sSchedulerService(
@@ -203,7 +199,7 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_destroy_container_success(self, service, container_scheduler):
-        """测试成功销毁 Pod"""
+        """Test destroy container success."""
         await service.destroy_container("sandbox-sess-123")
 
         container_scheduler.stop_container.assert_called_once()
@@ -211,7 +207,7 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_destroy_container_with_error(self, service, container_scheduler):
-        """测试销毁 Pod 时出错"""
+        """Test destroy container with error."""
         container_scheduler.stop_container.side_effect = RuntimeError("Stop failed")
 
         with pytest.raises(RuntimeError):
@@ -219,7 +215,7 @@ class TestK8sSchedulerService:
 
     @pytest.mark.asyncio
     async def test_get_container_info(self, service, container_scheduler):
-        """测试获取 Pod 信息"""
+        """Test get container info."""
         container_info = Mock()
         container_scheduler.get_container_status.return_value = container_info
 
@@ -232,7 +228,7 @@ class TestK8sSchedulerService:
     async def test_execute_success(
         self, service, container_scheduler, executor_client
     ):
-        """测试成功执行代码"""
+        """Test execute success."""
         # Mock K8s API response
         mock_pod_info = Mock()
         mock_pod_info.status.pod_ip = "10.0.0.100"
@@ -269,7 +265,7 @@ class TestK8sSchedulerService:
     async def test_execute_pod_no_ip(
         self, service, container_scheduler, executor_client
     ):
-        """测试 Pod 没有 IP 地址"""
+        """Test execute Pod no ip."""
         mock_pod_info = Mock()
         mock_pod_info.status.pod_ip = None
 
@@ -293,14 +289,14 @@ class TestK8sSchedulerService:
                 )
 
     def test_cluster_node_properties(self, service):
-        """测试集群节点属性"""
+        """Test cluster node properties."""
         assert service._cluster_node.id == "k8s-cluster"
         assert service._cluster_node.type == "kubernetes"
         assert service._cluster_node.status == "healthy"
         assert service._cluster_node.max_sessions == 1000
 
     def test_default_disable_bwrap(self, container_scheduler, template_repo, executor_client):
-        """测试默认禁用 bwrap"""
+        """Test default disable bwrap."""
         with patch.dict(os.environ, {"POD_NAME": "cp-0", "POD_UID": "uid-0"}, clear=False):
             service = K8sSchedulerService(
                 container_scheduler=container_scheduler,
@@ -311,7 +307,7 @@ class TestK8sSchedulerService:
         assert service._disable_bwrap is True
 
     def test_custom_disable_bwrap(self, container_scheduler, template_repo, executor_client):
-        """测试自定义禁用 bwrap"""
+        """Test custom disable bwrap."""
         with patch.dict(os.environ, {"POD_NAME": "cp-0", "POD_UID": "uid-0"}, clear=False):
             service = K8sSchedulerService(
                 container_scheduler=container_scheduler,

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/storage/test_s3_storage.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/storage/test_s3_storage.py
@@ -308,7 +308,7 @@ class TestS3Storage:
         """Test initialize creates bucket."""
         from botocore.exceptions import ClientError
 
-        # Test setup.
+        # head_bucket raises a 404 error.
         error_response = {'Error': {'Code': '404'}}
         mock_boto_client.head_bucket.side_effect = ClientError(error_response, 'HeadBucket')
         mock_boto_client.meta.region_name = 'us-west-2'
@@ -330,7 +330,7 @@ class TestS3Storage:
 
         await storage.initialize()
 
-        # Test setup.
+        # us-east-1 does not need LocationConstraint.
         call_args = mock_boto_client.create_bucket.call_args
         assert 'CreateBucketConfiguration' not in call_args[1]
 
@@ -356,7 +356,7 @@ class TestS3Storage:
         mock_boto_client.head_object.side_effect = Exception("Not Found")
         mock_boto_client.upload_file = Mock()
 
-        # Create test data.
+        # Create content larger than 5 MB.
         large_content = b"x" * (6 * 1024 * 1024)  # 6MB
 
         await storage.upload_file("s3://test-bucket/large.bin", large_content)
@@ -370,7 +370,7 @@ class TestS3Storage:
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.put_object.return_value = {}
 
-        # Test setup.
+        # Directory marker exists.
         mock_boto_client.head_object.return_value = {}
         mock_boto_client.delete_object.return_value = {}
 
@@ -387,7 +387,7 @@ class TestS3Storage:
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.put_object.return_value = {}
 
-        # Test setup.
+        # Directory marker does not exist.
         error_response = {'Error': {'Code': '404'}}
         mock_boto_client.head_object.side_effect = ClientError(error_response, 'HeadObject')
 
@@ -400,7 +400,7 @@ class TestS3Storage:
     async def test_delete_prefix_empty(self, storage, mock_boto_client):
         """Test delete prefix empty."""
         mock_paginator = Mock()
-        mock_paginator.paginate.return_value = [{}]  # Test setup.
+        mock_paginator.paginate.return_value = [{}]  # No Contents.
         mock_boto_client.get_paginator.return_value = mock_paginator
 
         deleted_count = await storage.delete_prefix("sessions/empty/")
@@ -426,7 +426,7 @@ class TestS3Storage:
     async def test_list_files_empty(self, storage, mock_boto_client):
         """Test list files empty."""
         mock_paginator = Mock()
-        mock_paginator.paginate.return_value = [{}]  # Test setup.
+        mock_paginator.paginate.return_value = [{}]  # No Contents.
         mock_boto_client.get_paginator.return_value = mock_paginator
 
         files = await storage.list_files("empty/")

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/storage/test_s3_storage.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/storage/test_s3_storage.py
@@ -1,8 +1,4 @@
-"""
-S3 存储单元测试
-
-测试 S3Storage 类的功能。
-"""
+"""Unit tests for S3 storage."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 from datetime import datetime
@@ -12,17 +8,17 @@ from src.infrastructure.storage.s3_storage import S3Storage
 
 
 class TestS3Storage:
-    """S3 存储测试"""
+    """Tests for TestS3Storage."""
 
     @pytest.fixture
     def mock_boto_client(self):
-        """模拟 boto3 客户端"""
+        """Create boto client."""
         client = Mock()
         return client
 
     @pytest.fixture
     def mock_settings(self):
-        """模拟配置"""
+        """Create settings."""
         settings = Mock()
         settings.s3_endpoint_url = "http://localhost:9000"
         settings.s3_access_key_id = "minioadmin"
@@ -33,48 +29,48 @@ class TestS3Storage:
 
     @pytest.fixture
     def storage(self, mock_boto_client, mock_settings):
-        """创建 S3 存储实例"""
+        """Create storage."""
         with patch('src.infrastructure.storage.s3_storage.boto3.client', return_value=mock_boto_client):
             with patch('src.infrastructure.storage.s3_storage.get_settings', return_value=mock_settings):
                 return S3Storage()
 
     def test_parse_s3_path_with_prefix(self, storage):
-        """测试解析带 s3:// 前缀的路径"""
+        """Test parse S3 path with prefix."""
         bucket, key = storage._parse_s3_path("s3://my-bucket/path/to/file.txt")
 
         assert bucket == "my-bucket"
         assert key == "path/to/file.txt"
 
     def test_parse_s3_path_without_prefix(self, storage):
-        """测试解析不带 s3:// 前缀的路径"""
+        """Test parse S3 path without prefix."""
         bucket, key = storage._parse_s3_path("path/to/file.txt")
 
         assert bucket == storage._bucket
         assert key == "path/to/file.txt"
 
     def test_parse_s3_path_with_leading_slash(self, storage):
-        """测试解析带前导斜杠的路径"""
+        """Test parse S3 path with leading slash."""
         bucket, key = storage._parse_s3_path("/path/to/file.txt")
 
         assert bucket == storage._bucket
         assert key == "path/to/file.txt"
 
     def test_build_s3_path(self, storage):
-        """测试构建 S3 路径"""
+        """Test build S3 path."""
         path = storage._build_s3_path("my-bucket", "path/to/file.txt")
 
         assert path == "s3://my-bucket/path/to/file.txt"
 
     @pytest.mark.asyncio
     async def test_upload_file_small(self, storage, mock_boto_client):
-        """测试上传小文件"""
+        """Test upload file small."""
         mock_boto_client.head_object.return_value = {}
         mock_boto_client.put_object.return_value = {}
 
         content = b"hello world"
         await storage.upload_file("s3://test-bucket/test.txt", content, "text/plain")
 
-        # 验证调用了 put_object
+        # Verify expected behavior.
         mock_boto_client.put_object.assert_called_once()
         call_args = mock_boto_client.put_object.call_args
         assert call_args[1]["Bucket"] == "test-bucket"
@@ -84,19 +80,19 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_upload_file_with_bucket_check(self, storage, mock_boto_client):
-        """测试上传文件时检查 bucket 存在"""
+        """Test upload file with bucket check."""
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.head_object.side_effect = Exception("Not Found")
         mock_boto_client.put_object.return_value = {}
 
         await storage.upload_file("s3://test-bucket/test.txt", b"content")
 
-        # 应该检查 bucket
+        # Verify expected behavior.
         mock_boto_client.head_bucket.assert_called()
 
     @pytest.mark.asyncio
     async def test_download_file(self, storage, mock_boto_client):
-        """测试下载文件"""
+        """Test download file."""
         mock_response = {
             'Body': Mock(read=Mock(return_value=b'file content'))
         }
@@ -112,7 +108,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_file_exists_true(self, storage, mock_boto_client):
-        """测试检查文件存在（存在）"""
+        """Test file exists true."""
         mock_boto_client.head_object.return_value = {}
 
         exists = await storage.file_exists("s3://test-bucket/test.txt")
@@ -121,7 +117,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_file_exists_false(self, storage, mock_boto_client):
-        """测试检查文件存在（不存在）"""
+        """Test file exists false."""
         from botocore.exceptions import ClientError
         error_response = {'Error': {'Code': '404'}}
         mock_boto_client.head_object.side_effect = ClientError(error_response, 'HeadObject')
@@ -132,7 +128,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_file_exists_error(self, storage, mock_boto_client):
-        """测试检查文件存在时出错"""
+        """Test file exists error."""
         from botocore.exceptions import ClientError
         error_response = {'Error': {'Code': '403'}}
         mock_boto_client.head_object.side_effect = ClientError(error_response, 'HeadObject')
@@ -142,7 +138,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_get_file_info(self, storage, mock_boto_client):
-        """测试获取文件信息"""
+        """Test get file info."""
         mock_response = {
             'ContentLength': 1024,
             'ContentType': 'text/plain',
@@ -160,7 +156,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_get_file_info_default_content_type(self, storage, mock_boto_client):
-        """测试获取文件信息（缺少 content_type）"""
+        """Test get file info default content type."""
         mock_response = {
             'ContentLength': 2048,
             'LastModified': datetime.now(),
@@ -174,7 +170,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_generate_presigned_url(self, storage, mock_boto_client):
-        """测试生成预签名 URL"""
+        """Test generate presigned URL."""
         mock_boto_client.generate_presigned_url.return_value = "https://s3.amazonaws.com/..."
 
         url = await storage.generate_presigned_url("s3://test-bucket/test.txt", 3600)
@@ -184,7 +180,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_delete_file(self, storage, mock_boto_client):
-        """测试删除文件"""
+        """Test delete file."""
         mock_boto_client.delete_object.return_value = {}
 
         await storage.delete_file("s3://test-bucket/test.txt")
@@ -196,8 +192,8 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_delete_prefix(self, storage, mock_boto_client):
-        """测试删除指定前缀的所有文件"""
-        # 模拟分页器
+        """Test delete prefix."""
+        # Mock test dependency.
         mock_paginator = Mock()
         mock_page_iterator = [
             {
@@ -223,7 +219,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_delete_prefix_with_bucket_in_prefix(self, storage, mock_boto_client):
-        """测试删除带 bucket 的前缀"""
+        """Test delete prefix with bucket in prefix."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [
@@ -239,7 +235,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files(self, storage, mock_boto_client):
-        """测试列出文件"""
+        """Test list files."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [
@@ -267,7 +263,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files_with_limit(self, storage, mock_boto_client):
-        """测试列出文件（限制数量）"""
+        """Test list files with limit."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [
@@ -283,7 +279,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files_with_bucket_in_prefix(self, storage, mock_boto_client):
-        """测试列出文件（带 bucket）"""
+        """Test list files with bucket in prefix."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [
@@ -295,12 +291,12 @@ class TestS3Storage:
         files = await storage.list_files("s3://test-bucket/sessions/sess_123/")
 
         assert len(files) == 1
-        # key 应该是相对于 bucket 的路径，包含 sessions/sess_123/file.txt
+        # Verify expected behavior.
         assert 'sessions/' in files[0]['key']
 
     @pytest.mark.asyncio
     async def test_initialize_success(self, storage, mock_boto_client):
-        """测试初始化成功"""
+        """Test initialize success."""
         mock_boto_client.head_bucket.return_value = {}
 
         await storage.initialize()
@@ -309,10 +305,10 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_initialize_creates_bucket(self, storage, mock_boto_client):
-        """测试初始化时创建 bucket"""
+        """Test initialize creates bucket."""
         from botocore.exceptions import ClientError
 
-        # head_bucket 抛出 404 错误
+        # Test setup.
         error_response = {'Error': {'Code': '404'}}
         mock_boto_client.head_bucket.side_effect = ClientError(error_response, 'HeadBucket')
         mock_boto_client.meta.region_name = 'us-west-2'
@@ -324,7 +320,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_initialize_creates_bucket_us_east_1(self, storage, mock_boto_client):
-        """测试初始化时创建 bucket（us-east-1 区域）"""
+        """Test initialize creates bucket us east 1."""
         from botocore.exceptions import ClientError
 
         error_response = {'Error': {'Code': '404'}}
@@ -334,13 +330,13 @@ class TestS3Storage:
 
         await storage.initialize()
 
-        # us-east-1 不需要 LocationConstraint
+        # Test setup.
         call_args = mock_boto_client.create_bucket.call_args
         assert 'CreateBucketConfiguration' not in call_args[1]
 
     @pytest.mark.asyncio
     async def test_initialize_bucket_create_error(self, storage, mock_boto_client):
-        """测试初始化时创建 bucket 失败"""
+        """Test initialize bucket create error."""
         from botocore.exceptions import ClientError
 
         error_response = {'Error': {'Code': '404'}}
@@ -350,61 +346,61 @@ class TestS3Storage:
         create_error = ClientError({'Error': {'Code': '403'}}, 'CreateBucket')
         mock_boto_client.create_bucket.side_effect = create_error
 
-        # 不应该抛出异常，只是记录错误
+        # Verify expected behavior.
         await storage.initialize()
 
     @pytest.mark.asyncio
     async def test_upload_large_file(self, storage, mock_boto_client):
-        """测试上传大文件（分片上传）"""
+        """Test upload large file."""
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.head_object.side_effect = Exception("Not Found")
         mock_boto_client.upload_file = Mock()
 
-        # 创建大于 5MB 的内容
+        # Create test data.
         large_content = b"x" * (6 * 1024 * 1024)  # 6MB
 
         await storage.upload_file("s3://test-bucket/large.bin", large_content)
 
-        # 大文件应该使用 upload_file
+        # Verify expected behavior.
         mock_boto_client.upload_file.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_upload_file_removes_directory_marker(self, storage, mock_boto_client):
-        """测试上传文件时删除目录标记"""
+        """Test upload file removes directory marker."""
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.put_object.return_value = {}
 
-        # 目录标记存在
+        # Test setup.
         mock_boto_client.head_object.return_value = {}
         mock_boto_client.delete_object.return_value = {}
 
         await storage.upload_file("s3://test-bucket/dir/file.txt", b"content")
 
-        # 应该删除目录标记
+        # Verify expected behavior.
         mock_boto_client.delete_object.assert_called()
 
     @pytest.mark.asyncio
     async def test_upload_file_directory_marker_not_exists(self, storage, mock_boto_client):
-        """测试上传文件时目录标记不存在"""
+        """Test upload file directory marker not exists."""
         from botocore.exceptions import ClientError
 
         mock_boto_client.head_bucket.return_value = {}
         mock_boto_client.put_object.return_value = {}
 
-        # 目录标记不存在
+        # Test setup.
         error_response = {'Error': {'Code': '404'}}
         mock_boto_client.head_object.side_effect = ClientError(error_response, 'HeadObject')
 
         await storage.upload_file("s3://test-bucket/dir/file.txt", b"content")
 
-        # 不应该删除目录标记
+        # Verify expected behavior.
         mock_boto_client.delete_object.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_delete_prefix_empty(self, storage, mock_boto_client):
-        """测试删除空前缀"""
+        """Test delete prefix empty."""
         mock_paginator = Mock()
-        mock_paginator.paginate.return_value = [{}]  # 没有 Contents
+        mock_paginator.paginate.return_value = [{}]  # Test setup.
         mock_boto_client.get_paginator.return_value = mock_paginator
 
         deleted_count = await storage.delete_prefix("sessions/empty/")
@@ -413,7 +409,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_delete_prefix_error(self, storage, mock_boto_client):
-        """测试删除前缀时出错"""
+        """Test delete prefix error."""
         from botocore.exceptions import ClientError
 
         mock_paginator = Mock()
@@ -428,9 +424,9 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files_empty(self, storage, mock_boto_client):
-        """测试列出空目录"""
+        """Test list files empty."""
         mock_paginator = Mock()
-        mock_paginator.paginate.return_value = [{}]  # 没有 Contents
+        mock_paginator.paginate.return_value = [{}]  # Test setup.
         mock_boto_client.get_paginator.return_value = mock_paginator
 
         files = await storage.list_files("empty/")
@@ -439,7 +435,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files_error(self, storage, mock_boto_client):
-        """测试列出文件时出错"""
+        """Test list files error."""
         from botocore.exceptions import ClientError
 
         mock_paginator = Mock()
@@ -454,7 +450,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_delete_prefix_relative_path(self, storage, mock_boto_client):
-        """测试删除相对路径前缀"""
+        """Test delete prefix relative path."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [
@@ -470,7 +466,7 @@ class TestS3Storage:
 
     @pytest.mark.asyncio
     async def test_list_files_relative_path(self, storage, mock_boto_client):
-        """测试列出相对路径文件"""
+        """Test list files relative path."""
         mock_paginator = Mock()
         mock_paginator.paginate.return_value = [{
             'Contents': [

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/test_default_data.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/test_default_data.py
@@ -1,4 +1,4 @@
-"""默认 seed 数据测试。"""
+"""Unit tests for default data."""
 
 from src.infrastructure.persistence.seed.default_data import (
     DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY,
@@ -10,7 +10,7 @@ from src.infrastructure.persistence.seed.default_data import (
 
 
 def test_default_template_images_use_swr_registry(monkeypatch):
-    """测试默认模板镜像使用 SWR 仓库地址。"""
+    """Test default template images use swr registry."""
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE_REGISTRY", raising=False)
@@ -34,7 +34,7 @@ def test_default_template_images_use_swr_registry(monkeypatch):
 
 
 def test_default_template_images_can_use_template_image_tag(monkeypatch):
-    """测试可通过 TEMPLATE_IMAGE_TAG 覆盖默认模板镜像 tag。"""
+    """Test default template images can use template image tag."""
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE_REGISTRY", raising=False)
@@ -56,7 +56,7 @@ def test_default_template_images_can_use_template_image_tag(monkeypatch):
 
 
 def test_default_template_images_can_be_overridden_independently(monkeypatch):
-    """测试部署时可分别覆盖两个默认模板镜像。"""
+    """Test default template images can be overridden independently."""
     monkeypatch.setenv("DEFAULT_TEMPLATE_IMAGE", "registry.local/python-basic:dev")
     monkeypatch.setenv(
         "DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE",
@@ -71,7 +71,7 @@ def test_default_template_images_can_be_overridden_independently(monkeypatch):
 
 
 def test_default_template_images_can_use_registry_and_repositories(monkeypatch):
-    """测试可分别配置默认模板镜像仓库路径，tag 仍跟随项目版本配置。"""
+    """Test default template images can use registry and repositories."""
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE", raising=False)
     monkeypatch.setenv("DEFAULT_TEMPLATE_IMAGE_REGISTRY", "registry.local/team")
@@ -93,7 +93,7 @@ def test_default_template_images_can_use_registry_and_repositories(monkeypatch):
 
 
 def test_default_template_images_use_swr_when_registry_is_empty(monkeypatch):
-    """测试 Helm 注入空 registry 时仍回退到默认 SWR 仓库地址。"""
+    """Test default template images use swr when registry is empty."""
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE", raising=False)
     monkeypatch.delenv("DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE", raising=False)
     monkeypatch.setenv("DEFAULT_TEMPLATE_IMAGE_REGISTRY", "")
@@ -116,7 +116,7 @@ def test_default_template_images_use_swr_when_registry_is_empty(monkeypatch):
 
 
 def test_default_templates_include_multi_language(monkeypatch):
-    """测试默认模板包含多语言复合模板。"""
+    """Test default templates include multi language."""
     monkeypatch.delenv("DEFAULT_TEMPLATE_IMAGE", raising=False)
     monkeypatch.setenv(
         "DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE",

--- a/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/test_task_manager.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/infrastructure/test_task_manager.py
@@ -1,8 +1,4 @@
-"""
-后台任务管理器单元测试
-
-测试 BackgroundTask 和 BackgroundTaskManager 的功能。
-"""
+"""Unit tests for task manager."""
 import pytest
 import asyncio
 from unittest.mock import Mock, AsyncMock, patch
@@ -14,16 +10,16 @@ from src.infrastructure.background_tasks.task_manager import (
 
 
 class TestBackgroundTask:
-    """后台任务测试"""
+    """Tests for TestBackgroundTask."""
 
     @pytest.fixture
     def task_func(self):
-        """创建模拟任务函数"""
+        """Create task func."""
         return AsyncMock()
 
     @pytest.fixture
     def task(self, task_func):
-        """创建后台任务"""
+        """Create task."""
         return BackgroundTask(
             name="test_task",
             func=task_func,
@@ -32,7 +28,7 @@ class TestBackgroundTask:
         )
 
     def test_init(self, task_func):
-        """测试任务初始化"""
+        """Test init."""
         task = BackgroundTask(
             name="test_task",
             func=task_func,
@@ -47,12 +43,12 @@ class TestBackgroundTask:
         assert task._task is None
 
     def test_is_running_false_initially(self, task):
-        """测试初始状态为未运行"""
+        """Test is running false initially."""
         assert task.is_running is False
 
     @pytest.mark.asyncio
     async def test_start_task(self, task, task_func):
-        """测试启动任务"""
+        """Test start task."""
         await task.start()
 
         assert task._running is True
@@ -63,7 +59,7 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_start_already_running_task(self, task, task_func):
-        """测试启动已在运行的任务"""
+        """Test start already running task."""
         await task.start()
 
         # Should not create a new task
@@ -77,7 +73,7 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_stop_task(self, task, task_func):
-        """测试停止任务"""
+        """Test stop task."""
         await task.start()
         await task.stop()
 
@@ -85,14 +81,14 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_stop_not_running_task(self, task):
-        """测试停止未运行的任务"""
+        """Test stop not running task."""
         # Should not raise error
         await task.stop()
         assert task._running is False
 
     @pytest.mark.asyncio
     async def test_task_executes_func(self, task_func):
-        """测试任务执行函数"""
+        """Test task executes func."""
         task = BackgroundTask(
             name="test_task",
             func=task_func,
@@ -108,7 +104,7 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_task_with_initial_delay(self, task_func):
-        """测试带初始延迟的任务"""
+        """Test task with initial delay."""
         task = BackgroundTask(
             name="test_task",
             func=task_func,
@@ -130,7 +126,7 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_task_handles_exception(self, task_func):
-        """测试任务处理异常"""
+        """Test task handles exception."""
         task_func.side_effect = RuntimeError("Test error")
 
         task = BackgroundTask(
@@ -151,7 +147,7 @@ class TestBackgroundTask:
 
     @pytest.mark.asyncio
     async def test_is_running_property(self, task, task_func):
-        """测试 is_running 属性"""
+        """Test is running property."""
         assert task.is_running is False
 
         await task.start()
@@ -162,27 +158,27 @@ class TestBackgroundTask:
 
 
 class TestBackgroundTaskManager:
-    """后台任务管理器测试"""
+    """Tests for TestBackgroundTaskManager."""
 
     @pytest.fixture
     def manager(self):
-        """创建任务管理器"""
+        """Create manager."""
         return BackgroundTaskManager()
 
     @pytest.fixture
     def task_func(self):
-        """创建模拟任务函数"""
+        """Create task func."""
         return AsyncMock()
 
     def test_init(self):
-        """测试管理器初始化"""
+        """Test init."""
         manager = BackgroundTaskManager()
 
         assert manager._tasks == []
         assert manager._running is False
 
     def test_register_task(self, manager, task_func):
-        """测试注册任务"""
+        """Test register task."""
         manager.register_task(
             name="test_task",
             func=task_func,
@@ -193,7 +189,7 @@ class TestBackgroundTaskManager:
         assert manager.task_count == 1
 
     def test_register_multiple_tasks(self, manager, task_func):
-        """测试注册多个任务"""
+        """Test register multiple tasks."""
         manager.register_task("task1", task_func, 5)
         manager.register_task("task2", task_func, 10)
         manager.register_task("task3", task_func, 15)
@@ -201,7 +197,7 @@ class TestBackgroundTaskManager:
         assert manager.task_count == 3
 
     def test_task_count(self, manager, task_func):
-        """测试任务计数"""
+        """Test task count."""
         assert manager.task_count == 0
 
         manager.register_task("task1", task_func, 5)
@@ -212,7 +208,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_start_all(self, manager, task_func):
-        """测试启动所有任务"""
+        """Test start all."""
         manager.register_task("task1", task_func, 0.1)
         manager.register_task("task2", task_func, 0.1)
 
@@ -226,7 +222,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_start_all_already_running(self, manager, task_func):
-        """测试在已运行时启动所有任务"""
+        """Test start all already running."""
         manager.register_task("task1", task_func, 0.1)
 
         await manager.start_all()
@@ -239,7 +235,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_stop_all(self, manager, task_func):
-        """测试停止所有任务"""
+        """Test stop all."""
         manager.register_task("task1", task_func, 0.1)
         manager.register_task("task2", task_func, 0.1)
 
@@ -250,14 +246,14 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_stop_all_not_running(self, manager):
-        """测试停止未运行的管理器"""
+        """Test stop all not running."""
         # Should not raise error
         await manager.stop_all()
         assert manager.running is False
 
     @pytest.mark.asyncio
     async def test_lifecycle_context_manager(self, manager, task_func):
-        """测试生命周期上下文管理器"""
+        """Test lifecycle context manager."""
         manager.register_task("task1", task_func, 0.1)
 
         async with manager.lifecycle():
@@ -267,7 +263,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_lifecycle_context_manager_with_exception(self, manager, task_func):
-        """测试生命周期上下文管理器处理异常"""
+        """Test lifecycle context manager with exception."""
         manager.register_task("task1", task_func, 0.1)
 
         with pytest.raises(RuntimeError):
@@ -279,7 +275,7 @@ class TestBackgroundTaskManager:
         assert manager.running is False
 
     def test_get_task_status(self, manager, task_func):
-        """测试获取任务状态"""
+        """Test get task status."""
         manager.register_task("task1", task_func, 5)
         manager.register_task("task2", task_func, 10)
 
@@ -292,7 +288,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_get_task_status_running(self, manager, task_func):
-        """测试获取运行中任务状态"""
+        """Test get task status running."""
         manager.register_task("task1", task_func, 0.5)
         manager.register_task("task2", task_func, 0.5)
 
@@ -306,7 +302,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_running_property(self, manager, task_func):
-        """测试 running 属性"""
+        """Test running property."""
         assert manager.running is False
 
         manager.register_task("task1", task_func, 0.5)
@@ -318,7 +314,7 @@ class TestBackgroundTaskManager:
 
     @pytest.mark.asyncio
     async def test_multiple_tasks_execute_independently(self, manager):
-        """测试多个任务独立执行"""
+        """Test multiple tasks execute independently."""
         call_counts = {"task1": 0, "task2": 0}
 
         async def task1_func():

--- a/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/middleware/test_logging_middleware.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/middleware/test_logging_middleware.py
@@ -1,8 +1,4 @@
-"""
-日志中间件单元测试
-
-测试 RequestLoggingMiddleware 的功能。
-"""
+"""Unit tests for logging middleware."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 import uuid
@@ -14,21 +10,21 @@ from src.interfaces.rest.middleware.logging_middleware import RequestLoggingMidd
 
 
 class TestRequestLoggingMiddleware:
-    """日志中间件测试"""
+    """Tests for TestRequestLoggingMiddleware."""
 
     @pytest.fixture
     def mock_app(self):
-        """模拟 ASGI 应用"""
+        """Create app."""
         return Mock()
 
     @pytest.fixture
     def middleware(self, mock_app):
-        """创建中间件"""
+        """Create middleware."""
         return RequestLoggingMiddleware(mock_app)
 
     @pytest.fixture
     def mock_request(self):
-        """创建模拟请求"""
+        """Create request."""
         request = MagicMock(spec=Request)
         request.method = "GET"
         request.url = MagicMock()
@@ -40,7 +36,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.fixture
     def mock_response(self):
-        """创建模拟响应"""
+        """Create response."""
         response = MagicMock(spec=Response)
         response.status_code = 200
         response.headers = {}
@@ -48,7 +44,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_generates_request_id(self, middleware, mock_request, mock_response):
-        """测试生成请求 ID"""
+        """Test dispatch generates request ID."""
         async def call_next(request):
             return mock_response
 
@@ -63,7 +59,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_binds_context(self, middleware, mock_request, mock_response):
-        """测试绑定上下文"""
+        """Test dispatch binds context."""
         async def call_next(request):
             return mock_response
 
@@ -80,7 +76,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_adds_request_id_header(self, middleware, mock_request, mock_response):
-        """测试添加请求 ID 响应头"""
+        """Test dispatch adds request ID header."""
         async def call_next(request):
             return mock_response
 
@@ -93,7 +89,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_adds_process_time_header(self, middleware, mock_request, mock_response):
-        """测试添加处理时间响应头"""
+        """Test dispatch adds process time header."""
         async def call_next(request):
             return mock_response
 
@@ -106,7 +102,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_clears_context(self, middleware, mock_request, mock_response):
-        """测试清理上下文"""
+        """Test dispatch clears context."""
         async def call_next(request):
             return mock_response
 
@@ -119,7 +115,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_clears_context_on_exception(self, middleware, mock_request):
-        """测试异常时清理上下文"""
+        """Test dispatch clears context on exception."""
         async def call_next(request):
             raise RuntimeError("Test error")
 
@@ -133,7 +129,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_handles_no_client(self, middleware, mock_request, mock_response):
-        """测试处理无客户端信息"""
+        """Test dispatch handles no client."""
         mock_request.client = None
 
         async def call_next(request):
@@ -147,7 +143,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_with_different_status_codes(self, middleware, mock_request):
-        """测试不同状态码"""
+        """Test dispatch with different status codes."""
         for status_code in [200, 201, 400, 404, 500]:
             mock_response = MagicMock(spec=Response)
             mock_response.status_code = status_code
@@ -163,7 +159,7 @@ class TestRequestLoggingMiddleware:
 
     @pytest.mark.asyncio
     async def test_dispatch_with_post_request(self, middleware, mock_response):
-        """测试 POST 请求"""
+        """Test dispatch with post request."""
         mock_request = MagicMock(spec=Request)
         mock_request.method = "POST"
         mock_request.url = MagicMock()

--- a/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/schemas/test_install_session_dependencies_request.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/schemas/test_install_session_dependencies_request.py
@@ -1,6 +1,4 @@
-"""
-增量安装依赖请求模型测试。
-"""
+"""Unit tests for install session dependencies request."""
 
 import pytest
 from pydantic import ValidationError

--- a/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/test_main.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/interfaces/rest/test_main.py
@@ -1,8 +1,4 @@
-"""
-FastAPI 主应用单元测试
-
-测试 FastAPI 应用的创建和配置。
-"""
+"""Unit tests for main."""
 import pytest
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 from fastapi import FastAPI, Request
@@ -19,10 +15,10 @@ from src.shared.errors.domain import NotFoundError, ValidationError
 
 
 class TestCreateApp:
-    """创建应用测试"""
+    """Tests for TestCreateApp."""
 
     def test_create_app_returns_fastapi_instance(self):
-        """测试创建应用返回 FastAPI 实例"""
+        """Test create app returns fastapi instance."""
         with patch('src.interfaces.rest.main.lifespan'):
             app = create_app()
 
@@ -30,7 +26,7 @@ class TestCreateApp:
             assert app.title == "Sandbox Control Plane"
 
     def test_create_app_has_correct_metadata(self):
-        """测试应用元数据"""
+        """Test create app has correct metadata."""
         with patch('src.interfaces.rest.main.lifespan'):
             app = create_app()
 
@@ -41,7 +37,7 @@ class TestCreateApp:
             assert app.openapi_url == "/openapi.json"
 
     def test_create_app_registers_cors_middleware(self):
-        """测试注册 CORS 中间件"""
+        """Test create app registers CORS middleware."""
         with patch('src.interfaces.rest.main.lifespan'):
             app = create_app()
 
@@ -54,7 +50,7 @@ class TestCreateApp:
             assert cors_found
 
     def test_create_app_registers_gzip_middleware(self):
-        """测试注册 Gzip 中间件"""
+        """Test create app registers Gzip middleware."""
         with patch('src.interfaces.rest.main.lifespan'):
             app = create_app()
 
@@ -67,7 +63,7 @@ class TestCreateApp:
             assert gzip_found
 
     def test_create_app_registers_routes(self):
-        """测试注册路由"""
+        """Test create app registers routes."""
         with patch('src.interfaces.rest.main.lifespan'):
             app = create_app()
 
@@ -78,7 +74,7 @@ class TestCreateApp:
             assert "/openapi.json" in routes
 
     def test_create_app_has_lifespan(self):
-        """测试应用有生命周期管理"""
+        """Test create app has lifespan."""
         with patch('src.interfaces.rest.main.lifespan') as mock_lifespan:
             app = create_app()
 
@@ -87,15 +83,15 @@ class TestCreateApp:
 
 
 class TestRegisterExceptionHandlers:
-    """异常处理器测试"""
+    """Tests for TestRegisterExceptionHandlers."""
 
     @pytest.fixture
     def app(self):
-        """创建测试应用"""
+        """Create app."""
         return FastAPI()
 
     def test_register_exception_handlers_adds_handlers(self, app):
-        """测试注册异常处理器"""
+        """Test register exception handlers adds handlers."""
         _register_exception_handlers(app)
 
         # Check that exception handlers are registered
@@ -105,7 +101,7 @@ class TestRegisterExceptionHandlers:
 
     @pytest.mark.asyncio
     async def test_not_found_error_handler(self, app):
-        """测试 NotFound 异常处理"""
+        """Test not found error handler."""
         _register_exception_handlers(app)
 
         handler = app.exception_handlers[NotFoundError]
@@ -124,7 +120,7 @@ class TestRegisterExceptionHandlers:
 
     @pytest.mark.asyncio
     async def test_validation_error_handler(self, app):
-        """测试 ValidationError 异常处理"""
+        """Test validation error handler."""
         _register_exception_handlers(app)
 
         handler = app.exception_handlers[ValidationError]
@@ -143,7 +139,7 @@ class TestRegisterExceptionHandlers:
 
     @pytest.mark.asyncio
     async def test_global_exception_handler(self, app):
-        """测试全局异常处理"""
+        """Test global exception handler."""
         _register_exception_handlers(app)
 
         handler = app.exception_handlers[Exception]
@@ -162,15 +158,15 @@ class TestRegisterExceptionHandlers:
 
 
 class TestRegisterRoutes:
-    """路由注册测试"""
+    """Tests for TestRegisterRoutes."""
 
     @pytest.fixture
     def app(self):
-        """创建测试应用"""
+        """Create app."""
         return FastAPI()
 
     def test_register_routes_adds_routers(self, app):
-        """测试注册路由"""
+        """Test register routes adds routers."""
         _register_routes(app)
 
         routes = [route.path for route in app.routes]
@@ -180,7 +176,7 @@ class TestRegisterRoutes:
         assert "/" in routes  # Root endpoint
 
     def test_root_endpoint_exists(self, app):
-        """测试根端点存在"""
+        """Test root endpoint exists."""
         _register_routes(app)
 
         # Find root route
@@ -194,15 +190,15 @@ class TestRegisterRoutes:
 
 
 class TestRegisterMiddleware:
-    """中间件注册测试"""
+    """Tests for TestRegisterMiddleware."""
 
     @pytest.fixture
     def app(self):
-        """创建测试应用"""
+        """Create app."""
         return FastAPI()
 
     def test_register_middleware_adds_request_logging(self, app):
-        """测试注册请求日志中间件"""
+        """Test register middleware adds request logging."""
         _register_middleware(app)
 
         # Check that middleware is added

--- a/infra/sandbox/sandbox_control_plane/tests/unit/shared/errors/test_infrastructure_errors.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/shared/errors/test_infrastructure_errors.py
@@ -1,8 +1,4 @@
-"""
-基础设施错误单元测试
-
-测试基础设施层的错误类型。
-"""
+"""Unit tests for infrastructure errors."""
 import pytest
 
 from src.shared.errors.infrastructure import (
@@ -18,21 +14,21 @@ from src.shared.errors.infrastructure import (
 
 
 class TestInfrastructureError:
-    """基础设施错误基类测试"""
+    """Tests for TestInfrastructureError."""
 
     def test_is_exception(self):
-        """测试继承自 Exception"""
+        """Test is exception."""
         error = InfrastructureError("Test error")
         assert isinstance(error, Exception)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = InfrastructureError("Test error message")
         assert str(error) == "Test error message"
         assert error.message == "Test error message"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = ValueError("Original error")
         error = InfrastructureError("Wrapper error", original_error=original)
 
@@ -40,7 +36,7 @@ class TestInfrastructureError:
         assert error.original_error is original
 
     def test_without_original_error(self):
-        """测试不带原始错误"""
+        """Test without original error."""
         error = InfrastructureError("Test error")
 
         assert error.message == "Test error"
@@ -48,20 +44,20 @@ class TestInfrastructureError:
 
 
 class TestDatabaseError:
-    """数据库错误测试"""
+    """Tests for TestDatabaseError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = DatabaseError("Database connection failed")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = DatabaseError("Connection timeout")
         assert str(error) == "Connection timeout"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = ConnectionRefusedError("Connection refused")
         error = DatabaseError("Database error", original_error=original)
 
@@ -69,20 +65,20 @@ class TestDatabaseError:
 
 
 class TestConnectionError:
-    """连接错误测试"""
+    """Tests for TestConnectionError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = ConnectionError("Connection failed")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = ConnectionError("Failed to connect to server")
         assert str(error) == "Failed to connect to server"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = TimeoutError("Connection timeout")
         error = ConnectionError("Connection error", original_error=original)
 
@@ -90,20 +86,20 @@ class TestConnectionError:
 
 
 class TestStorageError:
-    """存储错误测试"""
+    """Tests for TestStorageError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = StorageError("Storage error")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = StorageError("Failed to upload file")
         assert str(error) == "Failed to upload file"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = IOError("Disk full")
         error = StorageError("Storage error", original_error=original)
 
@@ -111,20 +107,20 @@ class TestStorageError:
 
 
 class TestHTTPClientError:
-    """HTTP 客户端错误测试"""
+    """Tests for TestHTTPClientError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = HTTPClientError("HTTP error")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = HTTPClientError("Request timeout")
         assert str(error) == "Request timeout"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = Exception("Network error")
         error = HTTPClientError("HTTP client error", original_error=original)
 
@@ -132,20 +128,20 @@ class TestHTTPClientError:
 
 
 class TestContainerError:
-    """容器错误测试"""
+    """Tests for TestContainerError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = ContainerError("Container error")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = ContainerError("Failed to start container")
         assert str(error) == "Failed to start container"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = RuntimeError("Docker daemon not running")
         error = ContainerError("Container error", original_error=original)
 
@@ -153,20 +149,20 @@ class TestContainerError:
 
 
 class TestKubernetesError:
-    """Kubernetes 错误测试"""
+    """Tests for TestKubernetesError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = KubernetesError("Kubernetes error")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = KubernetesError("Pod failed to start")
         assert str(error) == "Pod failed to start"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = Exception("API server unavailable")
         error = KubernetesError("Kubernetes error", original_error=original)
 
@@ -174,20 +170,20 @@ class TestKubernetesError:
 
 
 class TestMessagingError:
-    """消息队列错误测试"""
+    """Tests for TestMessagingError."""
 
     def test_inherits_from_infrastructure_error(self):
-        """测试继承自 InfrastructureError"""
+        """Test inherits from infrastructure error."""
         error = MessagingError("Messaging error")
         assert isinstance(error, InfrastructureError)
 
     def test_message(self):
-        """测试错误消息"""
+        """Test message."""
         error = MessagingError("Failed to publish message")
         assert str(error) == "Failed to publish message"
 
     def test_with_original_error(self):
-        """测试带原始错误"""
+        """Test with original error."""
         original = Exception("Queue not found")
         error = MessagingError("Messaging error", original_error=original)
 
@@ -195,10 +191,10 @@ class TestMessagingError:
 
 
 class TestErrorHierarchy:
-    """错误层次结构测试"""
+    """Tests for TestErrorHierarchy."""
 
     def test_all_errors_inherit_from_infrastructure_error(self):
-        """测试所有错误都继承自 InfrastructureError"""
+        """Test all errors inherit from infrastructure error."""
         errors = [
             DatabaseError("test"),
             ConnectionError("test"),
@@ -214,7 +210,7 @@ class TestErrorHierarchy:
             assert isinstance(error, Exception)
 
     def test_errors_can_be_caught_by_base_class(self):
-        """测试可以通过基类捕获所有错误"""
+        """Test errors can be caught by base class."""
         errors_to_raise = [
             DatabaseError("db error"),
             ContainerError("container error"),

--- a/infra/sandbox/sandbox_control_plane/tests/unit/shared/utils/test_dependencies.py
+++ b/infra/sandbox/sandbox_control_plane/tests/unit/shared/utils/test_dependencies.py
@@ -1,8 +1,4 @@
-"""
-依赖解析工具单元测试
-
-测试 shared/utils/dependencies.py 模块的功能。
-"""
+"""Unit tests for dependencies."""
 import pytest
 
 from src.shared.utils.dependencies import (
@@ -14,27 +10,27 @@ from src.shared.utils.dependencies import (
 
 
 class TestParseDependenciesToPipSpecs:
-    """依赖解析测试"""
+    """Tests for TestParseDependenciesToPipSpecs."""
 
     def test_parse_empty_list(self):
-        """测试解析空列表"""
+        """Test parse empty list."""
         result = parse_dependencies_to_pip_specs([])
         assert result == []
 
     def test_parse_none(self):
-        """测试解析 None"""
+        """Test parse none."""
         result = parse_dependencies_to_pip_specs(None)
         assert result == []
 
     def test_parse_string_dependencies(self):
-        """测试解析字符串格式的依赖"""
+        """Test parse string dependencies."""
         deps = ["requests==2.31.0", "pandas>=2.0"]
         result = parse_dependencies_to_pip_specs(deps)
 
         assert result == ["requests==2.31.0", "pandas>=2.0"]
 
     def test_parse_dict_dependencies_with_version(self):
-        """测试解析字典格式的依赖（带版本）"""
+        """Test parse dict dependencies with version."""
         deps = [
             {"name": "requests", "version": "==2.31.0"},
             {"name": "pandas", "version": ">=2.0"}
@@ -44,7 +40,7 @@ class TestParseDependenciesToPipSpecs:
         assert result == ["requests==2.31.0", "pandas>=2.0"]
 
     def test_parse_dict_dependencies_without_version(self):
-        """测试解析字典格式的依赖（不带版本）"""
+        """Test parse dict dependencies without version."""
         deps = [
             {"name": "requests"},
             {"name": "pandas", "version": ""}
@@ -54,7 +50,7 @@ class TestParseDependenciesToPipSpecs:
         assert result == ["requests", "pandas"]
 
     def test_parse_mixed_dependencies(self):
-        """测试解析混合格式的依赖"""
+        """Test parse mixed dependencies."""
         deps = [
             "requests==2.31.0",
             {"name": "pandas", "version": ">=2.0"},
@@ -65,7 +61,7 @@ class TestParseDependenciesToPipSpecs:
         assert result == ["requests==2.31.0", "pandas>=2.0", "numpy"]
 
     def test_parse_complex_version_specs(self):
-        """测试解析复杂版本规格"""
+        """Test parse complex version specs."""
         deps = [
             {"name": "requests", "version": ">=2.28.0,<3.0"},
             {"name": "django", "version": "==4.2.*"}
@@ -77,24 +73,24 @@ class TestParseDependenciesToPipSpecs:
 
 
 class TestFormatDependenciesForScript:
-    """格式化依赖脚本测试"""
+    """Tests for TestFormatDependenciesForScript."""
 
     def test_format_empty_list(self):
-        """测试格式化空列表"""
+        """Test format empty list."""
         deps_json, deps_list = format_dependencies_for_script([])
 
         assert deps_json == ""
         assert deps_list == ""
 
     def test_format_none(self):
-        """测试格式化 None"""
+        """Test format none."""
         deps_json, deps_list = format_dependencies_for_script(None)
 
         assert deps_json == ""
         assert deps_list == ""
 
     def test_format_string_dependencies(self):
-        """测试格式化字符串依赖"""
+        """Test format string dependencies."""
         deps = ["requests==2.31.0", "pandas>=2.0"]
         deps_json, deps_list = format_dependencies_for_script(deps)
 
@@ -104,7 +100,7 @@ class TestFormatDependenciesForScript:
         assert '"pandas>=2.0"' in deps_list
 
     def test_format_dict_dependencies(self):
-        """测试格式化字典依赖"""
+        """Test format dict dependencies."""
         deps = [{"name": "requests", "version": "==2.31.0"}]
         deps_json, deps_list = format_dependencies_for_script(deps)
 
@@ -114,10 +110,10 @@ class TestFormatDependenciesForScript:
 
 
 class TestBuildDependencyInstallScript:
-    """构建依赖安装脚本测试"""
+    """Tests for TestBuildDependencyInstallScript."""
 
     def test_build_script(self):
-        """测试构建安装脚本"""
+        """Test build script."""
         script = build_dependency_install_script()
 
         assert "pip3 install" in script
@@ -126,22 +122,22 @@ class TestBuildDependencyInstallScript:
 
 
 class TestFormatDependencyInstallScriptForShell:
-    """格式化 Shell 脚本测试"""
+    """Tests for TestFormatDependencyInstallScriptForShell."""
 
     def test_format_empty_list(self):
-        """测试格式化空列表"""
+        """Test format empty list."""
         result = format_dependency_install_script_for_shell([])
 
         assert result == ""
 
     def test_format_none(self):
-        """测试格式化 None"""
+        """Test format none."""
         result = format_dependency_install_script_for_shell(None)
 
         assert result == ""
 
     def test_format_dependencies(self):
-        """测试格式化依赖"""
+        """Test format dependencies."""
         deps = [
             {"name": "requests", "version": "==2.31.0"},
             "pandas>=2.0"
@@ -153,14 +149,14 @@ class TestFormatDependencyInstallScriptForShell:
         assert "/opt/sandbox-venv" in result
 
     def test_format_includes_pip_specs(self):
-        """测试格式化包含 pip 规格"""
+        """Test format includes pip specs."""
         deps = ["requests==2.31.0"]
         result = format_dependency_install_script_for_shell(deps)
 
         assert "requests==2.31.0" in result
 
     def test_format_includes_success_message(self):
-        """测试格式化包含成功消息"""
+        """Test format includes success message."""
         deps = ["requests"]
         result = format_dependency_install_script_for_shell(deps)
 

--- a/infra/sandbox/sandbox_web/README.md
+++ b/infra/sandbox/sandbox_web/README.md
@@ -63,7 +63,7 @@ npm run dev
 
 The development server starts at http://localhost:1101.
 
-### build the project
+### Build the project
 
 ```bash
 npm run build

--- a/infra/sandbox/sandbox_web/README.md
+++ b/infra/sandbox/sandbox_web/README.md
@@ -1,124 +1,124 @@
 # Sandbox Web
 
-沙箱管理平台前端服务，用于对接 Sandbox Control Plane API，实现模板管理、会话管理和代码执行功能。
+Frontend service for the sandbox management platform. It integrates with the Sandbox Control Plane API to provide template management, session management, and code execution.
 
-## 技术栈
+## Technology stack
 
-- **React 18.3.1** - 用户界面库
-- **TypeScript 5.8.2** - 类型安全的 JavaScript 超集
-- **Ant Design 5.26.2** - 企业级 UI 设计语言和组件库
-- **Rsbuild** - 基于 Rspack 的构建工具
-- **react-router-dom** - 路由管理
-- **axios** - HTTP 客户端
-- **@monaco-editor/react** - Monaco 代码编辑器
+- **React 18.3.1** - UI library
+- **TypeScript 5.8.2** - Type-safe JavaScript superset
+- **Ant Design 5.26.2** - Enterprise UI design language and component library
+- **Rsbuild** - build tool based on Rspack
+- **react-router-dom** - Routing management
+- **axios** - HTTP client
+- **@monaco-editor/react** - Monaco code editor
 
-## 项目结构
+## Project structure
 
 ```
 sandbox_web/
-├── public/               # 公共静态资源
+├── public/               # Public static assets
 ├── src/
-│   ├── apis/            # API 接口管理
+│   ├── apis/            # API management
 │   │   ├── sessions/    # Session API
 │   │   ├── templates/   # Template API
 │   │   ├── executions/  # Execution API
 │   │   ├── files/       # File Upload/Download API
 │   │   └── health/      # Health Check API
-│   ├── components/      # React 组件
-│   │   ├── Layout/      # 布局组件
-│   │   ├── CodeEditor/  # 代码编辑器
+│   ├── components/      # React components
+│   │   ├── Layout/      # Layout component
+│   │   ├── CodeEditor/  # Code editor
 │   │   └── ...
-│   ├── hooks/           # 自定义 Hooks
-│   ├── pages/           # 页面入口
-│   ├── styles/          # 样式文件
-│   ├── utils/           # 工具函数
-│   ├── types/           # 类型定义
-│   ├── constants/       # 常量定义
-│   ├── router/          # 路由配置
+│   ├── hooks/           # Custom hooks
+│   ├── pages/           # Page entries
+│   ├── styles/          # Style files
+│   ├── utils/           # Utility functions
+│   ├── types/           # Type definitions
+│   ├── constants/       # Constant definitions
+│   ├── router/          # Router configuration
 │   ├── App.tsx
 │   └── main.tsx
-├── rsbuild.config.mts   # Rsbuild 配置
+├── rsbuild.config.mts   # Rsbuild configuration
 ├── package.json
 └── tsconfig.json
 ```
 
-## 快速开始
+## Quick Start
 
-### 环境要求
+### Requirements
 
 - Node.js 18+
-- npm 或 yarn
+- npm or yarn
 
-### 安装依赖
+### Install dependencies
 
 ```bash
 npm install
 ```
 
-### 开发模式
+### Development mode
 
 ```bash
 npm run dev
 ```
 
-开发服务器将在 http://localhost:1101 启动。
+The development server starts at http://localhost:1101.
 
-### 构建项目
+### build the project
 
 ```bash
 npm run build
 ```
 
-### 代码检查
+### Code linting
 
 ```bash
 npm run lint
 ```
 
-## 功能模块
+## Feature modules
 
-### 模板管理
-- 创建、编辑、删除执行环境模板
-- 支持 Python 3.11、Node.js 20、Java 17、Go 1.21 运行时
-- 配置 CPU、内存、磁盘等资源限制
+### Template management
+- Create, edit, and delete execution environment templates
+- Supports Python 3.11, Node.js 20, Java 17, and Go 1.21 runtimes
+- Configure CPU, memory, disk, and other resource limits
 
-### 会话管理
-- 创建和管理代码执行会话
-- 实时查看会话状态
-- 上传/下载会话文件
-- 支持 Python 依赖包安装
+### Session management
+- Create and manage code execution sessions
+- View session status in real time
+- Upload/download session files
+- Supports Python dependency installation
 
-### 代码执行
-- 在线代码编辑器 (Monaco Editor)
-- 支持 Lambda Handler 格式
-- 执行历史查看
-- 实时结果展示
+### Code execution
+- Online code editor (Monaco Editor)
+- Supports the Lambda Handler format
+- View execution history
+- Display results in real time
 
-## API 对接
+## API integration
 
-前端服务通过代理对接 `http://localhost:8000` 的 Control Plane API。
+The frontend service connects to `http://localhost:8000` Control Plane API through a proxy.
 
-主要端点：
-- `/api/v1/templates` - 模板管理
-- `/api/v1/sessions` - 会话管理
-- `/api/v1/executions` - 代码执行
+Main endpoints:
+- `/api/v1/templates` - Template management
+- `/api/v1/sessions` - Session management
+- `/api/v1/executions` - Code execution
 
-## 开发规范
+## Development conventions
 
-### 组件命名
-- 组件名使用 PascalCase：`<MyComponent />`
-- 文件名与组件名保持一致
+### Component naming
+- Use PascalCase for component names：`<MyComponent />`
+- Keep file names consistent with component names
 
-### 代码规范
-- 使用 TypeScript 进行类型检查
-- 函数组件使用 Hooks
-- 遵循 ESLint 和 Prettier 配置
+### Code conventions
+- Use TypeScript for type checking
+- Use Hooks in function components
+- Follow the ESLint and Prettier configuration
 
-## 设计规范
+## Design specifications
 
-| 属性 | 值 |
+| property | value |
 |------|-----|
-| 主色 | #126ee3 |
-| 背景色 | #fafafa |
-| 边框色 | #e7edf7 |
-| 圆角 | 4px / 8px / 12px |
+| Primary color | #126ee3 |
+| Background color | #fafafa |
+| Border color | #e7edf7 |
+| Border radius | 4px / 8px / 12px |

--- a/infra/sandbox/sandbox_web/src/App.tsx
+++ b/infra/sandbox/sandbox_web/src/App.tsx
@@ -1,5 +1,5 @@
 /**
- * App 根组件
+ * App root component
  */
 import { Router } from '@/router';
 import '@/styles/main.less';

--- a/infra/sandbox/sandbox_web/src/apis/executions/api.ts
+++ b/infra/sandbox/sandbox_web/src/apis/executions/api.ts
@@ -1,5 +1,5 @@
 /**
- * Execution API 实现
+ * Execution API implementation
  */
 import { API_ENDPOINTS, DEFAULT_PAGINATION } from '@/constants/api';
 import { get, post } from '@/utils/http/request';
@@ -11,28 +11,28 @@ import type {
 } from './types';
 
 /**
- * 提交代码执行
+ * Submit code execution
  */
 export function executeCode(sessionId: string, data: ExecuteCodeRequest): Promise<ExecuteCodeResponse> {
   return post<ExecuteCodeResponse>(API_ENDPOINTS.EXECUTE(sessionId), data);
 }
 
 /**
- * 获取执行状态
+ * Get execution status
  */
 export function getExecutionStatus(executionId: string): Promise<ExecutionResponse> {
   return get<ExecutionResponse>(API_ENDPOINTS.EXECUTION_STATUS(executionId));
 }
 
 /**
- * 获取执行结果
+ * Get execution result
  */
 export function getExecutionResult(executionId: string): Promise<ExecutionResponse> {
   return get<ExecutionResponse>(API_ENDPOINTS.EXECUTION_RESULT(executionId));
 }
 
 /**
- * 获取会话的执行列表
+ * Get the execution list for a session
  */
 export function listSessionExecutions(
   sessionId: string,

--- a/infra/sandbox/sandbox_web/src/apis/executions/index.ts
+++ b/infra/sandbox/sandbox_web/src/apis/executions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Execution API 导出
+ * Execution API exports
  */
 export * from './types';
 export * from './api';

--- a/infra/sandbox/sandbox_web/src/apis/executions/types.ts
+++ b/infra/sandbox/sandbox_web/src/apis/executions/types.ts
@@ -1,5 +1,5 @@
 /**
- * Execution API 类型定义
+ * Execution API type definitions
  */
 export type {
   ExecutionResponse,

--- a/infra/sandbox/sandbox_web/src/apis/files/api.ts
+++ b/infra/sandbox/sandbox_web/src/apis/files/api.ts
@@ -1,15 +1,15 @@
 /**
- * File API 实现
+ * File API implementation
  */
 import { API_ENDPOINTS } from '@/constants/api';
 import apiClient from '@/utils/http/axios';
 import type { FileUploadResponse } from './types';
 
 /**
- * 上传文件到会话工作区
- * @param sessionId 会话ID
- * @param file 要上传的文件
- * @param path 文件在会话工作区中的路径（作为 URL 参数，默认使用文件名）
+ * Upload a file to the session workspace
+ * @param sessionId Session ID
+ * @param file File to upload
+ * @param path File path in the session workspace (as a URL parameter; defaults to the file name)
  */
 export async function uploadFile(
   sessionId: string,
@@ -23,7 +23,7 @@ export async function uploadFile(
   const formData = new FormData();
   formData.append('file', file);
 
-  // path 是必填参数，如果未提供则使用文件名
+  // path is required; use the file name if it is not provided
   const uploadPath = path || file.name;
 
   const response = await apiClient.post<FileUploadResponse>(
@@ -36,7 +36,7 @@ export async function uploadFile(
         overwrite: options?.overwrite ?? false,
       },
       headers: {
-        // 覆盖默认的 application/json，让 axios 自动检测 FormData 并设置正确的 Content-Type
+        // Override the default application/json so axios can detect FormData and set the correct Content-Type
         'Content-Type': undefined as any,
       },
     }
@@ -45,7 +45,7 @@ export async function uploadFile(
 }
 
 /**
- * 从会话工作区下载文件
+ * Download a file from the session workspace
  */
 export async function downloadFile(sessionId: string, filePath: string): Promise<Blob> {
   const response = await apiClient.get<Blob>(

--- a/infra/sandbox/sandbox_web/src/apis/files/index.ts
+++ b/infra/sandbox/sandbox_web/src/apis/files/index.ts
@@ -1,5 +1,5 @@
 /**
- * File API 导出
+ * File API exports
  */
 export * from './api';
 export * from './types';

--- a/infra/sandbox/sandbox_web/src/apis/files/types.ts
+++ b/infra/sandbox/sandbox_web/src/apis/files/types.ts
@@ -1,4 +1,4 @@
 /**
- * File API 类型定义
+ * File API type definitions
  */
 export type { FileUploadResponse } from '@/types/api';

--- a/infra/sandbox/sandbox_web/src/apis/health/api.ts
+++ b/infra/sandbox/sandbox_web/src/apis/health/api.ts
@@ -1,26 +1,26 @@
 /**
- * Health API 实现
+ * Health API implementation
  */
 import { API_ENDPOINTS } from '@/constants/api';
 import { get, post } from '@/utils/http/request';
 import type { HealthResponse } from '@/types/api';
 
 /**
- * 健康检查
+ * Health Check
  */
 export function healthCheck(): Promise<HealthResponse> {
   return get<HealthResponse>(API_ENDPOINTS.HEALTH);
 }
 
 /**
- * 详细健康检查
+ * Detailed health check
  */
 export function detailedHealthCheck(): Promise<Record<string, unknown>> {
   return get<Record<string, unknown>>(API_ENDPOINTS.HEALTH_DETAILED);
 }
 
 /**
- * 手动触发状态同步
+ * Manually trigger state synchronization
  */
 export function triggerStateSync(): Promise<Record<string, unknown>> {
   return post<Record<string, unknown>>(API_ENDPOINTS.HEALTH + '/sync', {});

--- a/infra/sandbox/sandbox_web/src/apis/health/index.ts
+++ b/infra/sandbox/sandbox_web/src/apis/health/index.ts
@@ -1,4 +1,4 @@
 /**
- * Health API 导出
+ * Health API exports
  */
 export * from './api';

--- a/infra/sandbox/sandbox_web/src/apis/sessions/api.ts
+++ b/infra/sandbox/sandbox_web/src/apis/sessions/api.ts
@@ -1,5 +1,5 @@
 /**
- * Session API 实现
+ * Session API implementation
  */
 import { API_ENDPOINTS, LONG_TASK_HTTP_TIMEOUT } from '@/constants/api';
 import { get, post, del } from '@/utils/http/request';
@@ -12,21 +12,21 @@ import type {
 } from './types';
 
 /**
- * 获取会话列表
+ * Get session list
  */
 export function listSessions(params?: ListSessionsParams): Promise<SessionListResponse> {
   return get<SessionListResponse>(API_ENDPOINTS.SESSIONS, { params });
 }
 
 /**
- * 获取会话详情
+ * Get session details
  */
 export function getSession(sessionId: string): Promise<SessionResponse> {
   return get<SessionResponse>(API_ENDPOINTS.SESSION(sessionId));
 }
 
 /**
- * 创建会话
+ * createsession
  */
 export function createSession(data: CreateSessionRequest): Promise<SessionResponse> {
   return post<SessionResponse>(API_ENDPOINTS.SESSIONS, data, {
@@ -35,7 +35,7 @@ export function createSession(data: CreateSessionRequest): Promise<SessionRespon
 }
 
 /**
- * 安装会话依赖
+ * Install session dependencies
  */
 export function installSessionDependencies(
   sessionId: string,
@@ -47,7 +47,7 @@ export function installSessionDependencies(
 }
 
 /**
- * 终止会话
+ * Terminate session
  */
 export function terminateSession(sessionId: string): Promise<SessionResponse> {
   return del<SessionResponse>(API_ENDPOINTS.SESSION(sessionId));

--- a/infra/sandbox/sandbox_web/src/apis/sessions/index.ts
+++ b/infra/sandbox/sandbox_web/src/apis/sessions/index.ts
@@ -1,5 +1,5 @@
 /**
- * Session API 导出
+ * Session API exports
  */
 export * from './types';
 export * from './api';

--- a/infra/sandbox/sandbox_web/src/apis/sessions/types.ts
+++ b/infra/sandbox/sandbox_web/src/apis/sessions/types.ts
@@ -1,5 +1,5 @@
 /**
- * Session API 类型定义
+ * Session API type definitions
  */
 export type {
   SessionResponse,

--- a/infra/sandbox/sandbox_web/src/apis/templates/api.ts
+++ b/infra/sandbox/sandbox_web/src/apis/templates/api.ts
@@ -1,5 +1,5 @@
 /**
- * Template API 实现
+ * Template API implementation
  */
 import { API_ENDPOINTS, DEFAULT_PAGINATION } from '@/constants/api';
 import { get, post, put, del } from '@/utils/http/request';
@@ -10,7 +10,7 @@ import type {
 } from './types';
 
 /**
- * 获取模板列表
+ * Get template list
  */
 export function listTemplates(params?: { limit?: number; offset?: number }): Promise<TemplateResponse[]> {
   return get<TemplateResponse[]>(API_ENDPOINTS.TEMPLATES, {
@@ -19,28 +19,28 @@ export function listTemplates(params?: { limit?: number; offset?: number }): Pro
 }
 
 /**
- * 获取模板详情
+ * Get template details
  */
 export function getTemplate(templateId: string): Promise<TemplateResponse> {
   return get<TemplateResponse>(API_ENDPOINTS.TEMPLATE(templateId));
 }
 
 /**
- * 创建模板
+ * Create template
  */
 export function createTemplate(data: CreateTemplateRequest): Promise<TemplateResponse> {
   return post<TemplateResponse>(API_ENDPOINTS.TEMPLATES, data);
 }
 
 /**
- * 更新模板
+ * Update template
  */
 export function updateTemplate(templateId: string, data: UpdateTemplateRequest): Promise<TemplateResponse> {
   return put<TemplateResponse>(API_ENDPOINTS.TEMPLATE(templateId), data);
 }
 
 /**
- * 删除模板
+ * Delete template
  */
 export function deleteTemplate(templateId: string): Promise<{ message: string }> {
   return del<{ message: string }>(API_ENDPOINTS.TEMPLATE(templateId));

--- a/infra/sandbox/sandbox_web/src/apis/templates/index.ts
+++ b/infra/sandbox/sandbox_web/src/apis/templates/index.ts
@@ -1,5 +1,5 @@
 /**
- * Template API 导出
+ * Template API exports
  */
 export * from './types';
 export * from './api';

--- a/infra/sandbox/sandbox_web/src/apis/templates/types.ts
+++ b/infra/sandbox/sandbox_web/src/apis/templates/types.ts
@@ -1,6 +1,6 @@
 /**
- * Template API 类型定义
- * 重新导出全局类型以保持模块独立性
+ * Template API type definitions
+ * Re-export global types to keep the module independent
  */
 export type {
   TemplateResponse,

--- a/infra/sandbox/sandbox_web/src/components/Layout/Sidebar.tsx
+++ b/infra/sandbox/sandbox_web/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 /**
- * 侧边栏导航组件
- * 基于 Figma 设计
+ * Sidebar navigation component
+ * Based on the Figma design
  */
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Menu } from 'antd';
@@ -27,19 +27,19 @@ function getItem(
   } as MenuItem;
 }
 
-/** 侧边栏菜单项 */
+/** Sidebar menu item */
 const menuItems: MenuItem[] = [
   getItem('会话管理', 'sessions', <CodeOutlined />),
   getItem('模版管理', 'templates', <FileOutlined />),
   getItem('代码执行', 'execute', <PlayCircleOutlined />),
 ];
 
-/** 侧边栏组件 */
+/** Sidebar component */
 export function Sidebar() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  // 获取当前激活的菜单项
+  // Get the currently active menu item
   const getSelectedKey = () => {
     const path = location.pathname;
     if (path.startsWith('/sessions')) return 'sessions';
@@ -60,7 +60,7 @@ export function Sidebar() {
         flexDirection: 'column',
       }}
     >
-      {/* Logo 区域 */}
+      {/* Logo area */}
       <div
         style={{
           padding: '24px',
@@ -89,7 +89,7 @@ export function Sidebar() {
         </p>
       </div>
 
-      {/* 导航菜单 */}
+      {/* Navigation menu */}
       <div style={{ flex: 1, padding: '16px' }}>
         <Menu
           mode="inline"

--- a/infra/sandbox/sandbox_web/src/components/Layout/index.tsx
+++ b/infra/sandbox/sandbox_web/src/components/Layout/index.tsx
@@ -1,6 +1,6 @@
 /**
- * 布局组件
- * 基于 Figma 设计
+ * Layout component
+ * Based on the Figma design
  */
 import { Outlet } from 'react-router-dom';
 import { Layout } from 'antd';
@@ -8,7 +8,7 @@ import { Sidebar } from './Sidebar';
 
 const { Sider, Content } = Layout;
 
-/** 布局组件 */
+/** Layout component */
 export default function LayoutComponent() {
   return (
     <Layout style={{ minHeight: '100vh', backgroundColor: '#fafafa' }}>

--- a/infra/sandbox/sandbox_web/src/constants/api.ts
+++ b/infra/sandbox/sandbox_web/src/constants/api.ts
@@ -1,10 +1,10 @@
 /**
- * API 相关常量
+ * API-related constants
  */
 
 export { getApiBaseUrl } from '@/utils/config';
 
-/** API 端点路径 */
+/** API endpoint paths */
 export const API_ENDPOINTS = {
   // Health
   HEALTH: '/api/v1/health',
@@ -33,14 +33,14 @@ export const API_ENDPOINTS = {
     `/api/v1/sessions/${sessionId}/files/${filePath}`,
 } as const;
 
-/** 默认分页参数 */
+/** Default pagination parameters */
 export const DEFAULT_PAGINATION = {
   LIMIT: 50,
   OFFSET: 0,
 } as const;
 
-/** HTTP 超时时间（毫秒） */
+/** HTTP timeout (milliseconds) */
 export const HTTP_TIMEOUT = 30000;
 
-/** 长耗时 HTTP 超时时间（毫秒） */
+/** Long-running HTTP timeout (milliseconds) */
 export const LONG_TASK_HTTP_TIMEOUT = 180000;

--- a/infra/sandbox/sandbox_web/src/constants/runtime.ts
+++ b/infra/sandbox/sandbox_web/src/constants/runtime.ts
@@ -1,13 +1,13 @@
 /**
- * 运行时类型常量
+ * Runtime type constants
  */
 
 import type { RuntimeType, CodeLanguage, SessionStatus, ExecutionStatus } from '@/types/api';
 
-/** 支持的运行时类型 */
+/** Supported runtime types */
 export const RUNTIME_TYPES: readonly RuntimeType[] = ['python3.11', 'nodejs20', 'java17', 'go1.21'] as const;
 
-/** 运行时类型显示名称映射 */
+/** Runtime type display-name mapping */
 export const RUNTIME_TYPE_LABELS: Record<RuntimeType, string> = {
   'python3.11': 'Python 3.11',
   'nodejs20': 'Node.js 20',
@@ -15,17 +15,17 @@ export const RUNTIME_TYPE_LABELS: Record<RuntimeType, string> = {
   'go1.21': 'Go 1.21',
 } as const;
 
-/** 支持的编程语言 */
+/** Supported programming languages */
 export const CODE_LANGUAGES: readonly CodeLanguage[] = ['python', 'javascript', 'shell'] as const;
 
-/** 编程语言显示名称映射 */
+/** Programming language display-name mapping */
 export const CODE_LANGUAGE_LABELS: Record<CodeLanguage, string> = {
   python: 'Python',
   javascript: 'JavaScript',
   shell: 'Shell',
 } as const;
 
-/** 会话状态显示名称映射 */
+/** Session status display-name mapping */
 export const SESSION_STATUS_LABELS: Record<SessionStatus, string> = {
   PENDING: '等待中',
   CREATING: '启动中',
@@ -37,7 +37,7 @@ export const SESSION_STATUS_LABELS: Record<SessionStatus, string> = {
   TIMEOUT: '超时',
 } as const;
 
-/** 执行状态显示名称映射 */
+/** Execution status display-name mapping */
 export const EXECUTION_STATUS_LABELS: Record<ExecutionStatus, string> = {
   PENDING: '等待中',
   RUNNING: '执行中',
@@ -47,7 +47,7 @@ export const EXECUTION_STATUS_LABELS: Record<ExecutionStatus, string> = {
   CRASHED: '崩溃',
 } as const;
 
-/** 资源配置选项 */
+/** Resource configuration options */
 export const RESOURCE_OPTIONS = {
   CPU: ['0.5', '1', '2', '4'] as const,
   MEMORY: ['128Mi', '256Mi', '512Mi', '1Gi', '2Gi', '4Gi', '8Gi'] as const,

--- a/infra/sandbox/sandbox_web/src/hooks/useExecution.ts
+++ b/infra/sandbox/sandbox_web/src/hooks/useExecution.ts
@@ -1,5 +1,5 @@
 /**
- * 执行管理 Hook
+ * Execution management hook
  */
 import { useState, useCallback } from 'react';
 import { message } from 'antd';
@@ -15,7 +15,7 @@ export function useExecution() {
   const [loading, setLoading] = useState(false);
   const [currentExecution, setCurrentExecution] = useState<ExecutionResponse | null>(null);
 
-  // 提交代码执行
+  // Submit code execution
   const executeCode = useCallback(async (
     sessionId: string,
     data: ExecuteCodeRequest
@@ -23,7 +23,7 @@ export function useExecution() {
     setLoading(true);
     try {
       const result = await executionsApi.executeCode(sessionId, data);
-      // 轮询获取执行结果
+      // Poll for execution results
       pollExecutionResult(result.execution_id);
       return result;
     } catch (error) {
@@ -35,9 +35,9 @@ export function useExecution() {
     }
   }, []);
 
-  // 轮询执行结果
+  // Poll execution results
   const pollExecutionResult = useCallback(async (executionId: string) => {
-    const maxAttempts = 60; // 最多轮询 60 次 (约 1 分钟)
+    const maxAttempts = 60; // Poll at most 60 times, about 1 minute.
     let attempts = 0;
 
     const poll = async () => {
@@ -46,7 +46,7 @@ export function useExecution() {
         const result = await executionsApi.getExecutionResult(executionId);
         setCurrentExecution(result);
 
-        // 如果执行还在进行中，继续轮询
+        // Continue polling if execution is still in progress
         if (
           result.status === 'pending' ||
           result.status === 'PENDING' ||
@@ -54,19 +54,19 @@ export function useExecution() {
           result.status === 'RUNNING'
         ) {
           if (attempts < maxAttempts) {
-            setTimeout(poll, 1000); // 1 秒后重试
+            setTimeout(poll, 1000); // Retry after 1 second.
           }
         } else {
-          // 执行完成，添加到历史记录并清除当前执行
+          // When execution completes, add it to history and clear the current execution
           setExecutions((prev) => {
-            // 检查是否已存在，避免重复添加
+            // Check whether it already exists to avoid duplicate additions
             const exists = prev.some(e => e.id === result.id);
             if (exists) {
               return prev;
             }
             return [result, ...prev];
           });
-          // 延迟清除 currentExecution，让用户看到最终状态
+          // Delay clearing currentExecution so the user can see the final state
           setTimeout(() => setCurrentExecution(null), 100);
           if (result.status === 'completed' || result.status === 'COMPLETED') {
             message.success('代码执行成功');
@@ -87,7 +87,7 @@ export function useExecution() {
     poll();
   }, []);
 
-  // 获取会话的执行列表
+  // Get the execution list for a session
   const fetchSessionExecutions = useCallback(async (sessionId: string) => {
     setLoading(true);
     try {
@@ -101,7 +101,7 @@ export function useExecution() {
     }
   }, []);
 
-  // 清空当前执行
+  // Clear current execution
   const clearCurrentExecution = useCallback(() => {
     setCurrentExecution(null);
   }, []);

--- a/infra/sandbox/sandbox_web/src/hooks/useSessions.ts
+++ b/infra/sandbox/sandbox_web/src/hooks/useSessions.ts
@@ -1,5 +1,5 @@
 /**
- * 会话管理 Hook
+ * Session management hook
  */
 import { useState, useCallback, useRef } from 'react';
 import { message } from 'antd';
@@ -11,7 +11,7 @@ import type {
   SessionStatus,
 } from '@apis/sessions';
 
-/** 会话统计 */
+/** Session statistics */
 export interface SessionStats {
   total: number;
   starting: number;
@@ -24,7 +24,7 @@ export function useSessions() {
   const [loading, setLoading] = useState(false);
   const isLoadingRef = useRef(false);
 
-  // 获取统计 - 支持小写状态值
+  // Get statistics; supports lowercase status values
   const stats: SessionStats = {
     total: sessions.length,
     starting: sessions.filter((s) =>
@@ -38,9 +38,9 @@ export function useSessions() {
     ).length,
   };
 
-  // 获取会话列表
+  // Get session list
   const fetchSessions = useCallback(async () => {
-    // 使用 ref 防止重复请求
+    // Use a ref to prevent duplicate requests
     if (isLoadingRef.current) return;
     isLoadingRef.current = true;
     setLoading(true);
@@ -56,7 +56,7 @@ export function useSessions() {
     }
   }, []);
 
-  // 创建会话
+  // createsession
   const createSession = useCallback(async (data: CreateSessionRequest) => {
     setLoading(true);
     try {
@@ -73,7 +73,7 @@ export function useSessions() {
     }
   }, []);
 
-  // 终止会话
+  // Terminate session
   const terminateSession = useCallback(async (id: string) => {
     setLoading(true);
     try {

--- a/infra/sandbox/sandbox_web/src/hooks/useTemplates.ts
+++ b/infra/sandbox/sandbox_web/src/hooks/useTemplates.ts
@@ -1,5 +1,5 @@
 /**
- * 模板管理 Hook
+ * Template management hook
  */
 import { useState, useCallback } from 'react';
 import { message } from 'antd';
@@ -14,7 +14,7 @@ export function useTemplates() {
   const [templates, setTemplates] = useState<TemplateResponse[]>([]);
   const [loading, setLoading] = useState(false);
 
-  // 获取模板列表
+  // Get template list
   const fetchTemplates = useCallback(async () => {
     setLoading(true);
     try {
@@ -28,7 +28,7 @@ export function useTemplates() {
     }
   }, []);
 
-  // 创建模板
+  // Create template
   const createTemplate = useCallback(async (data: CreateTemplateRequest) => {
     setLoading(true);
     try {
@@ -45,7 +45,7 @@ export function useTemplates() {
     }
   }, []);
 
-  // 更新模板
+  // Update template
   const updateTemplate = useCallback(
     async (id: string, data: UpdateTemplateRequest) => {
       setLoading(true);
@@ -67,7 +67,7 @@ export function useTemplates() {
     []
   );
 
-  // 删除模板
+  // Delete template
   const deleteTemplate = useCallback(async (id: string) => {
     setLoading(true);
     try {

--- a/infra/sandbox/sandbox_web/src/main.tsx
+++ b/infra/sandbox/sandbox_web/src/main.tsx
@@ -1,5 +1,5 @@
 /**
- * 应用入口文件
+ * Application entry file
  */
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';

--- a/infra/sandbox/sandbox_web/src/pages/execute/index.tsx
+++ b/infra/sandbox/sandbox_web/src/pages/execute/index.tsx
@@ -1,5 +1,5 @@
 /**
- * 代码执行页面
+ * Code execution page
  */
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -22,7 +22,7 @@ const CODE_TEMPLATES: Record<CodeLanguage, string> = {
 }`,
   shell: `pwd
 ls -la
-# 也支持:
+# Also supports:
 # bash run.sh
 # python scripts/analyze_project.py
 # bash python scripts/analyze_project.py`,

--- a/infra/sandbox/sandbox_web/src/pages/sessions/index.tsx
+++ b/infra/sandbox/sandbox_web/src/pages/sessions/index.tsx
@@ -1,5 +1,5 @@
 /**
- * 会话管理页面
+ * Session management page
  */
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -73,12 +73,12 @@ export default function SessionsPage() {
   const [installSessionName, setInstallSessionName] = useState<string>('');
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
-  // 初始加载
+  // Initial load
   useEffect(() => {
     fetchSessions();
   }, [fetchSessions]);
 
-  // 定时刷新，依赖安装进行中时加快轮询
+  // Periodic refresh; poll faster while dependency installation is in progress
   useEffect(() => {
     const hasInstallingDependencies = sessions.some(
       (session) => session.dependency_install_status === 'installing',
@@ -100,7 +100,7 @@ export default function SessionsPage() {
     };
   }, [fetchSessions, sessions]);
 
-  // 打开创建模态框时获取模板列表
+  // Get the template list when opening the create modal
   const handleOpenCreateModal = async () => {
     await fetchTemplates();
     form.setFieldsValue({
@@ -110,11 +110,11 @@ export default function SessionsPage() {
     setShowCreateModal(true);
   };
 
-  // 当选择模版时，自动带入配置
+  // Automatically populate configuration when a template is selected
   const handleTemplateChange = (templateId: string) => {
     const template = templates.find((t) => t.id === templateId);
     if (template) {
-      // 自动填充资源配置
+      // Automatically fill resource configuration
       form.setFieldsValue({
         cpu: template.default_cpu_cores.toString(),
         memory: `${template.default_memory_mb}Mi`,
@@ -124,7 +124,7 @@ export default function SessionsPage() {
     }
   };
 
-  // 查看详情
+  // View details
   const handleViewDetail = (record: SessionResponse) => {
     setDetailSession(record);
     setShowDetailModal(true);
@@ -134,12 +134,12 @@ export default function SessionsPage() {
     setDetailSession((prev) => (prev?.id === updatedSession.id ? updatedSession : prev));
   };
 
-  // 跳转到执行页面并选中会话
+  // Navigate to the execution page and select the session
   const handleExecuteCode = (sessionId: string) => {
     navigate(`/execute?sessionId=${sessionId}`);
   };
 
-  // 过滤会话
+  // Filter sessions
   const filteredSessions = sessions.filter((s) => {
     const matchesSearch =
       s.id.toLowerCase().includes(searchQuery.toLowerCase()) ||
@@ -150,7 +150,7 @@ export default function SessionsPage() {
     return matchesSearch && matchesStatus;
   });
 
-  // 创建会话
+  // createsession
   const handleCreate = async () => {
     try {
       const values = await form.validateFields();
@@ -166,20 +166,20 @@ export default function SessionsPage() {
       form.resetFields();
       setDepInput('');
     } catch (error) {
-      // 表单验证失败或创建失败
+      // Form validation or creation failed
     }
   };
 
-  // 终止会话
+  // Terminate session
   const handleTerminate = async (id: string) => {
     try {
       await terminateSession(id);
     } catch (error) {
-      // 终止失败
+      // terminatefailed
     }
   };
 
-  // 打开上传文件模态框
+  // Open the upload file modal
   const handleOpenUploadModal = (record: SessionResponse) => {
     setUploadSessionId(record.id);
     setUploadSessionName(record.id);
@@ -239,7 +239,7 @@ export default function SessionsPage() {
     }
   };
 
-  // 处理文件上传
+  // handlefileupload
   const handleUpload = async () => {
     if (fileList.length === 0) {
       message.warning('请选择要上传的文件');
@@ -287,7 +287,7 @@ export default function SessionsPage() {
     }
   };
 
-  // 状态配置 - 支持小写状态值（API 返回小写）
+  // Status configuration - supports lowercase status values returned by the API
   const getStatusConfig = (status: string) => {
     const configs: Record<
       string,
@@ -301,7 +301,7 @@ export default function SessionsPage() {
       TERMINATED: { color: 'default', icon: '⏹', label: SESSION_STATUS_LABELS.TERMINATED },
       FAILED: { color: 'error', icon: '✗', label: SESSION_STATUS_LABELS.FAILED },
       TIMEOUT: { color: 'error', icon: '⏱', label: SESSION_STATUS_LABELS.TIMEOUT },
-      // 支持小写（API 返回）
+      // Supports lowercase values returned by the API
       pending: { color: 'warning', icon: '⏱', label: SESSION_STATUS_LABELS.PENDING },
       creating: { color: 'processing', icon: '🔄', label: SESSION_STATUS_LABELS.CREATING },
       starting: { color: 'processing', icon: '🔄', label: SESSION_STATUS_LABELS.STARTING },
@@ -339,7 +339,7 @@ export default function SessionsPage() {
     return <Tag>待安装</Tag>;
   };
 
-  // 表格列定义
+  // Table column definitions
   const columns = [
     {
       title: '会话ID',
@@ -391,7 +391,7 @@ export default function SessionsPage() {
       width: 150,
       fixed: 'right' as const,
       render: (_: unknown, record: SessionResponse) => {
-        // 判断是否可以终止（只有运行中/启动中的会话可以终止）
+        // Determine whether the session can be terminated; only running or starting sessions can be terminated
         const canTerminate =
           record.status === 'running' ||
           record.status === 'RUNNING' ||
@@ -475,7 +475,7 @@ export default function SessionsPage() {
 
   return (
     <>
-      {/* 页面标题 */}
+      {/* Page title */}
       <div style={{ marginBottom: 24 }}>
         <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
           <div
@@ -503,7 +503,7 @@ export default function SessionsPage() {
         </p>
       </div>
 
-      {/* 统计卡片 */}
+      {/* Statistics cards */}
       <div style={{ display: 'flex', gap: 16, marginBottom: 24 }}>
         <Card
           style={{
@@ -583,7 +583,7 @@ export default function SessionsPage() {
         </Card>
       </div>
 
-      {/* 筛选状态提示 */}
+      {/* Filter status hint */}
       {statusFilter && (
         <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
           <Tag
@@ -596,7 +596,7 @@ export default function SessionsPage() {
         </div>
       )}
 
-      {/* 会话列表 */}
+      {/* sessionlist */}
       <div
         style={{
           backgroundColor: '#ffffff',
@@ -605,7 +605,7 @@ export default function SessionsPage() {
           padding: 24,
         }}
       >
-        {/* 搜索和操作栏 */}
+        {/* Search and action bar */}
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 24 }}>
           <Input
             placeholder="搜索会话ID或模版ID"
@@ -620,7 +620,7 @@ export default function SessionsPage() {
           </Button>
         </div>
 
-        {/* 会话表格 */}
+        {/* Session table */}
         <Table
           columns={columns}
           dataSource={filteredSessions}
@@ -631,7 +631,7 @@ export default function SessionsPage() {
         />
       </div>
 
-      {/* 创建会话对话框 */}
+      {/* Create session dialog */}
       <Modal
         title="创建新会话"
         open={showCreateModal}
@@ -760,7 +760,7 @@ export default function SessionsPage() {
         </Form>
       </Modal>
 
-      {/* 详情模态框 */}
+      {/* Details modal */}
       <Modal
         title="会话详情"
         open={showDetailModal}
@@ -926,7 +926,7 @@ export default function SessionsPage() {
         </Form>
       </Modal>
 
-      {/* 上传文件模态框 */}
+      {/* Upload file modal */}
       <Modal
         title="上传文件"
         open={showUploadModal}

--- a/infra/sandbox/sandbox_web/src/pages/templates/index.tsx
+++ b/infra/sandbox/sandbox_web/src/pages/templates/index.tsx
@@ -1,5 +1,5 @@
 /**
- * 模板管理页面
+ * Template management page
  */
 import { useState, useEffect } from 'react';
 import { Button, Input, Table, Modal, Form, InputNumber, Select, Tag, Space, Popconfirm, Descriptions } from 'antd';
@@ -24,14 +24,14 @@ export default function TemplatesPage() {
     fetchTemplates();
   }, [fetchTemplates]);
 
-  // 过滤模板
+  // Filter templates
   const filteredTemplates = templates.filter(
     (t) =>
       t.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       t.id.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
-  // 创建模板
+  // Create template
   const handleCreate = async () => {
     try {
       const values = await form.validateFields();
@@ -39,22 +39,22 @@ export default function TemplatesPage() {
       setShowCreateModal(false);
       form.resetFields();
     } catch (error) {
-      // 表单验证失败或创建失败
+      // Form validation or creation failed
     }
   };
 
-  // 查看详情
+  // View details
   const handleViewDetail = async (template: TemplateResponse) => {
     try {
       const detail = await templatesApi.getTemplate(template.id);
       setSelectedTemplate(detail);
       setShowDetailModal(true);
     } catch (error) {
-      // 获取详情失败
+      // Failed to get details
     }
   };
 
-  // 打开编辑模态框
+  // Open the edit modal
   const handleOpenEdit = async (template: TemplateResponse) => {
     try {
       const detail = await templatesApi.getTemplate(template.id);
@@ -70,11 +70,11 @@ export default function TemplatesPage() {
       });
       setShowEditModal(true);
     } catch (error) {
-      // 获取详情失败
+      // Failed to get details
     }
   };
 
-  // 保存编辑
+  // Save edits
   const handleEditSave = async () => {
     if (!selectedTemplate) return;
     try {
@@ -85,20 +85,20 @@ export default function TemplatesPage() {
       setSelectedTemplate(null);
       fetchTemplates();
     } catch (error) {
-      // 保存失败
+      // Save failed
     }
   };
 
-  // 删除模板
+  // Delete template
   const handleDelete = async (id: string) => {
     try {
       await deleteTemplate(id);
     } catch (error) {
-      // 删除失败
+      // Delete failed
     }
   };
 
-  // 表格列定义
+  // Table column definitions
   const columns = [
     {
       title: '模版ID',
@@ -174,7 +174,7 @@ export default function TemplatesPage() {
 
   return (
     <>
-      {/* 页面标题 */}
+      {/* Page title */}
       <div style={{ marginBottom: 24 }}>
         <div style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
           <div
@@ -202,7 +202,7 @@ export default function TemplatesPage() {
         </p>
       </div>
 
-      {/* 内容区域 */}
+      {/* Content area */}
       <div
         style={{
           backgroundColor: '#ffffff',
@@ -211,7 +211,7 @@ export default function TemplatesPage() {
           padding: 24,
         }}
       >
-        {/* 搜索和操作栏 */}
+        {/* Search and action bar */}
         <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 24 }}>
           <Input
             placeholder="搜索模版名称或ID"
@@ -226,7 +226,7 @@ export default function TemplatesPage() {
           </Button>
         </div>
 
-        {/* 模板表格 */}
+        {/* Template table */}
         <Table
           columns={columns}
           dataSource={filteredTemplates}
@@ -237,7 +237,7 @@ export default function TemplatesPage() {
         />
       </div>
 
-      {/* 创建模版对话框 */}
+      {/* Create template dialog */}
       <Modal
         title="创建新模版"
         open={showCreateModal}
@@ -330,7 +330,7 @@ export default function TemplatesPage() {
         </Form>
       </Modal>
 
-      {/* 详情模态框 */}
+      {/* Details modal */}
       <Modal
         title="模板详情"
         open={showDetailModal}
@@ -388,7 +388,7 @@ export default function TemplatesPage() {
         )}
       </Modal>
 
-      {/* 编辑模态框 */}
+      {/* Edit modal */}
       <Modal
         title="编辑模板"
         open={showEditModal}

--- a/infra/sandbox/sandbox_web/src/router/index.tsx
+++ b/infra/sandbox/sandbox_web/src/router/index.tsx
@@ -1,5 +1,5 @@
 /**
- * Router 组件
+ * Router component
  */
 import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
@@ -8,12 +8,12 @@ import zhCN from 'antd/locale/zh_CN';
 import LayoutComponent from '@components/Layout';
 import { sandboxTheme } from '@/styles/theme';
 
-// 懒加载页面组件
+// Lazy-load page components
 const SessionsPage = lazy(() => import('@pages/sessions'));
 const TemplatesPage = lazy(() => import('@pages/templates'));
 const ExecutePage = lazy(() => import('@pages/execute'));
 
-/** 加载中组件 */
+/** Loading component */
 function PageLoading() {
   return (
     <div
@@ -29,7 +29,7 @@ function PageLoading() {
   );
 }
 
-/** Router 组件 */
+/** Router component */
 export function Router() {
   return (
     <BrowserRouter>

--- a/infra/sandbox/sandbox_web/src/styles/theme.ts
+++ b/infra/sandbox/sandbox_web/src/styles/theme.ts
@@ -1,46 +1,46 @@
 /**
- * Ant Design 主题配置
- * 基于 Figma 设计规范
+ * Ant Design theme configuration
+ * Based on the Figma design specification
  */
 import type { ThemeConfig } from 'antd';
 
-/** Sandbox 主题配置 */
+/** Sandbox theme configuration */
 export const sandboxTheme: ThemeConfig = {
   token: {
-    // 主色
+    // Primary color
     colorPrimary: '#126ee3',
     colorPrimaryHover: '#0f5dc2',
     colorPrimaryActive: '#0b4fa8',
 
-    // 背景色
+    // Background color
     colorBgLayout: '#fafafa',
     colorBgContainer: '#ffffff',
     colorBgElevated: '#ffffff',
 
-    // 边框色
+    // Border color
     colorBorder: '#e7edf7',
     colorBorderSecondary: '#d9d9d9',
 
-    // 文字颜色
+    // Text color
     colorText: 'rgba(0,0,0,0.85)',
     colorTextSecondary: 'rgba(0,0,0,0.65)',
     colorTextTertiary: '#677489',
     colorTextQuaternary: 'rgba(0,0,0,0.45)',
     colorTextPlaceholder: 'rgba(0,0,0,0.25)',
 
-    // 功能色
+    // Functional colors
     colorSuccess: '#52c41a',
     colorWarning: '#faad14',
     colorError: '#ff4d4f',
     colorInfo: '#1890ff',
 
-    // 圆角
+    // Border radius
     borderRadius: 4,
     borderRadiusLG: 8,
     borderRadiusSM: 4,
     borderRadiusXS: 2,
 
-    // 字体大小
+    // Font size
     fontSize: 14,
     fontSizeHeading1: 20,
     fontSizeHeading2: 16,
@@ -50,12 +50,12 @@ export const sandboxTheme: ThemeConfig = {
     fontSizeSM: 12,
     fontSizeXL: 24,
 
-    // 行高
+    // Line height
     lineHeight: 1.5715,
     lineHeightLG: 1.5,
     lineHeightSM: 1.66,
 
-    // 间距
+    // Spacing
     marginXS: 8,
     marginSM: 12,
     margin: 16,
@@ -63,7 +63,7 @@ export const sandboxTheme: ThemeConfig = {
     marginLG: 24,
     marginXL: 32,
 
-    // 其他
+    // Other settings
     wireframe: false,
   },
   components: {

--- a/infra/sandbox/sandbox_web/src/types/api.ts
+++ b/infra/sandbox/sandbox_web/src/types/api.ts
@@ -1,32 +1,32 @@
 /**
- * API 类型定义
- * 基于 Control Plane OpenAPI 规范
+ * API type definitions
+ * Based on the Control Plane OpenAPI specification
  */
 
 // ============================================
-// 通用类型
+// Common types
 // ============================================
 
-/** 运行时类型 */
+/** Runtime type */
 export type RuntimeType = 'python3.11' | 'nodejs20' | 'java17' | 'go1.21';
 
-/** 会话状态 */
+/** Session status */
 export type SessionStatus = 'PENDING' | 'CREATING' | 'STARTING' | 'RUNNING' | 'COMPLETED' | 'TERMINATED' | 'FAILED' | 'TIMEOUT';
 
-/** 依赖安装状态 */
+/** Dependency installation status */
 export type DependencyInstallStatus = 'pending' | 'installing' | 'completed' | 'failed';
 
-/** 执行状态 */
+/** Execution status */
 export type ExecutionStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED' | 'TIMEOUT' | 'CRASHED';
 
-/** 编程语言 */
+/** Programming language */
 export type CodeLanguage = 'python' | 'javascript' | 'shell';
 
 // ============================================
-// Template 相关类型
+// Template-related types
 // ============================================
 
-/** 模板响应 */
+/** Template response */
 export interface TemplateResponse {
   id: string;
   name: string;
@@ -42,7 +42,7 @@ export interface TemplateResponse {
   updated_at?: string;
 }
 
-/** 创建模板请求 */
+/** Create template request */
 export interface CreateTemplateRequest {
   id: string;
   name: string;
@@ -55,7 +55,7 @@ export interface CreateTemplateRequest {
   default_env_vars?: Record<string, string>;
 }
 
-/** 更新模板请求 */
+/** Update template request */
 export interface UpdateTemplateRequest {
   name?: string;
   image_url?: string;
@@ -67,10 +67,10 @@ export interface UpdateTemplateRequest {
 }
 
 // ============================================
-// Session 相关类型
+// Session-related types
 // ============================================
 
-/** 资源限制响应 */
+/** Resource limit response */
 export interface ResourceLimitResponse {
   cpu: string;
   memory: string;
@@ -78,7 +78,7 @@ export interface ResourceLimitResponse {
   max_processes?: number;
 }
 
-/** 会话响应 */
+/** Session response */
 export interface SessionResponse {
   id: string;
   template_id: string;
@@ -104,13 +104,13 @@ export interface SessionResponse {
   last_activity_at?: string;
 }
 
-/** 依赖包规范 */
+/** Dependency spec */
 export interface DependencySpec {
   name: string;
   version?: string;
 }
 
-/** 已安装依赖 */
+/** Installed dependency */
 export interface InstalledDependencyResponse {
   name: string;
   version: string;
@@ -119,7 +119,7 @@ export interface InstalledDependencyResponse {
   is_from_template?: boolean;
 }
 
-/** 创建会话请求 */
+/** Create session request */
 export interface CreateSessionRequest {
   template_id?: string;
   timeout?: number;
@@ -135,13 +135,13 @@ export interface CreateSessionRequest {
   allow_version_conflicts?: boolean;
 }
 
-/** 安装会话依赖请求 */
+/** Install session dependencies request */
 export interface InstallSessionDependenciesRequest {
   python_package_index_url?: string;
   dependencies: DependencySpec[];
 }
 
-/** 会话列表响应 */
+/** sessionlistresponse */
 export interface SessionListResponse {
   items: SessionResponse[];
   total: number;
@@ -149,7 +149,7 @@ export interface SessionListResponse {
   offset: number;
 }
 
-/** 会话列表查询参数 */
+/** Session list query parameters */
 export interface ListSessionsParams {
   status?: SessionStatus | null;
   template_id?: string | null;
@@ -158,10 +158,10 @@ export interface ListSessionsParams {
 }
 
 // ============================================
-// Execution 相关类型
+// Execution-related types
 // ============================================
 
-/** 文件制品响应 */
+/** fileartifactresponse */
 export interface ArtifactResponse {
   path: string;
   size: number;
@@ -171,7 +171,7 @@ export interface ArtifactResponse {
   checksum?: string;
 }
 
-/** 执行指标 */
+/** Execution metrics */
 export interface ExecutionMetrics {
   duration_ms: number;
   cpu_time_ms?: number;
@@ -180,7 +180,7 @@ export interface ExecutionMetrics {
   io_write_bytes?: number;
 }
 
-/** 执行响应 */
+/** Execution response */
 export interface ExecutionResponse {
   id: string;
   session_id: string;
@@ -202,7 +202,7 @@ export interface ExecutionResponse {
   metrics?: ExecutionMetrics;
 }
 
-/** 执行代码请求 */
+/** executioncoderequest */
 export interface ExecuteCodeRequest {
   code: string;
   language: CodeLanguage;
@@ -211,7 +211,7 @@ export interface ExecuteCodeRequest {
   working_directory?: string;
 }
 
-/** 执行代码响应 */
+/** executioncoderesponse */
 export interface ExecuteCodeResponse {
   execution_id: string;
   session_id: string;
@@ -219,7 +219,7 @@ export interface ExecuteCodeResponse {
   created_at?: string;
 }
 
-/** 文件上传响应 */
+/** File upload response */
 export interface FileUploadResponse {
   session_id: string;
   mode: 'file' | 'archive_extract';
@@ -230,7 +230,7 @@ export interface FileUploadResponse {
   size: number;
 }
 
-/** 执行列表响应 */
+/** executionlistresponse */
 export interface ExecutionListResponse {
   items: ExecutionResponse[];
   total: number;
@@ -239,17 +239,17 @@ export interface ExecutionListResponse {
 }
 
 // ============================================
-// Health 相关类型
+// Health-related types
 // ============================================
 
-/** 健康检查响应 */
+/** Health Checkresponse */
 export interface HealthResponse {
   status: string;
   version: string;
   uptime: number;
 }
 
-/** 详细健康检查响应 */
+/** Detailed health checkresponse */
 export interface DetailedHealthResponse extends Record<string, unknown> {
   status: string;
   version?: string;
@@ -258,10 +258,10 @@ export interface DetailedHealthResponse extends Record<string, unknown> {
 }
 
 // ============================================
-// File 相关类型
+// File-related types
 // ============================================
 
-/** 文件上传响应 */
+/** File upload response */
 export interface FileUploadResponse {
   session_id: string;
   file_path: string;
@@ -269,10 +269,10 @@ export interface FileUploadResponse {
 }
 
 // ============================================
-// 通用 API 响应类型
+// Common API response types
 // ============================================
 
-/** API 错误响应 */
+/** API errorresponse */
 export interface ErrorResponse {
   detail: Array<{
     loc: Array<string | number>;
@@ -281,7 +281,7 @@ export interface ErrorResponse {
   }>;
 }
 
-/** 分页参数 */
+/** Pagination parameters */
 export interface PaginationParams {
   limit?: number;
   offset?: number;

--- a/infra/sandbox/sandbox_web/src/types/global.ts
+++ b/infra/sandbox/sandbox_web/src/types/global.ts
@@ -1,11 +1,11 @@
 /**
- * 全局类型定义
+ * Global type definitions
  */
 
-/** 路由路径 */
+/** Route path */
 export type RoutePath = '/' | '/templates' | '/sessions' | '/execute' | '/files';
 
-/** 应用菜单项 */
+/** Application menu item */
 export interface MenuItem {
   key: string;
   label: string;
@@ -13,7 +13,7 @@ export interface MenuItem {
   icon: string;
 }
 
-/** 应用状态 */
+/** Application state */
 export interface AppState {
   currentRoute: RoutePath;
   sidebarCollapsed: boolean;

--- a/infra/sandbox/sandbox_web/src/utils/http/axios.ts
+++ b/infra/sandbox/sandbox_web/src/utils/http/axios.ts
@@ -1,10 +1,10 @@
 /**
- * Axios 实例配置
+ * Axios instance configuration
  */
 import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 import { getApiBaseUrl, HTTP_TIMEOUT } from '@/constants/api';
 
-/** 创建 API 客户端实例 */
+/** Create an API client instance */
 export const apiClient: AxiosInstance = axios.create({
   baseURL: getApiBaseUrl(),
   timeout: HTTP_TIMEOUT,
@@ -13,7 +13,7 @@ export const apiClient: AxiosInstance = axios.create({
   },
 });
 
-/** 请求拦截器 */
+/** Request interceptor */
 apiClient.interceptors.request.use(
   (config) => {
     // Dynamically set baseURL from runtime config
@@ -24,7 +24,7 @@ apiClient.interceptors.request.use(
       console.debug(`[API] Request to: ${config.baseURL}${config.url}`);
     }
 
-    // 可以在这里添加认证 token
+    // Authentication tokens can be added here
     // const token = localStorage.getItem('token');
     // if (token) {
     //   config.headers.Authorization = `Bearer ${token}`;
@@ -36,23 +36,23 @@ apiClient.interceptors.request.use(
   }
 );
 
-/** 响应拦截器 */
+/** Response interceptor */
 apiClient.interceptors.response.use(
   (response: AxiosResponse) => {
-    // 直接返回响应数据
+    // Return response data directly
     return response.data;
   },
   (error) => {
-    // 统一错误处理
+    // Unified error handling
     if (error.response) {
-      // 服务器返回错误状态码
+      // Server returned an error status code
       const { status, data } = error.response;
       console.error(`API Error [${status}]:`, data);
     } else if (error.request) {
-      // 请求已发出但没有收到响应
+      // Request was sent but no response was received
       console.error('Network Error:', error.message);
     } else {
-      // 请求配置错误
+      // Request configuration error
       console.error('Request Error:', error.message);
     }
     return Promise.reject(error);

--- a/infra/sandbox/sandbox_web/src/utils/http/request.ts
+++ b/infra/sandbox/sandbox_web/src/utils/http/request.ts
@@ -1,39 +1,39 @@
 /**
- * HTTP 请求封装工具
+ * HTTP request wrapper utilities
  */
 import apiClient from './axios';
 import type { AxiosRequestConfig } from 'axios';
 
 /**
- * 通用 GET 请求
+ * Generic GET request
  */
 export function get<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T> {
   return apiClient.get<T>(url, config);
 }
 
 /**
- * 通用 POST 请求
+ * Generic POST request
  */
 export function post<T = unknown>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
   return apiClient.post<T>(url, data, config);
 }
 
 /**
- * 通用 PUT 请求
+ * Generic PUT request
  */
 export function put<T = unknown>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
   return apiClient.put<T>(url, data, config);
 }
 
 /**
- * 通用 DELETE 请求
+ * Generic DELETE request
  */
 export function del<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T> {
   return apiClient.delete<T>(url, config);
 }
 
 /**
- * 通用 PATCH 请求
+ * Generic PATCH request
  */
 export function patch<T = unknown>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T> {
   return apiClient.patch<T>(url, data, config);


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Translate infra/sandbox README files and documentation indexes covered by the comment-translation scope
- [x] Translate code comments and Python docstrings under infra/sandbox
- [x] Keep logs, UI/user-facing strings, API contract text, i18n text, generated fixtures, and test data unchanged unless they are comments/docstrings

---

## Why

- Related Issue: Part of #993
- Related Feature: Comment translation cleanup
- Background: Split the large issue into module-level PRs so review remains manageable.

---

## How

- Key implementation points:
  - Updated README.md files under infra/sandbox to English.
  - Translated comments/docstrings in sandbox control plane, executor, deployment configs, and sandbox_web source files.
  - Used scoped scans to distinguish comments/docstrings from runtime strings, UI text, and test data.
- Breaking changes (API, config, database, etc.): None. Comment/documentation-only change.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- PASS: target-scope Chinese comment/docstring/README scan returned 0 hits.
- PASS: git diff --check.
- PASS: Python py_compile for 44 changed Python files.
- PASS: npm run build in infra/sandbox/sandbox_web.
- NOT RUN: npm run lint fails before code linting due existing ESLint config issue: .eslintrc.js is treated as ESM because package.json has type=module, so module is not defined.
- NOT RUN: full unit/integration test suites because this PR only changes comments/docs and sandbox integration tests require external services.

---

## Risk & Rollback

- Potential risks: Low; the change is limited to comments/docstrings and README text. Runtime/user-facing strings were intentionally left unchanged.
- Rollback plan: Revert this PR commit.

---

## Additional Notes

- This PR covers only the infra/sandbox module slice of #993.