### PR TITLE
fix(bkn): preserve large integer precision

### DIFF
--- a/adp/bkn/bkn-backend/server/common/convert.go
+++ b/adp/bkn/bkn-backend/server/common/convert.go
@@ -7,7 +7,10 @@
 package common
 
 import (
+	"encoding/json"
+	"fmt"
 	"math"
+	"strconv"
 	"strings"
 )
 
@@ -38,6 +41,42 @@ func BytesToGiB(bytes int64) float64 {
 
 func GiBToBytes(gib int64) int64 {
 	return gib * oneGiB
+}
+
+// AnyToFloat64 converts supported numeric values to float64.
+func AnyToFloat64(value any) (float64, error) {
+	switch v := value.(type) {
+	case json.Number:
+		return v.Float64()
+	case float32:
+		return float64(v), nil
+	case float64:
+		return v, nil
+	case int:
+		return float64(v), nil
+	case int8:
+		return float64(v), nil
+	case int16:
+		return float64(v), nil
+	case int32:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint:
+		return float64(v), nil
+	case uint8:
+		return float64(v), nil
+	case uint16:
+		return float64(v), nil
+	case uint32:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	default:
+		return 0, fmt.Errorf("cannot convert type %T to float64", value)
+	}
 }
 
 // Deduplicate a string slice.

--- a/adp/bkn/bkn-backend/server/common/convert_test.go
+++ b/adp/bkn/bkn-backend/server/common/convert_test.go
@@ -7,6 +7,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -59,6 +60,27 @@ func Test_Convert_GiBToBytes(t *testing.T) {
 		Convey("GiBToBytes3", func() {
 			actual := GiBToBytes(0)
 			So(actual, ShouldEqual, 0)
+		})
+	})
+}
+
+func Test_Convert_AnyToFloat64(t *testing.T) {
+	Convey("Test AnyToFloat64", t, func() {
+		Convey("json.Number", func() {
+			actual, err := AnyToFloat64(json.Number("0.95"))
+			So(err, ShouldBeNil)
+			So(actual, ShouldAlmostEqual, 0.95)
+		})
+
+		Convey("legacy float64", func() {
+			actual, err := AnyToFloat64(float64(0.95))
+			So(err, ShouldBeNil)
+			So(actual, ShouldAlmostEqual, 0.95)
+		})
+
+		Convey("invalid value", func() {
+			_, err := AnyToFloat64([]int{1})
+			So(err, ShouldNotBeNil)
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/bytedance/sonic"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
@@ -24,8 +25,9 @@ import (
 )
 
 var (
-	vbAccessOnce sync.Once
-	vbAccess     interfaces.VegaBackendAccess
+	vbAccessOnce     sync.Once
+	vbAccess         interfaces.VegaBackendAccess
+	vegaResponseJSON = sonic.Config{UseNumber: true}.Froze()
 )
 
 type vegaBackendAccess struct {
@@ -400,7 +402,8 @@ func (vba *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID 
 	}
 
 	var response interfaces.DatasetQueryResponse
-	if err := json.Unmarshal([]byte(respData), &response); err != nil {
+	// Dynamic resource fields must keep their original JSON number representation.
+	if err := vegaResponseJSON.Unmarshal(respData, &response); err != nil {
 		common.LogSafeError(ctx, "Failed to unmarshal QueryDatasetData response", err)
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmarshal QueryDatasetData response failed")
 		return nil, fmt.Errorf("failed to unmarshal QueryDatasetData response: %v", err)

--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -7,10 +7,17 @@
 package vega_backend
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
+	rmock "github.com/openbkn-ai/bkn-foundry/comm-go/rest/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"bkn-backend/interfaces"
 )
@@ -45,4 +52,64 @@ func TestResourceDataQueryRequestUsesPagingContract(t *testing.T) {
 		_, err := resourceDataQueryRequest(&interfaces.ResourceDataQueryParams{})
 		require.Error(t, err)
 	})
+}
+
+func TestQueryResourceDataPreservesLargeIntegers(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+	mockHTTPClient.EXPECT().
+		PostNoUnmarshal(gomock.Any(), "http://vega/resources/resource-1/data", gomock.Any(), gomock.Any()).
+		Return(http.StatusOK, []byte(`{
+			"entries":[{
+				"int64_max":9223372036854775807,
+				"int64_over":9223372036854775808,
+				"uint64_max":18446744073709551615,
+				"int64_min":-9223372036854775808,
+				"safe":42,
+				"ratio":1.5,
+				"text":"00123",
+				"flag":true,
+				"nothing":null,
+				"nested":{"uint64_max":18446744073709551615}
+			}],
+			"total_count":1
+		}`), nil)
+
+	access := &vegaBackendAccess{
+		httpClient: mockHTTPClient,
+		baseUrl:    "http://vega",
+	}
+	response, err := access.QueryResourceData(context.Background(), "resource-1", &interfaces.ResourceDataQueryParams{
+		Paging: interfaces.ResourceDataPagingRequest{Mode: "single"},
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Entries, 1)
+	assert.EqualValues(t, 1, response.TotalCount)
+
+	expected := map[string]string{
+		"int64_max":  "9223372036854775807",
+		"int64_over": "9223372036854775808",
+		"uint64_max": "18446744073709551615",
+		"int64_min":  "-9223372036854775808",
+		"safe":       "42",
+		"ratio":      "1.5",
+	}
+	for field, literal := range expected {
+		number, ok := response.Entries[0][field].(json.Number)
+		require.Truef(t, ok, "%s should decode as json.Number", field)
+		assert.Equal(t, literal, number.String())
+	}
+	assert.Equal(t, "00123", response.Entries[0]["text"])
+	assert.Equal(t, true, response.Entries[0]["flag"])
+	assert.Nil(t, response.Entries[0]["nothing"])
+	nested, ok := response.Entries[0]["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, json.Number("18446744073709551615"), nested["uint64_max"])
+
+	wire, err := sonic.Marshal(response)
+	require.NoError(t, err)
+	for _, literal := range expected {
+		assert.Contains(t, string(wire), literal)
+	}
+	assert.False(t, strings.Contains(string(wire), "e+"))
 }

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -1134,8 +1134,7 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 			if len(atIDMap) == 0 || atIDMap[actionType.ATID] {
 				// Extract _score when present.
 				if scoreVal, ok := entry["_score"]; ok {
-					if scoreFloat, ok := scoreVal.(float64); ok {
-						score := float64(scoreFloat)
+					if score, err := common.AnyToFloat64(scoreVal); err == nil {
 						actionType.Score = &score
 					}
 				}

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -810,9 +810,8 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 					WithErrorDetails(fmt.Sprintf("failed to Unmarshal dataset entry to MetricDefinition, %s", err.Error()))
 			}
 			if scoreVal, ok := entry["_score"]; ok {
-				if scoreFloat, ok := scoreVal.(float64); ok {
-					s := float64(scoreFloat)
-					m.Score = &s
+				if score, err := common.AnyToFloat64(scoreVal); err == nil {
+					m.Score = &score
 				}
 			}
 			m.Vector = nil

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1728,8 +1728,7 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 				}
 				// Extract _score when present.
 				if scoreVal, ok := entry["_score"]; ok {
-					if scoreFloat, ok := scoreVal.(float64); ok {
-						score := float64(scoreFloat)
+					if score, err := common.AnyToFloat64(scoreVal); err == nil {
 						objectType.Score = &score
 					}
 				}

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -971,8 +971,7 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 			if len(rtIDMap) == 0 || rtIDMap[relationType.RTID] {
 				// Extract _score when present.
 				if scoreVal, ok := entry["_score"]; ok {
-					if scoreFloat, ok := scoreVal.(float64); ok {
-						score := float64(scoreFloat)
+					if score, err := common.AnyToFloat64(scoreVal); err == nil {
 						relationType.Score = &score
 					}
 				}

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -630,8 +630,7 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 			}
 
 			if scoreVal, ok := entry["_score"]; ok {
-				if scoreFloat, ok := scoreVal.(float64); ok {
-					score := float64(scoreFloat)
+				if score, err := common.AnyToFloat64(scoreVal); err == nil {
 					riskType.Score = &score
 				}
 			}

--- a/adp/bkn/ontology-query/server/common/convert_test.go
+++ b/adp/bkn/ontology-query/server/common/convert_test.go
@@ -7,6 +7,7 @@
 package common
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -92,6 +93,14 @@ func Test_Convert_GiBToBytes(t *testing.T) {
 	})
 }
 
+func Test_AnyToFloat64(t *testing.T) {
+	Convey("Test AnyToFloat64 with json.Number", t, func() {
+		result, err := AnyToFloat64(json.Number("0.95"))
+		So(err, ShouldBeNil)
+		So(result, ShouldAlmostEqual, 0.95)
+	})
+}
+
 func Test_AnyToInt64(t *testing.T) {
 	Convey("Test AnyToInt64", t, func() {
 		Convey("成功 - int类型", func() {
@@ -170,6 +179,12 @@ func Test_AnyToInt64(t *testing.T) {
 			result, err := AnyToInt64("42")
 			So(err, ShouldBeNil)
 			So(result, ShouldEqual, 42)
+		})
+
+		Convey("成功 - json.Number类型", func() {
+			result, err := AnyToInt64(json.Number("9223372036854775807"))
+			So(err, ShouldBeNil)
+			So(result, ShouldEqual, int64(9223372036854775807))
 		})
 
 		Convey("失败 - string类型无效", func() {

--- a/adp/bkn/ontology-query/server/common/convert_test.go
+++ b/adp/bkn/ontology-query/server/common/convert_test.go
@@ -181,7 +181,7 @@ func Test_AnyToInt64(t *testing.T) {
 			So(result, ShouldEqual, 42)
 		})
 
-		Convey("成功 - json.Number类型", func() {
+		Convey("success - json.Number type", func() {
 			result, err := AnyToInt64(json.Number("9223372036854775807"))
 			So(err, ShouldBeNil)
 			So(result, ShouldEqual, int64(9223372036854775807))

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -8,12 +8,12 @@ package vega_backend
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
 
+	"github.com/bytedance/sonic"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	vbOnce sync.Once
-	vb     interfaces.VegaBackendAccess
+	vbOnce           sync.Once
+	vb               interfaces.VegaBackendAccess
+	vegaResponseJSON = sonic.Config{UseNumber: true}.Froze()
 )
 
 type vegaBackendAccess struct {
@@ -77,7 +78,8 @@ func (v *vegaBackendAccess) QueryResourceData(ctx context.Context, resourceID st
 		return nil, interfaces.NewVegaDownstreamError(respCode, string(respData))
 	}
 	var response interfaces.DatasetQueryResponse
-	if err := json.Unmarshal([]byte(respData), &response); err != nil {
+	// Dynamic resource fields must keep their original JSON number representation.
+	if err := vegaResponseJSON.Unmarshal(respData, &response); err != nil {
 		return nil, fmt.Errorf("unmarshal QueryResourceData response: %w", err)
 	}
 	return &response, nil

--- a/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -2,11 +2,13 @@ package vega_backend
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	rmock "github.com/openbkn-ai/bkn-foundry/comm-go/rest/mock"
 	"github.com/smartystreets/goconvey/convey"
 	"go.opentelemetry.io/otel"
@@ -131,5 +133,69 @@ func TestNormalizeResourceDataQueryParams(t *testing.T) {
 			},
 		})
 		convey.So(got.Paging.Limit, convey.ShouldEqual, 50)
+	})
+}
+
+func TestVegaBackendAccessQueryResourceDataPreservesLargeIntegers(t *testing.T) {
+	convey.Convey("QueryResourceData preserves dynamic JSON number literals", t, func() {
+		mockCtrl := gomock.NewController(t)
+		mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+		mockHTTPClient.EXPECT().
+			PostNoUnmarshal(gomock.Any(), "http://vega/resources/resource-1/data", gomock.Any(), gomock.Any()).
+			Return(http.StatusOK, []byte(`{
+				"entries":[{
+					"int64_max":9223372036854775807,
+					"int64_over":9223372036854775808,
+					"uint64_max":18446744073709551615,
+					"int64_min":-9223372036854775808,
+					"safe":42,
+					"ratio":1.5,
+					"text":"00123",
+					"flag":true,
+					"nothing":null,
+					"nested":{"uint64_max":18446744073709551615}
+				}],
+				"total_count":1,
+				"search_after":[18446744073709551615]
+			}`), nil)
+
+		access := &vegaBackendAccess{
+			httpClient: mockHTTPClient,
+			baseURL:    "http://vega",
+		}
+		response, err := access.QueryResourceData(context.Background(), "resource-1", &interfaces.ResourceDataQueryParams{})
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(response.Entries, convey.ShouldHaveLength, 1)
+		convey.So(response.TotalCount, convey.ShouldEqual, int64(1))
+
+		expected := map[string]string{
+			"int64_max":  "9223372036854775807",
+			"int64_over": "9223372036854775808",
+			"uint64_max": "18446744073709551615",
+			"int64_min":  "-9223372036854775808",
+			"safe":       "42",
+			"ratio":      "1.5",
+		}
+		for field, literal := range expected {
+			number, ok := response.Entries[0][field].(json.Number)
+			convey.So(ok, convey.ShouldBeTrue)
+			convey.So(number.String(), convey.ShouldEqual, literal)
+		}
+		convey.So(response.Entries[0]["text"], convey.ShouldEqual, "00123")
+		convey.So(response.Entries[0]["flag"], convey.ShouldEqual, true)
+		convey.So(response.Entries[0]["nothing"], convey.ShouldBeNil)
+		nested, ok := response.Entries[0]["nested"].(map[string]any)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(nested["uint64_max"], convey.ShouldResemble, json.Number("18446744073709551615"))
+		searchAfter, ok := response.SearchAfter[0].(json.Number)
+		convey.So(ok, convey.ShouldBeTrue)
+		convey.So(searchAfter.String(), convey.ShouldEqual, "18446744073709551615")
+
+		wire, err := sonic.Marshal(response)
+		convey.So(err, convey.ShouldBeNil)
+		for _, literal := range expected {
+			convey.So(strings.Contains(string(wire), literal), convey.ShouldBeTrue)
+		}
+		convey.So(strings.Contains(string(wire), "e+"), convey.ShouldBeFalse)
 	})
 }

--- a/adp/bkn/ontology-query/server/logics/common.go
+++ b/adp/bkn/ontology-query/server/logics/common.go
@@ -1141,6 +1141,16 @@ func parseTime(value any) (time.Time, error) {
 		return time.Unix(v, 0), nil
 	case float64:
 		return time.Unix(int64(v), 0), nil
+	case json.Number:
+		timestamp, err := v.Int64()
+		if err != nil {
+			floatTimestamp, floatErr := v.Float64()
+			if floatErr != nil {
+				return time.Time{}, fmt.Errorf("unable to parse JSON number as time: %s", v)
+			}
+			timestamp = int64(floatTimestamp)
+		}
+		return time.Unix(timestamp, 0), nil
 	case string:
 		// Try parsing as RFC3339
 		if t, err := time.Parse(time.RFC3339, v); err == nil {
@@ -1264,6 +1274,8 @@ func isNumeric(value any) bool {
 		return true
 	case float32, float64:
 		return true
+	case json.Number:
+		return true
 	}
 	return false
 }
@@ -1295,6 +1307,9 @@ func toFloat64(value any) float64 {
 		return float64(v)
 	case float64:
 		return v
+	case json.Number:
+		result, _ := v.Float64()
+		return result
 	}
 	return 0
 }

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -654,7 +654,7 @@ func Test_GetObjectID(t *testing.T) {
 			So(uk["id"], ShouldEqual, "123")
 		})
 
-		Convey("成功 - 大整数主键保持精度", func() {
+		Convey("success - large integer primary key preserves precision", func() {
 			objectType := &interfaces.ObjectType{
 				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
 					OTID:        "ot1",

--- a/adp/bkn/ontology-query/server/logics/common_test.go
+++ b/adp/bkn/ontology-query/server/logics/common_test.go
@@ -8,7 +8,9 @@ package logics
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	cond "ontology-query/common/condition"
 	oerrors "ontology-query/errors"
@@ -652,6 +654,20 @@ func Test_GetObjectID(t *testing.T) {
 			So(uk["id"], ShouldEqual, "123")
 		})
 
+		Convey("成功 - 大整数主键保持精度", func() {
+			objectType := &interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID:        "ot1",
+					PrimaryKeys: []string{"id"},
+				},
+			}
+			largeID := json.Number("9223372036854775808")
+
+			id, uk := GetObjectID(map[string]any{"id": largeID}, objectType)
+			So(id, ShouldEqual, "ot1-9223372036854775808")
+			So(uk["id"], ShouldResemble, largeID)
+		})
+
 		Convey("成功 - 多主键", func() {
 			objectType := &interfaces.ObjectType{
 				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
@@ -705,6 +721,24 @@ func Test_GetObjectID(t *testing.T) {
 			So(id, ShouldEqual, "ot1-123___NULL__")
 			So(uk["id"], ShouldEqual, "123")
 		})
+	})
+}
+
+func Test_JSONNumberCompatibility(t *testing.T) {
+	Convey("json.Number remains compatible with local condition evaluation", t, func() {
+		value := json.Number("1700000000")
+		parsed, err := parseTime(value)
+		So(err, ShouldBeNil)
+		So(parsed, ShouldResemble, time.Unix(1700000000, 0))
+		parsed, err = parseTime(json.Number("1700000000.9"))
+		So(err, ShouldBeNil)
+		So(parsed, ShouldResemble, time.Unix(1700000000, 0))
+		So(isNumeric(json.Number("0.95")), ShouldBeTrue)
+		So(toFloat64(json.Number("0.95")), ShouldAlmostEqual, 0.95)
+
+		matched, err := compareValues(json.Number("2"), float64(1), ">", "")
+		So(err, ShouldBeNil)
+		So(matched, ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Preserve Vega dynamic JSON number literals in bkn-backend and ontology-query.
- [x] Keep score, time, and numeric consumers compatible with json.Number.
- [x] Add focused regression coverage for int64 and uint64 boundaries and unchanged non-number fields.

---

## Why

- Related Issue: [openbkn-ai/bkn-studio#464](https://github.com/openbkn-ai/bkn-studio/issues/464)
- Related Feature: N/A — bug fix for object preview precision.
- Background: Vega resource entries are decoded into map[string]any. Default JSON decoding converts numbers to float64, so integers above the IEEE-754 safe range lose precision before they reach the preview response.

---

## How

- Key implementation points:
  - Decode Vega resource responses with a reusable Sonic configuration using UseNumber.
  - Preserve strongly typed response fields such as total_count and paging metadata.
  - Convert json.Number only at consumers that explicitly require float64, such as _score.
  - Keep ontology local time and numeric condition handling compatible with json.Number.
- Breaking changes (API, config, database, etc.): None. Dynamic numeric values use json.Number internally, while the JSON wire format remains numeric and unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no cross-service integration environment was used.
- [ ] Verified in test environment — pending deployment by the maintainers.

Test notes:

- I18N_MODE_UT=true go test ./... in adp/bkn/bkn-backend/server
- I18N_MODE_UT=true go test ./... in adp/bkn/ontology-query/server
- I18N_MODE_UT=true go vet ./... in both modules
- git diff --check

---

## Risk & Rollback

- Potential risks: Code that inspects dynamic Vega numeric values by concrete Go type will now receive json.Number instead of float64. Known score, time, and numeric consumers have been adapted and covered by tests. Local comparisons of very large integers retain the existing float64 comparison semantics.
- Rollback plan: Revert commit 5af326c4 to restore the previous decoder and consumer behavior.

---

## Additional Notes

- String, boolean, null, nested object, decimal, signed integer, and uint64 boundary cases are covered by adapter regression tests.
- No API schema, configuration, dependency, or database changes.

Closes openbkn-ai/bkn-studio#464
