### PR TITLE
fix(bkn-agent): adopt Context Loader receipt evidence

### DIFF
--- a/docs/plans/2026-08-19-mcp-receipt-evidence.md
+++ b/docs/plans/2026-08-19-mcp-receipt-evidence.md
@@ -1,0 +1,73 @@
+# MCP Receipt Evidence Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Preserve Context Loader's authoritative MCP receipt evidence references so an internal bkn-agent Claim can cite retrieval provenance.
+
+**Architecture:** Extend the bkn-agent receipt normalizer to accept the MCP `bkn_receipt` envelope and register only its validated observed evidence references against the current tool operation. Keep Context Loader as the sole retrieval-fact producer; missing, failed, or malformed receipts produce no candidate source.
+
+**Tech Stack:** Python, pytest, bkn-agent evidence session state.
+
+---
+
+### Task 1: Demonstrate the missing MCP receipt adoption
+
+**Files:**
+- Modify: `infra/bkn-agent/app/test/test_evidence_reliability.py`
+- Test: `infra/bkn-agent/app/test/test_evidence_reliability.py`
+
+**Step 1: Write the failing test**
+
+Create a test that passes a successful `bkn_receipt` containing `observed_evidence_refs` to `record_fact_receipt`, then asserts the matching tool message exposes the event in `bkn-candidate-source-event-ids`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest -q app/test/test_evidence_reliability.py -k mcp_receipt`
+
+Expected: FAIL because `bkn_receipt` is not parsed.
+
+### Task 2: Adopt only authoritative completed MCP receipt references
+
+**Files:**
+- Modify: `infra/bkn-agent/app/evidence.py`
+- Test: `infra/bkn-agent/app/test/test_evidence_reliability.py`
+
+**Step 1: Write failing edge-case tests**
+
+Cover a failed/pending receipt and invalid references. Both must leave the candidate set empty.
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest -q app/test/test_evidence_reliability.py -k mcp_receipt`
+
+Expected: FAIL because receipt status and reference validation are not enforced.
+
+**Step 3: Write minimal implementation**
+
+Normalize `bkn_receipt` only when it is a completed durable receipt, validate every event id, and register each reference with the current operation and result context hash. Preserve existing header and toolbox receipt paths.
+
+**Step 4: Run focused tests**
+
+Run: `pytest -q app/test/test_evidence_reliability.py -k mcp_receipt`
+
+Expected: PASS.
+
+### Task 3: Verify regression boundaries
+
+**Files:**
+- Test: `infra/bkn-agent/app/test/test_evidence_reliability.py`
+- Test: `infra/bkn-agent/app/test/test_toolbox_tools.py`
+
+**Step 1: Run relevant suites**
+
+Run: `pytest -q app/test/test_evidence_reliability.py app/test/test_toolbox_tools.py`
+
+Expected: PASS.
+
+**Step 2: Run lint and the bkn-agent test target**
+
+Run the repository-supported bkn-agent checks from its module directory.
+
+**Step 3: Commit**
+
+Commit the focused implementation, tests, and this plan with a Conventional Commit message.

--- a/docs/plans/2026-08-19-mcp-receipt-evidence.md
+++ b/docs/plans/2026-08-19-mcp-receipt-evidence.md
@@ -71,3 +71,22 @@ Run the repository-supported bkn-agent checks from its module directory.
 **Step 3: Commit**
 
 Commit the focused implementation, tests, and this plan with a Conventional Commit message.
+
+### Task 4: Preserve the MCP result contract at the Context Loader boundary
+
+**Files:**
+- Modify: `infra/bkn-agent/app/core/context_loader.py`
+- Test: `infra/bkn-agent/app/test/test_context_loader.py`
+- Test: `infra/bkn-agent/app/test/test_limits_and_gates.py`
+
+The context-injection wrapper must retain `content_and_artifact`; otherwise
+LangChain stringifies the raw MCP tuple before the model sees it, while the
+evidence candidate hash is calculated from the content blocks. Exercise a
+bound Context Loader tool through `ainvoke` with a real MCP-style
+`(content, artifact)` result and assert the candidate is supplied to the model.
+
+Limit receipt admission to 100 distinct valid evidence event ids and normalize
+Context Loader `business_refs` into the local safe-reference schema before
+recording downstream facts. The receipt trust decision must use an internal
+wrapper capability token, not metadata that a third-party MCP server might
+eventually be able to supply.

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -48,6 +48,9 @@ logger = logging.getLogger("bkn-agent.context-loader")
 _LIFECYCLE_TOOLS = {"bkn_start_interaction", "bkn_finish_interaction"}
 
 _CONNECTION_NAME = "context_loader"
+# Metadata originating from an MCP server is not a trust boundary.  This token
+# is created only by _bind_context and checked by tools.instrument_tool_calls.
+_MCP_RECEIPT_TRUST_TOKEN = object()
 
 # The session for this execution. load_tools sets it while loading, and the
 # runner or graph takes the real ids out of it for evidence.begin_interaction so
@@ -174,7 +177,15 @@ def _bind_context(tool: Any, session: ContextLoaderSession) -> Any:
         name=tool.name,
         description=tool.description,
         args_schema=tool.args_schema,
-        metadata={**(getattr(tool, "metadata", None) or {}), "bkn_context_loader": True},
+        # Context Loader MCP tools return (content, artifact).  Keep that
+        # contract through the context-injection wrapper so LangChain emits the
+        # same ToolMessage content the evidence receipt was hashed against.
+        response_format=getattr(tool, "response_format", "content"),
+        metadata={
+            **(getattr(tool, "metadata", None) or {}),
+            "bkn_context_loader": True,
+            "bkn_context_loader_trust_token": _MCP_RECEIPT_TRUST_TOKEN,
+        },
     )
 
 

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -305,7 +305,10 @@ def instrument_tool_calls(tools: list[Any], account_id: str, account_type: str) 
             __inner=inner,
             __tool_name=tool_name,
             __tool_id=tool_id,
-            __trust_mcp_receipt=metadata.get("bkn_context_loader") is True,
+            __trust_mcp_receipt=(
+                metadata.get("bkn_context_loader_trust_token")
+                is context_loader._MCP_RECEIPT_TRUST_TOKEN
+            ),
             **kwargs,
         ):
             operation_id, parent_event_id = evidence.new_operation()

--- a/infra/bkn-agent/app/core/tools.py
+++ b/infra/bkn-agent/app/core/tools.py
@@ -16,6 +16,22 @@ from app.errors import bad_request
 logger = logging.getLogger("bkn-agent.tools")
 
 
+def _mcp_result_body_and_content(result: Any) -> tuple[dict[str, Any] | None, Any]:
+    """Extract MCP structured content while preserving the model-visible content."""
+    if isinstance(result, dict):
+        return result, result
+    if not isinstance(result, tuple) or len(result) != 2:
+        return None, result
+    content, artifact = result
+    if not isinstance(artifact, dict):
+        return None, content
+    for key in ("structured_content", "structuredContent"):
+        structured = artifact.get(key)
+        if isinstance(structured, dict):
+            return structured, content
+    return None, content
+
+
 def _context_loader_allowed_tools(tool_refs: list[dict]) -> set[str] | None:
     """Merge the allowlists of the Context Loader references.
 
@@ -285,7 +301,13 @@ def instrument_tool_calls(tools: list[Any], account_id: str, account_type: str) 
         tool_name = str(getattr(tool, "name", "tool"))
         tool_id = str(metadata.get("bkn_tool_id") or tool_name)
 
-        async def _traced(__inner=inner, __tool_name=tool_name, __tool_id=tool_id, **kwargs):
+        async def _traced(
+            __inner=inner,
+            __tool_name=tool_name,
+            __tool_id=tool_id,
+            __trust_mcp_receipt=metadata.get("bkn_context_loader") is True,
+            **kwargs,
+        ):
             operation_id, parent_event_id = evidence.new_operation()
             called = evidence.tool_called(
                 tool_id=__tool_id,
@@ -318,6 +340,7 @@ def instrument_tool_calls(tools: list[Any], account_id: str, account_type: str) 
                 raise
             finally:
                 observability.reset_operation_headers(header_token)
+            result_body, result_content = _mcp_result_body_and_content(result)
             result_text = result if isinstance(result, str) else str(result)
             observed = evidence.tool_result_observed(
                 tool_id=__tool_id,
@@ -333,8 +356,9 @@ def instrument_tool_calls(tools: list[Any], account_id: str, account_type: str) 
             )
             evidence.record_fact_receipt(
                 operation_id=operation_id,
-                body=result if isinstance(result, dict) else None,
-                context_hash=evidence.tool_message_context_hash(result),
+                body=result_body,
+                context_hash=evidence.tool_message_context_hash(result_content),
+                trust_mcp_receipt=__trust_mcp_receipt,
             )
             await evidence.submit_events([event for event in (called, observed) if event], account_id, account_type)
             return result

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -31,6 +31,7 @@ _REF_FIELDS = {
     "summary_hash",
 }
 _DERIVABLE_DOWNSTREAM_EVENTS = {"retrieval.completed"}
+_MAX_MCP_RECEIPT_EVIDENCE_REFS = 100
 
 
 class EvidenceSubmissionError(RuntimeError):
@@ -467,6 +468,38 @@ def _safe_refs(value: Any) -> list[dict[str, Any]]:
     return refs
 
 
+def _mcp_business_refs(value: Any) -> list[dict[str, Any]]:
+    """Map Context Loader receipt references into the agent's safe-ref shape.
+
+    Context Loader owns the receipt schema, whose business references describe
+    domain/version but not the local provenance fields required by evidence.
+    The mapping is deliberately narrow: no display text or unknown fields cross
+    the boundary into the agent event.
+    """
+    if not isinstance(value, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for item in value[:_MAX_MCP_RECEIPT_EVIDENCE_REFS]:
+        if not isinstance(item, dict):
+            continue
+        ref_id = item.get("ref_id")
+        ref_type = item.get("ref_type")
+        version = item.get("version")
+        if not all(isinstance(field, str) and field for field in (ref_id, ref_type)):
+            continue
+        normalized.append(
+            {
+                "ref_id": ref_id,
+                "ref_type": ref_type,
+                "source_system": "context-loader",
+                "validity": "observed",
+                "version_status": version if isinstance(version, str) and version else "unversioned",
+                "visibility": "visible",
+            }
+        )
+    return _safe_refs(normalized)
+
+
 def record_downstream_fact(
     *,
     event_id: str,
@@ -541,13 +574,20 @@ def record_fact_receipt(
     references = mcp_receipt.get("observed_evidence_refs")
     if not isinstance(references, list):
         return
+    business_refs = _mcp_business_refs(mcp_receipt.get("business_refs"))
+    accepted: set[str] = set()
     for reference in references:
-        if not isinstance(reference, str):
+        if (
+            len(accepted) >= _MAX_MCP_RECEIPT_EVIDENCE_REFS
+            or not _valid_id(reference)
+            or reference in accepted
+        ):
             continue
+        accepted.add(reference)
         record_downstream_fact(
             event_id=reference,
             operation_id=operation_id,
-            business_refs=mcp_receipt.get("business_refs"),
+            business_refs=business_refs,
             context_hash=context_hash,
         )
 

--- a/infra/bkn-agent/app/evidence.py
+++ b/infra/bkn-agent/app/evidence.py
@@ -494,6 +494,7 @@ def record_fact_receipt(
     body: Any = None,
     context_hash: str | None = None,
     expected_event_type: str | None = None,
+    trust_mcp_receipt: bool = False,
 ) -> None:
     normalized_headers = {
         str(key).lower(): value for key, value in (headers or {}).items()
@@ -519,15 +520,36 @@ def record_fact_receipt(
     )
     if not isinstance(event_id, str):
         event_id = _expected_downstream_event_id(expected_event_type, operation_id)
-    if not isinstance(event_id, str):
+    if isinstance(event_id, str):
+        record_downstream_fact(
+            event_id=event_id,
+            operation_id=operation_id,
+            evidence_refs=structured("evidence_refs", "bkn-fact-evidence-refs"),
+            business_refs=structured("business_refs", "bkn-fact-business-refs"),
+            context_hash=context_hash,
+        )
         return
-    record_downstream_fact(
-        event_id=event_id,
-        operation_id=operation_id,
-        evidence_refs=structured("evidence_refs", "bkn-fact-evidence-refs"),
-        business_refs=structured("business_refs", "bkn-fact-business-refs"),
-        context_hash=context_hash,
-    )
+
+    mcp_receipt = body.get("bkn_receipt") if isinstance(body, dict) else None
+    if not trust_mcp_receipt or not isinstance(mcp_receipt, dict):
+        return
+    if (
+        mcp_receipt.get("receipt_status") != "completed"
+        or mcp_receipt.get("evidence_durability") != "durable"
+    ):
+        return
+    references = mcp_receipt.get("observed_evidence_refs")
+    if not isinstance(references, list):
+        return
+    for reference in references:
+        if not isinstance(reference, str):
+            continue
+        record_downstream_fact(
+            event_id=reference,
+            operation_id=operation_id,
+            business_refs=mcp_receipt.get("business_refs"),
+            context_hash=context_hash,
+        )
 
 
 def _expected_downstream_event_id(

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -8,6 +8,7 @@
 import asyncio
 
 import pytest
+from langchain_core.tools import StructuredTool
 
 from app import auth
 from app.core import context_loader
@@ -93,6 +94,24 @@ def test_session_injects_bkn_context_and_hides_it(monkeypatch):
     assert business.calls == [
         {"kn_id": "kn-1", "bkn_context": {"conversation_id": "conv_real", "interaction_id": "int_real"}}
     ]
+
+
+def test_bound_context_loader_tool_preserves_mcp_artifact_response_format():
+    async def raw_call(**_kwargs):
+        return ([{"type": "text", "text": "result"}], {"structured_content": {}})
+
+    raw = StructuredTool.from_function(
+        coroutine=raw_call,
+        name="search_schema",
+        description="search",
+        response_format="content_and_artifact",
+    )
+
+    bound = context_loader._bind_context(
+        raw, context_loader.ContextLoaderSession("conv-1", "int-1")
+    )
+
+    assert bound.response_format == "content_and_artifact"
 
 
 def test_session_tools_can_be_limited_to_an_explicit_read_only_allow_list(monkeypatch):

--- a/infra/bkn-agent/app/test/test_evidence_reliability.py
+++ b/infra/bkn-agent/app/test/test_evidence_reliability.py
@@ -318,6 +318,82 @@ def test_canonical_fact_receipt_overrides_expected_downstream_event_id():
     assert headers["bkn-candidate-source-event-ids"] == '["evt_tool_canonical"]'
 
 
+def test_trusted_completed_mcp_receipt_adopts_observed_evidence_refs():
+    token = observability.set_context(observability.build_context(_headers()))
+    interaction = evidence.begin_interaction("intent", "task", "agent-1", "bkn.agent.task")
+    try:
+        result = {"bkn_receipt": {
+            "receipt_status": "completed",
+            "evidence_durability": "durable",
+            "observed_evidence_refs": ["evt_context_retrieval_1"],
+        }}
+        evidence.record_fact_receipt(
+            operation_id="op_context_retrieval_1",
+            body=result,
+            context_hash=evidence.tool_message_context_hash("context-result"),
+            trust_mcp_receipt=True,
+        )
+        headers = evidence.model_context_headers(
+            [ToolMessage(content="context-result", tool_call_id="call-context")],
+            "op_model_context",
+        )
+    finally:
+        evidence.end_interaction(interaction)
+        observability.reset_context(token)
+
+    assert headers["bkn-candidate-source-event-ids"] == '["evt_context_retrieval_1"]'
+
+
+def test_trusted_mcp_receipt_without_durable_completed_evidence_is_not_adopted():
+    token = observability.set_context(observability.build_context(_headers()))
+    interaction = evidence.begin_interaction("intent", "task", "agent-1", "bkn.agent.task")
+    try:
+        evidence.record_fact_receipt(
+            operation_id="op_context_retrieval_2",
+            body={"bkn_receipt": {
+                "receipt_status": "pending",
+                "evidence_durability": "durable",
+                "observed_evidence_refs": ["evt_context_retrieval_2"],
+            }},
+            context_hash=evidence.tool_message_context_hash("pending-result"),
+            trust_mcp_receipt=True,
+        )
+        headers = evidence.model_context_headers(
+            [ToolMessage(content="pending-result", tool_call_id="call-pending")],
+            "op_model_pending",
+        )
+    finally:
+        evidence.end_interaction(interaction)
+        observability.reset_context(token)
+
+    assert headers == {}
+
+
+def test_trusted_mcp_receipt_ignores_invalid_evidence_refs():
+    token = observability.set_context(observability.build_context(_headers()))
+    interaction = evidence.begin_interaction("intent", "task", "agent-1", "bkn.agent.task")
+    try:
+        evidence.record_fact_receipt(
+            operation_id="op_context_retrieval_3",
+            body={"bkn_receipt": {
+                "receipt_status": "completed",
+                "evidence_durability": "durable",
+                "observed_evidence_refs": ["", "not valid", 7],
+            }},
+            context_hash=evidence.tool_message_context_hash("invalid-result"),
+            trust_mcp_receipt=True,
+        )
+        headers = evidence.model_context_headers(
+            [ToolMessage(content="invalid-result", tool_call_id="call-invalid")],
+            "op_model_invalid",
+        )
+    finally:
+        evidence.end_interaction(interaction)
+        observability.reset_context(token)
+
+    assert headers == {}
+
+
 def test_mf_model_call_propagates_operation_and_consumes_stable_fact(monkeypatch):
     captured = {}
 

--- a/infra/bkn-agent/app/test/test_evidence_reliability.py
+++ b/infra/bkn-agent/app/test/test_evidence_reliability.py
@@ -394,6 +394,45 @@ def test_trusted_mcp_receipt_ignores_invalid_evidence_refs():
     assert headers == {}
 
 
+def test_trusted_mcp_receipt_caps_evidence_and_normalizes_business_refs():
+    token = observability.set_context(observability.build_context(_headers()))
+    interaction = evidence.begin_interaction("intent", "task", "agent-1", "bkn.agent.task")
+    try:
+        evidence.record_fact_receipt(
+            operation_id="op_context_retrieval_4",
+            body={"bkn_receipt": {
+                "receipt_status": "completed",
+                "evidence_durability": "durable",
+                "observed_evidence_refs": [f"evt_context_retrieval_{i}" for i in range(101)],
+                "business_refs": [{
+                    "ref_id": "object:knowledge_network:purchase_order",
+                    "ref_type": "object_type",
+                    "business_domain_id": "domain-supply-chain",
+                    "version": "v1",
+                    "display_hint": "Purchase order",
+                }],
+            }},
+            context_hash=evidence.tool_message_context_hash("capped-result"),
+            trust_mcp_receipt=True,
+        )
+        current = evidence._interaction.get()
+    finally:
+        evidence.end_interaction(interaction)
+        observability.reset_context(token)
+
+    assert current is not None
+    assert len(current.fact_candidates) == 100
+    assert "evt_context_retrieval_100" not in current.fact_candidates
+    assert current.fact_candidates["evt_context_retrieval_0"]["business_refs"] == [{
+        "ref_id": "object:knowledge_network:purchase_order",
+        "ref_type": "object_type",
+        "source_system": "context-loader",
+        "validity": "observed",
+        "version_status": "v1",
+        "visibility": "visible",
+    }]
+
+
 def test_mf_model_call_propagates_operation_and_consumes_stable_fact(monkeypatch):
     captured = {}
 

--- a/infra/bkn-agent/app/test/test_limits_and_gates.py
+++ b/infra/bkn-agent/app/test/test_limits_and_gates.py
@@ -3,10 +3,9 @@ import asyncio
 
 import pytest
 from fastapi import HTTPException
-from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
 
-from app.core import graph, tools
+from app.core import context_loader, graph, tools
 from app import evidence, observability
 from app.models import AgentOut
 
@@ -114,9 +113,16 @@ def test_generic_tools_get_distinct_operations_and_dynamic_causality_headers(mon
 def test_context_loader_tools_trust_mcp_receipts_but_external_tools_do_not(monkeypatch):
     captured = []
 
-    async def run() -> tuple[list[dict], dict]:
+    async def context_loader_run(*, bkn_context: dict) -> tuple[list[dict], dict]:
+        assert bkn_context == {"conversation_id": "conv-1", "interaction_id": "int-1"}
         return (
             [{"type": "text", "text": "retrieval result"}],
+            {"structured_content": {"bkn_receipt": {"receipt_status": "completed"}}},
+        )
+
+    async def external_run() -> tuple[list[dict], dict]:
+        return (
+            [{"type": "text", "text": "external result"}],
             {"structured_content": {"bkn_receipt": {"receipt_status": "completed"}}},
         )
 
@@ -127,13 +133,12 @@ def test_context_loader_tools_trust_mcp_receipts_but_external_tools_do_not(monke
         captured.append(kwargs)
 
     context_loader_tool = StructuredTool.from_function(
-        coroutine=run,
+        coroutine=context_loader_run,
         name="search_schema",
         description="context loader",
-        metadata={"bkn_context_loader": True},
     )
     external_tool = StructuredTool.from_function(
-        coroutine=run,
+        coroutine=external_run,
         name="external_search",
         description="external",
         metadata={"bkn_context_loader": "false"},
@@ -150,7 +155,10 @@ def test_context_loader_tools_trust_mcp_receipts_but_external_tools_do_not(monke
     )
     interaction_token = evidence.begin_interaction("question", "task", "agent-1", "bkn.agent.task")
     try:
-        wrapped = tools.instrument_tool_calls([context_loader_tool, external_tool], "acct", "user")
+        bound = context_loader._bind_context(
+            context_loader_tool, context_loader.ContextLoaderSession("conv-1", "int-1")
+        )
+        wrapped = tools.instrument_tool_calls([bound, external_tool], "acct", "user")
         asyncio.run(wrapped[0].coroutine())
         asyncio.run(wrapped[1].coroutine())
     finally:
@@ -165,7 +173,8 @@ def test_context_loader_tools_trust_mcp_receipts_but_external_tools_do_not(monke
 def test_context_loader_mcp_receipt_links_retrieval_event_to_model_candidates(monkeypatch):
     content = [{"type": "text", "text": "retrieval result"}]
 
-    async def run() -> tuple[list[dict], dict]:
+    async def run(*, bkn_context: dict) -> tuple[list[dict], dict]:
+        assert bkn_context == {"conversation_id": "conv-1", "interaction_id": "int-1"}
         return (
             content,
             {"structured_content": {"bkn_receipt": {
@@ -182,7 +191,12 @@ def test_context_loader_mcp_receipt_links_retrieval_event_to_model_candidates(mo
         coroutine=run,
         name="search_schema",
         description="context loader",
-        metadata={"bkn_context_loader": True},
+        args_schema={
+            "type": "object",
+            "properties": {"bkn_context": {"type": "object"}},
+            "required": ["bkn_context"],
+        },
+        response_format="content_and_artifact",
     )
     monkeypatch.setattr(evidence, "submit_events", fake_submit)
     trace_token = observability.set_context(
@@ -195,10 +209,18 @@ def test_context_loader_mcp_receipt_links_retrieval_event_to_model_candidates(mo
     )
     interaction_token = evidence.begin_interaction("question", "task", "agent-1", "bkn.agent.task")
     try:
-        wrapped = tools.instrument_tool_calls([tool], "acct", "user")
-        asyncio.run(wrapped[0].coroutine())
+        bound = context_loader._bind_context(
+            tool, context_loader.ContextLoaderSession("conv-1", "int-1")
+        )
+        wrapped = tools.instrument_tool_calls([bound], "acct", "user")
+        message = asyncio.run(wrapped[0].ainvoke({
+            "args": {},
+            "id": "call-context-retrieval",
+            "name": "search_schema",
+            "type": "tool_call",
+        }))
         headers = evidence.model_context_headers(
-            [ToolMessage(content=content, tool_call_id="call-context-retrieval")],
+            [message],
             "op-model-context-retrieval",
         )
     finally:

--- a/infra/bkn-agent/app/test/test_limits_and_gates.py
+++ b/infra/bkn-agent/app/test/test_limits_and_gates.py
@@ -3,6 +3,7 @@ import asyncio
 
 import pytest
 from fastapi import HTTPException
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import StructuredTool
 
 from app.core import graph, tools
@@ -108,6 +109,103 @@ def test_generic_tools_get_distinct_operations_and_dynamic_causality_headers(mon
     assert called[0]["operation_id"] != called[1]["operation_id"]
     assert propagated[0]["bkn-operation-id"] == called[0]["operation_id"]
     assert propagated[1]["bkn-operation-id"] == called[1]["operation_id"]
+
+
+def test_context_loader_tools_trust_mcp_receipts_but_external_tools_do_not(monkeypatch):
+    captured = []
+
+    async def run() -> tuple[list[dict], dict]:
+        return (
+            [{"type": "text", "text": "retrieval result"}],
+            {"structured_content": {"bkn_receipt": {"receipt_status": "completed"}}},
+        )
+
+    async def fake_submit(*_args, **_kwargs):
+        return True
+
+    def capture_receipt(**kwargs):
+        captured.append(kwargs)
+
+    context_loader_tool = StructuredTool.from_function(
+        coroutine=run,
+        name="search_schema",
+        description="context loader",
+        metadata={"bkn_context_loader": True},
+    )
+    external_tool = StructuredTool.from_function(
+        coroutine=run,
+        name="external_search",
+        description="external",
+        metadata={"bkn_context_loader": "false"},
+    )
+    monkeypatch.setattr(evidence, "submit_events", fake_submit)
+    monkeypatch.setattr(evidence, "record_fact_receipt", capture_receipt)
+    trace_token = observability.set_context(
+        observability.TraceContext(
+            trace_id="1234567890abcdef1234567890abcdef",
+            request_id="req_mcp_receipt_001",
+            traceparent="00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+            entry_boundary="external",
+        )
+    )
+    interaction_token = evidence.begin_interaction("question", "task", "agent-1", "bkn.agent.task")
+    try:
+        wrapped = tools.instrument_tool_calls([context_loader_tool, external_tool], "acct", "user")
+        asyncio.run(wrapped[0].coroutine())
+        asyncio.run(wrapped[1].coroutine())
+    finally:
+        evidence.end_interaction(interaction_token)
+        observability.reset_context(trace_token)
+
+    assert captured[0]["trust_mcp_receipt"] is True
+    assert captured[1]["trust_mcp_receipt"] is False
+    assert captured[0]["body"]["bkn_receipt"]["receipt_status"] == "completed"
+
+
+def test_context_loader_mcp_receipt_links_retrieval_event_to_model_candidates(monkeypatch):
+    content = [{"type": "text", "text": "retrieval result"}]
+
+    async def run() -> tuple[list[dict], dict]:
+        return (
+            content,
+            {"structured_content": {"bkn_receipt": {
+                "receipt_status": "completed",
+                "evidence_durability": "durable",
+                "observed_evidence_refs": ["evt_context_retrieval_4"],
+            }}},
+        )
+
+    async def fake_submit(*_args, **_kwargs):
+        return True
+
+    tool = StructuredTool.from_function(
+        coroutine=run,
+        name="search_schema",
+        description="context loader",
+        metadata={"bkn_context_loader": True},
+    )
+    monkeypatch.setattr(evidence, "submit_events", fake_submit)
+    trace_token = observability.set_context(
+        observability.TraceContext(
+            trace_id="1234567890abcdef1234567890abcdef",
+            request_id="req_mcp_receipt_002",
+            traceparent="00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+            entry_boundary="external",
+        )
+    )
+    interaction_token = evidence.begin_interaction("question", "task", "agent-1", "bkn.agent.task")
+    try:
+        wrapped = tools.instrument_tool_calls([tool], "acct", "user")
+        asyncio.run(wrapped[0].coroutine())
+        headers = evidence.model_context_headers(
+            [ToolMessage(content=content, tool_call_id="call-context-retrieval")],
+            "op-model-context-retrieval",
+        )
+    finally:
+        evidence.end_interaction(interaction_token)
+        observability.reset_context(trace_token)
+
+    assert headers["bkn-candidate-source-event-ids"] == '["evt_context_retrieval_4"]'
 
 
 def _sub_agent(mode="task", status="published") -> AgentOut:


### PR DESCRIPTION
## What Changed

- Adopt authoritative Context Loader MCP receipt evidence only for tools carrying the internal `bkn_context_loader: true` marker.
- Unwrap the MCP `(content, structured_content)` result shape and retain the model-visible content hash for Claim adoption.
- Add regressions for completed durable receipts, missing or invalid receipt references, external MCP rejection, and the end-to-end model candidate path.
- Add the implementation plan.

---

## Why

- Related Issue: Closes #702
- Background: a fresh internal bkn-agent using Context Loader over MCP could receive a retrieval fact but fail to make it available to the final Claim.

---

## How

- `record_fact_receipt` preserves existing header and toolbox receipt behavior, then adopts valid `observed_evidence_refs` only from a trusted completed, durable MCP receipt.
- Tool trust uses the strict boolean Context Loader marker, not a tool name, URL, or arbitrary non-empty metadata.
- Breaking changes: none. No API, configuration, database, Trace Schema, or third-party Agent protocol changes.

---

## Testing

- [x] Unit tests passed locally: `OTEL_SDK_DISABLED=true /private/tmp/bkn702-venv/bin/python -m pytest -q app/test` (238 passed).
- [x] Static compilation: `/private/tmp/bkn702-venv/bin/python -m compileall -q app`.
- [ ] Verified in test environment: post-merge verification is tracked by #746.

Test notes: the regression covers the real MCP adapter tuple shape and verifies the retrieval event reaches the model candidate-source header.

---

## Risk & Rollback

- Potential risks: only Context Loader-marked tools with completed, durable receipts contribute Claim sources; malformed data remains fail-closed.
- Rollback plan: revert commit `da3e02a03`; no migration or data repair is required.

---

## Additional Notes

- Design/implementation plan: `docs/plans/2026-08-19-mcp-receipt-evidence.md`.
- Independent review completed; no blocking findings remain.