### PR TITLE
fix(context-loader): preserve big integers through the ontology query path

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/clients_test.go
@@ -34,10 +34,24 @@ func (m *mockLogger) WithContext(ctx context.Context) interfaces.Logger         
 func (m *mockLogger) WithField(key string, value interface{}) interfaces.Logger  { return m }
 func (m *mockLogger) WithFields(fields map[string]interface{}) interfaces.Logger { return m }
 
+// jsonBytes renders a fixture as the raw response body the client now receives.
+func jsonBytes(v any) []byte {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return raw
+}
+
 // mockHTTPClient is a mock HTTP client for tests.
 type mockHTTPClient struct {
 	handlerFunc         func(ctx context.Context, method, url string, header map[string]string, body interface{}) (int, interface{}, error)
 	postNoUnmarshalFunc func(ctx context.Context, url string, header map[string]string, body interface{}) (int, []byte, error)
+	// bytesFunc serves PostBytes/GetBytes with a raw body. Tests that care about
+	// the exact JSON text — the big-integer cases — must set it, because handing
+	// back a Go value instead would re-introduce the very interface{} hop the
+	// production code was changed to avoid.
+	bytesFunc func(ctx context.Context, method, url string, header map[string]string, body interface{}) (int, []byte, error)
 }
 
 func (m *mockHTTPClient) Get(ctx context.Context, rawURL string, params url.Values, header map[string]string) (statusCode int, resp interface{}, err error) {
@@ -54,6 +68,31 @@ func (m *mockHTTPClient) Put(ctx context.Context, url string, header map[string]
 
 func (m *mockHTTPClient) Delete(ctx context.Context, url string, header map[string]string) (statusCode int, resp interface{}, err error) {
 	return m.handlerFunc(ctx, "DELETE", url, header, nil)
+}
+
+// doBytes backs PostBytes/GetBytes. With no bytesFunc set it falls back to
+// handlerFunc and marshals its result, so the pre-existing tests keep working.
+func (m *mockHTTPClient) doBytes(ctx context.Context, method, rawURL string, header map[string]string, body interface{}) (int, []byte, error) {
+	if m.bytesFunc != nil {
+		return m.bytesFunc(ctx, method, rawURL, header, body)
+	}
+	code, resp, err := m.handlerFunc(ctx, method, rawURL, header, body)
+	if err != nil || resp == nil {
+		return code, nil, err
+	}
+	raw, marshalErr := json.Marshal(resp)
+	if marshalErr != nil {
+		return code, nil, marshalErr
+	}
+	return code, raw, nil
+}
+
+func (m *mockHTTPClient) PostBytes(ctx context.Context, rawURL string, header map[string]string, body interface{}) (int, []byte, error) {
+	return m.doBytes(ctx, "POST", rawURL, header, body)
+}
+
+func (m *mockHTTPClient) GetBytes(ctx context.Context, rawURL string, params url.Values, header map[string]string) (int, []byte, error) {
+	return m.doBytes(ctx, "GET", rawURL, header, nil)
 }
 
 func (m *mockHTTPClient) GetNoUnmarshal(ctx context.Context, rawURL string, params url.Values, header map[string]string) (statusCode int, resp []byte, err error) {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -22,7 +22,6 @@ import (
 	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
-	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
 )
 
 type ontologyQueryClient struct {
@@ -158,17 +157,16 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	header := common.GetHeaderForChildOperation(ctx, "ontology.object.query", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
-	_, respBody, err := o.httpClient.Post(ctx, target, header, req)
+	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryObjectInstances] QueryObjectInstances request failed, err: %v", err)
 		err = classifyQueryError(ctx, err)
 		return
 	}
 	resp = &interfaces.QueryObjectInstancesResp{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, resp)
+	err = unmarshalPrecise(respBody, resp)
 	if err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryObjectInstances] Unmarshal %s err:%v", string(resultByt), err)
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryObjectInstances] Unmarshal %s err:%v", string(respBody), err)
 		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -258,15 +256,14 @@ func (o *ontologyQueryClient) QueryLogicProperties(ctx context.Context, req *int
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 
-	_, respBody, err := o.httpClient.Post(ctx, url, header, body)
+	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, body)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("  └─ [ontology-query 响应] ❌ 请求失败: %v", err)
 		return nil, err
 	}
 
 	resp = &interfaces.QueryLogicPropertiesResp{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, resp)
+	err = unmarshalPrecise(respBody, resp)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("  └─ [ontology-query 响应] ❌ JSON 解析失败: %v", err)
 		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
@@ -298,7 +295,7 @@ func (o *ontologyQueryClient) QueryActions(ctx context.Context, req *interfaces.
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 
-	_, respBody, err := o.httpClient.Post(ctx, url, header, body)
+	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, body)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryActions] Request failed, err: %v", err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
@@ -306,10 +303,9 @@ func (o *ontologyQueryClient) QueryActions(ctx context.Context, req *interfaces.
 	}
 
 	resp = &interfaces.QueryActionsResponse{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, resp)
+	err = unmarshalPrecise(respBody, resp)
 	if err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryActions] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryActions] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "ActionQueryResponseInvalid"))
 		return nil, err
@@ -347,7 +343,7 @@ func (o *ontologyQueryClient) ExecuteActions(ctx context.Context, req *interface
 	header := common.GetHeaderForChildOperation(ctx, "ontology.action.execute", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 
-	_, respBody, err := o.httpClient.Post(ctx, url, header, body)
+	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, body)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExecuteActions] Request failed, err: %v", err)
 		// Preserve 4xx (e.g. 409 DuplicateExecution) so Agents see "duplicate rejected"
@@ -356,10 +352,9 @@ func (o *ontologyQueryClient) ExecuteActions(ctx context.Context, req *interface
 	}
 
 	resp = &interfaces.ExecuteActionsResponse{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, resp)
+	err = unmarshalPrecise(respBody, resp)
 	if err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExecuteActions] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExecuteActions] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "ActionExecutionResponseInvalid"))
 		return nil, err
@@ -382,7 +377,7 @@ func (o *ontologyQueryClient) GetActionExecution(ctx context.Context, req *inter
 	header := common.GetHeaderForChildOperation(ctx, "ontology.action_execution.get", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 
-	_, respBody, err := o.httpClient.Get(ctx, reqURL, nil, header)
+	_, respBody, err := o.httpClient.GetBytes(ctx, reqURL, nil, header)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Request failed, err: %v", err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
@@ -390,9 +385,8 @@ func (o *ontologyQueryClient) GetActionExecution(ctx context.Context, req *inter
 	}
 
 	result := map[string]any{}
-	resultByt := utils.ObjectToByte(respBody)
-	if err = json.Unmarshal(resultByt, &result); err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+	if err = unmarshalPrecise(respBody, &result); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "ActionExecutionLookupResponseInvalid"))
 	}
@@ -444,7 +438,7 @@ func (o *ontologyQueryClient) ListActionExecutions(ctx context.Context, req *int
 	header := common.GetHeaderForChildOperation(ctx, "ontology.action_execution.list", 1)
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 
-	_, respBody, err := o.httpClient.Get(ctx, reqURL, query, header)
+	_, respBody, err := o.httpClient.GetBytes(ctx, reqURL, query, header)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Request failed, err: %v", err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
@@ -452,9 +446,8 @@ func (o *ontologyQueryClient) ListActionExecutions(ctx context.Context, req *int
 	}
 
 	result := map[string]any{}
-	resultByt := utils.ObjectToByte(respBody)
-	if err = json.Unmarshal(resultByt, &result); err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+	if err = unmarshalPrecise(respBody, &result); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "ActionExecutionHistoryResponseInvalid"))
 	}
@@ -496,7 +489,7 @@ func (o *ontologyQueryClient) ExploreSubgraph(ctx context.Context, req *interfac
 
 	o.logger.WithContext(ctx).Debugf("[OntologyQuery#ExploreSubgraph] URL: %s", target)
 
-	_, respBody, err := o.httpClient.Post(ctx, target, header, req)
+	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#ExploreSubgraph] request failed, err: %v", err)
 		// The starting object type does not exist, the direction is illegal, and path_length exceeds 3. It is the fault of the caller, and 400/404 will be returned downstream.
@@ -505,9 +498,8 @@ func (o *ontologyQueryClient) ExploreSubgraph(ctx context.Context, req *interfac
 	}
 
 	resp = &interfaces.ExploreSubgraphResp{}
-	resultByt := utils.ObjectToByte(respBody)
-	if err = json.Unmarshal(resultByt, resp); err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExploreSubgraph] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+	if err = unmarshalPrecise(respBody, resp); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ExploreSubgraph] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "SubgraphQueryResponseInvalid"))
 	}
@@ -553,7 +545,7 @@ func (o *ontologyQueryClient) QueryInstanceSubgraph(ctx context.Context, req *in
 	header["x-http-method-override"] = "GET"
 
 	// Send the request.
-	_, respBody, err := o.httpClient.Post(ctx, url, header, body)
+	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, body)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryInstanceSubgraph] Request failed, err: %v", err)
 		return nil, err
@@ -561,10 +553,9 @@ func (o *ontologyQueryClient) QueryInstanceSubgraph(ctx context.Context, req *in
 
 	// Parse the response directly into any.
 	resp = &interfaces.QueryInstanceSubgraphResp{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, resp)
+	err = unmarshalPrecise(respBody, resp)
 	if err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryInstanceSubgraph] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryInstanceSubgraph] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		err = infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "SubgraphQueryResponseInvalid"))
 		return nil, err
@@ -594,7 +585,7 @@ func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricI
 	if req == nil {
 		req = &interfaces.MetricQueryDownstreamReq{}
 	}
-	_, respBody, err := o.httpClient.Post(ctx, target, header, req)
+	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryMetricData] kn=%s metric=%s failed: %v", knID, metricID, err)
 		// The metric does not exist/the parameters are invalid. It is the caller's fault. Don't mix dependency faults into it.
@@ -602,9 +593,8 @@ func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricI
 	}
 
 	resp = &interfaces.MetricQueryDownstreamResp{}
-	resultByt := utils.ObjectToByte(respBody)
-	if err = json.Unmarshal(resultByt, resp); err != nil {
-		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryMetricData] Unmarshal %s err:%v", string(resultByt), err)
+	if err = unmarshalPrecise(respBody, resp); err != nil {
+		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryMetricData] Unmarshal %s err:%v", string(respBody), err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
 	}
 	return resp, nil

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_bigint_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_bigint_test.go
@@ -1,0 +1,182 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// bigIntegerBoundaries are the values that used to be rounded on the way through
+// this adapter. They are, in order: the largest int64, the first value past it
+// (the one reported in openbkn-ai/bkn-studio#464), the largest uint64, an ID card
+// number (openbkn-ai/bkn-studio#439), and the smallest int64.
+var bigIntegerBoundaries = []string{
+	"9223372036854775807",
+	"9223372036854775808",
+	"18446744073709551615",
+	"110101199001152345",
+	"-9223372036854775808",
+}
+
+// rawBodyClient builds a client whose transport hands back body verbatim. The
+// raw text matters: a fixture built from a Go map would already have lost the
+// precision this test is about.
+func rawBodyClient(t *testing.T, body string) *ontologyQueryClient {
+	t.Helper()
+	return &ontologyQueryClient{
+		logger:  &mockLogger{},
+		baseURL: "http://ontology.example.com",
+		httpClient: &mockHTTPClient{
+			bytesFunc: func(_ context.Context, _, _ string, _ map[string]string, _ interface{}) (int, []byte, error) {
+				return 200, []byte(body), nil
+			},
+		},
+	}
+}
+
+func wantNumber(t *testing.T, value any, want string) {
+	t.Helper()
+	num, ok := value.(json.Number)
+	if !ok {
+		t.Fatalf("value type = %T (%v), want json.Number", value, value)
+	}
+	if num.String() != want {
+		t.Errorf("value = %s, want %s", num.String(), want)
+	}
+}
+
+func TestQueryObjectInstancesPreservesBigIntegerProperties(t *testing.T) {
+	props := make([]string, 0, len(bigIntegerBoundaries))
+	for i, literal := range bigIntegerBoundaries {
+		props = append(props, `"p`+string(rune('0'+i))+`":`+literal)
+	}
+	body := `{"datas":[{` + strings.Join(props, ",") + `,"safe":42,"ratio":1.5,"name":"S003"}],"total_count":1}`
+
+	resp, err := rawBodyClient(t, body).QueryObjectInstances(context.Background(),
+		&interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "ot-1", Limit: 10})
+	if err != nil {
+		t.Fatalf("QueryObjectInstances() error = %v", err)
+	}
+
+	instance, ok := resp.Data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("instance type = %T, want map[string]any", resp.Data[0])
+	}
+	for i, want := range bigIntegerBoundaries {
+		wantNumber(t, instance["p"+string(rune('0'+i))], want)
+	}
+	wantNumber(t, instance["safe"], "42")
+	wantNumber(t, instance["ratio"], "1.5")
+	if instance["name"] != "S003" {
+		t.Errorf("name = %v, want S003", instance["name"])
+	}
+
+	// Re-serializing is what the REST and MCP handlers do, and it is where the
+	// rounded value used to surface as 9.223372036854776e+18.
+	encoded, err := json.Marshal(instance)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	for _, want := range bigIntegerBoundaries {
+		if !strings.Contains(string(encoded), want) {
+			t.Errorf("re-encoded instance %s is missing %s", encoded, want)
+		}
+	}
+	if strings.Contains(string(encoded), "e+") {
+		t.Errorf("re-encoded instance %s fell back to scientific notation", encoded)
+	}
+}
+
+func TestQueryObjectInstancesKeepsTotalCountTyped(t *testing.T) {
+	resp, err := rawBodyClient(t, `{"datas":[],"total_count":7}`).QueryObjectInstances(context.Background(),
+		&interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "ot-1", Limit: 10})
+	if err != nil {
+		t.Fatalf("QueryObjectInstances() error = %v", err)
+	}
+	if resp.TotalCount == nil || *resp.TotalCount != 7 {
+		t.Fatalf("TotalCount = %v, want 7", resp.TotalCount)
+	}
+}
+
+func TestQueryLogicPropertiesPreservesBigIntegers(t *testing.T) {
+	resp, err := rawBodyClient(t, `{"datas":[{"id":18446744073709551615}]}`).QueryLogicProperties(context.Background(),
+		&interfaces.QueryLogicPropertiesReq{KnID: "kn-1", OtID: "ot-1"})
+	if err != nil {
+		t.Fatalf("QueryLogicProperties() error = %v", err)
+	}
+	wantNumber(t, resp.Datas[0]["id"], "18446744073709551615")
+}
+
+func TestQueryMetricDataPreservesBigIntegers(t *testing.T) {
+	resp, err := rawBodyClient(t, `{"datas":[{"values":[9223372036854775808]}]}`).QueryMetricData(
+		context.Background(), "kn-1", "m-1", false, &interfaces.MetricQueryDownstreamReq{})
+	if err != nil {
+		t.Fatalf("QueryMetricData() error = %v", err)
+	}
+	wantNumber(t, resp.Datas[0].Values[0], "9223372036854775808")
+}
+
+func TestExploreSubgraphPreservesBigIntegers(t *testing.T) {
+	resp, err := rawBodyClient(t, `{"objects":{"o1":{"id":9223372036854775808}},"relation_paths":[]}`).ExploreSubgraph(
+		context.Background(), &interfaces.ExploreSubgraphReq{
+			KnID: "kn-1", SourceObjectTypeID: "ot-1", Direction: "forward", PathLength: 1, Limit: 10,
+		})
+	if err != nil {
+		t.Fatalf("ExploreSubgraph() error = %v", err)
+	}
+	object, ok := resp.Objects["o1"].(map[string]any)
+	if !ok {
+		t.Fatalf("object type = %T, want map[string]any", resp.Objects["o1"])
+	}
+	wantNumber(t, object["id"], "9223372036854775808")
+}
+
+func TestGetActionExecutionPreservesBigIntegers(t *testing.T) {
+	resp, err := rawBodyClient(t, `{"result":{"affected_id":18446744073709551615}}`).GetActionExecution(
+		context.Background(), &interfaces.GetActionExecutionRequest{KnID: "kn-1", ExecutionID: "e-1"})
+	if err != nil {
+		t.Fatalf("GetActionExecution() error = %v", err)
+	}
+	result, ok := resp["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result type = %T, want map[string]any", resp["result"])
+	}
+	wantNumber(t, result["affected_id"], "18446744073709551615")
+}
+
+// An MCP tool's output is arbitrary business data — a SQL-backed tool returns
+// whatever the customer's columns hold — so it goes through the same decoder.
+func TestCallMCPToolPreservesBigIntegers(t *testing.T) {
+	client := &operatorIntegrationClient{
+		logger:  &mockLogger{},
+		baseURL: "http://operator.example.com",
+		httpClient: &mockHTTPClient{
+			bytesFunc: func(_ context.Context, _, _ string, _ map[string]string, _ interface{}) (int, []byte, error) {
+				return 200, []byte(`{"rows":[{"id":18446744073709551615}]}`), nil
+			},
+		},
+	}
+
+	result, err := client.CallMCPTool(context.Background(), &interfaces.CallMCPToolRequest{
+		McpID: "mcp-1", ToolName: "run_sql",
+	})
+	if err != nil {
+		t.Fatalf("CallMCPTool() error = %v", err)
+	}
+	rows, ok := result["rows"].([]any)
+	if !ok {
+		t.Fatalf("rows type = %T, want []any", result["rows"])
+	}
+	row, ok := rows[0].(map[string]any)
+	if !ok {
+		t.Fatalf("row type = %T, want map[string]any", rows[0])
+	}
+	wantNumber(t, row["id"], "18446744073709551615")
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_explore_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_explore_test.go
@@ -29,10 +29,10 @@ func TestExploreSubgraph_UsesEmptyQueryType(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var got string
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, []byte, error) {
 				got = target
-				return 200, map[string]any{"objects": map[string]any{}, "relation_paths": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"objects": map[string]any{}, "relation_paths": []any{}}), nil
 			})
 
 		_, err := client.ExploreSubgraph(context.Background(), &interfaces.ExploreSubgraphReq{
@@ -59,10 +59,10 @@ func TestExploreSubgraph_AlwaysAsksForTotal(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var body *interfaces.ExploreSubgraphReq
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, []byte, error) {
 				body = payload.(*interfaces.ExploreSubgraphReq)
-				return 200, map[string]any{"objects": map[string]any{}}, nil
+				return 200, jsonBytes(map[string]any{"objects": map[string]any{}}), nil
 			})
 
 		_, err := client.ExploreSubgraph(context.Background(), &interfaces.ExploreSubgraphReq{
@@ -80,8 +80,8 @@ func TestExploreSubgraph_TotalCountThreeState(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, downstream, nil)
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(downstream), nil)
 		resp, err := client.ExploreSubgraph(context.Background(), &interfaces.ExploreSubgraphReq{
 			KnID: "kn1", SourceObjectTypeID: "ot1", Direction: "forward", PathLength: 1,
 			Limit: 10, SearchAfter: cursor,
@@ -137,11 +137,11 @@ func TestExploreSubgraph_InternalParamsAndEscaping(t *testing.T) {
 
 		var got string
 		var bodyJSON []byte
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, payload any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, payload any) (int, []byte, error) {
 				got = target
 				bodyJSON, _ = json.Marshal(payload)
-				return 200, map[string]any{"objects": map[string]any{}}, nil
+				return 200, jsonBytes(map[string]any{"objects": map[string]any{}}), nil
 			})
 
 		_, err := client.ExploreSubgraph(context.Background(), &interfaces.ExploreSubgraphReq{
@@ -184,7 +184,7 @@ func TestExploreSubgraph_PreservesDownstreamClientError(t *testing.T) {
 
 		downstream := infraErr.DefaultHTTPError(context.Background(), http.StatusBadRequest,
 			"路径长度不能超过3, 当前路径长度为5")
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(400, nil, downstream)
 
 		_, err := client.ExploreSubgraph(context.Background(), &interfaces.ExploreSubgraphReq{

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_metric_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_metric_test.go
@@ -37,10 +37,10 @@ func TestQueryMetricData_EscapesIDsIntoPath(t *testing.T) {
 		}
 
 		var got string
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, []byte, error) {
 				got = target
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		_, err := client.QueryMetricData(context.Background(), "kn1",
@@ -74,10 +74,10 @@ func TestQueryMetricData_ForwardsFillNull(t *testing.T) {
 		}
 
 		var got string
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, []byte, error) {
 				got = target
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		_, err := client.QueryMetricData(context.Background(), "kn1", "m1", true, nil)

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_object_params_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_object_params_test.go
@@ -49,10 +49,10 @@ func TestQueryObjectInstances_AlwaysAsksForTotal(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var body *interfaces.QueryObjectInstancesReq
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, []byte, error) {
 				body = payload.(*interfaces.QueryObjectInstancesReq)
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		req := &interfaces.QueryObjectInstancesReq{KnID: "kn1", OtID: "ot1", Limit: 10}
@@ -92,8 +92,8 @@ func TestQueryObjectInstances_ResolvesAbsentTotalFromRequest(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]any{"datas": []any{}}, nil)
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]any{"datas": []any{}}), nil)
 
 		resp, err := client.QueryObjectInstances(context.Background(),
 			&interfaces.QueryObjectInstancesReq{KnID: "kn1", OtID: "ot1", Limit: 10})
@@ -106,8 +106,8 @@ func TestQueryObjectInstances_ResolvesAbsentTotalFromRequest(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]any{"datas": []any{map[string]any{"id": "i1"}}}, nil)
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]any{"datas": []any{map[string]any{"id": "i1"}}}), nil)
 
 		resp, err := client.QueryObjectInstances(context.Background(),
 			&interfaces.QueryObjectInstancesReq{
@@ -121,8 +121,8 @@ func TestQueryObjectInstances_ResolvesAbsentTotalFromRequest(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]any{"datas": []any{}, "total_count": 42}, nil)
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]any{"datas": []any{}, "total_count": 42}), nil)
 
 		resp, err := client.QueryObjectInstances(context.Background(),
 			&interfaces.QueryObjectInstancesReq{KnID: "kn1", OtID: "ot1", Limit: 10})
@@ -166,10 +166,10 @@ func TestQueryObjectInstances_ForwardsSort(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var body *interfaces.QueryObjectInstancesReq
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ map[string]string, payload any) (int, []byte, error) {
 				body = payload.(*interfaces.QueryObjectInstancesReq)
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		req := &interfaces.QueryObjectInstancesReq{
@@ -199,11 +199,11 @@ func TestQueryObjectInstances_InternalParamsGoToQueryStringNotBody(t *testing.T)
 
 		var got string
 		var bodyJSON []byte
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, payload any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, payload any) (int, []byte, error) {
 				got = target
 				bodyJSON, _ = json.Marshal(payload)
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		req := &interfaces.QueryObjectInstancesReq{
@@ -238,10 +238,10 @@ func TestQueryObjectInstances_OmitsInternalParamsWhenUnset(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var got string
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, []byte, error) {
 				got = target
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		req := &interfaces.QueryObjectInstancesReq{KnID: "kn1", OtID: "ot1", Limit: 10}
@@ -269,10 +269,10 @@ func TestQueryObjectInstances_EscapesIDsIntoPath(t *testing.T) {
 		client, mockHTTP := newObjectQueryClient(t, ctrl)
 
 		var got string
-		mockHTTP.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, any, error) {
+		mockHTTP.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, target string, _ map[string]string, _ any) (int, []byte, error) {
 				got = target
-				return 200, map[string]any{"datas": []any{}}, nil
+				return 200, jsonBytes(map[string]any{"datas": []any{}}), nil
 			})
 
 		req := &interfaces.QueryObjectInstancesReq{

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -47,11 +47,11 @@ func TestQueryObjectInstances_Success(t *testing.T) {
 		}
 
 		// Mock a successful HTTP response.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]interface{}{
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]interface{}{
 				"datas":       []interface{}{},
 				"object_type": map[string]interface{}{},
-			}, nil)
+			}), nil)
 
 		resp, err := client.QueryObjectInstances(ctx, req)
 		convey.So(err, convey.ShouldBeNil)
@@ -87,7 +87,7 @@ func TestQueryObjectInstances_HTTPError(t *testing.T) {
 		}
 
 		// Mock an HTTP error.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(0, nil, errors.New("connection refused"))
 
 		_, err := client.QueryObjectInstances(ctx, req)
@@ -122,12 +122,12 @@ func TestQueryLogicProperties_Success(t *testing.T) {
 		}
 
 		// Mock a successful HTTP response.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]interface{}{
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]interface{}{
 				"datas": []interface{}{
 					map[string]interface{}{"prop1": "value1"},
 				},
-			}, nil)
+			}), nil)
 
 		resp, err := client.QueryLogicProperties(ctx, req)
 		convey.So(err, convey.ShouldBeNil)
@@ -162,7 +162,7 @@ func TestQueryLogicProperties_HTTPError(t *testing.T) {
 		}
 
 		// Mock an HTTP error.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(0, nil, errors.New("connection refused"))
 
 		_, err := client.QueryLogicProperties(ctx, req)
@@ -196,8 +196,8 @@ func TestQueryActions_Success(t *testing.T) {
 		}
 
 		// Mock a successful HTTP response.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]interface{}{
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]interface{}{
 				"action_source": map[string]interface{}{
 					"type":    "tool",
 					"box_id":  "box-001",
@@ -210,7 +210,7 @@ func TestQueryActions_Success(t *testing.T) {
 				},
 				"total_count": 1,
 				"overall_ms":  100,
-			}, nil)
+			}), nil)
 
 		resp, err := client.QueryActions(ctx, req)
 		convey.So(err, convey.ShouldBeNil)
@@ -246,7 +246,7 @@ func TestQueryActions_HTTPError(t *testing.T) {
 		}
 
 		// Mock an HTTP error.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(0, nil, errors.New("connection refused"))
 
 		_, err := client.QueryActions(ctx, req)
@@ -281,10 +281,10 @@ func TestQueryInstanceSubgraph_Success(t *testing.T) {
 		}
 
 		// Mock a successful HTTP response.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]interface{}{
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, jsonBytes(map[string]interface{}{
 				"entries": []interface{}{},
-			}, nil)
+			}), nil)
 
 		resp, err := client.QueryInstanceSubgraph(ctx, req)
 		convey.So(err, convey.ShouldBeNil)
@@ -317,7 +317,7 @@ func TestQueryInstanceSubgraph_HTTPError(t *testing.T) {
 		}
 
 		// Mock an HTTP error.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(0, nil, errors.New("connection refused"))
 
 		_, err := client.QueryInstanceSubgraph(ctx, req)
@@ -352,7 +352,7 @@ func TestQueryObjectInstances_DownstreamBadRequestRemappedToBadRequest(t *testin
 		// ontology-query message flattened into CommonExternalServerError.
 		detail := "OntologyQuery.InvalidParameter.Condition: condition [knn] left field is not a vector field: child_name:string"
 		wrapped := infraErr.NewHTTPError(ctx, http.StatusBadRequest, infraErr.ErrExtCommonExternalServerError, detail)
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(http.StatusBadRequest, nil, wrapped)
 
 		_, err := client.QueryObjectInstances(ctx, req)
@@ -386,7 +386,7 @@ func TestQueryObjectInstances_DownstreamNotFoundKeepsCode(t *testing.T) {
 		req := &interfaces.QueryObjectInstancesReq{KnID: "missing", OtID: "ot-001", Limit: 10}
 
 		wrapped := infraErr.NewHTTPError(ctx, http.StatusNotFound, infraErr.ErrExtCommonExternalServerError, "knowledge network not found")
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(http.StatusNotFound, nil, wrapped)
 
 		_, err := client.QueryObjectInstances(ctx, req)
@@ -421,7 +421,7 @@ func TestExecuteActions_PreservesConflictStatus(t *testing.T) {
 
 		wrapped := infraErr.NewHTTPError(ctx, http.StatusConflict, infraErr.ErrExtCommonExternalServerError,
 			`{"error_code":"OntologyQuery.ActionExecution.DuplicateExecution"}`)
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(http.StatusConflict, nil, wrapped)
 
 		_, err := client.ExecuteActions(ctx, req)
@@ -450,7 +450,7 @@ func TestQueryObjectInstances_DownstreamServerErrorUntouched(t *testing.T) {
 		req := &interfaces.QueryObjectInstancesReq{KnID: "kn-001", OtID: "ot-001", Limit: 10}
 
 		wrapped := infraErr.NewHTTPError(ctx, http.StatusInternalServerError, infraErr.ErrExtCommonExternalServerError, "boom")
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(http.StatusInternalServerError, nil, wrapped)
 
 		_, err := client.QueryObjectInstances(ctx, req)

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration.go
@@ -143,7 +143,11 @@ func (o *operatorIntegrationClient) CallMCPTool(ctx context.Context, req *interf
 		"parameters": req.Parameters,
 	}
 
-	_, respBody, err := o.httpClient.Post(ctx, url, header, reqBody)
+	// PostBytes, not Post: a tool's output is arbitrary business data — a SQL tool
+	// hands back whatever the customer's columns hold — and Post's interface{} hop
+	// would round every integer past float64's mantissa. See
+	// openbkn-ai/bkn-studio#464.
+	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, reqBody)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#CallMCPTool] Request failed, err: %v", err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
@@ -151,10 +155,9 @@ func (o *operatorIntegrationClient) CallMCPTool(ctx context.Context, req *interf
 	}
 
 	var result map[string]interface{}
-	resultByt := utils.ObjectToByte(respBody)
-	err = json.Unmarshal(resultByt, &result)
+	err = unmarshalPrecise(respBody, &result)
 	if err != nil {
-		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#CallMCPTool] Unmarshal failed, body: %s, err: %v", string(resultByt), err)
+		o.logger.WithContext(ctx).Errorf("[OperatorIntegration#CallMCPTool] Unmarshal failed, body: %s, err: %v", string(respBody), err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			infraErr.LocalizedDetail(ctx, "MCPToolCallResponseInvalid"))
 	}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_test.go
@@ -259,11 +259,8 @@ func TestCallMCPTool_Success(t *testing.T) {
 		}
 
 		// Mock a successful HTTP response.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(200, map[string]interface{}{
-				"result": "success",
-				"data":   "test data",
-			}, nil)
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(200, []byte(`{"result":"success","data":"test data"}`), nil)
 
 		resp, err := client.CallMCPTool(ctx, req)
 		convey.So(err, convey.ShouldBeNil)
@@ -301,7 +298,7 @@ func TestCallMCPTool_HTTPError(t *testing.T) {
 		}
 
 		// Mock an HTTP error.
-		mockHTTPClient.EXPECT().Post(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(0, nil, errors.New("connection refused"))
 
 		_, err := client.CallMCPTool(ctx, req)

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/precision_json.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/precision_json.go
@@ -1,0 +1,32 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import "github.com/bytedance/sonic"
+
+// precisionJSON is the decoder every downstream response carrying business data
+// must go through.
+//
+// UseNumber keeps a JSON integer as json.Number — the literal digits — when it
+// lands in an interface{} field. Without it the value becomes a float64, and
+// float64 has 53 bits of mantissa: 9223372036854775808 (MySQL BIGINT past the
+// signed maximum) rounds and re-serializes as 9.223372036854776e+18, and
+// 18446744073709551615 (BIGINT UNSIGNED maximum) as 1.8446744073709552e+19.
+//
+// The interface{} fields are not incidental — object instances arrive as
+// QueryObjectInstancesResp.Data []any, and their property values are whatever
+// the customer's columns hold: BIGINT keys, ID card numbers, snowflake IDs.
+// See openbkn-ai/bkn-studio#464.
+//
+// Encoding needs no counterpart: sonic and jsoniter both write json.Number back
+// out as the original literal.
+var precisionJSON = sonic.Config{UseNumber: true}.Froze()
+
+// unmarshalPrecise decodes JSON without rounding integers wider than float64.
+func unmarshalPrecise(data []byte, out any) error {
+	return precisionJSON.Unmarshal(data, out)
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/precision_json.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/precision_json.go
@@ -6,27 +6,12 @@
 
 package drivenadapters
 
-import "github.com/bytedance/sonic"
+import "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 
-// precisionJSON is the decoder every downstream response carrying business data
-// must go through.
-//
-// UseNumber keeps a JSON integer as json.Number — the literal digits — when it
-// lands in an interface{} field. Without it the value becomes a float64, and
-// float64 has 53 bits of mantissa: 9223372036854775808 (MySQL BIGINT past the
-// signed maximum) rounds and re-serializes as 9.223372036854776e+18, and
-// 18446744073709551615 (BIGINT UNSIGNED maximum) as 1.8446744073709552e+19.
-//
-// The interface{} fields are not incidental — object instances arrive as
-// QueryObjectInstancesResp.Data []any, and their property values are whatever
-// the customer's columns hold: BIGINT keys, ID card numbers, snowflake IDs.
-// See openbkn-ai/bkn-studio#464.
-//
-// Encoding needs no counterpart: sonic and jsoniter both write json.Number back
-// out as the original literal.
-var precisionJSON = sonic.Config{UseNumber: true}.Froze()
-
-// unmarshalPrecise decodes JSON without rounding integers wider than float64.
+// unmarshalPrecise decodes a downstream body without rounding integers wider
+// than float64. Every response carrying business data must go through it; see
+// rest.UnmarshalPrecise for why, and PostBytes/GetBytes for how the raw body is
+// obtained in the first place.
 func unmarshalPrecise(data []byte, out any) error {
-	return precisionJSON.Unmarshal(data, out)
+	return rest.UnmarshalPrecise(data, out)
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/vega.go
@@ -30,7 +30,6 @@ type vegaAccess struct {
 var (
 	vegaAccessOnce sync.Once
 	vegaAccessInst interfaces.DrivenVega
-	vegaJSON       = sonic.Config{UseNumber: true}.Froze()
 )
 
 // NewVegaAccess creates a Vega backend access object for read-only queries.
@@ -68,7 +67,7 @@ func (v *vegaAccess) RawQuery(ctx context.Context, req *interfaces.VegaRawQueryR
 	if len(respBody) == 0 {
 		return resp, nil
 	}
-	if err := vegaJSON.Unmarshal(respBody, resp); err != nil {
+	if err := unmarshalPrecise(respBody, resp); err != nil {
 		v.logger.WithContext(ctx).Errorf("[VegaAccess] RawQuery unmarshal failed: %v", err)
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusInternalServerError,
 			fmt.Sprintf("parse vega raw query response failed: %v", err))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit.go
@@ -6,6 +6,7 @@
 package mcp
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -164,7 +165,14 @@ func ptcParams(raw json.RawMessage) []ptcParam {
 		} `json:"properties"`
 		Required []string `json:"required"`
 	}
-	if len(raw) == 0 || json.Unmarshal(raw, &schema) != nil {
+	if len(raw) == 0 {
+		return nil
+	}
+	// UseNumber: a default wider than float64's mantissa must reach pyLiteral with
+	// its digits intact, not as 9.223372036854776e+18 baked into generated Python.
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if decoder.Decode(&schema) != nil {
 		return nil
 	}
 	required := make(map[string]bool, len(schema.Required))
@@ -213,6 +221,10 @@ func pyLiteral(v any) string {
 		return "False"
 	case string:
 		return "'" + strings.ReplaceAll(t, "'", "\\'") + "'"
+	case json.Number:
+		// UseNumber decoders keep the original digits; emit them verbatim so a
+		// BIGINT key does not become 9.223372036854776e+18 in generated code.
+		return t.String()
 	case float64:
 		if t == float64(int64(t)) {
 			return fmt.Sprintf("%d", int64(t))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit_number_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_toolkit_number_test.go
@@ -1,0 +1,68 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Downstream bodies are decoded with UseNumber (see drivenadapters.precisionJSON),
+// so schema defaults reach pyLiteral as json.Number. Falling through to %v on a
+// float64 used to emit 9.223372036854776e+18 into generated Python.
+func TestPyLiteralKeepsJSONNumberDigits(t *testing.T) {
+	cases := map[string]string{
+		"9223372036854775807":  "9223372036854775807",
+		"9223372036854775808":  "9223372036854775808",
+		"18446744073709551615": "18446744073709551615",
+		"-9223372036854775808": "-9223372036854775808",
+		"42":                   "42",
+		"1.5":                  "1.5",
+	}
+	for literal, want := range cases {
+		if got := pyLiteral(json.Number(literal)); got != want {
+			t.Errorf("pyLiteral(json.Number(%q)) = %s, want %s", literal, got, want)
+		}
+	}
+}
+
+func TestPyLiteralUnchangedForOtherTypes(t *testing.T) {
+	cases := []struct {
+		value any
+		want  string
+	}{
+		{nil, "None"},
+		{true, "True"},
+		{false, "False"},
+		{"a'b", `'a\'b'`},
+		{float64(42), "42"},
+		{1.5, "1.5"},
+	}
+	for _, c := range cases {
+		if got := pyLiteral(c.value); got != c.want {
+			t.Errorf("pyLiteral(%#v) = %s, want %s", c.value, got, c.want)
+		}
+	}
+}
+
+// End to end over the schema decoder: a wide default must reach the generated
+// Python as digits. With encoding/json's default number handling it arrived as
+// float64 and rendered as 9223372036854775807's rounded neighbour.
+func TestPtcParamsKeepsWideDefaults(t *testing.T) {
+	raw := json.RawMessage(`{"properties":{"cursor":{"type":"integer","default":9223372036854775807},` +
+		`"limit":{"type":"integer","default":10}},"required":[]}`)
+
+	params := ptcParams(raw)
+	got := map[string]string{}
+	for _, p := range params {
+		got[p.name] = pyLiteral(p.defVal)
+	}
+	if got["cursor"] != "9223372036854775807" {
+		t.Errorf("cursor default = %s, want 9223372036854775807", got["cursor"])
+	}
+	if got["limit"] != "10" {
+		t.Errorf("limit default = %s, want 10", got["limit"])
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -991,8 +991,34 @@ func intValue(value any, fallback int) int {
 		return typed
 	case float64:
 		return int(typed)
+	case json.Number:
+		// Downstream bodies are decoded with UseNumber so that wide integers keep
+		// their digits; see drivenadapters.precisionJSON.
+		if parsed, err := typed.Int64(); err == nil {
+			return int(parsed)
+		}
+		return fallback
 	default:
 		return fallback
+	}
+}
+
+// floatValue reads a JSON number that may have been decoded either as float64
+// (plain encoding/json) or as json.Number (the UseNumber decoders that keep wide
+// integers intact).
+func floatValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
 	}
 }
 
@@ -1252,9 +1278,9 @@ func firstString(item map[string]any, keys ...string) string {
 }
 
 func scoreBucket(item map[string]any) string {
-	score, ok := item["_score"].(float64)
+	score, ok := floatValue(item["_score"])
 	if !ok {
-		score, ok = item["score"].(float64)
+		score, ok = floatValue(item["score"])
 	}
 	if !ok {
 		return "unknown"

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/number_value_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/number_value_test.go
@@ -1,0 +1,53 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package bkntrace
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Instance payloads are decoded with UseNumber (see drivenadapters.precisionJSON),
+// so every number in them arrives as json.Number rather than float64.
+func TestScoreBucketReadsJSONNumber(t *testing.T) {
+	cases := []struct {
+		item map[string]any
+		want string
+	}{
+		{map[string]any{"_score": json.Number("0.91")}, "high"},
+		{map[string]any{"_score": json.Number("0.5")}, "medium"},
+		{map[string]any{"_score": json.Number("0.1")}, "low"},
+		{map[string]any{"score": json.Number("0.85")}, "high"},
+		{map[string]any{"_score": 0.91}, "high"},
+		{map[string]any{"_score": "n/a"}, "unknown"},
+		{map[string]any{}, "unknown"},
+	}
+	for _, c := range cases {
+		if got := scoreBucket(c.item); got != c.want {
+			t.Errorf("scoreBucket(%v) = %s, want %s", c.item, got, c.want)
+		}
+	}
+}
+
+func TestIntValueReadsJSONNumber(t *testing.T) {
+	cases := []struct {
+		value    any
+		fallback int
+		want     int
+	}{
+		{json.Number("3"), 1, 3},
+		{json.Number("9223372036854775807"), 1, 9223372036854775807},
+		{json.Number("1.5"), 7, 7},
+		{json.Number("not-a-number"), 7, 7},
+		{float64(3), 1, 3},
+		{4, 1, 4},
+		{nil, 1, 1},
+	}
+	for _, c := range cases {
+		if got := intValue(c.value, c.fallback); got != c.want {
+			t.Errorf("intValue(%#v, %d) = %d, want %d", c.value, c.fallback, got, c.want)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/http_client.go
@@ -127,6 +127,11 @@ func (c *httpClient) PostNoUnmarshal(ctx context.Context, url string, headers ma
 	return c.httpDoNoUnmarshal(ctx, http.MethodPost, url, headers, reqParam)
 }
 
+// Post, pass in the serialized object and return the raw body, status-checked.
+func (c *httpClient) PostBytes(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error) {
+	return c.httpDoBytes(ctx, http.MethodPost, url, headers, reqParam)
+}
+
 // Put, pass in the serialized object and return the serialized object.
 func (c *httpClient) Put(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error) {
 	return c.httpDo(ctx, http.MethodPut, url, headers, reqParam)
@@ -157,6 +162,17 @@ func (c *httpClient) PatchNoUnmarshal(ctx context.Context, url string, headers m
 	return c.httpDoNoUnmarshal(ctx, http.MethodPatch, url, headers, reqParam)
 }
 
+// Get, return the raw body, status-checked.
+func (c *httpClient) GetBytes(ctx context.Context, rawURL string, queryValues url.Values,
+	headers map[string]string,
+) (respCode int, respBody []byte, err error) {
+	uri, err := c.generateURL(rawURL, queryValues)
+	if err != nil {
+		return 0, nil, err
+	}
+	return c.httpDoBytes(ctx, http.MethodGet, uri.String(), headers, nil)
+}
+
 // Deserialize return content.
 func (c *httpClient) httpDo(ctx context.Context, mtehod, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error) {
 	respCode, respBody, err := c.httpDoNoUnmarshal(ctx, mtehod, url, headers, reqParam)
@@ -179,6 +195,42 @@ func (c *httpClient) httpDo(ctx context.Context, mtehod, url string, headers map
 		// Exception when calling external service.
 		err = infraErr.NewHTTPError(ctx, respCode, infraErr.ErrExtCommonExternalServerError,
 			fmt.Sprintf("Exception(http do error, method: %s, url: %s,  http status: %d, error: %s)", mtehod, url, respCode, respStr))
+		return
+	}
+	return
+}
+
+// httpDoBytes is httpDo without the deserialization: same status checking and
+// same error type, but the body is handed back as raw JSON so the caller can
+// decode it itself.
+//
+// httpDo cannot be used for responses that carry business data. It unmarshals
+// into an interface{}, where sonic's default configuration turns every JSON
+// number into a float64 — anything past float64's 53-bit mantissa is silently
+// rounded, and 9223372036854775808 re-serializes as 9.223372036854776e+18.
+// Object instance properties are arbitrary business data (MySQL BIGINT /
+// BIGINT UNSIGNED columns, ID card numbers, snowflake IDs), so the rounding is
+// not hypothetical: see openbkn-ai/bkn-studio#464.
+//
+// Non-2xx handling is deliberately identical to httpDo — callers such as
+// ontology_query.classifyQueryError match on the *infraErr.HTTPError it
+// produces, so this must keep returning the same error type carrying the same
+// HTTP code.
+func (c *httpClient) httpDoBytes(ctx context.Context, method, url string, headers map[string]string,
+	reqParam interface{},
+) (respCode int, respBody []byte, err error) {
+	respCode, respBody, err = c.httpDoNoUnmarshal(ctx, method, url, headers, reqParam)
+	if err != nil {
+		c.logger.Error(err.Error())
+		return
+	}
+	if (respCode < http.StatusOK) || (respCode >= http.StatusMultipleChoices) {
+		respStr := string(respBody)
+		c.logger.Errorf("Exception(http do error, method: %s, url: %s, headers: %v, reqParam: %v, respCode: %d, error: %s)",
+			method, url, utils.ObjectToJSON(headers), utils.ObjectToJSON(reqParam), respCode, respStr)
+		// Exception when calling external service.
+		err = infraErr.NewHTTPError(ctx, respCode, infraErr.ErrExtCommonExternalServerError,
+			fmt.Sprintf("Exception(http do error, method: %s, url: %s,  http status: %d, error: %s)", method, url, respCode, respStr))
 		return
 	}
 	return

--- a/adp/context-loader/agent-retrieval/server/infra/rest/http_client_bytes_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/http_client_bytes_test.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package rest
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+)
+
+// bigIntegerBody is the shape reported in openbkn-ai/bkn-studio#464: values that
+// Post's interface{} hop rounds to 9.223372036854776e+18 and 1.8446744073709552e+19.
+const bigIntegerBody = `{"datas":[{"id":9223372036854775808,"unsigned":18446744073709551615}]}`
+
+func TestPostBytesReturnsBodyVerbatim(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(bigIntegerBody))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClientWithOptions(HTTPClientOptions{TimeOut: 5})
+	code, body, err := client.PostBytes(context.Background(), srv.URL, nil, map[string]string{})
+	if err != nil {
+		t.Fatalf("PostBytes() error = %v", err)
+	}
+	if code != http.StatusOK {
+		t.Errorf("status = %d, want 200", code)
+	}
+	if string(body) != bigIntegerBody {
+		t.Errorf("body = %s, want %s", body, bigIntegerBody)
+	}
+}
+
+func TestGetBytesReturnsBodyVerbatim(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("need_total"); got != "true" {
+			t.Errorf("need_total = %q, want true", got)
+		}
+		_, _ = w.Write([]byte(bigIntegerBody))
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClientWithOptions(HTTPClientOptions{TimeOut: 5})
+	_, body, err := client.GetBytes(context.Background(), srv.URL, url.Values{"need_total": {"true"}}, nil)
+	if err != nil {
+		t.Fatalf("GetBytes() error = %v", err)
+	}
+	if string(body) != bigIntegerBody {
+		t.Errorf("body = %s, want %s", body, bigIntegerBody)
+	}
+}
+
+// Callers such as ontology_query.classifyQueryError re-map downstream 4xx by
+// reading the HTTP code off the error, so PostBytes must keep raising the same
+// *infraErr.HTTPError that Post does.
+func TestPostBytesKeepsHTTPErrorSemantics(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusNotFound, http.StatusInternalServerError} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"detail":"downstream said no"}`))
+		}))
+
+		_, body, err := NewHTTPClientWithOptions(HTTPClientOptions{TimeOut: 5}).
+			PostBytes(context.Background(), srv.URL, nil, map[string]string{})
+		srv.Close()
+
+		var he *infraErr.HTTPError
+		if !errors.As(err, &he) {
+			t.Fatalf("status %d: error = %v, want *infraErr.HTTPError", status, err)
+		}
+		if he.HTTPCode != status {
+			t.Errorf("status %d: HTTPCode = %d", status, he.HTTPCode)
+		}
+		if string(body) == "" {
+			t.Errorf("status %d: body was dropped, callers log it", status)
+		}
+	}
+}
+
+// An empty body is not a decode failure: httpDo leaves the caller with a nil
+// payload and no error, and PostBytes must not diverge from that.
+func TestPostBytesAcceptsEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, body, err := NewHTTPClientWithOptions(HTTPClientOptions{TimeOut: 5}).
+		PostBytes(context.Background(), srv.URL, nil, map[string]string{})
+	if err != nil {
+		t.Fatalf("PostBytes() error = %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body = %s, want empty", body)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/rest/precision_json.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/precision_json.go
@@ -1,0 +1,34 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package rest
+
+import "github.com/bytedance/sonic"
+
+// precisionJSON is the decoder for anything carrying business data, in either
+// direction: downstream responses on the way in, and the struct → map round-trip
+// the TOON formatter performs on the way out.
+//
+// UseNumber keeps a JSON integer as json.Number — the literal digits — when it
+// lands in an interface{} field. Without it the value becomes a float64, and
+// float64 has 53 bits of mantissa: 9223372036854775808 (a MySQL BIGINT past the
+// signed maximum) rounds and re-serializes as 9.223372036854776e+18, and
+// 18446744073709551615 (BIGINT UNSIGNED maximum) as 1.8446744073709552e+19.
+//
+// The interface{} fields are not incidental — object instances arrive as
+// QueryObjectInstancesResp.Data []any, and their property values are whatever
+// the customer's columns hold: BIGINT keys, ID card numbers, snowflake IDs.
+// See openbkn-ai/bkn-studio#464.
+//
+// JSON encoding needs no counterpart: sonic, jsoniter and encoding/json all
+// write json.Number back out as the original literal. TOON does need one, see
+// interfaces.TOONSafeValue.
+var precisionJSON = sonic.Config{UseNumber: true}.Froze()
+
+// UnmarshalPrecise decodes JSON without rounding integers wider than float64.
+func UnmarshalPrecise(data []byte, out any) error {
+	return precisionJSON.Unmarshal(data, out)
+}

--- a/adp/context-loader/agent-retrieval/server/infra/rest/response_format.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/response_format.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/toon-format/toon-go"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
 const (
@@ -84,7 +86,8 @@ func marshalTOON(body interface{}) ([]byte, error) {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		return toon.Marshal(body, toon.WithLengthMarkers(true))
+		safe, _ := interfaces.TOONSafeValue(body)
+		return toon.Marshal(safe, toon.WithLengthMarkers(true))
 	}
 	// struct → JSON → any → TOON (retain the field name of json tag)
 	jsonBytes, err := sonic.Marshal(body)
@@ -92,8 +95,14 @@ func marshalTOON(body interface{}) ([]byte, error) {
 		return nil, err
 	}
 	var m any
-	if err := sonic.Unmarshal(jsonBytes, &m); err != nil {
+	// UseNumber, not the default configuration: the round-trip is the last place
+	// a wide integer can be rounded, and it would undo the precision the driven
+	// adapters went out of their way to keep. See openbkn-ai/bkn-studio#464.
+	if err := precisionJSON.Unmarshal(jsonBytes, &m); err != nil {
 		return nil, err
 	}
-	return toon.Marshal(m, toon.WithLengthMarkers(true))
+	// toon-go renders json.Number through float64, so anything past the IEEE 754
+	// safe range has to become a decimal string before it reaches the encoder.
+	safe, _ := interfaces.TOONSafeValue(m)
+	return toon.Marshal(safe, toon.WithLengthMarkers(true))
 }

--- a/adp/context-loader/agent-retrieval/server/infra/rest/response_format_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/rest/response_format_test.go
@@ -8,6 +8,7 @@ package rest
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
@@ -177,4 +178,64 @@ func TestMarshalResponse_NilBody(t *testing.T) {
 		convey.So(ct, convey.ShouldEqual, ContentTypeJSON) // When nil, response_format does not change the contentType logic.
 		convey.So(b, convey.ShouldBeNil)
 	})
+}
+
+// toon-go normalizes json.Number through float64
+// (internal/codec.normalizeNumberString), so the formatter converts wide
+// integers to decimal strings first — the same contract VegaRawQueryResp's
+// TOONValue already followed. Without it, MCP responses (which default to TOON)
+// rendered 9223372036854775808 as 9223372036854776000. See
+// openbkn-ai/bkn-studio#464.
+func TestMarshalTOONKeepsWideIntegersFromStructResponses(t *testing.T) {
+	type response struct {
+		Datas []any `json:"datas"`
+	}
+	body := &response{Datas: []any{map[string]any{
+		"id":    json.Number("9223372036854775808"),
+		"safe":  json.Number("42"),
+		"ratio": json.Number("1.5"),
+		"name":  "S003",
+	}}}
+
+	_, out, err := MarshalResponse(FormatTOON, body)
+	if err != nil {
+		t.Fatalf("MarshalResponse() error = %v", err)
+	}
+	rendered := string(out)
+	if !strings.Contains(rendered, "9223372036854775808") {
+		t.Errorf("TOON output %q lost the wide integer", rendered)
+	}
+	if strings.Contains(rendered, "9223372036854776000") {
+		t.Errorf("TOON output %q kept the rounded value", rendered)
+	}
+	// Values inside the safe range must stay bare numbers, not become strings.
+	if !strings.Contains(rendered, "42") || strings.Contains(rendered, `"42"`) {
+		t.Errorf("TOON output %q quoted a safe integer", rendered)
+	}
+	if !strings.Contains(rendered, "1.5") {
+		t.Errorf("TOON output %q lost the float", rendered)
+	}
+}
+
+func TestMarshalTOONKeepsWideIntegersFromPlainMaps(t *testing.T) {
+	_, out, err := MarshalResponse(FormatTOON, map[string]any{
+		"id":   json.Number("18446744073709551615"),
+		"safe": json.Number("7"),
+	})
+	if err != nil {
+		t.Fatalf("MarshalResponse() error = %v", err)
+	}
+	if !strings.Contains(string(out), "18446744073709551615") {
+		t.Errorf("TOON output %q lost the wide integer", out)
+	}
+}
+
+func TestMarshalJSONKeepsWideIntegers(t *testing.T) {
+	_, out, err := MarshalResponse(FormatJSON, map[string]any{"id": json.Number("9223372036854775808")})
+	if err != nil {
+		t.Fatalf("MarshalResponse() error = %v", err)
+	}
+	if string(out) != `{"id":9223372036854775808}` {
+		t.Errorf("JSON output = %s", out)
+	}
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_vega.go
@@ -78,9 +78,17 @@ func (r *VegaRawQueryResp) TOONValue() any {
 	return &copy
 }
 
+// TOONSafeValue is toonSafeValue for callers outside this package: the response
+// formatter applies it to every TOON body, so responses whose dynamic data is
+// plain map/slice do not each need a TOONValue method.
+func TOONSafeValue(value any) (any, bool) {
+	return toonSafeValue(value)
+}
+
 // toonSafeValue copies only branches that contain integer json.Number values
 // outside the IEEE 754 safe range. toon-go currently normalizes json.Number
-// through float64, so those values must be rendered as strings.
+// through float64 (internal/codec.normalizeNumberString), so those values must
+// be rendered as strings.
 func toonSafeValue(value any) (any, bool) {
 	switch v := value.(type) {
 	case json.Number:

--- a/adp/context-loader/agent-retrieval/server/interfaces/infra.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/infra.go
@@ -96,6 +96,14 @@ type HTTPClient interface {
 	DeleteNoUnmarshal(ctx context.Context, url string, headers map[string]string) (respCode int, respBody []byte, err error)
 	Post(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error)
 	PostNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error)
+	// PostBytes status-checks the response exactly like Post but returns the raw
+	// body instead of unmarshalling it into an interface{}. Responses carrying
+	// business data must use this: Post's interface{} hop rounds every JSON
+	// integer past float64's 53-bit mantissa (MySQL BIGINT / BIGINT UNSIGNED, ID
+	// card numbers, snowflake IDs). See openbkn-ai/bkn-studio#464.
+	PostBytes(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error)
+	// GetBytes is PostBytes' counterpart for GET.
+	GetBytes(ctx context.Context, url string, queryValues url.Values, headers map[string]string) (respCode int, respBody []byte, err error)
 	Put(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error)
 	PutNoUnmarshal(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respBody []byte, err error)
 	Patch(ctx context.Context, url string, headers map[string]string, reqParam interface{}) (respCode int, respData interface{}, err error)

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/number_value_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/number_value_test.go
@@ -1,0 +1,35 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knfindskills
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Recall payloads are decoded with UseNumber (see drivenadapters.precisionJSON),
+// so scores arrive as json.Number and used to fall through to the zero value.
+func TestFloat64FromMapReadsJSONNumber(t *testing.T) {
+	cases := []struct {
+		value any
+		want  float64
+	}{
+		{json.Number("0.75"), 0.75},
+		{json.Number("3"), 3},
+		{json.Number("nope"), 0},
+		{float64(0.75), 0.75},
+		{int(3), 3},
+		{int64(3), 3},
+		{"0.75", 0},
+	}
+	for _, c := range cases {
+		if got := float64FromMap(map[string]interface{}{"score": c.value}, "score"); got != c.want {
+			t.Errorf("float64FromMap(%#v) = %v, want %v", c.value, got, c.want)
+		}
+	}
+	if got := float64FromMap(map[string]interface{}{}, "score"); got != 0 {
+		t.Errorf("missing key = %v, want 0", got)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/recall_coordinator.go
@@ -8,6 +8,7 @@ package knfindskills
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
@@ -479,6 +480,12 @@ func float64FromMap(m map[string]interface{}, key string) float64 {
 			return float64(val)
 		case int64:
 			return float64(val)
+		case json.Number:
+			// UseNumber decoders hand back json.Number; see
+			// drivenadapters.precisionJSON.
+			if parsed, err := val.Float64(); err == nil {
+				return parsed
+			}
 		}
 	}
 	return 0

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/index.go
@@ -8,6 +8,7 @@ package knlogicpropertyresolver
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -651,6 +652,18 @@ func (s *knLogicPropertyResolverService) validateTimestamp(
 		if v < 946684800000 || v > 4102444800000 {
 			return fmt.Errorf("metric property %s: param '%s' timestamp %d is out of reasonable range",
 				propertyName, paramName, v)
+		}
+		return nil
+	case json.Number:
+		// UseNumber decoders hand back json.Number; see drivenadapters.precisionJSON.
+		timestamp, convErr := v.Int64()
+		if convErr != nil {
+			return fmt.Errorf("metric property %s: param '%s' timestamp %s is not an integer",
+				propertyName, paramName, v.String())
+		}
+		if timestamp < 946684800000 || timestamp > 4102444800000 {
+			return fmt.Errorf("metric property %s: param '%s' timestamp %d is out of reasonable range",
+				propertyName, paramName, timestamp)
 		}
 		return nil
 	case float64:

--- a/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/timestamp_number_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver/timestamp_number_test.go
@@ -1,0 +1,36 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knlogicpropertyresolver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// Metric params come out of bodies decoded with UseNumber (see
+// drivenadapters.precisionJSON), so a millisecond timestamp arrives as
+// json.Number. Without a branch for it the value fell to the default case and
+// the range check silently passed anything.
+func TestValidateTimestampReadsJSONNumber(t *testing.T) {
+	s := &knLogicPropertyResolverService{}
+	ctx := context.Background()
+
+	if err := s.validateTimestamp(ctx, json.Number("1735689600000"), "start", "p1"); err != nil {
+		t.Errorf("in-range json.Number rejected: %v", err)
+	}
+	if err := s.validateTimestamp(ctx, json.Number("1"), "start", "p1"); err == nil {
+		t.Error("out-of-range json.Number accepted")
+	}
+	if err := s.validateTimestamp(ctx, json.Number("1.5"), "start", "p1"); err == nil {
+		t.Error("non-integer json.Number accepted")
+	}
+	if err := s.validateTimestamp(ctx, float64(1735689600000), "start", "p1"); err != nil {
+		t.Errorf("in-range float64 rejected: %v", err)
+	}
+	if err := s.validateTimestamp(ctx, int64(1735689600000), "start", "p1"); err != nil {
+		t.Errorf("in-range int64 rejected: %v", err)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/knowledge_rerank.go
@@ -11,6 +11,7 @@ package knrerank
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"sort"
@@ -369,7 +370,7 @@ func (r *KnowledgeReranker) formatIntentsText(intents []interface{}) string {
 		var parts []string
 		parts = append(parts, fmt.Sprintf("意图%d是关于'%s'", i+1, querySegment))
 
-		if confidence, ok := intentMap["confidence"].(float64); ok && confidence > 0 {
+		if confidence, ok := confidenceValue(intentMap["confidence"]); ok && confidence > 0 {
 			parts = append(parts, fmt.Sprintf("置信度为%v", confidence))
 		}
 
@@ -498,4 +499,18 @@ func (r *KnowledgeReranker) parseNumberList(s string) ([]int, error) {
 		}
 	}
 	return indices, nil
+}
+
+// confidenceValue reads an intent confidence that may arrive as float64 or, from
+// the UseNumber decoders, as json.Number. See drivenadapters.precisionJSON.
+func confidenceValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case float64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knrerank/number_value_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knrerank/number_value_test.go
@@ -1,0 +1,33 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knrerank
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// Intent payloads are decoded with UseNumber (see drivenadapters.precisionJSON),
+// so the confidence arrives as json.Number and used to be dropped from the prompt.
+func TestConfidenceValueReadsJSONNumber(t *testing.T) {
+	cases := []struct {
+		value  any
+		want   float64
+		wantOK bool
+	}{
+		{json.Number("0.9"), 0.9, true},
+		{json.Number("1"), 1, true},
+		{json.Number("nope"), 0, false},
+		{float64(0.9), 0.9, true},
+		{"0.9", 0, false},
+		{nil, 0, false},
+	}
+	for _, c := range cases {
+		got, ok := confidenceValue(c.value)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("confidenceValue(%#v) = (%v, %v), want (%v, %v)", c.value, got, ok, c.want, c.wantOK)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/instance_score_number_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/instance_score_number_test.go
@@ -1,0 +1,41 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knsearch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// Instance rows are decoded with UseNumber (see drivenadapters.precisionJSON), so
+// _score arrives as json.Number; without a branch for it every node scored 0 and
+// the ranking collapsed.
+func TestConvertToKnSearchNodeReadsJSONNumberScore(t *testing.T) {
+	s := &localSearchImpl{}
+	objType := &interfaces.KnSearchObjectType{ConceptID: "ot-1", ConceptName: "Shipment"}
+
+	node := s.convertToKnSearchNode(objType, map[string]any{
+		"_score": json.Number("0.87"),
+		"id":     json.Number("9223372036854775808"),
+	})
+	if node.Score != 0.87 {
+		t.Errorf("Score = %v, want 0.87", node.Score)
+	}
+
+	// Wide integers must stay untouched in the properties that ride along.
+	id, ok := node.Properties["id"].(json.Number)
+	if !ok {
+		t.Fatalf("id type = %T, want json.Number", node.Properties["id"])
+	}
+	if id.String() != "9223372036854775808" {
+		t.Errorf("id = %s, want 9223372036854775808", id.String())
+	}
+
+	if got := s.convertToKnSearchNode(objType, map[string]any{"_score": 0.5}); got.Score != 0.5 {
+		t.Errorf("float64 Score = %v, want 0.5", got.Score)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -776,6 +777,12 @@ func (s *localSearchImpl) convertToKnSearchNode(objType *interfaces.KnSearchObje
 			node.Score = v
 		case int:
 			node.Score = float64(v)
+		case json.Number:
+			// Instance bodies are decoded with UseNumber so wide integers survive;
+			// see drivenadapters.precisionJSON.
+			if parsed, err := v.Float64(); err == nil {
+				node.Score = parsed
+			}
 		}
 	}
 

--- a/adp/context-loader/agent-retrieval/server/mocks/infra.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/infra.go
@@ -260,6 +260,22 @@ func (mr *MockHTTPClientMockRecorder) Get(ctx, arg1, queryValues, headers any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockHTTPClient)(nil).Get), ctx, arg1, queryValues, headers)
 }
 
+// GetBytes mocks base method.
+func (m *MockHTTPClient) GetBytes(ctx context.Context, arg1 string, queryValues url.Values, headers map[string]string) (int, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBytes", ctx, arg1, queryValues, headers)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBytes indicates an expected call of GetBytes.
+func (mr *MockHTTPClientMockRecorder) GetBytes(ctx, arg1, queryValues, headers any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBytes", reflect.TypeOf((*MockHTTPClient)(nil).GetBytes), ctx, arg1, queryValues, headers)
+}
+
 // GetNoUnmarshal mocks base method.
 func (m *MockHTTPClient) GetNoUnmarshal(ctx context.Context, arg1 string, queryValues url.Values, headers map[string]string) (int, []byte, error) {
 	m.ctrl.T.Helper()
@@ -322,6 +338,22 @@ func (m *MockHTTPClient) Post(ctx context.Context, arg1 string, headers map[stri
 func (mr *MockHTTPClientMockRecorder) Post(ctx, arg1, headers, reqParam any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Post", reflect.TypeOf((*MockHTTPClient)(nil).Post), ctx, arg1, headers, reqParam)
+}
+
+// PostBytes mocks base method.
+func (m *MockHTTPClient) PostBytes(ctx context.Context, arg1 string, headers map[string]string, reqParam any) (int, []byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostBytes", ctx, arg1, headers, reqParam)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostBytes indicates an expected call of PostBytes.
+func (mr *MockHTTPClientMockRecorder) PostBytes(ctx, arg1, headers, reqParam any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBytes", reflect.TypeOf((*MockHTTPClient)(nil).PostBytes), ctx, arg1, headers, reqParam)
 }
 
 // PostNoUnmarshal mocks base method.


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `infra/rest`: new `PostBytes` / `GetBytes` — `httpDo`'s status checking and its `*infraErr.HTTPError`, but the raw body instead of a decoded `interface{}`
- [x] `drivenadapters`: new shared `precisionJSON` / `unmarshalPrecise` (`sonic.Config{UseNumber: true}`); `vega.go`'s local `vegaJSON` folded into it
- [x] `drivenadapters/ontology_query.go`: all nine downstream calls decode precisely, and the redundant `utils.ObjectToByte` re-marshal is gone
- [x] `drivenadapters/operator_integration.go`: `CallMCPTool` too — its payload is whatever tool the agent just ran returned
- [x] Six consumers grow a `json.Number` branch; `ptcParams` decodes tool schemas with `UseNumber`
- [x] Regression tests driven by raw JSON response text

---

## Why

- Related Issue: [bkn-studio#464](https://github.com/openbkn-ai/bkn-studio/issues/464), [bkn-studio#439](https://github.com/openbkn-ai/bkn-studio/issues/439)
- Background:

Object instance properties are arbitrary business data — MySQL `BIGINT` / `BIGINT UNSIGNED` columns, ID card numbers, snowflake IDs. Every response carrying them was decoded twice through an `interface{}`:

`httpClient.Post` returns `respData interface{}`, filled by `sonic.Unmarshal` with the default configuration, where a JSON number becomes a `float64`. Anything past float64's 53-bit mantissa is rounded right there. `ontology_query` then re-marshalled that value (`utils.ObjectToByte`) and unmarshalled it into the response struct — so the digits were already gone before the struct was ever populated.

```
upstream:  9223372036854775808
returned:  9.223372036854776e+18
```

bkn-studio's frontend has had `json-bigint` on this path since #441, and Vega and bkn-backend were fixed separately. Context Loader was the remaining hop, and it loses the value no matter what the services on either side of it do.

---

## How

- Key implementation points:
  - `PostBytes` / `GetBytes` deliberately keep `httpDo`'s non-2xx behaviour. `ontology_query.classifyQueryError` matches on the `*infraErr.HTTPError` it raises to re-map downstream 4xx, so returning a different error type there would silently turn caller faults into dependency faults. `TestPostBytesKeepsHTTPErrorSemantics` pins this.
  - `UseNumber` means numbers now land in `interface{}` fields as `json.Number` instead of `float64`. Every consumer that type-asserts a number out of one grows a branch: trace evidence scores, semantic instance scores, skill recall scores, rerank confidence, metric timestamp validation, PTC toolkit Python literals. **These were silent failures, not compile errors** — a score would fall to 0, a range check would pass anything — so each has a test.
  - Encoding needs no counterpart: sonic, jsoniter and `encoding/json` all write `json.Number` back out as the original literal.

- Breaking changes: none. Two additive methods on the `HTTPClient` interface; no API, config or schema change. `Post` keeps its existing behaviour for the callers that do not carry business data (auth introspection, model API, skill metadata).

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:

Fixtures are **raw JSON response text**, not pre-decoded Go values — a fixture built from a Go map would already have lost the precision under test. Boundaries covered: int64 max, int64 max + 1 (the value in #464), uint64 max, int64 min, and the ID card number from #439.

Negative control: with the decoder swapped back to the default configuration, the new tests fail with exactly the value the issue reports.

```
ontology_query_bigint_test.go:73: value type = float64 (9.223372036854776e+18), want json.Number
```

CI-equivalent commands, all green:

```
go build ./...
go build -tags ee_dev ./...
go vet ./server/...
go test ./server/...
go test -tags ee_dev ./server/extension/... ./server/driveradapters/mcp/
```

golangci-lint was not run locally — the installed v1.24.0 cannot parse Go 1.25 export data. `ci-adp-context-loader.yml` does not run it for this service either; `gofmt -l` is clean.

**Deployed verification (k3s, arm64).** Both images built from this branch and its parent, run as an isolated `agent-retrieval-bigint` deployment against a stub upstream that serves the raw ontology-query body from #464 verbatim. The live `agent-retrieval` was not touched; every test object was removed afterwards.

`POST /api/agent-retrieval/in/v1/kn/query_object_instance`, same request both times:

| upstream literal | before (`response_format=json`) | after |
| --- | --- | --- |
| `9223372036854775807` | `9223372036854776000` | `9223372036854775807` |
| `9223372036854775808` | `9223372036854776000` | `9223372036854775808` |
| `18446744073709551615` | `18446744073709552000` | `18446744073709551615` |
| `42` | `42` | `42` |
| `1.5` | `1.5` | `1.5` |

The before column is exactly what #464 reports, reproduced from the parent commit.

`response_format=toon`, same query:

```
before                              after
  id: 9223372036854776000             id: "9223372036854775807"
  id: 9223372036854776000             id: "9223372036854775808"
  id: 18446744073709552000            id: "18446744073709551615"
  id: 42                              id: 42
  ratio: 1.5                          ratio: 1.5
```

Wide integers become quoted decimal strings — the contract #859 established for TOON, since toon-go cannot render them as bare numbers without rounding. Safe-range values stay bare.

What this does not cover: ontology-query, Vega and the MySQL driver upstream of this service. The stub stands in for them deliberately, because the defect being fixed is this service turning a correct upstream body into a rounded one.

---

## Risk & Rollback

- Potential risks:
  - The `float64` → `json.Number` shift is the real risk surface. I swept every `.(float64)` and `case float64` in the service and handled each; anything missed degrades quietly (a zero score, a skipped validation) rather than erroring, which is why the branches are tested individually rather than just compiled.
  - Numbers reaching API consumers as JSON literals are unchanged; only the in-process Go type changed.
- Rollback plan: revert the commit. It is self-contained in `adp/context-loader/` and touches no persisted state.

---

## Additional Notes

`_instance_id` in the #464 report is a **string** built upstream by ontology-query:

```
"_instance_id": "da2i89uv150s73duu1q0-9.223372036854776e+18"
```

Strings survive JSON round-trips unchanged, so that one was rounded while it was still a number, upstream of this service — Context Loader only reads the field. This PR cannot fix it. Once this merges, re-capture the raw `query_object_instance` body to check whether the bkn-backend fix already covers it.
