### PR TITLE
Add pause:3.10.2 to the list of pre-pulled pause image versions.

### DIFF
--- a/deploy/scripts/services/k8s.sh
+++ b/deploy/scripts/services/k8s.sh
@@ -138,7 +138,7 @@ init_k8s_master() {
 
     # Pre-pull pause image with all possible versions and tag them
     log_info "Pre-pulling pause images with all versions..."
-    for pause_version in 3.6 3.9 3.10 3.10.0 3.10.1; do
+    for pause_version in 3.6 3.9 3.10 3.10.0 3.10.1 3.10.2; do
         log_info "Pulling pause:${pause_version}..."
         crictl pull "${IMAGE_REPOSITORY}/pause:${pause_version}" 2>/dev/null || true
         # Tag the image as registry.k8s.io version for kubeadm


### PR DESCRIPTION
Ubuntu containerd may use pause:3.10.2 as the sandbox image. Pre-pulling this version helps ensure kubeadm initialization can use the required pause image without an additional pull.

# Pull Request

## What Changed

Brief description of changes:

- [x] Deploy / Kubernetes initialization
- [ ] Feature/module 2
- [ ] Docs/doc 1

在 Kubernetes 初始化阶段新增 `pause:3.10.2` 镜像的预拉取与标签处理。

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background:

Ubuntu 使用 containerd 时可能默认使用 `pause:3.10.2` 作为 Pod sandbox 镜像。
此前脚本未预拉取该版本，可能导致 kubeadm 初始化阶段需要额外拉取镜像，
在离线或受限网络环境下造成初始化失败。

---

## How

- Key implementation points:
  - 将 `3.10.2` 添加到 pause 镜像版本列表。
  - 预拉取 `${IMAGE_REPOSITORY}/pause:3.10.2`。
  - 将镜像标记为 `registry.k8s.io/pause:3.10.2`。

- Breaking changes (API, config, database, etc.):

无。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

已完成脚本级 diff 检查；未执行完整 Kubernetes 集群初始化测试。

---

## Risk & Rollback

- Potential risks:

  - 初始化阶段会额外尝试拉取一个 pause 镜像版本。
  - 拉取失败会被现有脚本逻辑忽略，不影响后续流程。

- Rollback plan:

回退提交 `1ea176a80`，或从 pause 版本列表中移除 `3.10.2`。

---

## Additional Notes

该变更主要用于兼容 Ubuntu containerd 的 sandbox 镜像版本。