### PR TITLE
fix(trace): keep projection worker live during rebuild

### DIFF
--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -404,6 +404,15 @@ func runProjectionSupervisor(
 	if retryInterval <= 0 {
 		retryInterval = time.Second
 	}
+	var workerDone <-chan struct{}
+	if rebuild != nil {
+		done := make(chan struct{})
+		workerDone = done
+		go func() {
+			defer close(done)
+			runWorker(ctx)
+		}()
+	}
 	for rebuild != nil {
 		if err := rebuild(ctx); err == nil {
 			break
@@ -422,7 +431,11 @@ func runProjectionSupervisor(
 		}
 	}
 	metrics.Set(icoremetrics.ProjectionReady, 1)
-	runWorker(ctx)
+	if rebuild == nil {
+		runWorker(ctx)
+		return
+	}
+	<-workerDone
 }
 
 // newApp preserves the community route test seam. Archive routes are mounted

--- a/bkn-trace/agent-observability/src/boot/projection_supervisor_test.go
+++ b/bkn-trace/agent-observability/src/boot/projection_supervisor_test.go
@@ -45,7 +45,7 @@ func TestProjectionSupervisorRetriesRebuildBeforeStartingWorker(t *testing.T) {
 	}
 }
 
-func TestProjectionSupervisorStopsWhileRebuildIsUnavailable(t *testing.T) {
+func TestProjectionSupervisorStartsWorkerWhileRebuildIsUnavailable(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -74,7 +74,7 @@ func TestProjectionSupervisorStopsWhileRebuildIsUnavailable(t *testing.T) {
 	}
 	select {
 	case <-workerStarted:
-		t.Fatal("projection worker started before a successful rebuild")
-	default:
+	case <-time.After(time.Second):
+		t.Fatal("projection worker did not start while rebuild was unavailable")
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink.go
@@ -46,14 +46,37 @@ func New(client *opensearch.Client, index string) *Sink {
 }
 
 func (s *Sink) Project(ctx context.Context, item iprojectionoutbox.Item) error {
+	return s.projectVersion(ctx, s.index, item)
+}
+
+func (s *Sink) projectVersion(ctx context.Context, index string, item iprojectionoutbox.Item) error {
 	if item.AggregateVersion == 0 {
 		return iprojectionoutbox.Permanent(errors.New("projection aggregate version is required"))
 	}
 	_, err := s.client.IndexDocumentVersion(
-		ctx, s.index, iprojectionoutbox.DocumentID(item),
+		ctx, index, iprojectionoutbox.DocumentID(item),
 		item.AggregateVersion, item.Payload,
 	)
 	if errors.Is(err, opensearch.ErrVersionConflict) {
+		documentID := iprojectionoutbox.DocumentID(item)
+		existing, getErr := s.client.GetDocument(ctx, index, documentID)
+		if getErr != nil {
+			return fmt.Errorf("read version-conflicted projection %q: %w", documentID, getErr)
+		}
+		expected, canonicalErr := canonicalJSON(item.Payload)
+		if canonicalErr != nil {
+			return iprojectionoutbox.Permanent(fmt.Errorf("canonicalize projection %q: %w", documentID, canonicalErr))
+		}
+		actual, canonicalErr := canonicalJSON(existing.Source)
+		if canonicalErr != nil {
+			return fmt.Errorf("canonicalize stored projection %q: %w", documentID, canonicalErr)
+		}
+		if !bytes.Equal(expected, actual) {
+			return iprojectionoutbox.Permanent(fmt.Errorf(
+				"projection contract conflict for document %q at aggregate version %d",
+				documentID, item.AggregateVersion,
+			))
+		}
 		return nil
 	}
 	if opensearch.IsPermanentStatusError(err) {
@@ -94,20 +117,7 @@ func (s *Sink) EnsureBootstrap(ctx context.Context, indexVersion string) error {
 }
 
 func (s *Sink) ProjectVersion(ctx context.Context, indexVersion string, item iprojectionoutbox.Item) error {
-	if item.AggregateVersion == 0 {
-		return iprojectionoutbox.Permanent(errors.New("projection aggregate version is required"))
-	}
-	_, err := s.client.IndexDocumentVersion(
-		ctx, indexVersion, iprojectionoutbox.DocumentID(item),
-		item.AggregateVersion, item.Payload,
-	)
-	if errors.Is(err, opensearch.ErrVersionConflict) {
-		return nil
-	}
-	if opensearch.IsPermanentStatusError(err) {
-		return iprojectionoutbox.Permanent(err)
-	}
-	return err
+	return s.projectVersion(ctx, indexVersion, item)
 }
 
 func (s *Sink) ValidateVersion(

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchprojection/sink_test.go
@@ -49,11 +49,19 @@ func TestSinkIndexesByStableAggregateID(t *testing.T) {
 	}
 }
 
-func TestSinkAcknowledgesStaleAggregateVersionWithoutRetry(t *testing.T) {
+func TestSinkAcknowledgesVersionConflictWhenExistingDocumentMatches(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "version_conflict_engine_exception", http.StatusConflict)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			http.Error(w, "version_conflict_engine_exception", http.StatusConflict)
+			return
+		}
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"_source":{"row_version":1}}`))
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 	}))
 	t.Cleanup(server.Close)
 	sink := opensearchprojection.New(
@@ -65,7 +73,32 @@ func TestSinkAcknowledgesStaleAggregateVersionWithoutRetry(t *testing.T) {
 		AggregateVersion: 1, Payload: []byte(`{"row_version":1}`),
 	})
 	if err != nil {
-		t.Fatalf("stale aggregate version must be safely superseded: %v", err)
+		t.Fatalf("matching aggregate version must be safely acknowledged: %v", err)
+	}
+}
+
+func TestSinkRejectsVersionConflictWhenExistingDocumentDiffers(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			http.Error(w, "version_conflict_engine_exception", http.StatusConflict)
+			return
+		}
+		if r.Method == http.MethodGet {
+			_, _ = w.Write([]byte(`{"_source":{"row_version":1,"business_context":"legacy"}}`))
+			return
+		}
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+	sink := opensearchprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core")
+	err := sink.Project(context.Background(), iprojectionoutbox.Item{
+		AggregateType: "conversation", AggregateID: "conv-1", AggregateVersion: 1,
+		Payload: []byte(`{"row_version":1,"business_context":"managed"}`),
+	})
+	if err == nil || !strings.Contains(err.Error(), "projection contract conflict") {
+		t.Fatalf("different document at same version must report contract conflict: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Start the incremental projection worker while an explicitly configured historical rebuild retries.
- Treat an OpenSearch external-version conflict as idempotent only after the stored document canonically matches the expected payload.
- Add regression coverage for rebuild liveness and same-version content divergence.

## Why

- Closes #1024
- A rebuild against an outdated projection version could retry indefinitely and leave every new outbox item unclaimed.

## How

- The supervisor owns the worker lifetime, but no longer gates worker start on rebuild completion. `bkn_trace_projection_ready` remains 0 until rebuild succeeds.
- A same-version, different-content document now returns a permanent projection contract conflict.
- No API, configuration, or database-schema change.

## Testing

- [x] Unit tests passed locally (`go test ./...`)
- [x] Race checks passed for boot, projection sink, and rebuild service
- [ ] Verified in test environment (pending)

## Risk & Rollback

- During a failed rebuild, fresh events continue flowing to the currently aliased query index while historical repair remains pending.
- Roll back by reverting this commit; no data migration is involved.

## Additional Notes

- The target index for a contract-changing rebuild must still be a new versioned index followed by alias switch.