### PR TITLE
fix(observability): search audit actors by name

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/logsvc/cursor.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/cursor.go
@@ -93,6 +93,7 @@ func logFilterHash(query observabilityvo.LogQuery) string {
 		EventNames      []string   `json:"event_names,omitempty"`
 		BusinessDomain  string     `json:"business_domain,omitempty"`
 		ActorID         string     `json:"actor_id,omitempty"`
+		ActorQuery      string     `json:"actor,omitempty"`
 		ApplicationID   string     `json:"application_id,omitempty"`
 		ResourceType    string     `json:"resource_type,omitempty"`
 		ResourceID      string     `json:"resource_id,omitempty"`
@@ -111,7 +112,7 @@ func logFilterHash(query observabilityvo.LogQuery) string {
 		Categories: normalizedStrings(query.Categories), SeverityMinimum: query.SeverityMinimum,
 		Services: normalizedStrings(query.Services), Environments: normalizedStrings(query.Environments),
 		EventNames: normalizedStrings(query.EventNames), BusinessDomain: query.BusinessDomain,
-		ActorID: query.ActorID, ApplicationID: query.ApplicationID,
+		ActorID: query.ActorID, ActorQuery: query.ActorQuery, ApplicationID: query.ApplicationID,
 		ResourceType: query.ResourceType, ResourceID: query.ResourceID,
 		ConversationID: query.ConversationID, InteractionID: query.InteractionID,
 		OperationID: query.OperationID, RequestID: query.RequestID,

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -214,6 +214,7 @@ func (service *Service) listPage(
 		limit = 200
 	}
 	sourceQuery := query
+	sourceQuery.ActorQuery = ""
 	sourceQuery.Cursor = ""
 	sourceQuery.Limit = 200
 	if err := applyLogTimeWindow(&sourceQuery, queryWatermark); err != nil {
@@ -855,7 +856,7 @@ func matchesQuery(record observabilityvo.LogRecord, query observabilityvo.LogQue
 		matchesOptional(record.TraceID, query.TraceID) && matchesOptional(record.SpanID, query.SpanID) &&
 		matchesOptional(record.RequestID, query.RequestID) && matchesOptional(record.ConversationID, query.ConversationID) &&
 		matchesOptional(record.InteractionID, query.InteractionID) && matchesOptional(record.OperationID, query.OperationID) &&
-		matchesOptional(record.BusinessDomain, query.BusinessDomain) && matchesActor(record, query.ActorID) &&
+		matchesOptional(record.BusinessDomain, query.BusinessDomain) && matchesOptional(record.ActorID, query.ActorID) && matchesActor(record, query.ActorQuery) &&
 		matchesOptional(record.BusinessModule, query.BusinessModule) && matchesOptional(record.Action, query.Action) &&
 		matchesOptional(record.TargetType, query.TargetType) && matchesOptional(record.TargetID, query.TargetID) &&
 		matchesSet(record.Outcome, query.Outcomes) &&
@@ -869,6 +870,7 @@ func matchesQuery(record observabilityvo.LogRecord, query observabilityvo.LogQue
 func matchesOptional(actual, expected string) bool { return expected == "" || actual == expected }
 
 func matchesActor(record observabilityvo.LogRecord, expected string) bool {
+	expected = strings.TrimSpace(expected)
 	return expected == "" || record.ActorID == expected || strings.Contains(
 		strings.ToLower(record.ActorNameSnapshot), strings.ToLower(expected),
 	)

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -855,7 +855,7 @@ func matchesQuery(record observabilityvo.LogRecord, query observabilityvo.LogQue
 		matchesOptional(record.TraceID, query.TraceID) && matchesOptional(record.SpanID, query.SpanID) &&
 		matchesOptional(record.RequestID, query.RequestID) && matchesOptional(record.ConversationID, query.ConversationID) &&
 		matchesOptional(record.InteractionID, query.InteractionID) && matchesOptional(record.OperationID, query.OperationID) &&
-		matchesOptional(record.BusinessDomain, query.BusinessDomain) && matchesOptional(record.ActorID, query.ActorID) &&
+		matchesOptional(record.BusinessDomain, query.BusinessDomain) && matchesActor(record, query.ActorID) &&
 		matchesOptional(record.BusinessModule, query.BusinessModule) && matchesOptional(record.Action, query.Action) &&
 		matchesOptional(record.TargetType, query.TargetType) && matchesOptional(record.TargetID, query.TargetID) &&
 		matchesSet(record.Outcome, query.Outcomes) &&
@@ -867,6 +867,12 @@ func matchesQuery(record observabilityvo.LogRecord, query observabilityvo.LogQue
 }
 
 func matchesOptional(actual, expected string) bool { return expected == "" || actual == expected }
+
+func matchesActor(record observabilityvo.LogRecord, expected string) bool {
+	return expected == "" || record.ActorID == expected || strings.Contains(
+		strings.ToLower(record.ActorNameSnapshot), strings.ToLower(expected),
+	)
+}
 
 func matchesSet(actual string, expected []string) bool {
 	return len(expected) == 0 || contains(expected, actual)

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -214,6 +214,7 @@ func (service *Service) listPage(
 		limit = 200
 	}
 	sourceQuery := query
+	filterQuery := sourceQuery
 	sourceQuery.ActorQuery = ""
 	sourceQuery.Cursor = ""
 	sourceQuery.Limit = 200
@@ -283,11 +284,11 @@ func (service *Service) listPage(
 			}
 			if validProjection &&
 				contains(effectiveCategories, record.Category) && afterSourcePosition(record, pageBefore) &&
-				matchesQuery(record, sourceQuery) && canReadLog(profile, capabilities, record, query.IsAssociatedDrilldown()) {
+				matchesQuery(record, filterQuery) && canReadLog(profile, capabilities, record, query.IsAssociatedDrilldown()) {
 				candidates = append(candidates, logCandidate{record: record, adapterSourceID: source.ID()})
 			}
 		}
-		if rejectedProjections > 0 || normalizedAccuracy(page.CountAccuracy) != "exact" {
+		if rejectedProjections > 0 || filterQuery.ActorQuery != "" || normalizedAccuracy(page.CountAccuracy) != "exact" {
 			// Source totals describe its raw result set. Once the public contract
 			// rejects records or an adapter has already filtered its source result,
 			// retaining that raw total produces an impossible UI (for example “5

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service.go
@@ -214,7 +214,6 @@ func (service *Service) listPage(
 		limit = 200
 	}
 	sourceQuery := query
-	filterQuery := sourceQuery
 	sourceQuery.ActorQuery = ""
 	sourceQuery.Cursor = ""
 	sourceQuery.Limit = 200
@@ -232,6 +231,8 @@ func (service *Service) listPage(
 		[]string(nil), profile.ManagedKnowledgeNetworkIDs...,
 	)
 	sourceQuery.ObservedBefore = &queryWatermark
+	filterQuery := sourceQuery
+	filterQuery.ActorQuery = query.ActorQuery
 	succeeded := 0
 	failed := 0
 	coveragePartial := false

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -950,6 +950,21 @@ func TestMatchesQueryFiltersOperationAuditBusinessFields(t *testing.T) {
 	}
 }
 
+func TestMatchesQueryMatchesActorNameSnapshot(t *testing.T) {
+	record := observabilityvo.LogRecord{
+		ActorID: "266c6a42-6131-4d62-8f39-853e7093701c", ActorNameSnapshot: "Administrator",
+	}
+	if !matchesQuery(record, observabilityvo.LogQuery{ActorID: "administrator"}) {
+		t.Fatal("actor display name must be accepted case-insensitively")
+	}
+	if !matchesQuery(record, observabilityvo.LogQuery{ActorID: "266c6a42-6131-4d62-8f39-853e7093701c"}) {
+		t.Fatal("actor technical ID must remain accepted")
+	}
+	if matchesQuery(record, observabilityvo.LogQuery{ActorID: "operator"}) {
+		t.Fatal("unrelated actor display name must not match")
+	}
+}
+
 func TestOperationAuditOnlyRejectsIncompletePublicProjection(t *testing.T) {
 	record := validTestRecord(observabilityvo.LogRecord{
 		LogID: "audit-invalid", Category: observabilityvo.CategoryAuditAdmin, EventName: "user.created",

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -954,14 +954,27 @@ func TestMatchesQueryMatchesActorNameSnapshot(t *testing.T) {
 	record := observabilityvo.LogRecord{
 		ActorID: "266c6a42-6131-4d62-8f39-853e7093701c", ActorNameSnapshot: "Administrator",
 	}
-	if !matchesQuery(record, observabilityvo.LogQuery{ActorID: "administrator"}) {
+	if !matchesQuery(record, observabilityvo.LogQuery{ActorQuery: "administrator"}) {
 		t.Fatal("actor display name must be accepted case-insensitively")
 	}
 	if !matchesQuery(record, observabilityvo.LogQuery{ActorID: "266c6a42-6131-4d62-8f39-853e7093701c"}) {
 		t.Fatal("actor technical ID must remain accepted")
 	}
-	if matchesQuery(record, observabilityvo.LogQuery{ActorID: "operator"}) {
+	if matchesQuery(record, observabilityvo.LogQuery{ActorQuery: "operator"}) {
 		t.Fatal("unrelated actor display name must not match")
+	}
+}
+
+func TestListDoesNotPushActorNameQueryToSources(t *testing.T) {
+	source := &capturingSource{}
+	service := New([]Source{source})
+	if _, err := service.List(context.Background(), activeProfile("audit-a", "audit"), observabilityvo.LogQuery{
+		ActorQuery: "Administrator", Categories: []string{observabilityvo.CategoryAuditAdmin},
+	}); err != nil {
+		t.Fatalf("list audit logs: %v", err)
+	}
+	if source.query.ActorQuery != "" {
+		t.Fatalf("display-name filter must be applied after source retrieval: %+v", source.query)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -61,6 +61,7 @@ func (source partialCountSource) Search(context.Context, observabilityvo.LogQuer
 
 type capturingSource struct {
 	query observabilityvo.LogQuery
+	records []observabilityvo.LogRecord
 }
 
 type blockingSource struct {
@@ -106,7 +107,7 @@ func (source *capturingSource) ID() string { return "capturing" }
 
 func (source *capturingSource) Search(_ context.Context, query observabilityvo.LogQuery) (observabilityvo.SourcePage, error) {
 	source.query = query
-	return observabilityvo.SourcePage{CountAccuracy: "exact"}, nil
+	return observabilityvo.SourcePage{Records: validTestRecords(source.records), Count: int64(len(source.records)), CountAccuracy: "exact"}, nil
 }
 
 type fakeDetailSource struct {
@@ -579,7 +580,10 @@ func TestNotIntegratedAuthorizedSourcesAreDisclosedWithoutFalseHealth(t *testing
 }
 
 func TestListPushesTrustedAuthorizationScopeToSources(t *testing.T) {
-	source := &capturingSource{}
+	source := &capturingSource{records: []observabilityvo.LogRecord{{
+		LogID: "administrator-log", Category: observabilityvo.CategoryAuditAdmin, EventName: "user.created",
+		TenantID: "tenant-a", ActorID: "audit-a", EffectiveSubjectID: "audit-a", ActorNameSnapshot: "Administrator", EventTimestamp: time.Now(), TrustLevel: "trusted", IngressPrincipal: "bkn-safe",
+	}}}
 	service := New([]Source{source})
 	profile := activeProfile("builder-a", "network_builder")
 	profile.ManagedKnowledgeNetworkIDs = []string{"kn-a", "kn-b"}
@@ -966,15 +970,22 @@ func TestMatchesQueryMatchesActorNameSnapshot(t *testing.T) {
 }
 
 func TestListDoesNotPushActorNameQueryToSources(t *testing.T) {
-	source := &capturingSource{}
+	source := &capturingSource{records: []observabilityvo.LogRecord{{
+		LogID: "administrator-log", Category: observabilityvo.CategoryAuditAdmin, EventName: "user.created",
+		TenantID: "tenant-a", ActorID: "audit-a", EffectiveSubjectID: "audit-a", ActorNameSnapshot: "Administrator", EventTimestamp: time.Now(), TrustLevel: "trusted", IngressPrincipal: "bkn-safe",
+	}}}
 	service := New([]Source{source})
-	if _, err := service.List(context.Background(), activeProfile("audit-a", "audit"), observabilityvo.LogQuery{
+	result, err := service.List(context.Background(), activeProfile("audit-a", "audit"), observabilityvo.LogQuery{
 		ActorQuery: "Administrator", Categories: []string{observabilityvo.CategoryAuditAdmin},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("list audit logs: %v", err)
 	}
 	if source.query.ActorQuery != "" {
 		t.Fatalf("display-name filter must be applied after source retrieval: %+v", source.query)
+	}
+	if len(result.Records) != 1 || result.Count != 1 || result.CountExact {
+		t.Fatalf("actor-name filtering must return a visible lower-bound count: %+v", result)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/logsvc/service_test.go
@@ -984,6 +984,9 @@ func TestListDoesNotPushActorNameQueryToSources(t *testing.T) {
 	if source.query.ActorQuery != "" {
 		t.Fatalf("display-name filter must be applied after source retrieval: %+v", source.query)
 	}
+	if source.query.TimeFrom == nil || source.query.TimeTo == nil || source.query.ObservedBefore == nil {
+		t.Fatalf("source query must retain the frozen time window and watermark: %+v", source.query)
+	}
 	if len(result.Records) != 1 || result.Count != 1 || result.CountExact {
 		t.Fatalf("actor-name filtering must return a visible lower-bound count: %+v", result)
 	}

--- a/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/observabilityvo/log.go
@@ -77,6 +77,7 @@ type LogQuery struct {
 	EventNames       []string
 	BusinessDomain   string
 	ActorID          string
+	ActorQuery       string
 	ApplicationID    string
 	ResourceType     string
 	ResourceID       string

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/log_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/log_handler.go
@@ -266,7 +266,7 @@ func parseLogQuery(r *http.Request) (observabilityvo.LogQuery, error) {
 		BusinessModule: businessModule, Action: strings.TrimSpace(values.Get("action")),
 		TargetType: strings.TrimSpace(values.Get("target_type")), TargetID: strings.TrimSpace(values.Get("target_id")),
 		Outcomes: outcomes, Categories: categories, BusinessDomain: values.Get("business_domain_id"),
-		ActorID: values.Get("actor_id"), ApplicationID: values.Get("application_id"),
+		ActorID: strings.TrimSpace(values.Get("actor_id")), ActorQuery: strings.TrimSpace(values.Get("actor")), ApplicationID: values.Get("application_id"),
 		ConversationID: values.Get("conversation_id"), InteractionID: values.Get("interaction_id"),
 		OperationID: values.Get("operation_id"), RequestID: values.Get("request_id"),
 		TraceID: traceID,


### PR DESCRIPTION
## What Changed

- [x] Match audit actor filters against the recorded actor name snapshot in addition to the stable actor ID.
- [x] Add a focused regression test covering case-insensitive actor-name matching and ID compatibility.
- [ ] Docs/doc: not needed for this focused bug fix.

---

## Why

- Related Issue: N/A
- Related Feature: Log search
- Background: The audit page displays actor names, but the service accepted only exact actor IDs, so visible names such as `Administrator` could not be searched.

---

## How

- Key implementation points: preserve exact actor-ID matching and add case-insensitive matching against the immutable actor-name snapshot.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable)
- [ ] Verified in test environment (not deployed)

Test notes: `go test ./src/domain/service/logsvc -count=1` passed locally.

---

## Risk & Rollback

- Potential risks: Same-name actors can intentionally return the matching audit records; a stable actor ID remains available for exact narrowing.
- Rollback plan: Revert this single commit.

---

## Additional Notes

- No deployment is included in this PR.