### PR TITLE
fix(trace): page conversation interactions by lifecycle

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -151,7 +151,10 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 
 func (s *Service) ListInteractions(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.InteractionSummaryPage, error) {
 	if s.canPageCanonicalConversation(options) {
-		return s.listCanonicalConversationInteractions(ctx, options)
+		page, handled, err := s.listCanonicalConversationInteractions(ctx, options)
+		if err != nil || handled {
+			return page, err
+		}
 	}
 	loadOptions := options
 	loadOptions.Status = ""
@@ -221,20 +224,22 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 func (s *Service) listCanonicalConversationInteractions(
 	ctx context.Context,
 	options evidencevo.SummaryQueryOptions,
-) (evidencevo.InteractionSummaryPage, error) {
+) (evidencevo.InteractionSummaryPage, bool, error) {
 	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
 	if err != nil {
-		return evidencevo.InteractionSummaryPage{}, err
+		return evidencevo.InteractionSummaryPage{}, false, err
 	}
 	limit := normalizeSummaryLimit(options.Limit)
 	selection := isessionstore.InteractionPage{}
 	conversation := sessionvo.Conversation{}
+	foundCanonicalConversation := false
 	err = s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		var found bool
 		conversation, found = tx.PeekConversation(options.ConversationID)
 		if !found || !canReadCanonicalConversation(conversation, options.Scope) {
 			return nil
 		}
+		foundCanonicalConversation = true
 		query := isessionstore.InteractionPageQuery{
 			ConversationID: conversation.ID,
 			Limit:          limit,
@@ -246,13 +251,19 @@ func (s *Service) listCanonicalConversationInteractions(
 			}
 			query.AfterOrdinal = after.Ordinal
 		} else {
-			query.Offset = summaryOffset(options, 0)
+			query.Offset = summaryQueryOffset(options)
 		}
 		selection = tx.ListInteractionPage(query)
 		return nil
 	})
 	if err != nil {
-		return evidencevo.InteractionSummaryPage{}, err
+		return evidencevo.InteractionSummaryPage{}, false, err
+	}
+	// Managed lifecycle records are the paging source for newly created
+	// conversations. Older projection-only conversations have no lifecycle
+	// records, so retain the established projection path for those facts.
+	if !foundCanonicalConversation || selection.Total == 0 {
+		return evidencevo.InteractionSummaryPage{}, false, nil
 	}
 	entries := make([]evidencevo.InteractionListSummary, 0, len(selection.Entries))
 	metadata := summaryLoadMetadata{}
@@ -263,13 +274,13 @@ func (s *Service) listCanonicalConversationInteractions(
 			Limit: MaxSummaryQueryLimit,
 		})
 		if loadErr != nil {
-			return evidencevo.InteractionSummaryPage{}, loadErr
+			return evidencevo.InteractionSummaryPage{}, false, loadErr
 		}
 		mergeSummaryLoadMetadata(&metadata, factMetadata)
 		entries = append(entries, mergeCanonicalInteractionFacts(canonical, facts))
 	}
 	if err := s.applyCanonicalInteractionState(ctx, entries); err != nil {
-		return evidencevo.InteractionSummaryPage{}, err
+		return evidencevo.InteractionSummaryPage{}, false, err
 	}
 	page := evidencevo.InteractionSummaryPage{
 		Entries: append([]evidencevo.InteractionListSummary{}, entries...),
@@ -282,7 +293,7 @@ func (s *Service) listCanonicalConversationInteractions(
 		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.InteractionID})
 		page.NextCursor = &next
 	}
-	return page, nil
+	return page, true, nil
 }
 
 func (s *Service) canPageCanonicalConversation(options evidencevo.SummaryQueryOptions) bool {
@@ -1819,4 +1830,8 @@ func summaryOffset(options evidencevo.SummaryQueryOptions, length int) int {
 		return length
 	}
 	return (page - 1) * limit
+}
+
+func summaryQueryOffset(options evidencevo.SummaryQueryOptions) int {
+	return (normalizeSummaryPage(options.Page) - 1) * normalizeSummaryLimit(options.Limit)
 }

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -150,6 +150,9 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 }
 
 func (s *Service) ListInteractions(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.InteractionSummaryPage, error) {
+	if s.canPageCanonicalConversation(options) {
+		return s.listCanonicalConversationInteractions(ctx, options)
+	}
 	loadOptions := options
 	loadOptions.Status = ""
 	requests, _, metadata, err := s.loadExecutionSummaries(ctx, loadOptions)
@@ -210,6 +213,135 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 		page.NextCursor = &next
 	}
 	return page, nil
+}
+
+// Conversation-scoped interaction lists use the managed lifecycle as their
+// paging boundary. Receipt projections enrich only the selected turn page;
+// they must not decide the number or order of a conversation's turns.
+func (s *Service) listCanonicalConversationInteractions(
+	ctx context.Context,
+	options evidencevo.SummaryQueryOptions,
+) (evidencevo.InteractionSummaryPage, error) {
+	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
+	if err != nil {
+		return evidencevo.InteractionSummaryPage{}, err
+	}
+	limit := normalizeSummaryLimit(options.Limit)
+	selection := isessionstore.InteractionPage{}
+	conversation := sessionvo.Conversation{}
+	err = s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		var found bool
+		conversation, found = tx.PeekConversation(options.ConversationID)
+		if !found || !canReadCanonicalConversation(conversation, options.Scope) {
+			return nil
+		}
+		query := isessionstore.InteractionPageQuery{
+			ConversationID: conversation.ID,
+			Limit:          limit,
+		}
+		if hasCursor {
+			after, found := tx.PeekInteraction(cursor.ID)
+			if !found || after.ConversationID != conversation.ID {
+				return ErrSummaryCursorInvalid
+			}
+			query.AfterOrdinal = after.Ordinal
+		} else {
+			query.Offset = summaryOffset(options, 0)
+		}
+		selection = tx.ListInteractionPage(query)
+		return nil
+	})
+	if err != nil {
+		return evidencevo.InteractionSummaryPage{}, err
+	}
+	entries := make([]evidencevo.InteractionListSummary, 0, len(selection.Entries))
+	metadata := summaryLoadMetadata{}
+	for _, interaction := range selection.Entries {
+		canonical := canonicalInteractionListSummary(conversation, interaction)
+		facts, _, factMetadata, loadErr := s.loadExecutionSummaries(ctx, evidencevo.SummaryQueryOptions{
+			Scope: options.Scope, ConversationID: conversation.ID, InteractionID: interaction.ID,
+			Limit: MaxSummaryQueryLimit,
+		})
+		if loadErr != nil {
+			return evidencevo.InteractionSummaryPage{}, loadErr
+		}
+		mergeSummaryLoadMetadata(&metadata, factMetadata)
+		entries = append(entries, mergeCanonicalInteractionFacts(canonical, facts))
+	}
+	if err := s.applyCanonicalInteractionState(ctx, entries); err != nil {
+		return evidencevo.InteractionSummaryPage{}, err
+	}
+	page := evidencevo.InteractionSummaryPage{
+		Entries: append([]evidencevo.InteractionListSummary{}, entries...),
+		Total:   selection.Total, Page: normalizeSummaryPage(options.Page), PageSize: limit,
+		Truncated: metadata.Truncated, Partial: metadata.Truncated,
+		PartialReasons: append([]string{}, metadata.PartialReasons...),
+	}
+	if len(entries) > 0 && selection.HasMore {
+		last := entries[len(entries)-1]
+		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.InteractionID})
+		page.NextCursor = &next
+	}
+	return page, nil
+}
+
+func (s *Service) canPageCanonicalConversation(options evidencevo.SummaryQueryOptions) bool {
+	if s.sessionStore == nil || strings.TrimSpace(options.ConversationID) == "" {
+		return false
+	}
+	// Filters resolved only from call facts stay on the existing projection
+	// path; this fast path is intentionally limited to the conversation view.
+	return options.InteractionID == "" && options.TraceID == "" && options.Status == "" &&
+		options.AgentOrApp == "" && options.ExcludeAgentOrApp == "" && options.Service == "" &&
+		options.Tool == "" && options.ErrorKeyword == "" && options.BusinessDomain == "" && options.KnowledgeNetwork == "" &&
+		options.EvidenceCompleteness == "" && options.Keyword == "" && options.From.IsZero() && options.To.IsZero()
+}
+
+func canonicalInteractionListSummary(
+	conversation sessionvo.Conversation,
+	interaction sessionvo.Interaction,
+) evidencevo.InteractionListSummary {
+	entry := evidencevo.InteractionListSummary{
+		InteractionID: interaction.ID, ConversationID: conversation.ID,
+		RoundNumber: int(interaction.Ordinal),
+		AgentOrApp:  conversation.AgentName, AgentName: conversation.AgentName,
+		ApplicationPrincipalID: conversation.Owner.ApplicationPrincipalID,
+		EffectiveSubjectID:     conversation.Owner.EffectiveSubjectID,
+		BusinessDomain:         conversation.Owner.BusinessDomainID,
+	}
+	applyInteractionState(
+		&entry.Status, &entry.EvidenceCompleteness, &entry.PartialReasons,
+		&entry.StartedAt, &entry.CompletedAt, &entry.DurationMS, interaction,
+	)
+	return entry
+}
+
+func mergeCanonicalInteractionFacts(
+	canonical evidencevo.InteractionListSummary,
+	requests []evidencevo.RequestSummary,
+) evidencevo.InteractionListSummary {
+	if len(requests) == 0 {
+		return canonical
+	}
+	facts := buildInteractionListSummary(canonical.InteractionID, requests)
+	facts.ConversationID = canonical.ConversationID
+	facts.RoundNumber = canonical.RoundNumber
+	facts.StartedAt, facts.CompletedAt, facts.DurationMS = canonical.StartedAt, canonical.CompletedAt, canonical.DurationMS
+	facts.AgentOrApp, facts.AgentName = canonical.AgentOrApp, canonical.AgentName
+	facts.ApplicationPrincipalID = canonical.ApplicationPrincipalID
+	facts.EffectiveSubjectID, facts.BusinessDomain = canonical.EffectiveSubjectID, canonical.BusinessDomain
+	facts.Status, facts.EvidenceCompleteness = canonical.Status, canonical.EvidenceCompleteness
+	facts.PartialReasons = canonical.PartialReasons
+	return facts
+}
+
+func mergeSummaryLoadMetadata(target *summaryLoadMetadata, source summaryLoadMetadata) {
+	if source.Truncated {
+		target.Truncated = true
+	}
+	for _, reason := range source.PartialReasons {
+		target.PartialReasons = appendUniqueSummaryReason(target.PartialReasons, reason)
+	}
 }
 
 func buildConversationSummary(conversationID string, requests []evidencevo.RequestSummary) evidencevo.ConversationSummary {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1123,6 +1123,20 @@ func TestListConversationInteractionsPagesCanonicalTurnsBeforeLoadingFacts(t *te
 	}
 
 	source.queries = nil
+	options.Page = 2
+	secondByPage, err := service.ListInteractions(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list second interaction page by page number: %v", err)
+	}
+	if secondByPage.Total != 3 || len(secondByPage.Entries) != 1 || secondByPage.Entries[0].InteractionID != "interaction_first" || secondByPage.NextCursor != nil {
+		t.Fatalf("second canonical interaction page by page number = %+v", secondByPage)
+	}
+	if len(source.queries) != 1 || source.queries[0].InteractionID != "interaction_first" {
+		t.Fatalf("numbered second page must load only its interaction facts: %+v", source.queries)
+	}
+
+	source.queries = nil
+	options.Page = 1
 	options.Cursor = *first.NextCursor
 	second, err := service.ListInteractions(context.Background(), options)
 	if err != nil {
@@ -1133,6 +1147,36 @@ func TestListConversationInteractionsPagesCanonicalTurnsBeforeLoadingFacts(t *te
 	}
 	if len(source.queries) != 1 || source.queries[0].InteractionID != "interaction_first" {
 		t.Fatalf("second page must load only its interaction facts: %+v", source.queries)
+	}
+}
+
+func TestListInteractionsFallsBackToProjectionWhenConversationIsNotInLifecycle(t *testing.T) {
+	store := evidencestore.New()
+	seedBusinessProvenanceRequest(t, store, "req_legacy", "trace_legacy", "conversation_legacy", "interaction_legacy", "2026-08-10T08:00:00Z", "历史问题", "历史结果", "acct_demo")
+	sessions := sessionstore.New()
+	if err := sessions.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveConversation(sessionvo.Conversation{
+			ID: "conversation_legacy",
+			Owner: sessionvo.Owner{
+				TenantID: "tenant_demo", BusinessDomainID: "bd_demo",
+				EffectiveSubjectType: sessionvo.SubjectUser, EffectiveSubjectID: "acct_demo",
+			},
+			Status: sessionvo.ConversationClosed,
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed lifecycle conversation without turns: %v", err)
+	}
+	service := New(store, WithProjectionSource(store), WithSessionStore(sessions))
+
+	page, err := service.ListInteractions(context.Background(), evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), ConversationID: "conversation_legacy", Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("list projection-only interaction: %v", err)
+	}
+	if page.Total != 1 || len(page.Entries) != 1 || page.Entries[0].InteractionID != "interaction_legacy" {
+		t.Fatalf("projection-only interaction must remain visible: %+v", page)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -18,6 +18,7 @@ import (
 type capturingProjectionSource struct {
 	result    iprojectionsource.Result
 	resultFor func(iprojectionsource.Query) iprojectionsource.Result
+	errFor    func(iprojectionsource.Query) error
 	queries   []iprojectionsource.Query
 }
 
@@ -664,6 +665,11 @@ func TestTraceSummaryRootServiceComesFromTraceProducer(t *testing.T) {
 
 func (s *capturingProjectionSource) LoadExecutionProjection(_ context.Context, query iprojectionsource.Query) (iprojectionsource.Result, error) {
 	s.queries = append(s.queries, query)
+	if s.errFor != nil {
+		if err := s.errFor(query); err != nil {
+			return iprojectionsource.Result{}, err
+		}
+	}
 	if s.resultFor != nil {
 		return s.resultFor(query), nil
 	}
@@ -1062,6 +1068,83 @@ func TestListInteractionsKeepsChronologicalRoundNumbersWhileReturningNewestFirst
 		page.Entries[1].InteractionID != "interaction_second" || page.Entries[1].RoundNumber != 2 ||
 		page.Entries[2].InteractionID != "interaction_first" || page.Entries[2].RoundNumber != 1 {
 		t.Fatalf("newest-first entries must retain chronological round numbers: %+v", page.Entries)
+	}
+}
+
+func TestListConversationInteractionsPagesCanonicalTurnsBeforeLoadingFacts(t *testing.T) {
+	sessions := sessionstore.New()
+	owner := sessionvo.Owner{
+		TenantID: "tenant_demo", BusinessDomainID: "bd_demo",
+		ApplicationPrincipalID: "cursor-agent",
+		EffectiveSubjectType:   sessionvo.SubjectUser, EffectiveSubjectID: "acct_demo",
+	}
+	if err := sessions.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveConversation(sessionvo.Conversation{
+			ID: "conversation_paginated", Owner: owner, Status: sessionvo.ConversationActive,
+			CreatedAt: time.Date(2026, 8, 10, 8, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 8, 10, 8, 2, 0, 0, time.UTC),
+		})
+		for ordinal, interactionID := range []string{"interaction_first", "interaction_second", "interaction_third"} {
+			startedAt := time.Date(2026, 8, 10, 8, ordinal, 0, 0, time.UTC)
+			tx.SaveInteraction(sessionvo.Interaction{
+				ID: interactionID, ConversationID: "conversation_paginated", Ordinal: uint64(ordinal + 1),
+				ExecutionStatus: sessionvo.InteractionCompleted, EvidenceStatus: sessionvo.EvidenceNotApplicable,
+				CreatedAt: startedAt, UpdatedAt: startedAt,
+			})
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed canonical interactions: %v", err)
+	}
+
+	source := &capturingProjectionSource{
+		errFor: func(query iprojectionsource.Query) error {
+			if query.InteractionID == "" {
+				return errors.New("interaction facts must be read only after selecting a canonical page")
+			}
+			return nil
+		},
+	}
+	service := New(evidencestore.New(), WithProjectionSource(source), WithSessionStore(sessions))
+	options := evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), ConversationID: "conversation_paginated", Limit: 2,
+	}
+
+	first, err := service.ListInteractions(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list first interaction page: %v", err)
+	}
+	if first.Total != 3 || len(first.Entries) != 2 || first.Entries[0].InteractionID != "interaction_third" ||
+		first.Entries[1].InteractionID != "interaction_second" || first.NextCursor == nil {
+		t.Fatalf("first canonical interaction page = %+v", first)
+	}
+	if len(source.queries) != 2 || source.queries[0].InteractionID == "" || source.queries[1].InteractionID == "" {
+		t.Fatalf("facts must be loaded only for selected interactions: %+v", source.queries)
+	}
+
+	source.queries = nil
+	options.Cursor = *first.NextCursor
+	second, err := service.ListInteractions(context.Background(), options)
+	if err != nil {
+		t.Fatalf("list second interaction page: %v", err)
+	}
+	if second.Total != 3 || len(second.Entries) != 1 || second.Entries[0].InteractionID != "interaction_first" || second.NextCursor != nil {
+		t.Fatalf("second canonical interaction page = %+v", second)
+	}
+	if len(source.queries) != 1 || source.queries[0].InteractionID != "interaction_first" {
+		t.Fatalf("second page must load only its interaction facts: %+v", source.queries)
+	}
+}
+
+func TestCanonicalConversationPagingKeepsFactFiltersOnProjectionPath(t *testing.T) {
+	service := New(evidencestore.New(), WithSessionStore(sessionstore.New()))
+	base := evidencevo.SummaryQueryOptions{ConversationID: "conversation_paginated"}
+	if !service.canPageCanonicalConversation(base) {
+		t.Fatal("unfiltered conversation query must use lifecycle paging")
+	}
+	base.BusinessDomain = "bd_demo"
+	if service.canPageCanonicalConversation(base) {
+		t.Fatal("business-domain filter must stay on the projection query path")
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -18,6 +18,7 @@ import (
 const transactionRetries = 4
 
 const listInteractionsOrderBy = " ORDER BY ordinal_no ASC, interaction_id ASC"
+const listInteractionPageOrderBy = " ORDER BY ordinal_no DESC, interaction_id ASC"
 
 type Store struct {
 	db *sql.DB
@@ -338,6 +339,47 @@ func (t *transaction) ListInteractions(conversationID string) []sessionvo.Intera
 	}
 	t.err = rows.Err()
 	return result
+}
+
+func (t *transaction) ListInteractionPage(query isessionstore.InteractionPageQuery) isessionstore.InteractionPage {
+	page := isessionstore.InteractionPage{}
+	if t.err != nil || query.Limit <= 0 {
+		return page
+	}
+	if err := t.tx.QueryRowContext(t.ctx,
+		"SELECT COUNT(*) FROM bkn_trace_interactions WHERE conversation_id=?", query.ConversationID,
+	).Scan(&page.Total); err != nil {
+		t.err = err
+		return page
+	}
+	where := " WHERE conversation_id=?"
+	args := []any{query.ConversationID}
+	if query.AfterOrdinal != 0 {
+		where += " AND ordinal_no<?"
+		args = append(args, query.AfterOrdinal)
+	}
+	statement := interactionSelect + where + listInteractionPageOrderBy + " LIMIT ? OFFSET ?"
+	args = append(args, query.Limit+1, query.Offset)
+	rows, err := t.tx.QueryContext(t.ctx, statement, args...)
+	if err != nil {
+		t.err = err
+		return page
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value, scanErr := scanInteractionRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return page
+		}
+		page.Entries = append(page.Entries, value)
+	}
+	t.err = rows.Err()
+	if len(page.Entries) > query.Limit {
+		page.Entries = page.Entries[:query.Limit]
+		page.HasMore = true
+	}
+	return page
 }
 
 func (t *transaction) FindInteraction(interactionID string) (sessionvo.Interaction, bool) {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -175,6 +175,33 @@ func (tx memoryTransaction) ListInteractions(conversationID string) []sessionvo.
 	return result
 }
 
+func (tx memoryTransaction) ListInteractionPage(query isessionstore.InteractionPageQuery) isessionstore.InteractionPage {
+	entries := tx.ListInteractions(query.ConversationID)
+	result := make([]sessionvo.Interaction, 0, len(entries))
+	for index := len(entries) - 1; index >= 0; index-- {
+		interaction := entries[index]
+		if query.AfterOrdinal != 0 && interaction.Ordinal >= query.AfterOrdinal {
+			continue
+		}
+		result = append(result, interaction)
+	}
+	page := isessionstore.InteractionPage{Total: len(entries)}
+	start := query.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start >= len(result) || query.Limit <= 0 {
+		return page
+	}
+	end := start + query.Limit
+	if end > len(result) {
+		end = len(result)
+	}
+	page.Entries = append([]sessionvo.Interaction{}, result[start:end]...)
+	page.HasMore = end < len(result)
+	return page
+}
+
 func (tx memoryTransaction) NextInteractionOrdinal(conversationID string) uint64 {
 	var max uint64
 	for _, interaction := range tx.s.interactions {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store_test.go
@@ -42,3 +42,38 @@ func TestListFirstOperationSourceModulesByTraceIDsReturnsEarliestNonEmptyModule(
 		t.Fatalf("unexpected source module for unrequested trace")
 	}
 }
+
+func TestListInteractionPageUsesNewestOrdinalAndReportsHasMore(t *testing.T) {
+	store := New()
+	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		for ordinal, interactionID := range []string{"first", "second", "third", "fourth"} {
+			tx.SaveInteraction(sessionvo.Interaction{
+				ID:             interactionID,
+				ConversationID: "conversation-page",
+				Ordinal:        uint64(ordinal + 1),
+			})
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("seed interactions: %v", err)
+	}
+
+	var first, second isessionstore.InteractionPage
+	if err := store.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		first = tx.ListInteractionPage(isessionstore.InteractionPageQuery{
+			ConversationID: "conversation-page", Limit: 2,
+		})
+		second = tx.ListInteractionPage(isessionstore.InteractionPageQuery{
+			ConversationID: "conversation-page", Limit: 2, AfterOrdinal: first.Entries[len(first.Entries)-1].Ordinal,
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("read interaction pages: %v", err)
+	}
+	if first.Total != 4 || !first.HasMore || len(first.Entries) != 2 || first.Entries[0].ID != "fourth" || first.Entries[1].ID != "third" {
+		t.Fatalf("unexpected first page: %+v", first)
+	}
+	if second.Total != 4 || second.HasMore || len(second.Entries) != 2 || second.Entries[0].ID != "second" || second.Entries[1].ID != "first" {
+		t.Fatalf("unexpected final page: %+v", second)
+	}
+}

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -21,6 +21,7 @@ type Transaction interface {
 	PeekInteraction(interactionID string) (sessionvo.Interaction, bool)
 	FindInteraction(interactionID string) (sessionvo.Interaction, bool)
 	ListInteractions(conversationID string) []sessionvo.Interaction
+	ListInteractionPage(query InteractionPageQuery) InteractionPage
 	NextInteractionOrdinal(conversationID string) uint64
 	SaveInteraction(interaction sessionvo.Interaction)
 	FindOperationByKey(interactionID, operationKey string) (sessionvo.Operation, bool)
@@ -46,6 +47,22 @@ type Transaction interface {
 	ListAssemblyRevisions(interactionID string) []sessionvo.AssemblyRevision
 	SaveAssemblyRevision(revision sessionvo.AssemblyRevision)
 	AppendProjection(mutation sessionvo.ProjectionMutation)
+}
+
+// InteractionPageQuery keeps conversation-scoped interaction pagination at
+// the lifecycle store. The interaction ordinal is the managed chronological
+// order, while callers present the resulting page newest first.
+type InteractionPageQuery struct {
+	ConversationID string
+	Limit          int
+	Offset         int
+	AfterOrdinal   uint64
+}
+
+type InteractionPage struct {
+	Entries []sessionvo.Interaction
+	Total   int
+	HasMore bool
 }
 
 type Store interface {


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Page conversation-scoped Interaction lists from the managed lifecycle store.
- [x] Hydrate Receipt / Operation facts only for the selected Interaction page.
- [x] Add regression coverage for canonical paging, cursor continuation, exact fact filtering, and in-memory lifecycle paging.

## Why

- Related Issue: #1033
- Receipt candidate windows must not determine which turns are visible in a long managed conversation.

## How

- Use bkn_trace_interactions as the authoritative paging boundary with ordinal_no DESC and page_size + 1.
- Keep the existing opaque cursor contract; resume by resolving its Interaction ID to the lifecycle ordinal.
- Preserve the projection path for fact-derived filters, including business-domain filtering.

## Testing

- [x] Focused service and session-store Go tests.
- [x] Full Agent Observability module Go test suite, including httptest packages.

## Risk & Rollback

The change is limited to unfiltered conversation-scoped Interaction listing. Global and fact-filtered queries retain their existing path. Rollback is a single commit revert.

## Additional Notes

No MCP, SDK, public API, or new summary index is introduced.