### PR TITLE
fix(gokb): use zero value after failed type assertion in ConnectorWithNoticeHandler

### DIFF
--- a/comm-go/db/driver/kingbase/gokb/notice.go
+++ b/comm-go/db/driver/kingbase/gokb/notice.go
@@ -77,10 +77,10 @@ func ConnectorNoticeHandler(c driver.Connector) (f func(*Error)) {
 //
 // 注意:通知处理程序为同步执行，在返回之前不会继续处理命令
 func ConnectorWithNoticeHandler(c driver.Connector, handler func(*Error)) (nhc *NoticeHandlerConnector) {
-	if c, ok := c.(*NoticeHandlerConnector); ok {
-		c.noticeHandler = handler
-		return c
-	} else {
-		return &NoticeHandlerConnector{Connector: c, noticeHandler: handler}
+	nhc = &NoticeHandlerConnector{Connector: c, noticeHandler: handler}
+	if wrapped, ok := c.(*NoticeHandlerConnector); ok {
+		wrapped.noticeHandler = handler
+		nhc = wrapped
 	}
+	return nhc
 }

--- a/comm-go/db/driver/kingbase/gokb/notice_test.go
+++ b/comm-go/db/driver/kingbase/gokb/notice_test.go
@@ -1,0 +1,54 @@
+//go:build go1.10
+
+package gokb
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+)
+
+type fakeConnector struct{}
+
+func (fakeConnector) Connect(context.Context) (driver.Conn, error) { return nil, nil }
+func (fakeConnector) Driver() driver.Driver                        { return nil }
+
+func TestConnectorWithNoticeHandlerWrapsForeignConnector(t *testing.T) {
+	inner := fakeConnector{}
+	nhc := ConnectorWithNoticeHandler(inner, func(*Error) {})
+
+	// The returned connector must wrap the original connector. Before the
+	// fix, the else-branch referenced the shadowed variable (the failed
+	// type-assertion zero value), so Connector ended up as a nil
+	// *NoticeHandlerConnector instead of `inner`.
+	if nhc.Connector != driver.Connector(inner) {
+		t.Fatalf("ConnectorWithNoticeHandler lost the underlying connector: got %v, want %v", nhc.Connector, inner)
+	}
+	if nhc.noticeHandler == nil {
+		t.Fatal("notice handler was not set on the wrapper")
+	}
+}
+
+func TestConnectorWithNoticeHandlerReusesWrappedConnector(t *testing.T) {
+	inner := fakeConnector{}
+	first := ConnectorWithNoticeHandler(inner, func(*Error) {})
+	first.noticeHandler = nil // reset so we can observe the update below
+
+	second := ConnectorWithNoticeHandler(first, func(*Error) {})
+	if second != first {
+		t.Fatal("ConnectorWithNoticeHandler should reuse an existing NoticeHandlerConnector")
+	}
+	if second.noticeHandler == nil {
+		t.Fatal("notice handler was not updated on the reused connector")
+	}
+}
+
+func TestConnectorNoticeHandler(t *testing.T) {
+	if got := ConnectorNoticeHandler(fakeConnector{}); got != nil {
+		t.Fatal("expected nil handler for foreign connector")
+	}
+	nhc := ConnectorWithNoticeHandler(fakeConnector{}, func(*Error) {})
+	if ConnectorNoticeHandler(nhc) == nil {
+		t.Fatal("expected handler to be readable back")
+	}
+}


### PR DESCRIPTION
## Problem

`ConnectorWithNoticeHandler` in `comm-go/db/driver/kingbase/gokb/notice.go` had a subtle scoping bug:

```go
func ConnectorWithNoticeHandler(c driver.Connector, handler func(*Error)) (nhc *NoticeHandlerConnector) {
	if c, ok := c.(*NoticeHandlerConnector); ok {
		c.noticeHandler = handler
		return c
	} else {
		return &NoticeHandlerConnector{Connector: c, noticeHandler: handler} // ← `c` here is the zero value
	}
}
```

In Go, the variable declared in an if-statement initializer (`c, ok := ...`) is scoped to the **entire if/else statement**, including the `else` branch. So in the `else` branch, `c` is not the original `driver.Connector` parameter — it is the **zero value of the failed type assertion** (a nil `*NoticeHandlerConnector`).

Consequence: wrapping any connector that is not already a `NoticeHandlerConnector` produced `NoticeHandlerConnector{Connector: nil}`, silently losing the underlying connector. Any subsequent `Connect` on the returned connector would nil-panic / break `sql.OpenDB`.

`staticcheck` flags this as **SA9008** (`c refers to the result of a failed type assertion and is a zero value, not the value that was being type-asserted`).

## Fix

Construct the wrapper from the original parameter first, and overwrite it only when the assertion succeeds — the same pattern used by lib/pq's [`ConnectorWithNoticeHandler`](https://github.com/lib/pq/blob/master/notice.go):

```go
func ConnectorWithNoticeHandler(c driver.Connector, handler func(*Error)) (nhc *NoticeHandlerConnector) {
	nhc = &NoticeHandlerConnector{Connector: c, noticeHandler: handler}
	if wrapped, ok := c.(*NoticeHandlerConnector); ok {
		wrapped.noticeHandler = handler
		nhc = wrapped
	}
	return nhc
}
```

## Tests

Adds `notice_test.go` (the package previously had no tests) covering:

- wrapping a foreign connector **preserves** the underlying connector (fails on the old code with `got <nil>`)
- re-wrapping an existing `NoticeHandlerConnector` reuses and updates it in place
- `ConnectorNoticeHandler` read-back returns the handler / nil correctly

```
$ go test ./db/driver/kingbase/gokb/
ok  github.com/openbkn-ai/bkn-foundry/comm-go/db/driver/kingbase/gokb

$ staticcheck ./db/driver/kingbase/gokb/ | grep SA9008
(no findings)
```

## Scope

Intentionally minimal: only the buggy function + new tests. Other staticcheck/style findings in the gokb package (mostly inherited from the lib/pq fork) are left untouched.