### PR TITLE
refactor(bkn-agent): translate internal text

### DIFF
--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -120,7 +120,7 @@ async def _agent_tool(
         raise bad_request("BknAgent.ToolRef.AgentNotTask", agent_id=agent_id, mode=sub_agent.mode)
 
     async def call_sub_agent(message: str) -> str:
-        """调用子 agent 完成一次性任务，返回其最终回复。"""
+        """Call a child agent for a one-shot task and return its final response."""
         async with SessionLocal() as session:
             task = await dao.create_task(
                 session, sub_agent.agent_id, {"message": message}, account_id, parent_thread_id
@@ -156,7 +156,10 @@ async def _agent_tool(
         return output
 
     name = _derive_agent_tool_name(ref, sub_agent.name, sub_agent.agent_id)
-    description = ref.get("description") or f"调用子 agent「{sub_agent.name}」完成一次性任务。"
+    description = (
+        ref.get("description")
+        or f"Call the child agent '{sub_agent.name}' for a one-shot task."
+    )
     return StructuredTool.from_function(coroutine=call_sub_agent, name=name, description=description)
 
 
@@ -178,8 +181,10 @@ def _derive_agent_tool_name(ref: dict, agent_name: str, agent_id: str) -> str:
 
 def _read_skill_file_tool(account_id: str, account_type: str) -> StructuredTool:
     async def read_skill_file(skill_id: str, path: str) -> str:
-        """读取已挂载技能的附属文件（渐进式加载，大文件不常驻上下文）。
-        skill_id 与 path 取 system prompt 中该技能条目列出的值。"""
+        """Read an attached file from a mounted skill using progressive loading.
+
+        Use a skill_id and path listed for that skill in the system prompt.
+        """
         sid = normalize_skill_id(skill_id)
         url = f"{config.OPERATOR_INTEGRATION_BASE}/internal-v1/skills/{sid}/files/read"
         headers = {"x-account-id": account_id, "x-account-type": account_type, **observability.outbound_headers()}
@@ -194,7 +199,7 @@ def _read_skill_file_tool(account_id: str, account_type: str) -> StructuredTool:
             # Two hops, as in load_skills: the published surface returns a presigned URL, not the body
             async with session.get(meta["url"]) as resp:
                 if resp.status != 200:
-                    return f"read_skill_file failed: 对象存储 HTTP {resp.status}"
+                    return f"read_skill_file failed: object storage HTTP {resp.status}"
                 return await resp.text()
 
     return StructuredTool.from_function(coroutine=read_skill_file, name="read_skill_file")

--- a/infra/bkn-agent/app/dao.py
+++ b/infra/bkn-agent/app/dao.py
@@ -219,6 +219,10 @@ async def recover_stale_tasks(session: AsyncSession) -> int:
         .where(TaskRow.f_status.in_(("pending", "running")))
         .values(
             f_status="failed",
+            # This persisted, client-visible text stays in the service default
+            # locale until #826 P4 carries effective_locale into async task
+            # envelopes. Replacing it with English here would change the
+            # response contract instead of performing an internal-text cleanup.
             f_failure_detail="服务重启中断：任务未持久化执行状态，进程重启无法恢复，请重试。",
             f_update_time=now,
         )

--- a/infra/bkn-agent/app/test/test_limits_and_gates.py
+++ b/infra/bkn-agent/app/test/test_limits_and_gates.py
@@ -161,6 +161,7 @@ def test_agent_as_tool_accepts_published_task(monkeypatch):
     monkeypatch.setattr(dao, "get_agent", get_agent)
     t = asyncio.run(tools._agent_tool({"type": "agent", "agent_id": "sub-1"}, "u", "user", 0, None))
     assert t.name == "agent_sub_agent"
+    assert t.description == "Call the child agent 'sub_agent' for a one-shot task."
 
 
 def test_busy_thread_slot_released_on_setup_failure():

--- a/infra/bkn-agent/app/test/test_skill_source.py
+++ b/infra/bkn-agent/app/test/test_skill_source.py
@@ -102,6 +102,7 @@ def test_read_skill_file_uses_rel_path():
     from app.core.tools import _read_skill_file_tool
 
     tool = _read_skill_file_tool("acc", "user")
+    assert "Read an attached file from a mounted skill" in tool.description
     sess = _FakeSession()
 
     import app.core.tools as tools_mod

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -1,8 +1,10 @@
-{{- /* 单实例约束：任务恢复扫描与 thread 并发写都假设全局唯一副本，
-多副本会互相误回收任务、并发写同一 thread。多副本支持推迟到 #246，
-在此之前把 replicaCount 钉死在 1，防 --set 覆盖。 */}}
+{{- /* Single-replica constraint: task recovery scans and concurrent thread
+writes both assume one globally unique replica. Multiple replicas could reclaim
+one another's tasks or write the same thread concurrently. Multi-replica
+support is deferred to #246; until then, pin replicaCount to 1 so --set cannot
+override it. */}}
 {{- if ne (int .Values.replicaCount) 1 }}
-{{- fail (printf "bkn-agent 目前仅支持单副本（多副本见 #246），replicaCount 必须为 1，当前为 %v" .Values.replicaCount) }}
+{{- fail (printf "bkn-agent currently supports only one replica (see #246 for multi-replica support); replicaCount must be 1, got %v" .Values.replicaCount) }}
 {{- end }}
 apiVersion: apps/v1
 kind: Deployment

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -1,10 +1,15 @@
-# 必须保持 1。bkn-agent 当前有进程内状态、不跨副本：
-#   - 一次性任务是进程内 asyncio 任务（重启回收见 dao.recover_stale_tasks）
-#   - 同 thread 并发保护 _busy_threads 是进程内集合
-#   - 算子工厂全量同步在进程内串行
-# 多副本会导致：启动回收误杀别的副本活跃任务 / 同 thread 落不同副本并发写
-# checkpoint / 同步互相覆盖。真·多副本需分布式协调（任务租约+分布式锁+同步选主），
-# 见 issue #246。配合 deployment 的 maxSurge=0（滚动无重叠），单副本语义安全。
+# Must remain 1. bkn-agent currently keeps state in process and does not share
+# it across replicas:
+#   - One-shot jobs are in-process asyncio tasks (see dao.recover_stale_tasks
+#     for restart recovery).
+#   - The per-thread concurrency guard, _busy_threads, is an in-process set.
+#   - Full execution-factory synchronization is serialized in process.
+# Multiple replicas would let startup recovery reclaim another replica's live
+# jobs, allow concurrent writes when one thread reaches different replicas, and
+# overwrite checkpoints or synchronization results. True multi-replica support
+# requires distributed coordination (job leases, distributed locks, and sync
+# leader election); see issue #246. Together with maxSurge=0 in the deployment
+# (no overlap during rolling updates), one-replica semantics are safe.
 replicaCount: 1
 
 namespace: openbkn
@@ -22,9 +27,9 @@ service:
     port: 30800
     targetPort: 30800
 
-# 仅面向平台内部（Epic #202 硬约束）：本 chart 不含 ingress 模板，
-# 网关不得为 bkn-agent 开终端用户入口。产品面需要 agent 能力时
-# 由其后端以服务身份代理调用。
+# Platform-internal only (a hard constraint from Epic #202): this chart has no
+# ingress template, and the gateway must not expose bkn-agent to end-user
+# traffic. Product backends proxy agent requests with a service identity.
 
 depServices:
   rds:
@@ -36,16 +41,18 @@ depServices:
 
 runtime:
   mfModelApiPrivateBase: "http://mf-model-api:9898/api/private/mf-model-api/v1"
-  # 工具面与技能面统一走这里（#322）
+  # Both the tool and skill surfaces use this endpoint (#322).
   operatorIntegrationBase: "http://agent-operator-integration:9000/api/agent-operator-integration"
-  # Context Loader 的 MCP 面（ToolRef type=context_loader 由此装载）。这是公开面：
-  # 它挂 introspect，只认真实令牌，不吃 /in 的头部身份。
+  # The Context Loader MCP surface (loaded by ToolRef type=context_loader).
+  # This is a public surface with introspection: it accepts real tokens, not
+  # the header identity used by /in.
   contextLoaderMcpUrl: "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/"
   defaultModel: ""
   checkpointerBackend: "mysql"
-  # 建表统一归 migrations/bkn-agent/（core-data-migrator）。
-  # checkpointer 三张表（langgraph-checkpoint-mysql 固定表名）当前由首启
-  # 一次性开启此开关建出，后续固化进迁移后关回 false。
+  # Table creation belongs in migrations/bkn-agent/ (core-data-migrator).
+  # For now, enable this flag once on the first startup to create the three
+  # checkpointer tables (fixed names from langgraph-checkpoint-mysql), then set
+  # it back to false after the tables are captured in a migration.
   checkpointerAllowRuntimeDdl: "false"
 
 observability:
@@ -54,8 +61,9 @@ observability:
   bknTraceEvidenceIngestUrl: "http://agent-observability:8080/api/agent-observability/v1/evidence/events"
   bknTraceArtifactIngestUrl: "http://agent-observability:8080/api/agent-observability/v1/evidence/artifacts"
   bknTraceEvidenceTimeoutS: "3"
-  # 接入受保护的 agent-observability evidence/artifact 写入端点时必须配置为
-  # 该服务使用的既有 Secret 名称；留空只适用于未部署 Trace 的环境。
+  # When using protected agent-observability evidence/artifact ingest
+  # endpoints, set this to the existing Secret used by that service. Leave it
+  # empty only in environments without Trace.
   bknTraceEvidenceIngestTokenSecretName: ""
   bknTraceEvidenceIngestTokenSecretKey: "ingest-token"
 

--- a/infra/bkn-agent/scripts/export_openapi.py
+++ b/infra/bkn-agent/scripts/export_openapi.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
-"""导出冻结契约 docs/api/bkn-agent/bkn-agent.yaml（#212 spec 先行流程）。
+"""Export the frozen docs/api/bkn-agent/bkn-agent.yaml contract (#212).
 
-用法（infra/bkn-agent 下）：python scripts/export_openapi.py
-改 API 后必须重跑本脚本并将 spec diff 一并提交，否则 test_contract.py 红。
+Run from infra/bkn-agent with ``python scripts/export_openapi.py``. After an API
+change, rerun this script and commit the spec diff or test_contract.py will fail.
 """
 import json
 import sys

--- a/infra/bkn-agent/scripts/import-business-provenance-optimizer.sh
+++ b/infra/bkn-agent/scripts/import-business-provenance-optimizer.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 导入或更新业务溯源优化 Agent。脚本不保存任何凭据；调用方显式提供自己的
-# BKN Agent 管理端点与身份头，适用于本地、测试和正式环境。
+# Import or update the business-provenance optimization agent. This script
+# stores no credentials; callers explicitly provide their own BKN Agent
+# management endpoint and identity headers for local, test, or production use.
 : "${BKN_AGENT_URL:?set BKN_AGENT_URL, for example http://127.0.0.1:30800/api/bkn-agent/v1}"
 : "${BKN_ACCOUNT_ID:?set BKN_ACCOUNT_ID}"
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Translate production comments, docstrings, Helm diagnostics, and script guidance in `infra/bkn-agent` to English.
- [x] Translate built-in agent-tool and skill-file descriptions, with focused regression assertions.
- [x] Document the remaining persisted Chinese task failure detail as an intentional #826 P4 compatibility boundary.

---

## Why

- Related Issue: Closes #993 (the issue is already closed and originally excluded `infra/bkn-agent`; this is the requested follow-up applying the same cleanup rules).
- Related Feature: [Platform i18n #826](https://github.com/openbkn-ai/bkn-foundry/issues/826)
- Background: Finish the English-only cleanup for safe service-owned text without mechanically changing locale catalogs, business data, persisted response contracts, or unresolved LLM-language behavior.

---

## How

- Key implementation points:
  - Keep machine identifiers, the CJK-compatible agent-name regex, locale resources, tests/fixtures, and business packages unchanged.
  - Keep the model-facing skill scaffolding, structured-output fallback, and tool-budget notice unchanged because #826 has not yet defined Agent/LLM output-language behavior.
  - Reduce production-source Han scan hits from 47 to 16; every remaining hit is a documented compatibility or localization boundary.
- Breaking changes (API, config, database, etc.): None. No API/schema behavior, dependencies, database migrations, deployment, or stored-data rewrites.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no integration behavior changed.
- [ ] Verified in test environment — N/A; translation-only local change, no deployment performed.

Test notes:

- `python -m pytest app/test -q` — 233 passed, 1 upstream Starlette deprecation warning.
- `python3 tools/check_i18n_catalogs.py` — passed.
- `python3 -m unittest tools/test_check_i18n_catalogs.py` — 5 passed.
- `python3 -m py_compile infra/bkn-agent/app/core/tools.py infra/bkn-agent/app/dao.py infra/bkn-agent/scripts/export_openapi.py` — passed.
- `bash -n infra/bkn-agent/scripts/import-business-provenance-optimizer.sh` — passed.
- Parsed `infra/bkn-agent/charts/values.yaml` with PyYAML — passed.
- `git diff --check` — passed.
- Helm rendering was not run because Helm is not installed in the local environment; the template change is limited to a comment and the text passed to `fail`.

---

## Risk & Rollback

- Potential risks: The English fallback descriptions can slightly influence model tool selection, although their semantics are unchanged. The Helm validation error is now English.
- Rollback plan: Revert commit `9b4e4308`; there are no data or schema migrations to undo.

---

## Additional Notes

- No user/business data, locale catalog text, generated OpenAPI, fixtures, or documentation was mechanically rewritten.
- Remaining Han text is limited to the persisted default-locale restart detail (#826 P4), intentionally retained LLM prompts (#826), and compatibility tokens such as the CJK agent-name regex.
