### PR TITLE
fix(context-loader): clarify managed interaction lifecycle

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
@@ -34,7 +34,7 @@ func TestDefaultAgentLifecycleSurfaceIsTwoTools(t *testing.T) {
 	}
 }
 
-func TestStartInteractionSchemaExposesQuestionConversationAndOptionalAgentName(t *testing.T) {
+func TestStartInteractionSchemaRequiresQuestionAndAgentName(t *testing.T) {
 	input, _ := loadToolSchemas("bkn_start_interaction")
 	var schema struct {
 		Properties map[string]json.RawMessage `json:"properties"`
@@ -43,7 +43,7 @@ func TestStartInteractionSchemaExposesQuestionConversationAndOptionalAgentName(t
 	if err := json.Unmarshal(input, &schema); err != nil {
 		t.Fatal(err)
 	}
-	if !sameStringSet(schema.Required, []string{"question"}) {
+	if !sameStringSet(schema.Required, []string{"question", "agent_name"}) {
 		t.Fatalf("start required fields = %v", schema.Required)
 	}
 	want := []string{"agent_name", "conversation_id", "question"}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -209,12 +209,13 @@ func TestStartInteractionHidesCoreLeaseField(t *testing.T) {
 	}
 }
 
-func TestStartInteractionDeclaresOptionalBoundedAgentName(t *testing.T) {
+func TestStartInteractionRequiresBoundedStableAgentName(t *testing.T) {
 	input, _ := loadToolSchemas("bkn_start_interaction")
 	var schema struct {
 		Properties map[string]struct {
-			Type      string `json:"type"`
-			MaxLength int    `json:"maxLength"`
+			Type        string `json:"type"`
+			MaxLength   int    `json:"maxLength"`
+			Description string `json:"description"`
 		} `json:"properties"`
 		Required []string `json:"required"`
 	}
@@ -222,11 +223,11 @@ func TestStartInteractionDeclaresOptionalBoundedAgentName(t *testing.T) {
 		t.Fatalf("decode start schema: %v", err)
 	}
 	agentName, ok := schema.Properties["agent_name"]
-	if !ok || agentName.Type != "string" || agentName.MaxLength != 128 {
-		t.Fatalf("agent_name must be an optional bounded display declaration: %s", input)
+	if !ok || agentName.Type != "string" || agentName.MaxLength != 128 || agentName.Description != "当前 Agent 的固定名称。同一 conversation_id 中每次调用都传入相同值。" {
+		t.Fatalf("agent_name must be a required bounded stable declaration: %s", input)
 	}
-	if containsString(schema.Required, "agent_name") {
-		t.Fatalf("agent_name must remain optional: %s", input)
+	if !containsString(schema.Required, "agent_name") {
+		t.Fatalf("agent_name must be required: %s", input)
 	}
 }
 
@@ -375,9 +376,9 @@ func TestLifecycleSwaggerPathsRequestsAndResponsesAreStructurallyFrozen(t *testi
 	}
 }
 
-func TestLifecycleMCPInputRequiredFieldsMatchCorePathAndBody(t *testing.T) {
+func TestLifecycleMCPInputRequiredFieldsFollowAgentFacadeContract(t *testing.T) {
 	expected := map[string][]string{
-		"bkn_start_interaction":  {"question"},
+		"bkn_start_interaction":  {"question", "agent_name"},
 		"bkn_finish_interaction": {"interaction_id", "outcome"},
 	}
 	for tool, want := range expected {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -223,7 +223,7 @@ func TestStartInteractionRequiresBoundedStableAgentName(t *testing.T) {
 		t.Fatalf("decode start schema: %v", err)
 	}
 	agentName, ok := schema.Properties["agent_name"]
-	if !ok || agentName.Type != "string" || agentName.MaxLength != 128 || agentName.Description != "当前 Agent 的固定名称。同一 conversation_id 中每次调用都传入相同值。" {
+	if !ok || agentName.Type != "string" || agentName.MaxLength != 128 || agentName.Description != "The current Agent's stable name. Provide the same value on every call in the same conversation_id." {
 		t.Fatalf("agent_name must be a required bounded stable declaration: %s", input)
 	}
 	if !containsString(schema.Required, "agent_name") {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -123,6 +123,51 @@ func TestMCPLocaleBundleFallsBackWhenOverlayResourcesAreMalformed(t *testing.T) 
 	}
 }
 
+func TestServerInstructionsLeadWithManagedInteractionLifecycle(t *testing.T) {
+	tests := []struct {
+		locale      string
+		lifecycle   []string
+		exploration string
+	}{
+		{
+			locale: "zh-CN",
+			lifecycle: []string{
+				"处理每个新的用户问题时",
+				"conversation_id 在整个对话过程中保持不变",
+				"interaction_id 在当前用户问题开始后、回复完成前保持不变",
+				"回复用户前，调用 bkn_finish_interaction",
+				"下一个用户问题会开始新的 Interaction",
+			},
+			exploration: "探索顺序：",
+		},
+		{
+			locale: "en-US",
+			lifecycle: []string{
+				"For each new user question",
+				"conversation_id remains unchanged throughout the conversation",
+				"interaction_id remains unchanged from the start of the current user question until the reply is complete",
+				"Before replying to the user, call bkn_finish_interaction",
+				"The next user question starts a new Interaction",
+			},
+			exploration: "Suggested exploration order:",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.locale, func(t *testing.T) {
+			instructions := loadMCPLocaleBundle(test.locale).ServerInstructions()
+			for _, expected := range test.lifecycle {
+				if !strings.Contains(instructions, expected) {
+					t.Fatalf("instructions for %s omit %q:\n%s", test.locale, expected, instructions)
+				}
+			}
+			if lifecycleAt, explorationAt := strings.Index(instructions, test.lifecycle[0]), strings.Index(instructions, test.exploration); lifecycleAt < 0 || explorationAt < 0 || lifecycleAt >= explorationAt {
+				t.Fatalf("managed lifecycle must precede query guidance for %s:\n%s", test.locale, instructions)
+			}
+		})
+	}
+}
+
 func getNestedString(root map[string]any, path []string) (string, bool) {
 	var current any = root
 	for _, segment := range path {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -168,6 +168,30 @@ func TestServerInstructionsLeadWithManagedInteractionLifecycle(t *testing.T) {
 	}
 }
 
+func TestStartInteractionDescriptionGuidesStableAgentIdentity(t *testing.T) {
+	tests := []struct {
+		locale string
+		want   string
+	}{
+		{
+			locale: "zh-CN",
+			want:   "为当前用户问题开始一次受管 Interaction。传入完整的用户问题和当前 Agent 的固定名称；首次不传 conversation_id，后续传入当前对话的 conversation_id。返回本轮后续工具调用的 bkn_context 所需的 conversation_id 和 interaction_id。",
+		},
+		{
+			locale: "en-US",
+			want:   "Start a managed Interaction for the current user question. Provide the complete user question and the current Agent's stable name; omit conversation_id on the first turn, then provide the conversation_id for the current conversation. It returns the conversation_id and interaction_id required in bkn_context for subsequent tool calls in this turn.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.locale, func(t *testing.T) {
+			if got := loadMCPLocaleBundle(test.locale).ToolMeta("bkn_start_interaction").Description; got != test.want {
+				t.Fatalf("start description for %s = %q, want %q", test.locale, got, test.want)
+			}
+		})
+	}
+}
+
 func getNestedString(root map[string]any, path []string) (string, bool) {
 	var current any = root
 	for _, segment := range path {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -114,7 +114,7 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 		required = append(required, "question")
 		properties["agent_name"] = map[string]any{
 			"type": "string", "maxLength": 128,
-			"description": "当前 Agent 的固定名称。同一 conversation_id 中每次调用都传入相同值。",
+			"description": "The current Agent's stable name. Provide the same value on every call in the same conversation_id.",
 		}
 		required = append(required, "agent_name")
 	case "bkn_finish_interaction":

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -114,8 +114,9 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 		required = append(required, "question")
 		properties["agent_name"] = map[string]any{
 			"type": "string", "maxLength": 128,
-			"description": "Optionally declare a display name on the first turn; do not change it later.",
+			"description": "当前 Agent 的固定名称。同一 conversation_id 中每次调用都传入相同值。",
 		}
+		required = append(required, "agent_name")
 	case "bkn_finish_interaction":
 		properties["interaction_id"] = map[string]any{
 			"type": "string", "description": "Use the exact interaction_id returned by start.",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
@@ -1,5 +1,24 @@
 Context Loader knowledge network tools.
 
+Managed interaction lifecycle:
+
+For each new user question:
+
+1. Call bkn_start_interaction with the complete question.
+   On the first turn, omit conversation_id. On later turns, pass the conversation_id for the current conversation.
+
+2. This tool returns conversation_id and interaction_id.
+   conversation_id remains unchanged throughout the conversation.
+   interaction_id remains unchanged from the start of the current user question until the reply is complete.
+   Use both IDs in bkn_context for all other tool calls in this turn.
+
+3. Before replying to the user, call bkn_finish_interaction.
+   For a successful result, use outcome=completed and the final answer.
+   Otherwise, use failed, cancelled, or handed_off and provide the reason.
+   Then reply to the user.
+
+The next user question starts a new Interaction and continues using the current conversation_id.
+
 Suggested exploration order:
 1. Call list_knowledge_networks first to obtain a kn_id. Most other tools require kn_id.
 2. Call search_schema with natural language to discover object types, relation types, action types, metric types, data_source.id, supported condition operations, and physical columns.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -1,7 +1,4 @@
 {
-  "bkn_start_interaction": {
-    "input_schema.properties.agent_name.description": "The current Agent's stable name. Provide the same value on every call in the same conversation_id."
-  },
   "describe_resource": {
     "input_schema.properties.response_format.description": "Response format: json or toon. Defaults to toon.",
     "input_schema.properties.resource_id.description": "Data resource id returned by list_resources.",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -1,4 +1,7 @@
 {
+  "bkn_start_interaction": {
+    "input_schema.properties.agent_name.description": "The current Agent's stable name. Provide the same value on every call in the same conversation_id."
+  },
   "describe_resource": {
     "input_schema.properties.response_format.description": "Response format: json or toon. Defaults to toon.",
     "input_schema.properties.resource_id.description": "Data resource id returned by list_resources.",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -5,7 +5,8 @@
   },
   "bkn_start_interaction": {
     "title": "Start Interaction",
-    "group_title": "Session Lifecycle"
+    "group_title": "Session Lifecycle",
+    "description": "Start a managed Interaction for the current user question. Provide the complete user question and the current Agent's stable name; omit conversation_id on the first turn, then provide the conversation_id for the current conversation. It returns the conversation_id and interaction_id required in bkn_context for subsequent tool calls in this turn."
   },
   "search_schema": {
     "title": "Explore Schema",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/zh-CN/instructions.txt
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/zh-CN/instructions.txt
@@ -6,6 +6,25 @@
  */
 ContextLoader 知识网络查询工具集使用指南。
 
+受管交互流程：
+
+处理每个新的用户问题时：
+
+1. 调用 bkn_start_interaction，传入完整问题。
+   首次不传 conversation_id；后续传入当前对话的 conversation_id。
+
+2. 本工具返回 conversation_id 和 interaction_id。
+   conversation_id 在整个对话过程中保持不变；
+   interaction_id 在当前用户问题开始后、回复完成前保持不变。
+   本轮调用其他工具时，在 bkn_context 中使用这两个 ID。
+
+3. 回复用户前，调用 bkn_finish_interaction。
+   正常完成使用 outcome=completed 和最终答案；
+   未完成时使用 failed、cancelled 或 handed_off，并附原因。
+   然后回复用户。
+
+下一个用户问题会开始新的 Interaction，并继续使用当前 conversation_id。
+
 探索顺序：
 1. list_knowledge_networks 获取 kn_id（其余工具都需要 kn_id）。
 2. 摸清 schema，两条路二选一：

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -13,7 +13,7 @@
     "group": "lifecycle",
     "group_title": "会话生命周期",
     "order": 10,
-    "description": "Start one managed Interaction. Omit conversation_id on the first turn; reuse the returned conversation_id on later turns."
+    "description": "为当前用户问题开始一次受管 Interaction。传入完整的用户问题和当前 Agent 的固定名称；首次不传 conversation_id，后续传入当前对话的 conversation_id。返回本轮后续工具调用的 bkn_context 所需的 conversation_id 和 interaction_id。"
   },
   "search_schema": {
     "name": "search_schema",

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -7,9 +7,8 @@ info:
     Desktop 等 MCP 客户端可以直接接入，不必逐个封装 REST 调用。
 
     普通 Agent 默认只使用两个受管生命周期工具：`bkn_start_interaction`、
-    `bkn_finish_interaction`。首轮 start 只提交问题并由服务内部创建 Conversation，
-    首轮可选声明用于展示的 `agent_name`；名称在 Conversation 内固化，后续轮次省略
-    或保持相同值，不允许中途变更。后续轮次复用服务端返回的 `conversation_id`；finish 只提交当前 Interaction 的
+    `bkn_finish_interaction`。每轮 start 都提交完整问题和固定的 `agent_name`；首轮由服务内部创建 Conversation，
+    后续轮次复用服务端返回的 `conversation_id`，并传入同一 `agent_name`。finish 只提交当前 Interaction 的
     结果，不关闭可跨轮、跨日复用的 Conversation。业务工具包括 `search_schema`、
     `query_object_instance`、`query_instance_subgraph`、`get_logic_properties_values`、
     `get_action_info`、`execute_action`、`get_action_execution`、


### PR DESCRIPTION
## 背景与目标

第三方 Agent 容易把 Conversation 与 Interaction 的生命周期混淆：漏调 start / finish、跨问题沿用 interaction_id，或漏传身份字段。此次将规则拆到最适合的三个入口：初始化 instructions 规定整轮流程，`bkn_start_interaction` description 解释本次调用，schema 强制身份字段存在。

## MCP 描述与契约对比

| 位置 | 变更前 | 变更后 |
| --- | --- | --- |
| MCP server instructions | 只有知识网络探索和查询分流，没有受管交互顺序。 | 在查询指南前定义：每个新的用户问题 start；首轮省略 conversation_id、后续复用；本轮使用返回的两个 ID；回复前 finish；下一个问题新建 Interaction。 |
| `bkn_start_interaction` description | `Start one managed Interaction. Omit conversation_id on the first turn; reuse the returned conversation_id on later turns.` | 明确当前用户问题、完整问题、固定 Agent 名称、conversation_id 的首轮/后续语义，以及返回的两个 ID 用于本轮后续工具调用的 `bkn_context`。 |
| `agent_name` | 可选；只建议首轮声明，后续可省略。 | schema 必填；描述为同一 `conversation_id` 中每次调用均传入相同的 Agent 名称。 |
| 中英文目录 | 生命周期 instructions 已有中英文；工具元数据只有基线描述。 | `bkn_start_interaction` description 提供中文基线和独立英文 locale，避免英文 MCP 目录出现中文。 |
| 公开 MCP 文档 | 声明首轮可选 `agent_name`、后续可省略。 | 同步为每轮提交完整问题与固定 `agent_name`；后续复用 conversation_id 并传入同一名称。 |

## Agent 应执行的流程

1. 每个新的用户问题，调用 `bkn_start_interaction`，提供完整问题和 `agent_name`。
2. 首轮不传 `conversation_id`；后续轮传当前对话的 `conversation_id`。
3. 保存返回的 `conversation_id` 与 `interaction_id`。前者贯穿整个对话，后者只覆盖当前问题到回复完成前。
4. 本轮其他 OpenBKN 工具调用均在 `bkn_context` 中携带这两个 ID。
5. 回复用户前调用 `bkn_finish_interaction`；正常结果使用 `completed` 和最终答案。

全局 instructions 不重复 `agent_name` 规则：它由 start 工具 description 解释、由输入 schema 强制，以保持生命周期主叙事简洁。

## 兼容性与范围

- 这是对第三方 MCP 客户端的有意契约收紧：每轮 start 现在必须提供 `agent_name`。
- 仓内 `bkn-agent` 两条生产调用路径均已传入该字段。
- 同一 Conversation 中名称漂移会由 Core 的 `agent_name_conflict` 拒绝该轮 start；这是保持身份一致性的预期保护。
- 本 PR 有意将第三方 Agent 的每个新用户问题都建模为一轮受管 Interaction，即使该轮未调用知识网络业务工具，以保留完整的问题与最终回答闭环，并给弱模型提供单一的 start → finish 编排。

## 验证

- [x] `go test ./server/driveradapters/mcp -count=1`
- [x] `python3 -m unittest tools/test_check_i18n_catalogs.py`
- [x] `python3 tools/check_i18n_catalogs.py`
- [x] `git diff --check`