### PR TITLE
fix(trace): honor page offset in summary listings

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -1617,8 +1617,9 @@ func paginateTraceSummaries(filtered []evidencevo.TraceSummary, options evidence
 	if err != nil {
 		return evidencevo.TraceSummaryPage{}, err
 	}
-	start := 0
+	start := summaryOffset(options, len(filtered))
 	if hasCursor {
+		start = 0
 		for start < len(filtered) && !afterSummaryCursor(filtered[start].StartedAt, filtered[start].TraceID, cursor) {
 			start++
 		}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -34,6 +34,23 @@ func TestSummaryOffsetClampsOverflowingPage(t *testing.T) {
 	}
 }
 
+func TestPaginateTraceSummariesUsesPageOffset(t *testing.T) {
+	page, err := paginateTraceSummaries([]evidencevo.TraceSummary{
+		{TraceID: "trace_oldest", StartedAt: "2026-08-01T08:00:00Z"},
+		{TraceID: "trace_latest", StartedAt: "2026-08-03T08:00:00Z"},
+		{TraceID: "trace_middle", StartedAt: "2026-08-02T08:00:00Z"},
+	}, evidencevo.SummaryQueryOptions{Page: 2, Limit: 1})
+	if err != nil {
+		t.Fatalf("paginate trace summaries: %v", err)
+	}
+	if page.Total != 3 {
+		t.Fatalf("total = %d, want 3", page.Total)
+	}
+	if len(page.Entries) != 1 || page.Entries[0].TraceID != "trace_middle" {
+		t.Fatalf("page 2 entries = %+v, want trace_middle", page.Entries)
+	}
+}
+
 func TestListConversationsUsesCanonicalSessionStatus(t *testing.T) {
 	evidenceStore := evidencestore.New()
 	seedBusinessProvenanceRequest(


### PR DESCRIPTION
## What Changed

- Apply the requested page offset when listing Trace summaries without a cursor.
- Preserve cursor-based pagination behavior when a cursor is supplied.
- Add a regression test proving page 2 returns the second sorted Trace.

---

## Why

- Related Issue: N/A (reported during localhost Trace Analysis validation)
- Related Feature: BKN Trace Analysis
- Background: the handler parsed `page`, but the service always started at offset zero, so every page displayed the first-page entries.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: service-layer pagination correction)
- [ ] Verified in test environment (pending deployment)

Test notes:

- `GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc -run '^(TestPaginateTraceSummariesUsesPageOffset|TestSummaryOffsetClampsOverflowingPage)$' -count=1`
- `GOCACHE=/tmp/openbkn-go-cache go test ./src/domain/service/evidencesvc -count=1`

---

## Review Focus

- Confirm page-number pagination now applies the existing bounded `summaryOffset` helper.
- Confirm a supplied cursor remains the authoritative pagination cursor.

---

## Checklist

- [x] Changes are scoped to the reported bug
- [x] Regression coverage added
- [x] `git diff --check` passed
- [x] No API contract changes
