### PR TITLE
fix(bkn-safe): handle no-op department updates correctly

### DIFF
--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -352,14 +352,16 @@ func (s *Service) CreateDepartment(ctx context.Context, d *model.Department) err
 }
 
 // UpdateDepartment patches the given mutable fields (name/parent_id/type) of a
-// department. Returns gorm.ErrRecordNotFound when no row matches.
+// department. A no-op update may report zero affected rows on MySQL, so it is
+// still successful when the department exists. Returns gorm.ErrRecordNotFound
+// only when no row matches.
 func (s *Service) UpdateDepartment(ctx context.Context, id string, fields map[string]any) error {
 	res := s.db.WithContext(ctx).Model(&model.Department{}).Where("id = ?", id).Updates(fields)
 	if res.Error != nil {
 		return res.Error
 	}
 	if res.RowsAffected == 0 {
-		return gorm.ErrRecordNotFound
+		return s.requireDepartment(ctx, id)
 	}
 	return nil
 }

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -503,6 +503,37 @@ func TestDepartmentCRUD(t *testing.T) {
 	}
 }
 
+// A MySQL UPDATE that assigns the current values reports zero affected rows.
+// Saving a freshly created department without edits must therefore succeed,
+// rather than treating the zero count as a missing department.
+func TestDepartmentCreateThenSaveWithoutChanges(t *testing.T) {
+	r, _, _, _ := newAdminServer(t)
+
+	create := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments",
+		map[string]any{"name": "No-op", "type": "dept"})
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create: want 201, got %d (%s)", create.Code, create.Body.String())
+	}
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(create.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("create response did not return the generated department id")
+	}
+
+	save := adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/departments/"+created.ID,
+		map[string]any{
+			"name": "No-op", "parent_id": "", "type": "dept",
+			"manager_id": "", "code": "", "email": "", "remark": "",
+		})
+	if save.Code != http.StatusNoContent {
+		t.Fatalf("save without changes: want 204, got %d (%s)", save.Code, save.Body.String())
+	}
+}
+
 func TestRoleCRUDAndBuiltInProtection(t *testing.T) {
 	r, e, db, _ := newAdminServer(t)
 	db.Create(&model.Role{ID: "sys-1", Name: "超级管理员", Source: model.RoleSourceSystem})


### PR DESCRIPTION
- Treat zero affected rows as success when the department still exists
- Return not found only when the department is actually missing
- Add a regression test for saving a newly created department without changes

# Pull Request

## What Changed

修复 bkn-safe 部门无变更保存时被错误识别为不存在的问题。

- [x] 修复部门无变更更新逻辑
- [x] 增加新建部门后立即保存的回归测试
- [ ] 文档更新

---

## Why

- Related Issue: [Issue #407](https://github.com/openbkn-ai/bkn-studio/issues/407)
- Related Feature: 用户管理 / 部门管理
- Background:

  MySQL 在更新字段值未发生变化时可能返回 `RowsAffected=0`。原逻辑将其误判为部门不存在，导致前端提示 `department not found`。

---

## How

- Key implementation points:

  - 部门更新返回 0 行受影响时，重新确认部门是否存在。
  - 部门存在时将无变更更新视为成功。
  - 仅在部门确实不存在时返回 `NotFound`。
  - 增加“新建部门后不修改字段直接保存”的回归测试。

- Breaking changes (API, config, database, etc.):

  无。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- 已执行 `git diff --check`。
- 已增加定向回归测试，但本地 Go 测试因依赖下载和编译环境问题未能获得明确结果。
- 建议在 CI 中执行：

  ```bash
  cd bkn-safe/server
  go test ./internal/httpapi -run 'TestDepartmentCreateThenSaveWithoutChanges' -count=1 -v

Risk & Rollback
- Potential risks:
  低风险，仅调整部门更新接口对 RowsAffected=0 的处理，不改变数据库结构、权限或 API 请求格式。
- Rollback plan:
  回滚本次提交即可恢复原有逻辑。
Additional Notes
- 本次修改仅涉及 bkn-safe 部门更新服务及对应回归测试。
- 未提交、推送或修改其他工作区文件。