### PR TITLE
refactor(deploy): remove legacy proton Redis and ACR dev image refere…

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
@@ -50,12 +50,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}
-          {{- if ne .Values.runMode "dev" }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.service.repository }}:{{ .Values.image.service.tag }}"
           imagePullPolicy: {{ .Values.image.service.pullPolicy }}
-          {{- else}}
-          image: "acr.aishu.cn/client/godevenv:1.16.2"
-          {{- end}}
 
           env:
             {{- if .Values.service.loggerOutput}}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -123,7 +123,7 @@ depServices:
       masterPort: 26379
       slaveHost: ""
       slavePort: 26379
-      sentinelHost: proton-redis-proton-redis-sentinel.resource.svc.cluster.local
+      sentinelHost: redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       sentinelUsername: root
       sentinelPassword: yourpassword

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval-secret.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval-secret.yaml
@@ -8,7 +8,7 @@ redis:
     masterPort: 26379
     slaveHost: ""
     slavePort: 26379
-    sentinelHost: "proton-redis-proton-redis-sentinel.resource.svc.cluster.local"
+    sentinelHost: "redis-sentinel.resource.svc.cluster.local"
     sentinelPort: 26379
     sentinelUsername: "root"
     sentinelPassword: "<REPLACE_ME>"

--- a/adp/execution-factory/operator-integration/helm/agent-operator-integration/templates/deployment.yaml
+++ b/adp/execution-factory/operator-integration/helm/agent-operator-integration/templates/deployment.yaml
@@ -49,12 +49,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}
-          {{- if ne .Values.runMode "dev" }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.service.repository }}:{{ .Values.image.service.tag }}"
           imagePullPolicy: {{ .Values.image.service.pullPolicy }}
-          {{- else}}
-          image: "acr.aishu.cn/client/godevenv:1.16.2"
-          {{- end}}
 
           env:
             # bkn-safe (ISF replacement) authz cutover; empty = ISF, revertible.

--- a/adp/execution-factory/operator-integration/server/infra/config/agent-operator-integration-secret.yaml
+++ b/adp/execution-factory/operator-integration/server/infra/config/agent-operator-integration-secret.yaml
@@ -15,7 +15,7 @@ redis:
     masterPort: 26379
     slaveHost: ""
     slavePort: 26379
-    sentinelHost: "proton-redis-proton-redis-sentinel.resource.svc.cluster.local."
+    sentinelHost: "redis-sentinel.resource.svc.cluster.local"
     sentinelPort: 26379
     sentinelUsername: "root"
     sentinelPassword: "<REPLACE_ME>"

--- a/deploy/scripts/services/config.sh
+++ b/deploy/scripts/services/config.sh
@@ -122,11 +122,10 @@ STORAGE_EOF
     local redis_ns="${REDIS_NAMESPACE}"
     local redis_release_name="redis"
     
-    # Try to get actual StatefulSet name. The bundled chart is proton-redis, so
-    # its StatefulSet is {release-name}-proton-redis; plain "redis" covers a
-    # release whose chart names the StatefulSet after the release only.
+    # The bundled chart names its StatefulSet {release-name}-redis; plain
+    # "redis" covers a release whose StatefulSet matches the release name.
     local redis_sts_name=""
-    for sts_name in "${redis_release_name}-proton-redis" "${redis_release_name}-redis" "redis"; do
+    for sts_name in "${redis_release_name}-redis" "redis"; do
         if kubectl -n "${redis_ns}" get statefulset "${sts_name}" >/dev/null 2>&1; then
             redis_sts_name="${sts_name}"
             break
@@ -167,14 +166,13 @@ STORAGE_EOF
     # Try to get password from secret (check multiple possible secret names)
     # For redis chart: secret name is {release-name}-redis-secret (e.g., redis-secret)
     local redis_secret_names=(
-        "${redis_release_name}-proton-redis-secret"    # bundled proton-redis chart
         "${redis_release_name}-redis-secret"          # redis chart naming
         "${redis_release_name}-secret"                # generic naming
         "redis-auth"                                  # fallback
     )
     local redis_secret_password=""
-    # nonEncrpt-password is checked first: the bundled proton-redis chart keeps
-    # BOTH keys, and its "password" is not the value clients authenticate with.
+    # nonEncrpt-password is checked first because it is the client-authentication
+    # credential used by the bundled chart.
     for secret_name in "${redis_secret_names[@]}"; do
         for secret_key in nonEncrpt-password password; do
             # get_secret_b64_key already base64-decodes the Secret field, so this
@@ -199,7 +197,6 @@ STORAGE_EOF
     # For redis chart: service name is {release-name}-redis-sentinel
     # If release name is "redis", service is "redis-sentinel"
     local sentinel_svc_names=(
-        "${redis_release_name}-proton-redis-sentinel"   # bundled proton-redis chart
         "${redis_release_name}-redis-sentinel"          # redis chart naming
         "${redis_release_name}-sentinel"               # generic naming
         "redis-sentinel"                                # fallback

--- a/infra/mf-model-api/charts/values.yaml
+++ b/infra/mf-model-api/charts/values.yaml
@@ -68,7 +68,7 @@ depServices:
     connectType: sentinel
     enableSSL: false
     connectInfo:
-      sentinelHost: kg-redis-cluster-proton-redis-sentinel
+      sentinelHost: redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       username: root
       password: password

--- a/infra/mf-model-manager/charts/templates/deployment.yaml
+++ b/infra/mf-model-manager/charts/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 10 | quote }}
     spec:
       # Lower ndots from the ClusterFirst default of 5 to 1: sentinel returns
-      # redis-proton-redis-announce-0.resource.svc.cluster.local, which is an
+      # redis-redis-announce-0.resource.svc.cluster.local, which is an
       # FQDN with 4 dots. ndots=5 makes libc try every search-domain suffix first
       # (openbkn.svc.cluster.local / svc.cluster.local / cluster.local /
       # localdomain); each returns NXDOMAIN after about 1s, so FQDN resolution

--- a/infra/mf-model-manager/charts/values.yaml
+++ b/infra/mf-model-manager/charts/values.yaml
@@ -61,7 +61,7 @@ depServices:
     connectType: sentinel
     enableSSL: false
     connectInfo:
-      sentinelHost: kg-redis-cluster-proton-redis-sentinel
+      sentinelHost: redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       username: root
       password: password

--- a/infra/oss-gateway-backend/charts/templates/deployment.yaml
+++ b/infra/oss-gateway-backend/charts/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 10 | quote }}
     spec:
       # Reduce ndots from the ClusterFirst default of 5 to 1. Sentinel returns
-      # a four-dot FQDN such as redis-proton-redis-announce-0.resource.svc.cluster.local.
+      # a four-dot FQDN such as redis-redis-announce-0.resource.svc.cluster.local.
       # With ndots=5, libc first appends every search domain and each attempt can
       # spend about one second on NXDOMAIN. Redis Sentinel repeats the lookup at
       # startup, causing minute-long hangs and startup-probe CrashLoops. ndots=1

--- a/infra/oss-gateway-backend/charts/values.yaml
+++ b/infra/oss-gateway-backend/charts/values.yaml
@@ -55,7 +55,7 @@ depServices:
     connectType: sentinel
     enableSSL: false
     connectInfo:
-      sentinelHost: kg-redis-cluster-proton-redis-sentinel.resource.svc.cluster.local
+      sentinelHost: redis-sentinel.resource.svc.cluster.local
       sentinelPort: 26379
       username: root
       password: password


### PR DESCRIPTION
…nces

- replace legacy proton Redis Sentinel host defaults with redis-sentinel
- remove proton Redis resource-name compatibility probes from config generation
- update Redis announce FQDN comments to the bundled chart naming
- make development-mode charts use configured GHCR service images instead of acr.aishu.cn/client/godevenv

# Pull Request

## What Changed

Brief description of changes:

- [x] Remove legacy `proton-redis` resource-name probes from deployment config generation.
- [x] Update Redis Sentinel default hosts and announce-service comments to match the bundled `redis` chart naming.
- [x] Remove `acr.aishu.cn/client/godevenv:1.16.2` from the two development-mode deployment templates; use configured service images instead.

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: The repository no longer depends on the legacy Proton Redis chart naming or the `acr.aishu.cn` development image repository. The bundled Redis chart creates `redis-redis` and `redis-sentinel` resources.

---

## How

- Key implementation points:
  - Remove `proton-redis` StatefulSet, Secret, and Sentinel Service fallback names from `deploy/scripts/services/config.sh`.
  - Set Redis Sentinel defaults to `redis-sentinel.resource.svc.cluster.local`.
  - Update Redis announce FQDN comments to `redis-redis-announce-0.resource.svc.cluster.local`.
  - Make both affected charts resolve their image through existing `image.registry`, `image.service.repository`, and `image.service.tag` values in both release and dev modes.
- Breaking changes (API, config, database, etc.):
  - No API or database changes.
  - Existing clusters still using legacy Proton Redis resource names are no longer detected by config generation.
  - `runMode=dev` now requires a valid configured service image tag instead of using the removed ACR development image.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `bash -n deploy/scripts/services/config.sh`
- `helm lint` passed for:
  - `agent-retrieval`
  - `agent-operator-integration`
  - `mf-model-api`
  - `mf-model-manager`
  - `oss-gateway-backend`
- Rendered both affected application charts with `runMode=dev`; confirmed they use the configured GHCR service images.
- Confirmed no remaining `proton-redis` references in the relevant source scope and no remaining `acr.aishu.cn/client/godevenv:1.16.2` references.
- `git diff --check` passed.

---

## Risk & Rollback

- Potential risks:
  - Environments that still deploy the retired Proton Redis chart will no longer be auto-detected.
  - Manual dev-mode Helm installs need to provide a pullable service image tag.
- Rollback plan:
  - Revert this PR to restore the legacy Proton Redis fallback names and the ACR development-image branch.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.:
  - No UI changes.
  - This PR changes 11 files and intentionally excludes kubeconfig, MariaDB, port, Python RDS driver, and other AISHU-related cleanup.