### PR TITLE
docs(bkn-agent): say where the model-facing language boundary now falls

### DIFF
--- a/infra/bkn-agent/app/core/skills.py
+++ b/infra/bkn-agent/app/core/skills.py
@@ -71,10 +71,12 @@ async def _fetch_skill_content(session: aiohttp.ClientSession, capability_id: st
     # learns which files it may read and which skill_id read_skill_file needs.
     # Without it progressive loading is invisible to the model, which is the
     # same as not having it.
-    # The scaffolding text below is model-facing and intentionally stays as it
-    # is. What language the agent thinks and answers in is an open platform
-    # design question (#826, "Agent / LLM output language"); switching it would
-    # change model behaviour, not the API contract.
+    # Text injected into the system prompt stays as it is. The tool
+    # descriptions in core/tools.py are English, but those only tell the model
+    # what a tool does; this text tells it how to answer, and what language an
+    # agent thinks and answers in is still an open platform design question
+    # (#826, "Agent / LLM output language"). Changing it moves model behaviour,
+    # not the API contract, so it waits for that decision.
     others = [f["rel_path"] for f in (meta.get("files") or []) if f["rel_path"].upper() != "SKILL.MD"]
     header = f"## 技能 {skill_id}\n"
     if others:

--- a/infra/bkn-agent/app/core/structured.py
+++ b/infra/bkn-agent/app/core/structured.py
@@ -139,8 +139,9 @@ async def structured_extract_with_path(
     # model with no tools bound, so a model that follows that instruction answers
     # in natural language instead of JSON and burns the single retry; if it does
     # so twice the whole task fails.
-    # This instruction is model-facing and intentionally stays as it is; see the
-    # note in core/skills.py and #826 ("Agent / LLM output language").
+    # An instruction about how to answer, so it follows the system-prompt
+    # boundary rather than the tool-description one; see the note in
+    # core/skills.py and #826 ("Agent / LLM output language").
     instr = (
         "请只输出一个 JSON 对象，严格符合下面的 JSON Schema。"
         "本次调用不提供任何工具，请仅基于以上对话内容作答，不要请求调用工具。"

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -377,8 +377,9 @@ def apply_tool_call_cap(
                 # The wording has to be categorical: with a mere "just answer"
                 # the model keeps probing with retries and burns turns (observed
                 # on the VM: nine empty turns before it converged).
-                # This notice is model-facing and intentionally stays as it
-                # is; see the note in core/skills.py and #826.
+                # This steers how the model should answer next, so it follows
+                # the system-prompt boundary rather than the tool-description
+                # one above; see the note in core/skills.py and #826.
                 return (
                     f"tool call budget exhausted: 已用完本次执行的工具调用配额"
                     f"（max_tool_calls={max_tool_calls}）。禁止再调用任何工具——"


### PR DESCRIPTION
Comments only. No code change.

## Why

#1041 translated two tool descriptions — `call_sub_agent`'s default and `read_skill_file`'s — into English. Those are model-facing text, and three notes left by #927 still say that model-facing text "intentionally stays as it is":

```python
# app/core/tools.py:380
# This notice is model-facing and intentionally stays as it
# is; see the note in core/skills.py and #826.
```

That note sits **two functions below** descriptions that are now English, in the same file. Anyone reading it would conclude the comment and the code disagree, and the natural repair is the wrong one — reverting a change that was fine.

## The boundary moved, it did not disappear

A tool description tells the model *what a tool does*. The text these notes guard — skill scaffolding injected into the system prompt, the tool-budget notice, the structured-output instruction — tells it *how to answer*. What language an agent thinks and answers in is still an open platform question (#826, "Agent / LLM output language"), so that text still waits on a decision; the descriptions did not need to.

The three notes now say that instead of a blanket "model-facing stays".

## On the risk of #1041 itself

Low, as reviewed there. `call_sub_agent`'s default only applies when an `agent` tool reference carries no `description` of its own, `read_skill_file`'s only when skills are mounted, and neither touches tool names, parameter schemas, return shapes, or any execution path. The model already reads mixed-language input anyway — user data and toolbox-registered tool descriptions come in whatever language they were written.

This PR does not revert anything; it stops the comments from claiming otherwise.

`pytest app/test` — 233 passed.

Refs #927