### PR TITLE
style(bkn-safe): refine login control dimensions

### DIFF
--- a/bkn-safe/server/internal/httpapi/auth.go
+++ b/bkn-safe/server/internal/httpapi/auth.go
@@ -80,21 +80,21 @@ body:before{content:"";position:fixed;inset:0;z-index:-2;background-image:
 .note{font-size:13px;color:#64748d;background:#f9fbff;border:1px solid rgba(15,30,54,.08);
   border-radius:10px;padding:12px;margin:16px 0}
 input{width:100%;box-sizing:border-box;background:#fff;border:1px solid #d9d9d9;border-radius:9px;
-  padding:13px 14px;color:rgba(0,0,0,.88);font-size:15px;margin:7px 0;outline:none;
+  height:48px;padding:0 14px;color:rgba(0,0,0,.88);font-size:15px;margin:8px 0;outline:none;
   transition:border-color .2s,box-shadow .2s}
 input::placeholder{color:rgba(0,0,0,.35)}
 input:focus{border-color:#2563eb;box-shadow:0 0 0 2px rgba(37,99,235,.1)}
 ul{list-style:none;padding:0;margin:14px 0}
 li{padding:6px 0;font-size:14px;color:#152239}li:before{content:"✓ ";color:#2563eb}
-button,.btn{width:100%;box-sizing:border-box;border:0;border-radius:9px;padding:14px;
-  font:inherit;font-size:15px;font-weight:600;cursor:pointer;margin-top:8px;
+button,.btn{width:100%;height:48px;box-sizing:border-box;border:0;border-radius:9px;padding:0 16px;
+  display:inline-flex;align-items:center;justify-content:center;font:inherit;font-size:15px;font-weight:600;cursor:pointer;margin-top:10px;
   transition:background .2s,color .2s}
 .primary{background:#2563eb;color:#fff;box-shadow:0 2px 0 rgba(37,99,235,.1)}
 .primary:hover{background:#1d4ed8}
 .ghost{background:transparent;color:#64748d;font-weight:500}
 .ghost:hover{color:#dc2626}
 .err{color:#dc2626;font-size:13px;text-align:center;margin:8px 0 0}
-form{margin:0}
+form{width:min(400px,100%);margin:0 auto}
 @media (max-width:640px){body:before{background-position:60% center}.card{padding:36px 24px}.locale-switch{right:18px}}
 </style>`
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Refined the bkn-safe login form control dimensions.
- [x] Standardized login input height and sign-in button height to 48px.
- [x] Reduced the form width to 400px while preserving mobile responsiveness.

---

## Why

- Related Issue: Closes #994
- Related Feature: bkn-safe login page visual refinement
- Background:
  - The current login form controls looked too wide inside the widened login card.
  - This change aligns the input fields and sign-in button with a more conventional enterprise product login-page proportion.

---

## How

- Key implementation points:
  - Set login form width to `min(400px, 100%)`.
  - Set input height to `48px`.
  - Set button height to `48px` and center button content with inline-flex.
- Breaking changes (API, config, database, etc.):
  - None. This is a CSS-only login page visual adjustment.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [x] Verified in test environment

Test notes:

```bash
cd bkn-safe/server
go test ./internal/httpapi
CGO_ENABLED=0 go build -ldflags "-s -w" -o /tmp/bkn-safe-994-control-size-pr.bin .
```

Test environment verification:

- Deployed to `118.196.95.132` for manual validation.
- Verified the served login page contains the new `400px` form width and `48px` input/button heights.

---

## Risk & Rollback

- Potential risks:
  - Visual spacing may still need product-side fine tuning after manual review.
- Rollback plan:
  - Revert this PR, or roll the `bkn-safe` deployment back to the previous image recorded in `/root/openbkn-994-rollback-latest.txt` on `118.196.95.132`.

---

## Additional Notes

- This PR is intentionally scoped to login input/button sizing only.
- The branch was recreated from the latest `origin/main` so the PR diff only contains the current visual adjustment.
