### PR TITLE
fix(trace): page Trace and Conversation lists by identity

### DIFF
--- a/bkn-trace/agent-observability/locale/agent-observability.en-US.toml
+++ b/bkn-trace/agent-observability/locale/agent-observability.en-US.toml
@@ -92,6 +92,7 @@
 "failed to query evidence chain" = "failed to query evidence chain"
 "failed to query evidence node" = "failed to query evidence node"
 "failed to query execution summaries" = "failed to query execution summaries"
+"execution summary projection is catching up; retry the same page" = "execution summary projection is catching up; retry the same page"
 "failed to query operation facts" = "failed to query operation facts"
 "failed to query snapshot preview" = "failed to query snapshot preview"
 "failed to query trace spans" = "failed to query trace spans"

--- a/bkn-trace/agent-observability/locale/agent-observability.zh-CN.toml
+++ b/bkn-trace/agent-observability/locale/agent-observability.zh-CN.toml
@@ -92,6 +92,7 @@
 "failed to query evidence chain" = "证据链查询失败"
 "failed to query evidence node" = "证据节点查询失败"
 "failed to query execution summaries" = "执行摘要查询失败"
+"execution summary projection is catching up; retry the same page" = "执行摘要投影正在追平，请重试当前页"
 "failed to query operation facts" = "操作事实查询失败"
 "failed to query snapshot preview" = "快照预览查询失败"
 "failed to query trace spans" = "Trace Span 查询失败"

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -24,7 +24,10 @@ const (
 	maxReceiptsPerSummary    = 20
 )
 
-var ErrSummaryCursorInvalid = errors.New("BKN_TRACE_SUMMARY_CURSOR_INVALID")
+var (
+	ErrSummaryCursorInvalid = errors.New("BKN_TRACE_SUMMARY_CURSOR_INVALID")
+	ErrSummaryProjectionLag = errors.New("BKN_TRACE_SUMMARY_PROJECTION_LAG")
+)
 
 type summaryCursor struct {
 	StartedAt string `json:"started_at"`
@@ -89,6 +92,9 @@ func (s *Service) ListRequests(ctx context.Context, options evidencevo.SummaryQu
 }
 
 func (s *Service) ListConversations(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.ConversationSummaryPage, error) {
+	if page, handled, err := s.listConversationIdentityPage(ctx, options); handled || err != nil {
+		return page, err
+	}
 	loadOptions := options
 	loadOptions.Status = ""
 	requests, _, metadata, err := s.loadExecutionSummaries(ctx, loadOptions)
@@ -704,6 +710,14 @@ func (s *Service) applyCanonicalConversationState(
 			conversationIDs = append(conversationIDs, entry.ConversationID)
 		}
 		conversations := tx.ListConversationsByIDs(conversationIDs)
+		interactionIDs := make([]string, 0)
+		for _, requests := range requestsByConversation {
+			for _, request := range requests {
+				interactionIDs = append(interactionIDs, request.InteractionID)
+			}
+		}
+		interactions := tx.ListInteractionsByIDs(interactionIDs)
+		revisions := tx.ListAssemblyRevisionsByInteractionIDs(interactionIDs)
 		for index := range entries {
 			conversation, found := conversations[entries[index].ConversationID]
 			if !found {
@@ -712,7 +726,7 @@ func (s *Service) applyCanonicalConversationState(
 			applyCanonicalConversationEvidenceAndDuration(
 				&entries[index].EvidenceCompleteness, &entries[index].PartialReasons,
 				&entries[index].DurationMS,
-				tx, requestsByConversation[entries[index].ConversationID],
+				tx, requestsByConversation[entries[index].ConversationID], interactions, revisions,
 			)
 			entries[index].Status = string(conversation.Status)
 			if !conversation.CreatedAt.IsZero() {
@@ -741,6 +755,8 @@ func applyCanonicalConversationEvidenceAndDuration(
 	durationMS *int64,
 	tx isessionstore.Transaction,
 	requests []evidencevo.RequestSummary,
+	interactions map[string]sessionvo.Interaction,
+	revisions map[string][]sessionvo.AssemblyRevision,
 ) {
 	byInteraction := map[string][]evidencevo.RequestSummary{}
 	for _, request := range requests {
@@ -753,7 +769,10 @@ func applyCanonicalConversationEvidenceAndDuration(
 	canonicalCompleteness := ""
 	canonicalReasons := map[string]struct{}{}
 	for interactionID, interactionRequests := range byInteraction {
-		interaction, found := tx.PeekInteraction(interactionID)
+		interaction, found := interactions[interactionID]
+		if !found && interactions == nil {
+			interaction, found = tx.PeekInteraction(interactionID)
+		}
 		if found {
 			canonicalFound = true
 			total += canonicalInteractionDurationMS(interaction)
@@ -762,7 +781,7 @@ func applyCanonicalConversationEvidenceAndDuration(
 				canonicalCompleteness = candidate
 			}
 			if interaction.EvidenceStatus == sessionvo.EvidencePartial || interaction.EvidenceStatus == sessionvo.EvidenceFailed {
-				for _, reason := range latestAssemblyPartialReasons(tx, interactionID) {
+				for _, reason := range latestAssemblyPartialReasonsFromRevisions(revisions[interactionID]) {
 					canonicalReasons[reason] = struct{}{}
 				}
 			}
@@ -785,6 +804,13 @@ func applyCanonicalConversationEvidenceAndDuration(
 		*partialReasons = sortedSummarySet(canonicalReasons)
 	}
 	*durationMS = total
+}
+
+func latestAssemblyPartialReasonsFromRevisions(revisions []sessionvo.AssemblyRevision) []string {
+	if len(revisions) == 0 {
+		return []string{}
+	}
+	return append([]string{}, revisions[len(revisions)-1].PartialReasons...)
 }
 
 func canonicalFallbackEvidenceCompleteness(value string) string {
@@ -976,10 +1002,13 @@ func (s *Service) applyCanonicalRequestIdentity(ctx context.Context, requests []
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		conversationIDs := make([]string, 0, len(requests))
+		operationIDs := make([]string, 0, len(requests))
 		for _, request := range requests {
 			conversationIDs = append(conversationIDs, request.ConversationID)
+			operationIDs = append(operationIDs, request.OperationID)
 		}
 		byConversation := tx.ListConversationsByIDs(conversationIDs)
+		byOperation := tx.ListOperationsByIDs(operationIDs)
 		for index := range requests {
 			conversationID := requests[index].ConversationID
 			if conversationID == "" {
@@ -993,7 +1022,7 @@ func (s *Service) applyCanonicalRequestIdentity(ctx context.Context, requests []
 			requests[index].ApplicationPrincipalID = conversation.Owner.ApplicationPrincipalID
 			requests[index].EffectiveSubjectID = conversation.Owner.EffectiveSubjectID
 			if requests[index].OperationID != "" {
-				operation, operationFound := tx.PeekOperation(requests[index].OperationID)
+				operation, operationFound := byOperation[requests[index].OperationID]
 				if operationFound && operation.AttemptStatus == sessionvo.AttemptFailed && requests[index].ErrorSummary == "" {
 					requests[index].ErrorSummary = "OpenBKN operation failed"
 				}
@@ -1416,6 +1445,9 @@ func (s *Service) ListRequestTraces(ctx context.Context, requestID string, optio
 }
 
 func (s *Service) ListTraceExecutions(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.TraceSummaryPage, error) {
+	if page, handled, err := s.listTraceIdentityPage(ctx, options); handled || err != nil {
+		return page, err
+	}
 	var traces []evidencevo.TraceSummary
 	var metadata summaryLoadMetadata
 	var err error
@@ -1440,6 +1472,172 @@ func (s *Service) ListTraceExecutions(ctx context.Context, options evidencevo.Su
 		page.PartialReasons = append([]string{}, metadata.PartialReasons...)
 	}
 	return page, err
+}
+
+func (s *Service) listTraceIdentityPage(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.TraceSummaryPage, bool, error) {
+	pageStore, ok := s.sessionStore.(isessionstore.SummaryPageStore)
+	if !ok || s.projectionSource == nil || !canUseSummaryIdentityPage(options) {
+		return evidencevo.TraceSummaryPage{}, false, nil
+	}
+	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
+	if err != nil {
+		return evidencevo.TraceSummaryPage{}, true, err
+	}
+	query := summaryIdentityQuery(options)
+	if hasCursor {
+		query.Offset = 0
+		query.AfterStartedAt, query.AfterID = cursor.StartedAt, cursor.ID
+	}
+	identityPage, err := pageStore.ListTraceSummaryIdentities(ctx, query)
+	if err != nil {
+		return evidencevo.TraceSummaryPage{}, true, err
+	}
+	if len(identityPage.Entries) == 0 {
+		return evidencevo.TraceSummaryPage{Entries: []evidencevo.TraceSummary{}, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit)}, true, nil
+	}
+	ids := summaryIdentityIDs(identityPage.Entries)
+	_, traces, metadata, err := s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
+		Scope: options.Scope, BusinessDomain: options.BusinessDomain,
+		TraceIDs: ids, Limit: selectedSummaryCandidateLimit(len(ids)),
+	}, summaryLoadMetadata{})
+	if err != nil {
+		return evidencevo.TraceSummaryPage{}, true, err
+	}
+	byID := make(map[string]evidencevo.TraceSummary, len(traces))
+	for _, trace := range traces {
+		byID[trace.TraceID] = trace
+	}
+	entries := make([]evidencevo.TraceSummary, 0, len(ids))
+	for _, identity := range identityPage.Entries {
+		trace, found := byID[identity.ID]
+		if !found {
+			return evidencevo.TraceSummaryPage{}, true, ErrSummaryProjectionLag
+		}
+		trace.StartedAt = identity.StartedAt
+		entries = append(entries, trace)
+	}
+	page := evidencevo.TraceSummaryPage{Entries: entries, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit), Truncated: metadata.Truncated, Partial: metadata.Truncated, PartialReasons: append([]string{}, metadata.PartialReasons...)}
+	if identityPage.HasMore && len(identityPage.Entries) > 0 {
+		last := identityPage.Entries[len(identityPage.Entries)-1]
+		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.ID})
+		page.NextCursor = &next
+	}
+	return page, true, nil
+}
+
+func (s *Service) listConversationIdentityPage(ctx context.Context, options evidencevo.SummaryQueryOptions) (evidencevo.ConversationSummaryPage, bool, error) {
+	pageStore, ok := s.sessionStore.(isessionstore.SummaryPageStore)
+	if !ok || s.projectionSource == nil || !canUseSummaryIdentityPage(options) {
+		return evidencevo.ConversationSummaryPage{}, false, nil
+	}
+	cursor, hasCursor, err := decodeSummaryCursor(options.Cursor)
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, true, err
+	}
+	query := summaryIdentityQuery(options)
+	if hasCursor {
+		query.Offset = 0
+		query.AfterStartedAt, query.AfterID = cursor.StartedAt, cursor.ID
+	}
+	identityPage, err := pageStore.ListConversationSummaryIdentities(ctx, query)
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, true, err
+	}
+	if len(identityPage.Entries) == 0 {
+		return evidencevo.ConversationSummaryPage{Entries: []evidencevo.ConversationSummary{}, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit)}, true, nil
+	}
+	ids := summaryIdentityIDs(identityPage.Entries)
+	requests, _, metadata, err := s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
+		Scope: options.Scope, BusinessDomain: options.BusinessDomain,
+		ConversationIDs: ids, Limit: selectedSummaryCandidateLimit(len(ids)),
+	}, summaryLoadMetadata{})
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, true, err
+	}
+	selected := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		selected[id] = struct{}{}
+	}
+	grouped := make(map[string][]evidencevo.RequestSummary, len(ids))
+	for _, request := range requests {
+		if _, found := selected[request.ConversationID]; found {
+			grouped[request.ConversationID] = append(grouped[request.ConversationID], request)
+		}
+	}
+	byID := make(map[string]evidencevo.ConversationSummary, len(ids))
+	entriesForCanonical := make([]evidencevo.ConversationSummary, 0, len(ids))
+	for _, identity := range identityPage.Entries {
+		group := grouped[identity.ID]
+		if len(group) == 0 {
+			return evidencevo.ConversationSummaryPage{}, true, ErrSummaryProjectionLag
+		}
+		entriesForCanonical = append(entriesForCanonical, buildConversationSummary(identity.ID, group))
+	}
+	if err := s.applyCanonicalConversationState(ctx, entriesForCanonical, grouped); err != nil {
+		return evidencevo.ConversationSummaryPage{}, true, err
+	}
+	for _, entry := range entriesForCanonical {
+		byID[entry.ConversationID] = entry
+	}
+	entries := make([]evidencevo.ConversationSummary, 0, len(ids))
+	for _, identity := range identityPage.Entries {
+		if entry, found := byID[identity.ID]; found {
+			entries = append(entries, entry)
+		}
+	}
+	page := evidencevo.ConversationSummaryPage{Entries: entries, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit), Truncated: metadata.Truncated, Partial: metadata.Truncated, PartialReasons: append([]string{}, metadata.PartialReasons...)}
+	if identityPage.HasMore && len(identityPage.Entries) > 0 {
+		last := identityPage.Entries[len(identityPage.Entries)-1]
+		next := encodeSummaryCursor(summaryCursor{StartedAt: last.StartedAt, ID: last.ID})
+		page.NextCursor = &next
+	}
+	return page, true, nil
+}
+
+func canUseSummaryIdentityPage(options evidencevo.SummaryQueryOptions) bool {
+	return trustedQueryScope(options.Scope) &&
+		(options.Scope.AccessProfile == nil || options.Scope.AccessProfile.AccountActive && options.Scope.AccessProfile.TenantActive) &&
+		summaryAccessBoundaryMatches(options.Scope) &&
+		(options.BusinessDomain == "" || options.BusinessDomain == options.Scope.BusinessDomain) &&
+		(options.Scope.AccessProfile == nil || !evidencevo.NeedsCrossAccountCandidates(options.Scope) || evidencevo.HasTenantWideTraceAccess(*options.Scope.AccessProfile)) &&
+		options.TraceID == "" && options.ConversationID == "" && options.InteractionID == "" &&
+		options.Status == "" && options.AgentOrApp == "" && options.ExcludeAgentOrApp == "" &&
+		options.Service == "" && options.Tool == "" && options.ErrorKeyword == "" &&
+		options.KnowledgeNetwork == "" && options.EvidenceCompleteness == "" && options.Keyword == ""
+}
+
+func summaryAccessBoundaryMatches(scope evidencevo.QueryScope) bool {
+	if scope.AccessProfile == nil {
+		return true
+	}
+	profile := *scope.AccessProfile
+	return profile.TenantID != "" && scope.TenantID == profile.TenantID &&
+		profile.BusinessDomain != "" && scope.BusinessDomain == profile.BusinessDomain
+}
+
+func summaryIdentityQuery(options evidencevo.SummaryQueryOptions) isessionstore.SummaryPageQuery {
+	return isessionstore.SummaryPageQuery{Scope: options.Scope, From: options.From, To: options.To, BusinessDomain: options.BusinessDomain, Limit: normalizeSummaryLimit(options.Limit), Offset: summaryQueryOffset(options)}
+}
+
+func summaryIdentityIDs(entries []isessionstore.SummaryIdentity) []string {
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.ID != "" {
+			ids = append(ids, entry.ID)
+		}
+	}
+	return ids
+}
+
+func selectedSummaryCandidateLimit(identityCount int) int {
+	if identityCount <= 0 {
+		return 1
+	}
+	limit := identityCount * maxReceiptsPerSummary
+	if limit > MaxSummaryScanEntries {
+		return MaxSummaryScanEntries
+	}
+	return limit
 }
 
 func (s *Service) loadTraceExecutionSummaries(ctx context.Context, traceID string, scope evidencevo.QueryScope) ([]evidencevo.RequestSummary, []evidencevo.TraceSummary, summaryLoadMetadata, error) {
@@ -1545,7 +1743,10 @@ func summaryCandidateLimit(options evidencevo.SummaryQueryOptions) int {
 	limit := normalizeSummaryLimit(options.Limit)
 	page := normalizeSummaryPage(options.Page)
 	if options.Cursor != "" {
-		page = 1
+		// The compatibility path does not push cursors into Projection. Keep its
+		// historical scan window so a cursor never makes previously reachable
+		// entries disappear merely because the ordinary list fast path exists.
+		return MaxSummaryScanEntries
 	}
 	candidates := page*limit*maxReceiptsPerSummary + 1
 	if candidates > MaxSummaryScanEntries {
@@ -1814,7 +2015,10 @@ func decodeSummaryCursor(value string) (summaryCursor, bool, error) {
 		return summaryCursor{}, false, ErrSummaryCursorInvalid
 	}
 	var cursor summaryCursor
-	if err := json.Unmarshal(body, &cursor); err != nil || cursor.ID == "" {
+	if err := json.Unmarshal(body, &cursor); err != nil || cursor.ID == "" || cursor.StartedAt == "" {
+		return summaryCursor{}, false, ErrSummaryCursorInvalid
+	}
+	if _, err := time.Parse(time.RFC3339Nano, cursor.StartedAt); err != nil {
 		return summaryCursor{}, false, ErrSummaryCursorInvalid
 	}
 	return cursor, true, nil

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -95,9 +95,10 @@ func (s *Service) ListConversations(ctx context.Context, options evidencevo.Summ
 	if page, handled, err := s.listConversationIdentityPage(ctx, options); handled || err != nil {
 		return page, err
 	}
+	candidateLimit := summaryCandidateLimit(options)
 	loadOptions := options
 	loadOptions.Status = ""
-	requests, _, metadata, err := s.loadExecutionSummaries(ctx, loadOptions)
+	requests, _, metadata, err := s.loadExecutionSummariesWithCandidateLimit(ctx, loadOptions, candidateLimit)
 	if err != nil {
 		return evidencevo.ConversationSummaryPage{}, err
 	}
@@ -163,9 +164,10 @@ func (s *Service) ListInteractions(ctx context.Context, options evidencevo.Summa
 			return page, err
 		}
 	}
+	candidateLimit := summaryCandidateLimit(options)
 	loadOptions := options
 	loadOptions.Status = ""
-	requests, _, metadata, err := s.loadExecutionSummaries(ctx, loadOptions)
+	requests, _, metadata, err := s.loadExecutionSummariesWithCandidateLimit(ctx, loadOptions, candidateLimit)
 	if err != nil {
 		return evidencevo.InteractionSummaryPage{}, err
 	}
@@ -1713,6 +1715,10 @@ func mergeTraceBatches(batches []evidencevo.NormalizedTrace) []evidencevo.Normal
 }
 
 func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo.SummaryQueryOptions) ([]evidencevo.RequestSummary, []evidencevo.TraceSummary, summaryLoadMetadata, error) {
+	return s.loadExecutionSummariesWithCandidateLimit(ctx, options, summaryCandidateLimit(options))
+}
+
+func (s *Service) loadExecutionSummariesWithCandidateLimit(ctx context.Context, options evidencevo.SummaryQueryOptions, candidateLimit int) ([]evidencevo.RequestSummary, []evidencevo.TraceSummary, summaryLoadMetadata, error) {
 	if !trustedQueryScope(options.Scope) {
 		return []evidencevo.RequestSummary{}, []evidencevo.TraceSummary{}, summaryLoadMetadata{}, nil
 	}
@@ -1723,7 +1729,7 @@ func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo
 		Scope: options.Scope, From: options.From, To: options.To,
 		BusinessDomain: options.BusinessDomain, Status: options.Status,
 		TraceID: options.TraceID, InteractionID: options.InteractionID,
-		Limit: summaryCandidateLimit(options),
+		Limit: candidateLimit,
 	})
 	if err != nil {
 		return nil, nil, summaryLoadMetadata{}, err

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -21,6 +21,7 @@ const (
 	DefaultSummaryQueryLimit = 50
 	MaxSummaryQueryLimit     = 200
 	MaxSummaryScanEntries    = 2000
+	maxReceiptsPerSummary    = 20
 )
 
 var ErrSummaryCursorInvalid = errors.New("BKN_TRACE_SUMMARY_CURSOR_INVALID")
@@ -698,8 +699,13 @@ func (s *Service) applyCanonicalConversationState(
 		return nil
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		conversationIDs := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			conversationIDs = append(conversationIDs, entry.ConversationID)
+		}
+		conversations := tx.ListConversationsByIDs(conversationIDs)
 		for index := range entries {
-			conversation, found := tx.PeekConversation(entries[index].ConversationID)
+			conversation, found := conversations[entries[index].ConversationID]
 			if !found {
 				continue
 			}
@@ -969,20 +975,19 @@ func (s *Service) applyCanonicalRequestIdentity(ctx context.Context, requests []
 		return nil
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
-		byConversation := map[string]sessionvo.Conversation{}
+		conversationIDs := make([]string, 0, len(requests))
+		for _, request := range requests {
+			conversationIDs = append(conversationIDs, request.ConversationID)
+		}
+		byConversation := tx.ListConversationsByIDs(conversationIDs)
 		for index := range requests {
 			conversationID := requests[index].ConversationID
 			if conversationID == "" {
 				continue
 			}
-			conversation, cached := byConversation[conversationID]
-			if !cached {
-				var found bool
-				conversation, found = tx.PeekConversation(conversationID)
-				if !found {
-					continue
-				}
-				byConversation[conversationID] = conversation
+			conversation, found := byConversation[conversationID]
+			if !found {
+				continue
 			}
 			requests[index].AgentName = conversation.AgentName
 			requests[index].ApplicationPrincipalID = conversation.Owner.ApplicationPrincipalID
@@ -1003,10 +1008,11 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 		return nil
 	}
 	return s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
-		byConversation := map[string]sessionvo.Conversation{}
+		conversationIDs := make([]string, 0, len(traces))
 		traceIDs := make([]string, 0, len(traces))
 		seenTraceIDs := map[string]struct{}{}
 		for _, trace := range traces {
+			conversationIDs = append(conversationIDs, trace.ConversationID)
 			if trace.TraceID == "" {
 				continue
 			}
@@ -1016,18 +1022,12 @@ func (s *Service) applyCanonicalTraceIdentity(ctx context.Context, traces []evid
 			seenTraceIDs[trace.TraceID] = struct{}{}
 			traceIDs = append(traceIDs, trace.TraceID)
 		}
+		byConversation := tx.ListConversationsByIDs(conversationIDs)
 		sourceModulesByTraceID := tx.ListFirstOperationSourceModulesByTraceIDs(traceIDs)
 		for index := range traces {
 			conversationID := traces[index].ConversationID
 			if conversationID != "" {
-				conversation, cached := byConversation[conversationID]
-				if !cached {
-					var found bool
-					conversation, found = tx.PeekConversation(conversationID)
-					if found {
-						byConversation[conversationID] = conversation
-					}
-				}
+				conversation := byConversation[conversationID]
 				if conversation.ID != "" {
 					traces[index].AgentName = conversation.AgentName
 					traces[index].ApplicationPrincipalID = conversation.Owner.ApplicationPrincipalID
@@ -1521,7 +1521,7 @@ func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo
 		Scope: options.Scope, From: options.From, To: options.To,
 		BusinessDomain: options.BusinessDomain, Status: options.Status,
 		TraceID: options.TraceID, InteractionID: options.InteractionID,
-		Limit: MaxSummaryScanEntries,
+		Limit: summaryCandidateLimit(options),
 	})
 	if err != nil {
 		return nil, nil, summaryLoadMetadata{}, err
@@ -1539,6 +1539,19 @@ func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo
 	}
 	s.enrichTraceStats(ctx, traceSummaries)
 	return requests, traceSummaries, metadata, nil
+}
+
+func summaryCandidateLimit(options evidencevo.SummaryQueryOptions) int {
+	limit := normalizeSummaryLimit(options.Limit)
+	page := normalizeSummaryPage(options.Page)
+	if options.Cursor != "" {
+		page = 1
+	}
+	candidates := page*limit*maxReceiptsPerSummary + 1
+	if candidates > MaxSummaryScanEntries {
+		return MaxSummaryScanEntries
+	}
+	return candidates
 }
 
 func (s *Service) loadRequestExecutionSummaries(ctx context.Context, requestID string, scope evidencevo.QueryScope) ([]evidencevo.RequestSummary, []evidencevo.TraceSummary, summaryLoadMetadata, error) {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -1601,9 +1601,13 @@ func canUseSummaryIdentityPage(options evidencevo.SummaryQueryOptions) bool {
 		(options.BusinessDomain == "" || options.BusinessDomain == options.Scope.BusinessDomain) &&
 		(options.Scope.AccessProfile == nil || !evidencevo.NeedsCrossAccountCandidates(options.Scope) || evidencevo.HasTenantWideTraceAccess(*options.Scope.AccessProfile)) &&
 		options.TraceID == "" && options.ConversationID == "" && options.InteractionID == "" &&
-		options.Status == "" && options.AgentOrApp == "" && options.ExcludeAgentOrApp == "" &&
-		options.Service == "" && options.Tool == "" && options.ErrorKeyword == "" &&
-		options.KnowledgeNetwork == "" && options.EvidenceCompleteness == "" && options.Keyword == ""
+		!hasSummaryContentFilters(options)
+}
+
+func hasSummaryContentFilters(options evidencevo.SummaryQueryOptions) bool {
+	return options.Status != "" || options.AgentOrApp != "" || options.ExcludeAgentOrApp != "" ||
+		options.Service != "" || options.Tool != "" || options.ErrorKeyword != "" ||
+		options.KnowledgeNetwork != "" || options.EvidenceCompleteness != "" || options.Keyword != ""
 }
 
 func summaryAccessBoundaryMatches(scope evidencevo.QueryScope) bool {
@@ -1740,6 +1744,9 @@ func (s *Service) loadExecutionSummaries(ctx context.Context, options evidencevo
 }
 
 func summaryCandidateLimit(options evidencevo.SummaryQueryOptions) int {
+	if hasSummaryContentFilters(options) {
+		return MaxSummaryScanEntries
+	}
 	limit := normalizeSummaryLimit(options.Limit)
 	page := normalizeSummaryPage(options.Page)
 	if options.Cursor != "" {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -24,6 +24,162 @@ type capturingProjectionSource struct {
 
 type fixedTraceStatsSource map[string]int
 
+func pageSummaryTrace(traceID, requestID, at, account, domain string) evidencevo.NormalizedTrace {
+	return evidencevo.NormalizedTrace{
+		TraceID: traceID, RequestID: requestID, TenantID: "tenant_demo", BusinessDomain: domain,
+		AccountID: account, AccountType: "app", SchemaVersion: evidencevo.ArtifactContractVersion,
+		Events: []evidencevo.EvidenceEvent{{
+			EventID: "event-" + traceID, EventType: "agent.interaction.started", TraceID: traceID,
+			RequestID: requestID, ObservedAt: at, EmittedAt: at, OperationName: "agent.run",
+			Payload: map[string]any{"agent_id": "agent-demo"},
+		}},
+	}
+}
+
+type pagingSessionStore struct {
+	*sessionstore.Store
+	tracePage           isessionstore.SummaryIdentityPage
+	conversationPage    isessionstore.SummaryIdentityPage
+	traceQueries        []isessionstore.SummaryPageQuery
+	conversationQueries []isessionstore.SummaryPageQuery
+}
+
+func (store *pagingSessionStore) ListTraceSummaryIdentities(_ context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
+	store.traceQueries = append(store.traceQueries, query)
+	return store.tracePage, nil
+}
+
+func (store *pagingSessionStore) ListConversationSummaryIdentities(_ context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
+	store.conversationQueries = append(store.conversationQueries, query)
+	return store.conversationPage, nil
+}
+
+func TestListTraceExecutionsLoadsOnlySelectedPageIdentities(t *testing.T) {
+	base := evidencestore.New()
+	store := &pagingSessionStore{Store: sessionstore.New(), tracePage: isessionstore.SummaryIdentityPage{
+		Entries: []isessionstore.SummaryIdentity{{ID: "trace-page", StartedAt: "2026-08-19T09:00:00Z"}}, Total: 101, HasMore: true,
+	}}
+	projection := &capturingProjectionSource{result: iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{pageSummaryTrace("trace-page", "req-page", "2026-08-19T09:00:00Z", "acct_demo", "bd_demo")}}}
+	service := New(base, WithProjectionSource(projection), WithSessionStore(store))
+	from := time.Date(2026, 8, 19, 8, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)
+	page, err := service.ListTraceExecutions(context.Background(), evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), From: from, To: to, Limit: 20})
+	if err != nil {
+		t.Fatalf("list trace page: %v", err)
+	}
+	if page.Total != 101 || len(page.Entries) != 1 || page.Entries[0].TraceID != "trace-page" || page.NextCursor == nil {
+		t.Fatalf("page=%+v", page)
+	}
+	if len(projection.queries) != 1 || len(projection.queries[0].TraceIDs) != 1 || projection.queries[0].TraceIDs[0] != "trace-page" {
+		t.Fatalf("projection queries=%+v", projection.queries)
+	}
+	if !projection.queries[0].From.IsZero() || !projection.queries[0].To.IsZero() {
+		t.Fatalf("page expansion must not filter later facts by the identity time range: %+v", projection.queries[0])
+	}
+	if query := store.traceQueries[0]; !query.From.Equal(from) || !query.To.Equal(to) {
+		t.Fatalf("identity query must own the time filter: %+v", query)
+	}
+	store.tracePage = isessionstore.SummaryIdentityPage{Entries: []isessionstore.SummaryIdentity{{ID: "trace-next", StartedAt: "2026-08-19T08:59:00Z"}}, Total: 101}
+	projection.resultFor = func(query iprojectionsource.Query) iprojectionsource.Result {
+		return iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{pageSummaryTrace(query.TraceIDs[0], "req-next", "2026-08-19T08:59:00Z", "acct_demo", "bd_demo")}}
+	}
+	nextPage, err := service.ListTraceExecutions(context.Background(), evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), From: from, To: to, Limit: 20, Cursor: *page.NextCursor})
+	if err != nil || len(nextPage.Entries) != 1 || nextPage.Entries[0].TraceID != "trace-next" {
+		t.Fatalf("next page=%+v err=%v", nextPage, err)
+	}
+	if query := store.traceQueries[1]; query.AfterStartedAt != "2026-08-19T09:00:00Z" || query.AfterID != "trace-page" {
+		t.Fatalf("cursor query=%+v", query)
+	}
+}
+
+func TestListConversationsLoadsOnlySelectedPageIdentities(t *testing.T) {
+	base := evidencestore.New()
+	store := &pagingSessionStore{Store: sessionstore.New(), conversationPage: isessionstore.SummaryIdentityPage{
+		Entries: []isessionstore.SummaryIdentity{{ID: "conv-page", StartedAt: "2026-08-19T09:00:00Z"}}, Total: 31, HasMore: true,
+	}}
+	trace := pageSummaryTrace("trace-page", "req-page", "2026-08-19T09:00:00Z", "acct_demo", "bd_demo")
+	trace.ConversationID = "conv-page"
+	projection := &capturingProjectionSource{result: iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{trace}}}
+	service := New(base, WithProjectionSource(projection), WithSessionStore(store))
+	page, err := service.ListConversations(context.Background(), evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), Limit: 20})
+	if err != nil {
+		t.Fatalf("list conversation page: %v", err)
+	}
+	if page.Total != 31 || len(page.Entries) != 1 || page.Entries[0].ConversationID != "conv-page" || page.NextCursor == nil {
+		t.Fatalf("page=%+v", page)
+	}
+	if len(projection.queries) != 1 || len(projection.queries[0].ConversationIDs) != 1 || projection.queries[0].ConversationIDs[0] != "conv-page" {
+		t.Fatalf("projection queries=%+v", projection.queries)
+	}
+	store.conversationPage = isessionstore.SummaryIdentityPage{Entries: []isessionstore.SummaryIdentity{{ID: "conv-next", StartedAt: "2026-08-19T08:59:00Z"}}, Total: 31}
+	projection.resultFor = func(query iprojectionsource.Query) iprojectionsource.Result {
+		value := pageSummaryTrace("trace-next", "req-next", "2026-08-19T08:59:00Z", "acct_demo", "bd_demo")
+		value.ConversationID = query.ConversationIDs[0]
+		return iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{value}}
+	}
+	nextPage, err := service.ListConversations(context.Background(), evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), Limit: 20, Cursor: *page.NextCursor})
+	if err != nil || len(nextPage.Entries) != 1 || nextPage.Entries[0].ConversationID != "conv-next" {
+		t.Fatalf("next page=%+v err=%v", nextPage, err)
+	}
+	if query := store.conversationQueries[1]; query.Offset != 0 || query.AfterStartedAt != "2026-08-19T09:00:00Z" || query.AfterID != "conv-page" {
+		t.Fatalf("cursor query=%+v", query)
+	}
+}
+
+func TestListTraceExecutionsBoundsProjectionExpansionPerIdentity(t *testing.T) {
+	base := evidencestore.New()
+	store := &pagingSessionStore{Store: sessionstore.New(), tracePage: isessionstore.SummaryIdentityPage{
+		Entries: []isessionstore.SummaryIdentity{
+			{ID: "trace-heavy", StartedAt: "2026-08-19T09:00:00Z"},
+			{ID: "trace-next", StartedAt: "2026-08-19T08:59:00Z"},
+		},
+		Total: 2,
+	}}
+	projection := &capturingProjectionSource{resultFor: func(query iprojectionsource.Query) iprojectionsource.Result {
+		traces := make([]evidencevo.NormalizedTrace, 0, len(query.TraceIDs))
+		for _, traceID := range query.TraceIDs {
+			traces = append(traces, pageSummaryTrace(traceID, "request-"+traceID, "2026-08-19T09:00:00Z", "acct_demo", "bd_demo"))
+		}
+		return iprojectionsource.Result{Traces: traces}
+	}}
+	service := New(base, WithProjectionSource(projection), WithSessionStore(store))
+	page, err := service.ListTraceExecutions(context.Background(), evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), Limit: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page.Entries) != 2 || page.Entries[0].TraceID != "trace-heavy" || page.Entries[1].TraceID != "trace-next" {
+		t.Fatalf("one heavy identity must not starve later page identities: %+v", page)
+	}
+	if len(projection.queries) != 1 {
+		t.Fatalf("projection queries=%+v", projection.queries)
+	}
+	for _, query := range projection.queries {
+		if len(query.TraceIDs) != 2 || query.Limit != 2*maxReceiptsPerSummary {
+			t.Fatalf("the page must use one bounded batch expansion: %+v", query)
+		}
+	}
+}
+
+func TestSummaryIdentityPageDoesNotAdvancePastProjectionLag(t *testing.T) {
+	base := evidencestore.New()
+	store := &pagingSessionStore{Store: sessionstore.New(), tracePage: isessionstore.SummaryIdentityPage{
+		Entries: []isessionstore.SummaryIdentity{{ID: "trace-not-refreshed", StartedAt: "2026-08-19T09:00:00Z"}},
+		Total:   1,
+	}}
+	service := New(base, WithProjectionSource(&capturingProjectionSource{}), WithSessionStore(store))
+	page, err := service.ListTraceExecutions(context.Background(), evidencevo.SummaryQueryOptions{
+		Scope: summaryScope("acct_demo"), Limit: 20,
+	})
+	if !errors.Is(err, ErrSummaryProjectionLag) {
+		t.Fatalf("page=%+v err=%v", page, err)
+	}
+	if page.NextCursor != nil || len(page.Entries) != 0 {
+		t.Fatalf("projection lag must not return or advance a cursor: %+v", page)
+	}
+}
+
 func (source fixedTraceStatsSource) CountSpansByTraceIDs(_ context.Context, _ []string) (map[string]int, error) {
 	return source, nil
 }
@@ -32,6 +188,28 @@ func TestSummaryOffsetClampsOverflowingPage(t *testing.T) {
 	options := evidencevo.SummaryQueryOptions{Page: int(^uint(0) >> 1), Limit: MaxSummaryQueryLimit}
 	if offset := summaryOffset(options, 10); offset != 10 {
 		t.Fatalf("overflowing page offset = %d, want end of result set", offset)
+	}
+}
+
+func TestSummaryIdentityPageRequiresExactAuthorizationBoundary(t *testing.T) {
+	profile := &evidencevo.AccessProfile{
+		TenantID: "tenant_demo", BusinessDomain: "bd_demo", EffectiveSubjectID: "acct_demo",
+		AccountActive: true, TenantActive: true,
+	}
+	scope := summaryScope("acct_demo")
+	scope.AccessProfile = profile
+	if !canUseSummaryIdentityPage(evidencevo.SummaryQueryOptions{Scope: scope}) {
+		t.Fatal("matching trusted boundary must allow the identity page")
+	}
+	mismatchedProfile := *profile
+	mismatchedProfile.TenantID = "other-tenant"
+	scope.AccessProfile = &mismatchedProfile
+	if canUseSummaryIdentityPage(evidencevo.SummaryQueryOptions{Scope: scope}) {
+		t.Fatal("profile/scope mismatch must fall back before counting identities")
+	}
+	scope.AccessProfile = profile
+	if canUseSummaryIdentityPage(evidencevo.SummaryQueryOptions{Scope: scope, BusinessDomain: "other-domain"}) {
+		t.Fatal("a business-domain filter cannot replace the authorization boundary")
 	}
 }
 
@@ -449,7 +627,7 @@ func TestCanonicalConversationEvidenceReplacesRequestDerivedPartial(t *testing.T
 		duration := int64(0)
 		applyCanonicalConversationEvidenceAndDuration(
 			&completeness, new([]string), &duration, tx,
-			[]evidencevo.RequestSummary{{InteractionID: "interaction_complete"}},
+			[]evidencevo.RequestSummary{{InteractionID: "interaction_complete"}}, nil, nil,
 		)
 		if completeness != "complete" {
 			t.Fatalf("conversation evidence must come from canonical interactions, got %q", completeness)
@@ -475,7 +653,7 @@ func TestCanonicalConversationEvidenceKeepsMissingInteractionPartial(t *testing.
 			[]evidencevo.RequestSummary{
 				{InteractionID: "interaction_complete", EvidenceCompleteness: "partial"},
 				{InteractionID: "interaction_missing", Status: "completed", EvidenceCompleteness: "partial", PartialReasons: []string{"missing_canonical_interaction"}},
-			},
+			}, nil, nil,
 		)
 		if completeness != "partial" || !containsSummaryValue(reasons, "missing_canonical_interaction") {
 			t.Fatalf("missing canonical interaction must remain conservatively partial: completeness=%q reasons=%v", completeness, reasons)
@@ -505,7 +683,7 @@ func TestCanonicalConversationEvidenceNormalizesMissingInteractionContentUnavail
 					EvidenceCompleteness: "content_unavailable",
 					PartialReasons:       []string{"missing_canonical_interaction"},
 				},
-			},
+			}, nil, nil,
 		)
 		if completeness != "partial" || !containsSummaryValue(reasons, "missing_canonical_interaction") {
 			t.Fatalf("request vocabulary must normalize to canonical partial: completeness=%q reasons=%v", completeness, reasons)

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1636,9 +1636,18 @@ func TestListRequestsReportsBoundedProjectionTruncationAndPushdownQuery(t *testi
 		t.Fatalf("expected one bounded source call, got %+v", source.queries)
 	}
 	query := source.queries[0]
-	if query.Limit != 401 || !query.From.Equal(from) || !query.To.Equal(to) ||
+	if query.Limit != MaxSummaryScanEntries || !query.From.Equal(from) || !query.To.Equal(to) ||
 		query.BusinessDomain != "bd_demo" || query.Status != "running" {
-		t.Fatalf("reliable filters and cap must be pushed to source: %+v", query)
+		t.Fatalf("content-filter compatibility queries must keep the historical scan window: %+v", query)
+	}
+}
+
+func TestSummaryCandidateLimitUsesPageBudgetOnlyWithoutContentFilters(t *testing.T) {
+	if got := summaryCandidateLimit(evidencevo.SummaryQueryOptions{Page: 1, Limit: 20}); got != 401 {
+		t.Fatalf("ordinary page candidate limit=%d", got)
+	}
+	if got := summaryCandidateLimit(evidencevo.SummaryQueryOptions{Page: 1, Limit: 20, Keyword: "needle"}); got != MaxSummaryScanEntries {
+		t.Fatalf("content-filter candidate limit=%d", got)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1447,7 +1447,7 @@ func TestListRequestsReportsBoundedProjectionTruncationAndPushdownQuery(t *testi
 
 	page, err := service.ListRequests(context.Background(), evidencevo.SummaryQueryOptions{
 		Scope: summaryScope("acct_demo"), From: from, To: to,
-		Status: "running", BusinessDomain: "bd_demo", Keyword: "capped",
+		Status: "running", BusinessDomain: "bd_demo", Keyword: "capped", Limit: 20,
 	})
 
 	if err != nil || len(page.Entries) != 1 || !page.Truncated || !page.Partial ||
@@ -1458,7 +1458,7 @@ func TestListRequestsReportsBoundedProjectionTruncationAndPushdownQuery(t *testi
 		t.Fatalf("expected one bounded source call, got %+v", source.queries)
 	}
 	query := source.queries[0]
-	if query.Limit != MaxSummaryScanEntries || !query.From.Equal(from) || !query.To.Equal(to) ||
+	if query.Limit != 401 || !query.From.Equal(from) || !query.To.Equal(to) ||
 		query.BusinessDomain != "bd_demo" || query.Status != "running" {
 		t.Fatalf("reliable filters and cap must be pushed to source: %+v", query)
 	}

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -1651,6 +1651,37 @@ func TestSummaryCandidateLimitUsesPageBudgetOnlyWithoutContentFilters(t *testing
 	}
 }
 
+func TestStatusFilteredAggregateListsPreserveCompatibilityWindow(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		list func(*Service) error
+	}{
+		{name: "conversations", list: func(service *Service) error {
+			_, err := service.ListConversations(context.Background(), evidencevo.SummaryQueryOptions{
+				Scope: summaryScope("acct_demo"), Status: "failed", Limit: 50,
+			})
+			return err
+		}},
+		{name: "interactions", list: func(service *Service) error {
+			_, err := service.ListInteractions(context.Background(), evidencevo.SummaryQueryOptions{
+				Scope: summaryScope("acct_demo"), Status: "failed", Limit: 50,
+			})
+			return err
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := &capturingProjectionSource{}
+			service := NewWithProjectionSource(evidencestore.New(), source)
+			if err := test.list(service); err != nil {
+				t.Fatal(err)
+			}
+			if len(source.queries) != 1 || source.queries[0].Limit != MaxSummaryScanEntries || source.queries[0].Status != "" {
+				t.Fatalf("status must stay post-filtered without shrinking candidates: %+v", source.queries)
+			}
+		})
+	}
+}
+
 func TestListInteractionsPushesExactInteractionIDToProjection(t *testing.T) {
 	trace := evidencevo.NormalizedTrace{
 		TraceID: "trace_interaction_target", RequestID: "req_interaction_target",

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -443,6 +443,47 @@ func (t *transaction) PeekInteraction(interactionID string) (sessionvo.Interacti
 		WHERE interaction_id=?`, interactionID))
 }
 
+func (t *transaction) ListInteractionsByIDs(interactionIDs []string) map[string]sessionvo.Interaction {
+	result := make(map[string]sessionvo.Interaction, len(interactionIDs))
+	if t.err != nil {
+		return result
+	}
+	ids := make([]string, 0, len(interactionIDs))
+	seen := make(map[string]struct{}, len(interactionIDs))
+	for _, id := range interactionIDs {
+		if id != "" {
+			if _, found := seen[id]; !found {
+				seen[id] = struct{}{}
+				ids = append(ids, id)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return result
+	}
+	args := make([]any, len(ids))
+	for index, id := range ids {
+		args[index] = id
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	rows, err := t.tx.QueryContext(t.ctx, interactionSelect+` WHERE interaction_id IN (`+placeholders+`)`, args...)
+	if err != nil {
+		t.err = err
+		return result
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value, scanErr := scanInteractionRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return result
+		}
+		result[value.ID] = value
+	}
+	t.err = rows.Err()
+	return result
+}
+
 func (t *transaction) NextInteractionOrdinal(conversationID string) uint64 {
 	if t.err != nil {
 		return 0
@@ -526,6 +567,37 @@ func (t *transaction) PeekOperation(operationID string) (sessionvo.Operation, bo
 	}
 	return t.scanOperation(t.tx.QueryRowContext(t.ctx, operationSelect+`
 		WHERE operation_id=?`, operationID))
+}
+
+func (t *transaction) ListOperationsByIDs(operationIDs []string) map[string]sessionvo.Operation {
+	result := make(map[string]sessionvo.Operation, len(operationIDs))
+	if t.err != nil {
+		return result
+	}
+	ids := uniqueStoreIDs(operationIDs)
+	if len(ids) == 0 {
+		return result
+	}
+	args := make([]any, len(ids))
+	for index, id := range ids {
+		args[index] = id
+	}
+	rows, err := t.tx.QueryContext(t.ctx, operationSelect+` WHERE operation_id IN (`+storePlaceholders(len(ids))+`)`, args...)
+	if err != nil {
+		t.err = err
+		return result
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value, scanErr := scanOperationRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return result
+		}
+		result[value.ID] = value
+	}
+	t.err = rows.Err()
+	return result
 }
 
 func (t *transaction) ListOperations(interactionID string) []sessionvo.Operation {
@@ -1089,6 +1161,67 @@ func (t *transaction) ListAssemblyRevisions(interactionID string) []sessionvo.As
 	}
 	t.err = rows.Err()
 	return result
+}
+
+func (t *transaction) ListAssemblyRevisionsByInteractionIDs(interactionIDs []string) map[string][]sessionvo.AssemblyRevision {
+	result := make(map[string][]sessionvo.AssemblyRevision, len(interactionIDs))
+	if t.err != nil {
+		return result
+	}
+	ids := uniqueStoreIDs(interactionIDs)
+	if len(ids) == 0 {
+		return result
+	}
+	args := make([]any, len(ids))
+	for index, id := range ids {
+		args[index] = id
+	}
+	rows, err := t.tx.QueryContext(t.ctx, `
+		SELECT revision_id, revision_no, COALESCE(parent_revision_id, ''), interaction_id,
+			completion_manifest_version, included_receipt_ids, included_event_ids,
+			artifact_manifest_hash, assembly_completeness, COALESCE(partial_reasons, ''),
+			trigger_type, created_at
+		FROM bkn_trace_assembly_revisions
+		WHERE interaction_id IN (`+storePlaceholders(len(ids))+`) ORDER BY interaction_id, revision_no`, args...)
+	if err != nil {
+		t.err = err
+		return result
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var value sessionvo.AssemblyRevision
+		var receipts, events, reasons string
+		if scanErr := rows.Scan(&value.ID, &value.RevisionNo, &value.ParentRevisionID, &value.InteractionID, &value.CompletionManifestVersion, &receipts, &events, &value.ArtifactManifestHash, &value.Completeness, &reasons, &value.Trigger, &value.CreatedAt); scanErr != nil {
+			t.err = scanErr
+			return result
+		}
+		unmarshalJSON(receipts, &value.IncludedReceiptIDs)
+		unmarshalJSON(events, &value.IncludedEventIDs)
+		unmarshalJSON(reasons, &value.PartialReasons)
+		result[value.InteractionID] = append(result[value.InteractionID], value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
+func uniqueStoreIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func storePlaceholders(count int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
 }
 
 func (t *transaction) SaveAssemblyRevision(revision sessionvo.AssemblyRevision) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -175,6 +175,51 @@ func (t *transaction) PeekConversation(conversationID string) (sessionvo.Convers
 		WHERE conversation_id=?`, conversationID))
 }
 
+func (t *transaction) ListConversationsByIDs(conversationIDs []string) map[string]sessionvo.Conversation {
+	result := make(map[string]sessionvo.Conversation, len(conversationIDs))
+	if t.err != nil || len(conversationIDs) == 0 {
+		return result
+	}
+	uniqueIDs := make([]string, 0, len(conversationIDs))
+	seen := make(map[string]struct{}, len(conversationIDs))
+	for _, conversationID := range conversationIDs {
+		if conversationID == "" {
+			continue
+		}
+		if _, found := seen[conversationID]; found {
+			continue
+		}
+		seen[conversationID] = struct{}{}
+		uniqueIDs = append(uniqueIDs, conversationID)
+	}
+	if len(uniqueIDs) == 0 {
+		return result
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(uniqueIDs)), ",")
+	args := make([]any, len(uniqueIDs))
+	for index, conversationID := range uniqueIDs {
+		args[index] = conversationID
+	}
+	rows, err := t.tx.QueryContext(t.ctx, conversationSelect+` WHERE conversation_id IN (`+placeholders+`)`, args...)
+	if err != nil {
+		t.err = err
+		return result
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		conversation, scanErr := scanConversationRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return result
+		}
+		result[conversation.ID] = conversation
+	}
+	if err := rows.Err(); err != nil {
+		t.err = err
+	}
+	return result
+}
+
 func (t *transaction) FindIdempotency(
 	scope string,
 	owner sessionvo.Owner,

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page.go
@@ -13,7 +13,7 @@ import (
 
 func (s *Store) ListTraceSummaryIdentities(ctx context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
 	where, args := summaryOwnerWhere("r", query)
-	where = append(where, "r.trace_id IS NOT NULL", "r.trace_id<>''")
+	where = append(where, usableSummaryReceiptPredicates("r")...)
 	if !query.From.IsZero() {
 		where, args = append(where, "r.issued_at>=?"), append(args, query.From.UTC())
 	}
@@ -55,13 +55,8 @@ func (s *Store) ListTraceSummaryIdentities(ctx context.Context, query isessionst
 
 func (s *Store) ListConversationSummaryIdentities(ctx context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
 	where, args := summaryOwnerWhere("c", query)
-	where = append(where, "EXISTS (SELECT 1 FROM bkn_trace_receipts r WHERE r.conversation_id=c.conversation_id)")
-	if !query.From.IsZero() {
-		where, args = append(where, "c.created_at>=?"), append(args, query.From.UTC())
-	}
-	if !query.To.IsZero() {
-		where, args = append(where, "c.created_at<=?"), append(args, query.To.UTC())
-	}
+	receiptExists, receiptArgs := conversationSummaryReceiptExists(query)
+	where, args = append(where, receiptExists), append(args, receiptArgs...)
 	clause := strings.Join(where, " AND ")
 	var total int
 	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM bkn_trace_conversations c WHERE "+clause, args...).Scan(&total); err != nil {
@@ -91,6 +86,28 @@ func (s *Store) ListConversationSummaryIdentities(ctx context.Context, query ise
 		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("scan conversation summary identities: %w", err)
 	}
 	return isessionstore.SummaryIdentityPage{Entries: entries.values, Total: total, HasMore: entries.hasMore}, nil
+}
+
+func conversationSummaryReceiptExists(query isessionstore.SummaryPageQuery) (string, []any) {
+	where := []string{
+		"r.conversation_id=c.conversation_id",
+	}
+	where = append(where, usableSummaryReceiptPredicates("r")...)
+	args := make([]any, 0, 2)
+	if !query.From.IsZero() {
+		where, args = append(where, "r.issued_at>=?"), append(args, query.From.UTC())
+	}
+	if !query.To.IsZero() {
+		where, args = append(where, "r.issued_at<=?"), append(args, query.To.UTC())
+	}
+	return "EXISTS (SELECT 1 FROM bkn_trace_receipts r WHERE " + strings.Join(where, " AND ") + ")", args
+}
+
+func usableSummaryReceiptPredicates(alias string) []string {
+	return []string{
+		alias + ".trace_id IS NOT NULL", alias + ".trace_id<>''",
+		alias + ".request_id IS NOT NULL", alias + ".request_id<>''",
+	}
 }
 
 func summaryOwnerWhere(alias string, query isessionstore.SummaryPageQuery) ([]string, []any) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page.go
@@ -1,0 +1,168 @@
+package sessionstore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+func (s *Store) ListTraceSummaryIdentities(ctx context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
+	where, args := summaryOwnerWhere("r", query)
+	where = append(where, "r.trace_id IS NOT NULL", "r.trace_id<>''")
+	if !query.From.IsZero() {
+		where, args = append(where, "r.issued_at>=?"), append(args, query.From.UTC())
+	}
+	if !query.To.IsZero() {
+		where, args = append(where, "r.issued_at<=?"), append(args, query.To.UTC())
+	}
+	clause := strings.Join(where, " AND ")
+	var total int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(DISTINCT r.trace_id) FROM bkn_trace_receipts r WHERE "+clause, args...).Scan(&total); err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("count trace summary identities: %w", err)
+	}
+
+	having := ""
+	pageArgs := append([]any{}, args...)
+	if query.AfterStartedAt != "" && query.AfterID != "" {
+		startedAt, err := time.Parse(time.RFC3339Nano, query.AfterStartedAt)
+		if err != nil {
+			return isessionstore.SummaryIdentityPage{}, fmt.Errorf("parse trace summary cursor: %w", err)
+		}
+		having = " HAVING MIN(r.issued_at)<? OR (MIN(r.issued_at)=? AND r.trace_id>?)"
+		pageArgs = append(pageArgs, startedAt.UTC(), startedAt.UTC(), query.AfterID)
+	}
+	limit := normalizeSummaryPageLimit(query.Limit)
+	pageArgs = append(pageArgs, limit+1, normalizeSummaryPageOffset(query.Offset))
+	rows, err := s.db.QueryContext(ctx, `SELECT r.trace_id, MIN(r.issued_at)
+		FROM bkn_trace_receipts r WHERE `+clause+`
+		GROUP BY r.trace_id`+having+`
+		ORDER BY MIN(r.issued_at) DESC, r.trace_id ASC LIMIT ? OFFSET ?`, pageArgs...)
+	if err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("list trace summary identities: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	entries, err := scanSummaryIdentities(rows, limit)
+	if err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("scan trace summary identities: %w", err)
+	}
+	return isessionstore.SummaryIdentityPage{Entries: entries.values, Total: total, HasMore: entries.hasMore}, nil
+}
+
+func (s *Store) ListConversationSummaryIdentities(ctx context.Context, query isessionstore.SummaryPageQuery) (isessionstore.SummaryIdentityPage, error) {
+	where, args := summaryOwnerWhere("c", query)
+	where = append(where, "EXISTS (SELECT 1 FROM bkn_trace_receipts r WHERE r.conversation_id=c.conversation_id)")
+	if !query.From.IsZero() {
+		where, args = append(where, "c.created_at>=?"), append(args, query.From.UTC())
+	}
+	if !query.To.IsZero() {
+		where, args = append(where, "c.created_at<=?"), append(args, query.To.UTC())
+	}
+	clause := strings.Join(where, " AND ")
+	var total int
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM bkn_trace_conversations c WHERE "+clause, args...).Scan(&total); err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("count conversation summary identities: %w", err)
+	}
+
+	pageArgs := append([]any{}, args...)
+	if query.AfterStartedAt != "" && query.AfterID != "" {
+		startedAt, err := time.Parse(time.RFC3339Nano, query.AfterStartedAt)
+		if err != nil {
+			return isessionstore.SummaryIdentityPage{}, fmt.Errorf("parse conversation summary cursor: %w", err)
+		}
+		clause += " AND (c.created_at<? OR (c.created_at=? AND c.conversation_id>?))"
+		pageArgs = append(pageArgs, startedAt.UTC(), startedAt.UTC(), query.AfterID)
+	}
+	limit := normalizeSummaryPageLimit(query.Limit)
+	pageArgs = append(pageArgs, limit+1, normalizeSummaryPageOffset(query.Offset))
+	rows, err := s.db.QueryContext(ctx, `SELECT c.conversation_id, c.created_at
+		FROM bkn_trace_conversations c WHERE `+clause+`
+		ORDER BY c.created_at DESC, c.conversation_id ASC LIMIT ? OFFSET ?`, pageArgs...)
+	if err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("list conversation summary identities: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	entries, err := scanSummaryIdentities(rows, limit)
+	if err != nil {
+		return isessionstore.SummaryIdentityPage{}, fmt.Errorf("scan conversation summary identities: %w", err)
+	}
+	return isessionstore.SummaryIdentityPage{Entries: entries.values, Total: total, HasMore: entries.hasMore}, nil
+}
+
+func summaryOwnerWhere(alias string, query isessionstore.SummaryPageQuery) ([]string, []any) {
+	scope := query.Scope
+	domain := scope.BusinessDomain
+	where := make([]string, 0, 4)
+	args := make([]any, 0, 8)
+	if scope.TenantID != "" {
+		where, args = append(where, alias+".tenant_id=?"), append(args, scope.TenantID)
+	}
+	if domain != "" {
+		where, args = append(where, alias+".business_domain_id=?"), append(args, domain)
+	}
+	if scope.AccessProfile == nil {
+		where = append(where, alias+".effective_subject_type=?", alias+".effective_subject_id=?")
+		args = append(args, scope.AccountType, scope.AccountID)
+		return where, args
+	}
+	profile := *scope.AccessProfile
+	if evidencevo.HasTenantWideTraceAccess(profile) {
+		return where, args
+	}
+	owner := make([]string, 0, 2)
+	if profile.EffectiveSubjectID != "" {
+		owner, args = append(owner, alias+".effective_subject_id=?"), append(args, profile.EffectiveSubjectID)
+	}
+	if profile.ApplicationPrincipalID != "" {
+		owner, args = append(owner, alias+".application_principal_id=?"), append(args, profile.ApplicationPrincipalID)
+	}
+	if len(owner) > 0 {
+		where = append(where, "("+strings.Join(owner, " OR ")+")")
+	} else {
+		where = append(where, "1=0")
+	}
+	return where, args
+}
+
+type scannedSummaryIdentities struct {
+	values  []isessionstore.SummaryIdentity
+	hasMore bool
+}
+
+func scanSummaryIdentities(rows *sql.Rows, limit int) (scannedSummaryIdentities, error) {
+	values := make([]isessionstore.SummaryIdentity, 0, limit+1)
+	for rows.Next() {
+		var id string
+		var startedAt time.Time
+		if err := rows.Scan(&id, &startedAt); err != nil {
+			return scannedSummaryIdentities{}, err
+		}
+		values = append(values, isessionstore.SummaryIdentity{ID: id, StartedAt: startedAt.UTC().Format(time.RFC3339Nano)})
+	}
+	if err := rows.Err(); err != nil {
+		return scannedSummaryIdentities{}, err
+	}
+	hasMore := len(values) > limit
+	if hasMore {
+		values = values[:limit]
+	}
+	return scannedSummaryIdentities{values: values, hasMore: hasMore}, nil
+}
+
+func normalizeSummaryPageLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	return limit
+}
+
+func normalizeSummaryPageOffset(offset int) int {
+	if offset < 0 {
+		return 0
+	}
+	return offset
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page_test.go
@@ -1,0 +1,22 @@
+package sessionstore
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+)
+
+func TestSummaryOwnerWherePreservesLegacySubjectBoundary(t *testing.T) {
+	where, args := summaryOwnerWhere("r", isessionstore.SummaryPageQuery{Scope: evidencevo.QueryScope{
+		TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "subject-1", AccountType: "service",
+	}, BusinessDomain: "other-domain"})
+	wantWhere := []string{
+		"r.tenant_id=?", "r.business_domain_id=?", "r.effective_subject_type=?", "r.effective_subject_id=?",
+	}
+	wantArgs := []any{"tenant-1", "domain-1", "service", "subject-1"}
+	if !reflect.DeepEqual(where, wantWhere) || !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("where=%v args=%v", where, args)
+	}
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/summary_page_test.go
@@ -2,7 +2,9 @@ package sessionstore
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
@@ -18,5 +20,31 @@ func TestSummaryOwnerWherePreservesLegacySubjectBoundary(t *testing.T) {
 	wantArgs := []any{"tenant-1", "domain-1", "service", "subject-1"}
 	if !reflect.DeepEqual(where, wantWhere) || !reflect.DeepEqual(args, wantArgs) {
 		t.Fatalf("where=%v args=%v", where, args)
+	}
+}
+
+func TestConversationSummaryReceiptExistsExcludesPendingAndUsesReceiptTime(t *testing.T) {
+	from := time.Date(2026, 8, 19, 8, 30, 0, 0, time.UTC)
+	to := time.Date(2026, 8, 19, 9, 30, 0, 0, time.UTC)
+	clause, args := conversationSummaryReceiptExists(isessionstore.SummaryPageQuery{From: from, To: to})
+	for _, required := range []string{
+		"r.trace_id IS NOT NULL", "r.trace_id<>''", "r.request_id IS NOT NULL", "r.request_id<>''",
+		"r.issued_at>=?", "r.issued_at<=?",
+	} {
+		if !strings.Contains(clause, required) {
+			t.Fatalf("receipt predicate is missing %q: %s", required, clause)
+		}
+	}
+	if strings.Contains(clause, "c.created_at") || !reflect.DeepEqual(args, []any{from, to}) {
+		t.Fatalf("clause=%s args=%v", clause, args)
+	}
+}
+
+func TestUsableSummaryReceiptRequiresProjectedRequestAndTraceIdentity(t *testing.T) {
+	want := []string{
+		"r.trace_id IS NOT NULL", "r.trace_id<>''", "r.request_id IS NOT NULL", "r.request_id<>''",
+	}
+	if got := usableSummaryReceiptPredicates("r"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("predicates=%v", got)
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -14,6 +14,7 @@ import (
 )
 
 const maxProjectionDocuments = 10000
+const maxReceiptsPerSelectedIdentity = 20
 
 type Source struct {
 	client    *opensearch.Client
@@ -79,6 +80,25 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 	if err != nil {
 		return nil, nil, false, err
 	}
+	if hasBatchIdentitySelector(query) {
+		result := make([]receiptDocument, 0, len(candidates))
+		interactionSet := make(map[string]struct{})
+		for _, receipt := range candidates {
+			if !receiptMatchesScope(receipt, query.Scope) || !matchesReceiptQuery(receipt, query) {
+				continue
+			}
+			result = append(result, receipt)
+			if receipt.InteractionID != "" {
+				interactionSet[receipt.InteractionID] = struct{}{}
+			}
+		}
+		interactions := make([]string, 0, len(interactionSet))
+		for interactionID := range interactionSet {
+			interactions = append(interactions, interactionID)
+		}
+		sort.Strings(interactions)
+		return result, interactions, truncated, nil
+	}
 	interactionIDs := receiptInteractionIDs(candidates)
 	interactionReceipts, interactionTruncated, err := s.loadInteractionReceipts(ctx, query, interactionIDs)
 	if err != nil {
@@ -135,6 +155,12 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 			must = append(must, exactKeywordQuery(field, value))
 		}
 	}
+	if len(query.TraceIDs) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"trace_id.keyword": query.TraceIDs}})
+	}
+	if len(query.ConversationIDs) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"conversation_id.keyword": query.ConversationIDs}})
+	}
 	if applyScopeCandidates {
 		must = append(must, receiptScopeCandidates(query.Scope)...)
 	}
@@ -148,11 +174,24 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 		}
 		must = append(must, map[string]any{"range": map[string]any{"issued_at": bounds}})
 	}
-	body, err := json.Marshal(map[string]any{
+	queryBody := map[string]any{
 		"size":  size,
 		"query": map[string]any{"bool": map[string]any{"must": must}},
 		"sort":  []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
-	})
+	}
+	innerHitName := ""
+	if field, identityCount := batchIdentityCollapse(query); identityCount > 1 {
+		innerHitName = "selected_receipts"
+		queryBody["size"] = identityCount
+		queryBody["collapse"] = map[string]any{
+			"field": field,
+			"inner_hits": map[string]any{
+				"name": innerHitName, "size": maxReceiptsPerSelectedIdentity,
+				"sort": []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
+			},
+		}
+	}
+	body, err := json.Marshal(queryBody)
 	if err != nil {
 		return nil, false, err
 	}
@@ -163,7 +202,17 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 	var response struct {
 		Hits struct {
 			Hits []struct {
-				Source receiptDocument `json:"_source"`
+				Source    receiptDocument `json:"_source"`
+				InnerHits map[string]struct {
+					Hits struct {
+						Total struct {
+							Value int `json:"value"`
+						} `json:"total"`
+						Hits []struct {
+							Source receiptDocument `json:"_source"`
+						} `json:"hits"`
+					} `json:"hits"`
+				} `json:"inner_hits"`
 			} `json:"hits"`
 		} `json:"hits"`
 	}
@@ -171,8 +220,22 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 		return nil, false, fmt.Errorf("decode Core receipt projection: %w", err)
 	}
 	result := make([]receiptDocument, 0, len(response.Hits.Hits))
+	truncated := false
 	for _, hit := range response.Hits.Hits {
+		if innerHitName != "" {
+			inner := hit.InnerHits[innerHitName].Hits
+			for _, innerHit := range inner.Hits {
+				result = append(result, innerHit.Source)
+			}
+			if inner.Total.Value > len(inner.Hits) {
+				truncated = true
+			}
+			continue
+		}
 		result = append(result, hit.Source)
+	}
+	if innerHitName != "" {
+		return result, truncated, nil
 	}
 	return result, len(response.Hits.Hits) >= size, nil
 }
@@ -192,6 +255,12 @@ func (s *Source) loadInteractionReceipts(ctx context.Context, query iprojections
 
 func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
 	size := maxProjectionDocuments
+	if query.Limit > 0 && query.Limit < size {
+		// Keep the follow-up expansion within the same caller-owned candidate
+		// budget as the initial receipt search.  A list request must never turn
+		// a page-sized candidate query into a fixed 10k OpenSearch read.
+		size = query.Limit + 1
+	}
 	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
 	for field, value := range map[string]string{
 		"owner.tenant_id":          query.Scope.TenantID,
@@ -232,7 +301,22 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 }
 
 func hasExactReceiptSelector(query iprojectionsource.Query) bool {
-	return query.RequestID != "" || query.TraceID != "" || query.InteractionID != ""
+	return query.RequestID != "" || query.TraceID != "" || query.InteractionID != "" ||
+		len(query.TraceIDs) > 0 || len(query.ConversationIDs) > 0
+}
+
+func hasBatchIdentitySelector(query iprojectionsource.Query) bool {
+	return len(query.TraceIDs) > 0 || len(query.ConversationIDs) > 0
+}
+
+func batchIdentityCollapse(query iprojectionsource.Query) (string, int) {
+	if len(query.TraceIDs) > 0 {
+		return "trace_id.keyword", len(query.TraceIDs)
+	}
+	if len(query.ConversationIDs) > 0 {
+		return "conversation_id.keyword", len(query.ConversationIDs)
+	}
+	return "", 0
 }
 
 func receiptInteractionIDs(receipts []receiptDocument) []string {
@@ -290,6 +374,8 @@ func interactionMatchesScope(receipts []receiptDocument, scope evidencevo.QueryS
 func matchesReceiptQuery(receipt receiptDocument, query iprojectionsource.Query) bool {
 	if query.RequestID != "" && receipt.RequestID != query.RequestID ||
 		query.TraceID != "" && receipt.TraceID != query.TraceID ||
+		len(query.TraceIDs) > 0 && !containsProjectionID(query.TraceIDs, receipt.TraceID) ||
+		len(query.ConversationIDs) > 0 && !containsProjectionID(query.ConversationIDs, receipt.ConversationID) ||
 		query.InteractionID != "" && receipt.InteractionID != query.InteractionID ||
 		query.BusinessDomain != "" && receipt.Owner.BusinessDomainID != query.BusinessDomain {
 		return false
@@ -303,6 +389,15 @@ func matchesReceiptQuery(receipt receiptDocument, query iprojectionsource.Query)
 	}
 	return (query.From.IsZero() || !issuedAt.Before(query.From)) &&
 		(query.To.IsZero() || !issuedAt.After(query.To))
+}
+
+func containsProjectionID(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func exactKeywordQuery(field string, value string) map[string]any {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -144,6 +144,12 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 		size = query.Limit + 1
 	}
 	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
+	if hasBatchIdentitySelector(query) {
+		must = append(must,
+			map[string]any{"exists": map[string]any{"field": "trace_id"}},
+			map[string]any{"exists": map[string]any{"field": "request_id"}},
+		)
+	}
 	for field, value := range map[string]string{
 		"owner.tenant_id":          query.Scope.TenantID,
 		"owner.business_domain_id": firstNonEmpty(query.BusinessDomain, query.Scope.BusinessDomain),

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -82,6 +82,11 @@ func TestSourceCollapsesBatchCandidatesPerSelectedTrace(t *testing.T) {
 			!strings.Contains(query, `"size":20`) {
 			t.Fatalf("batch query must reserve an inner receipt budget per trace: %s", query)
 		}
+		for _, field := range []string{`"field":"trace_id"`, `"field":"request_id"`} {
+			if !strings.Contains(query, field) {
+				t.Fatalf("batch query must exclude pending receipts without %s: %s", field, query)
+			}
+		}
 		_, _ = io.WriteString(w, `{"hits":{"hits":[
 			{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":25},"hits":[{"_source":{"receipt_id":"receipt-heavy","owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"user-1"},"trace_id":"trace-heavy","conversation_id":"conv-heavy","interaction_id":"interaction-heavy","request_id":"request-heavy","issued_at":"2026-08-19T09:00:00Z"}}]}}}},
 			{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{"receipt_id":"receipt-next","owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"user-1"},"trace_id":"trace-next","conversation_id":"conv-next","interaction_id":"interaction-next","request_id":"request-next","issued_at":"2026-08-19T08:59:00Z"}}]}}}}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -50,6 +50,90 @@ func TestSourceLimitsReceiptCandidatesToRequestedLimitPlusLookahead(t *testing.T
 	}
 }
 
+func TestSourcePushesSelectedTraceAndConversationIDs(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		for _, expected := range []string{`"trace_id.keyword":["trace-1","trace-2"]`, `"conversation_id.keyword":["conv-1","conv-2"]`} {
+			if !strings.Contains(query, expected) {
+				t.Fatalf("missing %s in %s", expected, query)
+			}
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[]}}`)
+	}))
+	t.Cleanup(server.Close)
+	source := opensearchcoreprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil)
+	_, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{TenantID: "tenant-1"}, Limit: 20,
+		TraceIDs: []string{"trace-1", "trace-2"}, ConversationIDs: []string{"conv-1", "conv-2"},
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+}
+
+func TestSourceCollapsesBatchCandidatesPerSelectedTrace(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		if !strings.Contains(query, `"collapse":{"field":"trace_id.keyword"`) ||
+			!strings.Contains(query, `"size":20`) {
+			t.Fatalf("batch query must reserve an inner receipt budget per trace: %s", query)
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[
+			{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":25},"hits":[{"_source":{"receipt_id":"receipt-heavy","owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"user-1"},"trace_id":"trace-heavy","conversation_id":"conv-heavy","interaction_id":"interaction-heavy","request_id":"request-heavy","issued_at":"2026-08-19T09:00:00Z"}}]}}}},
+			{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{"receipt_id":"receipt-next","owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1","effective_subject_type":"user","effective_subject_id":"user-1"},"trace_id":"trace-next","conversation_id":"conv-next","interaction_id":"interaction-next","request_id":"request-next","issued_at":"2026-08-19T08:59:00Z"}}]}}}}
+		]}}`)
+	}))
+	t.Cleanup(server.Close)
+	source := opensearchcoreprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil)
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope:    evidencevo.QueryScope{TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user"},
+		TraceIDs: []string{"trace-heavy", "trace-next"}, Limit: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Traces) != 2 || !result.Truncated {
+		t.Fatalf("a heavy trace must not starve the next selected identity: %+v", result)
+	}
+}
+
+func TestSourceLimitsInteractionExpansionToCandidateBudget(t *testing.T) {
+	t.Parallel()
+
+	searches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		searches++
+		var query map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&query); err != nil {
+			t.Fatalf("decode query: %v", err)
+		}
+		if size, ok := query["size"].(float64); !ok || size != 21 {
+			t.Fatalf("query %d must be bounded by limit plus lookahead, got %#v", searches, query["size"])
+		}
+		if searches == 1 {
+			_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{"receipt_id":"rcpt-1","interaction_id":"int-1","owner":{"tenant_id":"tenant-1","business_domain_id":"domain-1"}}}]}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"hits":{"hits":[]}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	source := opensearchcoreprojection.New(opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", nil)
+	if _, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{TenantID: "tenant-1", BusinessDomain: "domain-1", AccountID: "user-1", AccountType: "user"},
+		Limit: 20,
+	}); err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if searches != 2 {
+		t.Fatalf("expected candidate and bounded interaction expansion queries, got %d", searches)
+	}
+}
+
 func TestSourceBuildsAuthorizedExecutionProjectionFromCoreReceiptsAndArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -21,7 +21,18 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 	if err != nil {
 		return iprojectionsource.Result{}, err
 	}
-	artifacts, artifactTruncated, err := s.listArtifactProjection(ctx, query)
+	artifactQuery := query
+	if len(artifactQuery.AuthorizedInteractionIDs) > 0 {
+		artifactQuery.ConversationIDs = nil
+		artifactQuery.TraceIDs = nil
+	} else if len(artifactQuery.ConversationIDs) > 0 && len(artifactQuery.TraceIDs) == 0 {
+		artifactQuery.TraceIDs = projectionTraceIDs(traces)
+		artifactQuery.ConversationIDs = nil
+		if len(artifactQuery.TraceIDs) == 0 {
+			return iprojectionsource.Result{Traces: traces, Artifacts: []evidencevo.EvidenceArtifact{}, Truncated: evidenceTruncated}, nil
+		}
+	}
+	artifacts, artifactTruncated, err := s.listArtifactProjection(ctx, artifactQuery)
 	if err != nil {
 		return iprojectionsource.Result{}, err
 	}
@@ -79,6 +90,9 @@ func (s *Store) listEvidenceProjectionPage(ctx context.Context, query iprojectio
 		},
 	})
 	must = appendProjectionIdentityFilters(must, query)
+	if len(query.ConversationIDs) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"bkn.conversation.id": query.ConversationIDs}})
+	}
 	must = appendEvidenceTimeFilter(must, query)
 	queryBody := map[string]any{
 		"size":  size,
@@ -301,7 +315,26 @@ func appendProjectionIdentityFilters(must []map[string]any, query iprojectionsou
 			must = append(must, map[string]any{"bool": exactTermQuery(item.field, item.value)})
 		}
 	}
+	if len(query.TraceIDs) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"trace_id": query.TraceIDs}})
+	}
 	return must
+}
+
+func projectionTraceIDs(traces []evidencevo.NormalizedTrace) []string {
+	ids := make([]string, 0, len(traces))
+	seen := make(map[string]struct{}, len(traces))
+	for _, trace := range traces {
+		if trace.TraceID == "" {
+			continue
+		}
+		if _, found := seen[trace.TraceID]; found {
+			continue
+		}
+		seen[trace.TraceID] = struct{}{}
+		ids = append(ids, trace.TraceID)
+	}
+	return ids
 }
 
 func appendEvidenceTimeFilter(must []map[string]any, query iprojectionsource.Query) []map[string]any {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
@@ -396,6 +396,92 @@ func TestOpenSearchProjectionSourceStopsAtScanCapAndMarksTruncated(t *testing.T)
 	}
 }
 
+func TestProjectionSourceExpandsConversationArtifactsBySelectedTraceIDs(t *testing.T) {
+	var evidenceQuery, artifactQuery string
+	trace := normalizedTrace()
+	trace.TraceID = "trace-selected"
+	trace.ConversationID = "conversation-selected"
+	document := toDocument(trace, mustTime(t, "2026-08-19T09:00:00Z"))
+	document.Aggregate = true
+	hit, _ := json.Marshal(map[string]any{"hits": map[string]any{"hits": []any{
+		map[string]any{"_id": document.DocumentID, "_source": document, "sort": []any{document.DocumentID}},
+	}}})
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPut && (r.URL.Path == "/bkn-trace-evidence-test" || r.URL.Path == "/bkn-trace-evidence-test-artifacts"):
+			return jsonResponse(`{"acknowledged":true}`), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test/_search":
+			body, _ := io.ReadAll(r.Body)
+			evidenceQuery = string(body)
+			return jsonResponse(string(hit)), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test-artifacts/_search":
+			body, _ := io.ReadAll(r.Body)
+			artifactQuery = string(body)
+			return jsonResponse(`{"hits":{"hits":[]}}`), nil
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+	store := New(client, "bkn-trace-evidence-test")
+	_, err := store.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			TenantID: trace.TenantID, BusinessDomain: trace.BusinessDomain,
+			AccountID: trace.AccountID, AccountType: trace.AccountType,
+		},
+		ConversationIDs: []string{trace.ConversationID}, Limit: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(evidenceQuery, `"bkn.conversation.id":["conversation-selected"]`) {
+		t.Fatalf("evidence query must select the requested conversation: %s", evidenceQuery)
+	}
+	if !strings.Contains(artifactQuery, `"trace_id":["trace-selected"]`) {
+		t.Fatalf("artifact query must use trace IDs resolved from the conversation page: %s", artifactQuery)
+	}
+	if strings.Contains(artifactQuery, "bkn.conversation.id") {
+		t.Fatalf("artifact mapping has no conversation field: %s", artifactQuery)
+	}
+}
+
+func TestProjectionSourceUsesAuthorizedInteractionsWhenConversationEvidenceIsMissing(t *testing.T) {
+	var artifactQuery string
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPut && (r.URL.Path == "/bkn-trace-evidence-test" || r.URL.Path == "/bkn-trace-evidence-test-artifacts"):
+			return jsonResponse(`{"acknowledged":true}`), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test/_search":
+			return jsonResponse(`{"hits":{"hits":[]}}`), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test-artifacts/_search":
+			body, _ := io.ReadAll(r.Body)
+			artifactQuery = string(body)
+			return jsonResponse(`{"hits":{"hits":[]}}`), nil
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+	store := New(client, "bkn-trace-evidence-test")
+	_, err := store.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope: evidencevo.QueryScope{
+			TenantID: "tenant_index", BusinessDomain: "bd_index", AccountID: "acct_index", AccountType: "app",
+		},
+		ConversationIDs:          []string{"conversation-degraded"},
+		AuthorizedInteractionIDs: []string{"interaction-authorized"},
+		Limit:                    20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(artifactQuery, `"interaction_id":["interaction-authorized"]`) {
+		t.Fatalf("degraded conversation must keep the Core-authorized artifact handoff: %s", artifactQuery)
+	}
+	if strings.Contains(artifactQuery, "bkn.conversation.id") || strings.Contains(artifactQuery, `"trace_id"`) {
+		t.Fatalf("authorized interaction lookup must not add unavailable conversation/trace fields: %s", artifactQuery)
+	}
+}
+
 func TestOwnershipMustSkipsAccountFiltersOnlyForExplicitTechnicalView(t *testing.T) {
 	profile := &evidencevo.AccessProfile{
 		TenantID: "tenant_index", BusinessDomain: "bd_index", AccountActive: true, TenantActive: true,

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -90,6 +90,16 @@ func (tx memoryTransaction) PeekConversation(conversationID string) (sessionvo.C
 	return tx.FindConversation(conversationID)
 }
 
+func (tx memoryTransaction) ListConversationsByIDs(conversationIDs []string) map[string]sessionvo.Conversation {
+	result := make(map[string]sessionvo.Conversation, len(conversationIDs))
+	for _, conversationID := range conversationIDs {
+		if conversation, found := tx.s.conversations[conversationID]; found {
+			result[conversationID] = conversation
+		}
+	}
+	return result
+}
+
 func (tx memoryTransaction) FindIdempotency(
 	scope string,
 	owner sessionvo.Owner,

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -169,6 +169,16 @@ func (tx memoryTransaction) PeekInteraction(interactionID string) (sessionvo.Int
 	return tx.FindInteraction(interactionID)
 }
 
+func (tx memoryTransaction) ListInteractionsByIDs(interactionIDs []string) map[string]sessionvo.Interaction {
+	result := make(map[string]sessionvo.Interaction, len(interactionIDs))
+	for _, interactionID := range interactionIDs {
+		if interaction, found := tx.s.interactions[interactionID]; found {
+			result[interactionID] = interaction
+		}
+	}
+	return result
+}
+
 func (tx memoryTransaction) ListInteractions(conversationID string) []sessionvo.Interaction {
 	result := make([]sessionvo.Interaction, 0)
 	for _, interaction := range tx.s.interactions {
@@ -353,6 +363,16 @@ func (tx memoryTransaction) PeekOperation(operationID string) (sessionvo.Operati
 	return tx.FindOperation(operationID)
 }
 
+func (tx memoryTransaction) ListOperationsByIDs(operationIDs []string) map[string]sessionvo.Operation {
+	result := make(map[string]sessionvo.Operation, len(operationIDs))
+	for _, operationID := range operationIDs {
+		if operation, found := tx.s.operations[operationID]; found {
+			result[operationID] = operation
+		}
+	}
+	return result
+}
+
 func (tx memoryTransaction) ListOperations(interactionID string) []sessionvo.Operation {
 	var result []sessionvo.Operation
 	for _, operation := range tx.s.operations {
@@ -534,6 +554,25 @@ func (tx memoryTransaction) ListAssemblyRevisions(interactionID string) []sessio
 		}
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].RevisionNo < result[j].RevisionNo })
+	return result
+}
+
+func (tx memoryTransaction) ListAssemblyRevisionsByInteractionIDs(interactionIDs []string) map[string][]sessionvo.AssemblyRevision {
+	requested := make(map[string]struct{}, len(interactionIDs))
+	for _, interactionID := range interactionIDs {
+		if interactionID != "" {
+			requested[interactionID] = struct{}{}
+		}
+	}
+	result := make(map[string][]sessionvo.AssemblyRevision, len(requested))
+	for _, revision := range tx.s.revisions {
+		if _, found := requested[revision.InteractionID]; found {
+			result[revision.InteractionID] = append(result[revision.InteractionID], revision)
+		}
+	}
+	for interactionID := range result {
+		sort.Slice(result[interactionID], func(i, j int) bool { return result[interactionID][i].RevisionNo < result[interactionID][j].RevisionNo })
+	}
 	return result
 }
 

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_summary_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/trace_summary_handler.go
@@ -133,5 +133,9 @@ func writeSummaryQueryError(w http.ResponseWriter, r *http.Request, err error) {
 		writeJSON(w, r, http.StatusBadRequest, rdto.ErrorResponse{Code: "INVALID_ARGUMENT", Message: "cursor is invalid"})
 		return
 	}
+	if errors.Is(err, evidencesvc.ErrSummaryProjectionLag) {
+		writeJSON(w, r, http.StatusServiceUnavailable, rdto.ErrorResponse{Code: "PROJECTION_LAG", Message: "execution summary projection is catching up; retry the same page"})
+		return
+	}
 	writeJSON(w, r, http.StatusInternalServerError, rdto.ErrorResponse{Code: "QUERY_FAILED", Message: "failed to query execution summaries"})
 }

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
@@ -8,14 +8,16 @@ import (
 )
 
 type Query struct {
-	Scope          evidencevo.QueryScope
-	From           time.Time
-	To             time.Time
-	BusinessDomain string
-	Status         string
-	RequestID      string
-	TraceID        string
-	InteractionID  string
+	Scope           evidencevo.QueryScope
+	From            time.Time
+	To              time.Time
+	BusinessDomain  string
+	Status          string
+	RequestID       string
+	TraceID         string
+	TraceIDs        []string
+	ConversationIDs []string
+	InteractionID   string
 	// AuthorizedInteractionIDs is an internal handoff from the Core projection.
 	// It carries an Interaction-level authorization decision to its artifact reader.
 	AuthorizedInteractionIDs []string

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
 )
 
@@ -20,6 +21,7 @@ type Transaction interface {
 	FindActiveInteraction(conversationID string) (sessionvo.Interaction, bool)
 	FindInteractionByStartKey(conversationID, idempotencyKey string) (sessionvo.Interaction, bool)
 	PeekInteraction(interactionID string) (sessionvo.Interaction, bool)
+	ListInteractionsByIDs(interactionIDs []string) map[string]sessionvo.Interaction
 	FindInteraction(interactionID string) (sessionvo.Interaction, bool)
 	ListInteractions(conversationID string) []sessionvo.Interaction
 	ListInteractionPage(query InteractionPageQuery) InteractionPage
@@ -27,6 +29,7 @@ type Transaction interface {
 	SaveInteraction(interaction sessionvo.Interaction)
 	FindOperationByKey(interactionID, operationKey string) (sessionvo.Operation, bool)
 	PeekOperation(operationID string) (sessionvo.Operation, bool)
+	ListOperationsByIDs(operationIDs []string) map[string]sessionvo.Operation
 	FindOperation(operationID string) (sessionvo.Operation, bool)
 	ListOperations(interactionID string) []sessionvo.Operation
 	SaveOperation(operation sessionvo.Operation)
@@ -46,6 +49,7 @@ type Transaction interface {
 	ListExpiredActiveInteractions(limit int) []sessionvo.Interaction
 	ListAssemblyDueInteractions(limit int) []sessionvo.Interaction
 	ListAssemblyRevisions(interactionID string) []sessionvo.AssemblyRevision
+	ListAssemblyRevisionsByInteractionIDs(interactionIDs []string) map[string][]sessionvo.AssemblyRevision
 	SaveAssemblyRevision(revision sessionvo.AssemblyRevision)
 	AppendProjection(mutation sessionvo.ProjectionMutation)
 }
@@ -68,4 +72,28 @@ type InteractionPage struct {
 
 type Store interface {
 	WithinTransaction(ctx context.Context, fn func(Transaction) error) error
+}
+
+type SummaryPageQuery struct {
+	Scope          evidencevo.QueryScope
+	From           time.Time
+	To             time.Time
+	BusinessDomain string
+	Limit          int
+	Offset         int
+	AfterStartedAt string
+	AfterID        string
+}
+
+type SummaryIdentity struct{ ID, StartedAt string }
+type SummaryIdentityPage struct {
+	Entries []SummaryIdentity
+	Total   int
+	HasMore bool
+}
+
+type SummaryPageStore interface {
+	Store
+	ListTraceSummaryIdentities(context.Context, SummaryPageQuery) (SummaryIdentityPage, error)
+	ListConversationSummaryIdentities(context.Context, SummaryPageQuery) (SummaryIdentityPage, error)
 }

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -11,6 +11,7 @@ type Transaction interface {
 	Now() time.Time
 	FindCurrentConversation(owner sessionvo.Owner, externalKey string) (sessionvo.Conversation, bool)
 	PeekConversation(conversationID string) (sessionvo.Conversation, bool)
+	ListConversationsByIDs(conversationIDs []string) map[string]sessionvo.Conversation
 	FindConversation(conversationID string) (sessionvo.Conversation, bool)
 	FindIdempotency(scope string, owner sessionvo.Owner, externalKey, idempotencyKey string) (sessionvo.IdempotencyRecord, bool)
 	ListConversations(owner sessionvo.Owner, limit int) []sessionvo.Conversation

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
@@ -1,0 +1,37 @@
+# Trace 与 Conversation 列表分页设计
+
+## 目标
+
+让 Trace 与 Conversation 的列表查询只读取当前页所需候选，并只对当前页执行
+canonical 补全；查询成本不再随历史 receipt 总量线性增长。
+
+## 决策
+
+Projection 现有文档是 receipt 粒度，而 Conversation 列表是 receipt 的服务端聚合。
+因此不能把固定扫描上限直接改为 `page_size`：这样会截断同一 Conversation 的 receipt，
+破坏汇总字段和稳定 cursor。
+
+本次采用两个分页读模型：
+
+1. Trace 列表在 Projection 查询中使用 `(started_at, trace_id)` 的稳定 cursor / `search_after`
+   边界，查询 `page_size + 1` 个 Trace 候选。canonical identity、span 统计与 artifact
+   扩展只作用于返回页。
+2. Conversation 列表写入并读取 Conversation 粒度的列表投影，使用
+   `(started_at, conversation_id)` 分页。当前页之外不读取 receipt，也不做 canonical
+   session 补全。
+3. `total` 通过独立 count / aggregation 取得；不得以读取全部候选计算。
+
+## 契约与边界
+
+- 保持既有 HTTP 返回结构、过滤语义和 cursor 的不透明性。
+- cursor 必须绑定稳定排序字段，防止重复和遗漏。
+- 不改变 Projection rebuild、alias 切换、MariaDB migration、部署或清理逻辑。
+- 读模型只能包含已有 Projection 可安全重建的派生数据；原始事实仍以 Core / Evidence
+  为权威来源。
+
+## 验证
+
+- 单元及 adapter 测试断言 OpenSearch 查询携带 `search_after`、`size=page_size+1` 与
+  稳定 tiebreaker。
+- 服务测试断言页面外 Trace / Conversation 不触发 canonical 查询或 artifact 扩展。
+- 多页测试断言无重复、无遗漏、顺序稳定；count 与页面扫描解耦。

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
@@ -2,39 +2,28 @@
 
 ## 目标
 
-让 Trace 与 Conversation 的列表查询只读取当前页所需候选，并只对当前页执行
-canonical 补全；查询成本不再随历史 receipt 总量线性增长。
+让 Trace 与 Conversation 的普通列表查询先在 Core 生命周期账本选择当前页身份，随后只扩展该页的 Receipt、Evidence、Artifact 与 canonical 数据。查询不再固定加载 2,000 个 execution summary。
 
 ## 决策
 
-Projection 现有文档是 receipt 粒度，而 Conversation 列表是 receipt 的服务端聚合。
-因此不能把固定扫描上限直接改为 `page_size`：这样会截断同一 Conversation 的 receipt，
-破坏汇总字段和稳定 cursor。
-
-本次采用两个分页读模型：
-
-1. Trace 列表在 Projection 查询中使用 `(started_at, trace_id)` 的稳定 cursor / `search_after`
-   边界，查询 `page_size + 1` 个 Trace 候选。canonical identity、span 统计与 artifact
-   扩展只作用于返回页。
-2. Trace 列表读模型由 Receipt / 调用事实的权威变化派生为
-   `trace-list:<trace_id>` 快照；它不是新的事实来源。每次相关事实变化更新同一
-   Trace 快照，以便按 `(started_at, trace_id)` 查询。
-3. Conversation 列表写入并读取 Conversation 粒度的列表投影，使用
-   `(started_at, conversation_id)` 分页。当前页之外不读取 receipt，也不做 canonical
-   session 补全。
-4. `total` 通过独立 count / aggregation 取得；不得以读取全部候选计算。
+1. Trace 以 Core Receipt 为身份事实源，在 MariaDB 按 `(MIN(issued_at) desc, trace_id asc)` 使用 keyset cursor 选择 `page_size + 1` 个身份。Evidence 写入失败的 degraded execution 仍可进入列表。
+2. Conversation 以 canonical Conversation 与其 Core Receipt 的存在关系为身份事实源，按 `(created_at desc, conversation_id asc)` 使用相同的 keyset cursor。并发插入新记录不会改变后续 cursor 的边界。
+3. 身份选择完成后，将当前页 Trace ID 或 Conversation ID 通过 `terms` 一次性下推到 Core/Evidence Projection。Core Receipt 查询按身份 `collapse`，每个身份保留独立的受控 `inner_hits` 预算，避免单个长 Trace/Conversation 吃掉整页候选；canonical 补全仍对整页执行一次集合查询。
+4. Trace 使用独立 `COUNT(DISTINCT trace_id)`；Conversation 使用独立精确 `COUNT(*)`，不通过候选窗口或近似聚合计算总数。
+5. Conversation、Interaction、Assembly Revision、Operation 与 Trace source module 的 canonical 数据均采用集合查询，禁止页内逐 ID SQL。
 
 ## 契约与边界
 
-- 保持既有 HTTP 返回结构、过滤语义和 cursor 的不透明性。
-- cursor 必须绑定稳定排序字段，防止重复和遗漏。
-- 不改变 Projection rebuild、alias 切换、MariaDB migration、部署或清理逻辑。
-- 读模型只能包含已有 Projection 可安全重建的派生数据；原始事实仍以 Core / Evidence
-  为权威来源。
+- 保持既有 HTTP 返回结构、授权边界、排序方向和 cursor 不透明性。
+- 只有可完整下推到身份索引的普通列表条件启用 fast path；复杂内容筛选继续使用兼容路径，避免改变筛选语义。
+- MariaDB 身份已提交但 Core Projection 尚未刷新时返回 `BKN_TRACE_SUMMARY_PROJECTION_LAG`，不返回短页、不生成或推进 cursor；调用方重试后从同一边界读取，避免跨存储可见性造成永久漏项。
+- 身份查询复用现有 MariaDB 表和索引；不新增数据库表、OpenSearch mapping、Projection rebuild 文档或 alias 行为。
+- 不执行部署、索引重建、数据删除、Schema migration 或生产配置修改。
 
 ## 验证
 
-- 单元及 adapter 测试断言 OpenSearch 查询携带 `search_after`、`size=page_size+1` 与
-  稳定 tiebreaker。
-- 服务测试断言页面外 Trace / Conversation 不触发 canonical 查询或 artifact 扩展。
-- 多页测试断言无重复、无遗漏、顺序稳定；count 与页面扫描解耦。
+- 服务测试断言 Trace 与 Conversation cursor 下推 `(started_at, id)`，并保留独立精确 Total。
+- MariaDB adapter 使用精确 count 与 `page_size+1` keyset 查询；普通 page 参数仍兼容 offset，cursor 后续页不再增长 offset。
+- 服务测试断言只将当前页 ID 交给 Projection，并验证 Trace 与 Conversation cursor 能继续到下一页。
+- Core Projection 测试断言页内 Trace/Conversation IDs 使用 `terms` 批量下推和按身份 collapse；长 Trace 达到截断上限时，同页后续身份仍会返回。
+- Evidence Projection 测试断言 Conversation 先解析当页 Trace IDs，再按真实 `trace_id` 字段读取 Artifact，避免查询不存在的 Conversation mapping。

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
@@ -16,10 +16,13 @@ Projection 现有文档是 receipt 粒度，而 Conversation 列表是 receipt �
 1. Trace 列表在 Projection 查询中使用 `(started_at, trace_id)` 的稳定 cursor / `search_after`
    边界，查询 `page_size + 1` 个 Trace 候选。canonical identity、span 统计与 artifact
    扩展只作用于返回页。
-2. Conversation 列表写入并读取 Conversation 粒度的列表投影，使用
+2. Trace 列表读模型由 Receipt / 调用事实的权威变化派生为
+   `trace-list:<trace_id>` 快照；它不是新的事实来源。每次相关事实变化更新同一
+   Trace 快照，以便按 `(started_at, trace_id)` 查询。
+3. Conversation 列表写入并读取 Conversation 粒度的列表投影，使用
    `(started_at, conversation_id)` 分页。当前页之外不读取 receipt，也不做 canonical
    session 补全。
-3. `total` 通过独立 count / aggregation 取得；不得以读取全部候选计算。
+4. `total` 通过独立 count / aggregation 取得；不得以读取全部候选计算。
 
 ## 契约与边界
 

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-design.md
@@ -6,8 +6,8 @@
 
 ## 决策
 
-1. Trace 以 Core Receipt 为身份事实源，在 MariaDB 按 `(MIN(issued_at) desc, trace_id asc)` 使用 keyset cursor 选择 `page_size + 1` 个身份。Evidence 写入失败的 degraded execution 仍可进入列表。
-2. Conversation 以 canonical Conversation 与其 Core Receipt 的存在关系为身份事实源，按 `(created_at desc, conversation_id asc)` 使用相同的 keyset cursor。并发插入新记录不会改变后续 cursor 的边界。
+1. Trace 以具备 `trace_id`、`request_id` 的可投影 Core Receipt 为身份事实源，在 MariaDB 按 `(MIN(issued_at) desc, trace_id asc)` 使用 keyset cursor 选择 `page_size + 1` 个身份。Evidence 写入失败的 degraded execution 仍可进入列表。
+2. Conversation 以 canonical Conversation 与其可投影 Core Receipt（`trace_id`、`request_id` 均已产生）的存在关系为身份事实源，按 `(created_at desc, conversation_id asc)` 使用相同的 keyset cursor。pending/abandoned Receipt 不进入列表身份全集；`from/to` 仍作用于 Receipt `issued_at`，保持兼容路径语义。
 3. 身份选择完成后，将当前页 Trace ID 或 Conversation ID 通过 `terms` 一次性下推到 Core/Evidence Projection。Core Receipt 查询按身份 `collapse`，每个身份保留独立的受控 `inner_hits` 预算，避免单个长 Trace/Conversation 吃掉整页候选；canonical 补全仍对整页执行一次集合查询。
 4. Trace 使用独立 `COUNT(DISTINCT trace_id)`；Conversation 使用独立精确 `COUNT(*)`，不通过候选窗口或近似聚合计算总数。
 5. Conversation、Interaction、Assembly Revision、Operation 与 Trace source module 的 canonical 数据均采用集合查询，禁止页内逐 ID SQL。
@@ -15,7 +15,7 @@
 ## 契约与边界
 
 - 保持既有 HTTP 返回结构、授权边界、排序方向和 cursor 不透明性。
-- 只有可完整下推到身份索引的普通列表条件启用 fast path；复杂内容筛选继续使用兼容路径，避免改变筛选语义。
+- 只有可完整下推到身份索引的普通列表条件启用 fast path；复杂内容筛选继续使用兼容路径及原有 2,000 候选窗口，避免改变筛选语义或 Total。
 - MariaDB 身份已提交但 Core Projection 尚未刷新时返回 `BKN_TRACE_SUMMARY_PROJECTION_LAG`，不返回短页、不生成或推进 cursor；调用方重试后从同一边界读取，避免跨存储可见性造成永久漏项。
 - 身份查询复用现有 MariaDB 表和索引；不新增数据库表、OpenSearch mapping、Projection rebuild 文档或 alias 行为。
 - 不执行部署、索引重建、数据删除、Schema migration 或生产配置修改。

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
@@ -38,7 +38,7 @@
 
 **Step 2:** Run the adapter tests and verify failure before adding the read model.
 
-**Step 3:** Emit authoritative trace-list snapshots from the Core projection path and make the mapping expose the required keyword/date fields. Do not alter rebuild supervisor or alias-switch behavior.
+**Step 3:** Derive `trace-list:<trace_id>` snapshots from authoritative Receipt / call-fact changes and make the mapping expose the required keyword/date fields. Do not alter rebuild supervisor or alias-switch behavior.
 
 **Step 4:** Implement page query/count methods; only an OpenSearch `404`/transport error remains an adapter error, never an in-memory fallback scan.
 

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
@@ -1,80 +1,14 @@
 # Trace List Pagination Implementation Plan
 
-> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+**Goal:** Select Trace and Conversation identities from the canonical Core lifecycle ledger before expanding current-page projection details and canonical state.
 
-**Goal:** Page Trace and Conversation lists from projection read models, then enrich only the selected page.
+## Tasks
 
-**Architecture:** Reuse the existing `conversation:<id>` Core projection documents as the Conversation page boundary. Add a trace-list projection document with stable `(started_at, trace_id)` ordering, and extend the Projection source with cursor-aware page/count methods. The summary service performs receipt/artifact and canonical enrichment only for returned IDs.
+1. Add an optional summary identity page port over the existing lifecycle store.
+2. Implement Trace and Conversation keyset pagination plus independent exact totals in MariaDB.
+3. Add batch Trace/Conversation ID filters to Core and Evidence Projection sources.
+4. Route ordinary Trace/Conversation list calls through identity selection and page-local expansion while retaining the legacy path for non-pushable filters.
+5. Replace per-item canonical reads with batch Conversation, Interaction, Assembly Revision, Operation, and Trace source-module queries.
+6. Verify candidate bounds, stable cursor traversal, batch ID pushdown, module tests, vet, and diff hygiene before review.
 
-**Tech Stack:** Go, MariaDB projection outbox, OpenSearch `search_after`, existing BKN Trace summary service and adapter tests.
-
----
-
-### Task 1: Define cursor-aware list read contracts
-
-**Files:**
-- Modify: `src/port/driven/iprojectionsource/port.go`
-- Modify: `src/domain/valueobject/evidencevo/summary.go`
-- Test: `src/domain/service/evidencesvc/summary_service_test.go`
-
-**Step 1:** Write failing service tests that require a `page_size=20` query to request 21 list candidates, preserve the opaque cursor, and keep the exact total separate from candidate entries.
-
-**Step 2:** Run the focused tests and verify they fail because the source only exposes the 2,000-entry execution scan.
-
-**Step 3:** Add typed trace/conversation list query and page results containing IDs, sort tuple, next cursor and count metadata; keep receipt expansion out of the list-selection contract.
-
-**Step 4:** Run focused tests and commit the contract change.
-
-### Task 2: Produce and query stable Trace list projection documents
-
-**Files:**
-- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go`
-- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
-- Modify: `src/drivenadapter/httpaccess/opensearchprojection/sink.go`
-- Modify: `src/drivenadapter/httpaccess/opensearchcoreprojection/source.go`
-- Test: `src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
-
-**Step 1:** Write failing adapter tests for a trace-list query with `size=limit+1`, exact scope filters, sort on `started_at` then `trace_id`, and OpenSearch `search_after` on the next page.
-
-**Step 2:** Run the adapter tests and verify failure before adding the read model.
-
-**Step 3:** Derive `trace-list:<trace_id>` snapshots from authoritative Receipt / call-fact changes and make the mapping expose the required keyword/date fields. Do not alter rebuild supervisor or alias-switch behavior.
-
-**Step 4:** Implement page query/count methods; only an OpenSearch `404`/transport error remains an adapter error, never an in-memory fallback scan.
-
-**Step 5:** Run focused adapter tests and commit.
-
-### Task 3: Page Conversations from existing Conversation projection documents
-
-**Files:**
-- Modify: `src/drivenadapter/httpaccess/opensearchcoreprojection/source.go`
-- Modify: `src/domain/service/evidencesvc/summary.go`
-- Test: `src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
-- Test: `src/domain/service/evidencesvc/summary_service_test.go`
-
-**Step 1:** Write failing tests for sorted Conversation document selection using `(updated_at, conversation_id)` with cursor and a separate count.
-
-**Step 2:** Write a failing service test proving receipt/artifact expansion receives only selected Conversation IDs.
-
-**Step 3:** Add the query path over existing `conversation:<id>` documents and scoped receipt expansion for those IDs.
-
-**Step 4:** Replace the full `loadExecutionSummaries` Conversation path with list selection followed by page-local enrichment; preserve authorization and all existing filters.
-
-**Step 5:** Run focused tests and commit.
-
-### Task 4: Batch canonical enrichment and end-to-end pagination verification
-
-**Files:**
-- Modify: `src/port/driven/isessionstore/port.go`
-- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
-- Modify: `src/domain/service/evidencesvc/summary.go`
-- Test: `src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go`
-- Test: `src/domain/service/evidencesvc/summary_service_test.go`
-
-**Step 1:** Write failing tests proving a Trace/Conversation page performs set-based canonical lookup rather than one query per Trace/Conversation.
-
-**Step 2:** Implement batch session/call-fact lookup methods and replace page-local loops.
-
-**Step 3:** Add multi-page tests for stable ordering, no duplicate/missing IDs, and page-size-bounded candidate/canonical work.
-
-**Step 4:** Run `go test ./...`, `go vet ./...`, `git diff --check`, then commit and request review. Do not deploy, rebuild an index, or clean data.
+No deploy, index rebuild, cleanup, schema migration, or alias change belongs to this plan.

--- a/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
+++ b/docs/plans/2026-08-19-issue-1058-list-pagination-plan.md
@@ -1,0 +1,80 @@
+# Trace List Pagination Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Page Trace and Conversation lists from projection read models, then enrich only the selected page.
+
+**Architecture:** Reuse the existing `conversation:<id>` Core projection documents as the Conversation page boundary. Add a trace-list projection document with stable `(started_at, trace_id)` ordering, and extend the Projection source with cursor-aware page/count methods. The summary service performs receipt/artifact and canonical enrichment only for returned IDs.
+
+**Tech Stack:** Go, MariaDB projection outbox, OpenSearch `search_after`, existing BKN Trace summary service and adapter tests.
+
+---
+
+### Task 1: Define cursor-aware list read contracts
+
+**Files:**
+- Modify: `src/port/driven/iprojectionsource/port.go`
+- Modify: `src/domain/valueobject/evidencevo/summary.go`
+- Test: `src/domain/service/evidencesvc/summary_service_test.go`
+
+**Step 1:** Write failing service tests that require a `page_size=20` query to request 21 list candidates, preserve the opaque cursor, and keep the exact total separate from candidate entries.
+
+**Step 2:** Run the focused tests and verify they fail because the source only exposes the 2,000-entry execution scan.
+
+**Step 3:** Add typed trace/conversation list query and page results containing IDs, sort tuple, next cursor and count metadata; keep receipt expansion out of the list-selection contract.
+
+**Step 4:** Run focused tests and commit the contract change.
+
+### Task 2: Produce and query stable Trace list projection documents
+
+**Files:**
+- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/rebuild.go`
+- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
+- Modify: `src/drivenadapter/httpaccess/opensearchprojection/sink.go`
+- Modify: `src/drivenadapter/httpaccess/opensearchcoreprojection/source.go`
+- Test: `src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
+
+**Step 1:** Write failing adapter tests for a trace-list query with `size=limit+1`, exact scope filters, sort on `started_at` then `trace_id`, and OpenSearch `search_after` on the next page.
+
+**Step 2:** Run the adapter tests and verify failure before adding the read model.
+
+**Step 3:** Emit authoritative trace-list snapshots from the Core projection path and make the mapping expose the required keyword/date fields. Do not alter rebuild supervisor or alias-switch behavior.
+
+**Step 4:** Implement page query/count methods; only an OpenSearch `404`/transport error remains an adapter error, never an in-memory fallback scan.
+
+**Step 5:** Run focused adapter tests and commit.
+
+### Task 3: Page Conversations from existing Conversation projection documents
+
+**Files:**
+- Modify: `src/drivenadapter/httpaccess/opensearchcoreprojection/source.go`
+- Modify: `src/domain/service/evidencesvc/summary.go`
+- Test: `src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
+- Test: `src/domain/service/evidencesvc/summary_service_test.go`
+
+**Step 1:** Write failing tests for sorted Conversation document selection using `(updated_at, conversation_id)` with cursor and a separate count.
+
+**Step 2:** Write a failing service test proving receipt/artifact expansion receives only selected Conversation IDs.
+
+**Step 3:** Add the query path over existing `conversation:<id>` documents and scoped receipt expansion for those IDs.
+
+**Step 4:** Replace the full `loadExecutionSummaries` Conversation path with list selection followed by page-local enrichment; preserve authorization and all existing filters.
+
+**Step 5:** Run focused tests and commit.
+
+### Task 4: Batch canonical enrichment and end-to-end pagination verification
+
+**Files:**
+- Modify: `src/port/driven/isessionstore/port.go`
+- Modify: `src/drivenadapter/dbaccess/mariadb/sessionstore/store.go`
+- Modify: `src/domain/service/evidencesvc/summary.go`
+- Test: `src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go`
+- Test: `src/domain/service/evidencesvc/summary_service_test.go`
+
+**Step 1:** Write failing tests proving a Trace/Conversation page performs set-based canonical lookup rather than one query per Trace/Conversation.
+
+**Step 2:** Implement batch session/call-fact lookup methods and replace page-local loops.
+
+**Step 3:** Add multi-page tests for stable ordering, no duplicate/missing IDs, and page-size-bounded candidate/canonical work.
+
+**Step 4:** Run `go test ./...`, `go vet ./...`, `git diff --check`, then commit and request review. Do not deploy, rebuild an index, or clean data.


### PR DESCRIPTION
## What Changed

- [x] Page ordinary Trace and Conversation lists from exact Core lifecycle identities with stable keyset cursors and exact totals.
- [x] Batch current-page Projection expansion with per-identity `collapse/inner_hits` budgets, plus batch canonical MariaDB enrichment.
- [x] Preserve degraded Artifact reads and fail fast with retryable `PROJECTION_LAG` semantics before advancing a cursor.
- [x] Document the pagination design and implementation boundary.

---

## Why

- Related Issue: Closes #1058
- Related Feature: BKN Trace evidence chain
- Background: Trace and Conversation list endpoints scanned and enriched up to 2,000 execution summaries before selecting the requested page.

---

## How

- Key implementation points:
  - MariaDB supplies authorized Trace/Conversation identity pages, exact counts, and `(started_at, id)` keyset cursors.
  - Current-page IDs are pushed to Core/Evidence Projection in one batch; Core uses `terms + collapse/inner_hits` so one long execution cannot starve later page identities.
  - Conversation, Interaction, Assembly Revision, Operation, and Trace source-module canonical reads are set-based.
  - Projection lag returns HTTP 503 without entries or a next cursor, preventing permanent gaps during async refresh.
  - Complex/non-pushable filters retain the compatibility path and its historical scan window.
- Breaking changes (API, config, database, etc.): None. No schema, mapping, rebuild, alias, deployment, or cleanup change.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./...`
- `go vet ./...`
- `git diff --check`
- Added regressions for cursor handoff, per-identity candidate fairness, exact authorization predicates, degraded Artifact lookup, and Projection lag.

---

## Risk & Rollback

- Potential risks: MariaDB lifecycle identities can briefly lead OpenSearch during projection refresh; the endpoint returns retryable 503 instead of a short page.
- Rollback plan: Revert this PR to restore the compatibility list path. No data or schema rollback is required.

---

## Additional Notes

- Real MariaDB container coverage for the new keyset/count SQL remains a non-blocking follow-up; predicate and service behavior are covered in this PR.
