### PR TITLE
feat(context-loader): skip object types the query has nothing to do with

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
       knn_k: {{ .Values.service.concept_search_config.knn_k }}
     instance_search_config:
       min_reranker_score: {{ .Values.service.instance_search_config.min_reranker_score }}
+      min_object_type_score_ratio: {{ .Values.service.instance_search_config.min_object_type_score_ratio }}
     oauth:
       public_host: {{ .Values.depServices.hydra.publicHost | quote }}
       public_port: {{ .Values.depServices.hydra.publicPort }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -61,6 +61,8 @@ service:
   instance_search_config:
     # 0 keeps the relevance gate off. See agent-retrieval.yaml for how to calibrate it.
     min_reranker_score: 0
+    # 0 keeps the object type pre-filter off. Same file for how to calibrate it.
+    min_object_type_score_ratio: 0
   rerank_llm: # The model uses the system default LLM by default; override per request through rerank_llm_model.
     temperature: 0
     top_k: 2

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
@@ -17,6 +17,12 @@ instance_search_config:
   # environments those bands sit an order of magnitude apart, and in different places.
   # Setting it above 0 makes every instance query pay for one reranker call.
   min_reranker_score: 0
+  # Skip an object type whose concept-recall score is below this fraction of the best-scoring one,
+  # before instance recall pays a downstream query for it. 0 leaves the pre-filter off.
+  # Measured spreads are narrow — concept recall has already kept only its top matches, so the worst
+  # survivor scored 0.21 and 0.27 of the best on two of our networks. Pick a value from the
+  # [ObjectTypePreFilter] debug line on your own data; the best-scoring object type is always kept.
+  min_object_type_score_ratio: 0
 oauth: # Corresponds to the Hydra service.
   public_host: "hydra-public.openbkn"
   public_port: 4444

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -164,6 +164,14 @@ type KnInstanceSearchConfig struct {
 	// and 0.74 on the other for the same kind of query. A caller cannot know which deployment it is
 	// talking to, so it cannot pick this value; whoever calibrated the deployment can.
 	MinRerankerScore float64 `yaml:"min_reranker_score"`
+	// MinObjectTypeScoreRatio skips an object type whose concept-recall score is below this fraction
+	// of the best-scoring object type of the same recall, before instance recall issues a query for
+	// it. 0 (the default) leaves the pre-filter off.
+	//
+	// Off by default for want of a portable value: concept recall has already kept only its best
+	// matches, so the spread among survivors is narrow — the worst one scored 0.21 and 0.27 of the
+	// best on two of our own networks. A ratio that trims one of them barely touches the other.
+	MinObjectTypeScoreRatio float64 `yaml:"min_object_type_score_ratio"`
 }
 
 // MFModelAPI configuration uses a unified PrivateBaseConfig structure.

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -271,6 +271,7 @@ type SemanticInstanceRetrievalConfig struct {
 	InstanceRerankMode                string  `json:"instance_rerank_mode,omitempty"`                   // off (default) / on / shadow.
 	MinRerankerScore                  float64 `json:"min_reranker_score,omitempty"`                     // 0 keeps the deployment's value.
 	ObjectTypeConcurrency             int     `json:"object_type_concurrency,omitempty"`                // Default 6.
+	MinObjectTypeScoreRatio           float64 `json:"min_object_type_score_ratio,omitempty"`            // 0 disables the object type pre-filter.
 }
 
 // RetrievalConfig retrieveconfiguration.

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -113,6 +113,14 @@ type KnSearchSemanticInstanceRetrievalConfig struct {
 	InstanceRerankMode string `json:"instance_rerank_mode" default:"off"`
 	// InstanceRerankModel overrides fine-ranking small model names; leave blank to use the default reranker configured by model management (#842).
 	InstanceRerankModel string `json:"instance_rerank_model,omitempty"`
+	// MinObjectTypeScoreRatio drops an object type from instance recall when concept recall scored it
+	// below this fraction of the best-scoring object type in the same recall. 0 (the default) keeps
+	// every object type concept recall selected.
+	//
+	// Relative rather than absolute because the score comes from BKN's own concept search and carries
+	// no fixed scale; relative to the best of the same pass is the one comparison it supports. The
+	// best-scoring object type is always kept, so the filter can narrow a query but never empty it.
+	MinObjectTypeScoreRatio float64 `json:"min_object_type_score_ratio,omitempty"`
 	// ObjectTypeConcurrency caps how many object types are queried at once. Each one costs at least
 	// one downstream query, and with a vector channel it also costs one embedding call, so a serial
 	// walk made latency the sum of every object type's round trip.
@@ -163,6 +171,13 @@ type KnSearchObjectType struct {
 	LogicProperties []*KnSearchLogicProperty `json:"logic_properties,omitempty"`
 	PrimaryKeys     []string                 `json:"primary_keys,omitempty"`
 	SampleData      map[string]any           `json:"sample_data,omitempty"`
+	// Score is concept recall's relevance score for this object type, kept off the wire (json:"-").
+	//
+	// It exists so instance recall can skip object types the query has nothing to do with, before
+	// paying a downstream query for them. It is not a response field: it is comparable only within
+	// one concept recall (BKN scores the whole candidate set in one pass), which is exactly the scope
+	// that uses it, and publishing it would invite comparisons across queries that do not hold.
+	Score float64 `json:"-"`
 }
 
 // KnSearchDataProperty data property (local response shape)

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -1015,6 +1015,7 @@ func (s *localSearchImpl) convertObjectTypesToLocal(objects []*interfaces.Object
 			Tags:        tags,
 			DataSource:  dataSource,
 			PrimaryKeys: primaryKeys,
+			Score:       obj.Score,
 		}
 
 		if len(obj.DataProperties) > 0 {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
@@ -195,6 +195,9 @@ func mergeSemanticInstanceRetrievalConfig(base, user *interfaces.KnSearchSemanti
 	if user.ObjectTypeConcurrency > 0 {
 		base.ObjectTypeConcurrency = user.ObjectTypeConcurrency
 	}
+	if user.MinObjectTypeScoreRatio > 0 {
+		base.MinObjectTypeScoreRatio = user.MinObjectTypeScoreRatio
+	}
 	if user.RerankTopN > 0 {
 		base.RerankTopN = user.RerankTopN
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/convert.go
@@ -127,6 +127,7 @@ func retrievalConfigStructToLocal(rc *interfaces.RetrievalConfig) *interfaces.Kn
 			InstanceRerankMode:                s.InstanceRerankMode,
 			MinRerankerScore:                  s.MinRerankerScore,
 			ObjectTypeConcurrency:             s.ObjectTypeConcurrency,
+			MinObjectTypeScoreRatio:           s.MinObjectTypeScoreRatio,
 			EnableGlobalFinalScoreRatioFilter: boolPtr(s.EnableGlobalFinalScoreRatioFilter),
 			GlobalFinalScoreRatio:             s.GlobalFinalScoreRatio,
 			ExactNameMatchScore:               s.ExactNameMatchScore,

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_type_prefilter_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_type_prefilter_test.go
@@ -1,0 +1,151 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License.
+// See the LICENSE file in the project root for details.
+
+package knsearch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func scoredObjectTypes(scores ...float64) []*interfaces.KnSearchObjectType {
+	out := make([]*interfaces.KnSearchObjectType, 0, len(scores))
+	for i, score := range scores {
+		out = append(out, &interfaces.KnSearchObjectType{
+			ConceptID:   fmt.Sprintf("ot_%02d", i),
+			ConceptName: fmt.Sprintf("ot_%02d", i),
+			Score:       score,
+			DataProperties: []*interfaces.KnSearchDataProperty{{
+				Name:                "name",
+				Type:                "text",
+				ConditionOperations: []interfaces.KnOperationType{interfaces.KnOperationTypeMatch},
+			}},
+		})
+	}
+	return out
+}
+
+func keptConceptIDs(objectTypes []*interfaces.KnSearchObjectType) []string {
+	out := make([]string, 0, len(objectTypes))
+	for _, objType := range objectTypes {
+		out = append(out, objType.ConceptID)
+	}
+	return out
+}
+
+func TestFilterObjectTypesByScore_DropsTheFarBehind(t *testing.T) {
+	svc := &localSearchImpl{logger: &mockLogger{}}
+	// 9.0 is the best; 0.2 and 0.1 are an order of magnitude behind it.
+	kept := svc.filterObjectTypesByScore(context.Background(), scoredObjectTypes(9.0, 4.5, 0.2, 0.1), 0.25)
+
+	if got := keptConceptIDs(kept); len(got) != 2 || got[0] != "ot_00" || got[1] != "ot_01" {
+		t.Fatalf("expected the two object types above a quarter of the best, got %v", got)
+	}
+}
+
+// No scores means concept recall had no signal to give, not that nothing is relevant.
+func TestFilterObjectTypesByScore_NoSignalKeepsEverything(t *testing.T) {
+	svc := &localSearchImpl{logger: &mockLogger{}}
+	kept := svc.filterObjectTypesByScore(context.Background(), scoredObjectTypes(0, 0, 0), 0.5)
+
+	if len(kept) != 3 {
+		t.Fatalf("expected all three object types, got %v", keptConceptIDs(kept))
+	}
+}
+
+// The filter may narrow a query. It may not empty one.
+func TestFilterObjectTypesByScore_AlwaysKeepsTheBest(t *testing.T) {
+	svc := &localSearchImpl{logger: &mockLogger{}}
+	kept := svc.filterObjectTypesByScore(context.Background(), scoredObjectTypes(0.4, 0.3, 0.2), 10)
+
+	if got := keptConceptIDs(kept); len(got) != 1 || got[0] != "ot_00" {
+		t.Fatalf("expected the best-scoring object type to survive any threshold, got %v", got)
+	}
+}
+
+// Off by default: the ratio has no portable value, so a deployment opts in after looking at the
+// spread this logs.
+func TestFilterObjectTypesByScore_DisabledByDefault(t *testing.T) {
+	svc := &localSearchImpl{logger: &mockLogger{}}
+	config := DefaultSemanticInstanceRetrievalConfig()
+	if config.MinObjectTypeScoreRatio != 0 {
+		t.Fatalf("expected the pre-filter off by default, got ratio %v", config.MinObjectTypeScoreRatio)
+	}
+	kept := svc.filterObjectTypesByScore(context.Background(),
+		scoredObjectTypes(9.0, 0.1), config.MinObjectTypeScoreRatio)
+	if len(kept) != 2 {
+		t.Fatalf("default config dropped object types: %v", keptConceptIDs(kept))
+	}
+}
+
+// An object type the query has nothing to do with costs a downstream query; the point of the filter
+// is that the query is never issued.
+func TestSemanticInstanceRetrieval_PreFilterSavesDownstreamQueries(t *testing.T) {
+	mockQuery := &mockOntologyQuery{
+		instancesFunc: func(req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+			return rowsToResp([]map[string]any{instanceRow(req.OtID, 9)}), nil
+		},
+	}
+	svc := &localSearchImpl{logger: &mockLogger{}, ontologyQuery: mockQuery}
+	config := DefaultRetrievalConfig()
+	config.SemanticInstanceRetrieval.MinObjectTypeScoreRatio = 0.25
+
+	if _, err := svc.semanticInstanceRetrieval(context.Background(),
+		&interfaces.KnSearchLocalRequest{KnID: "129", Query: "q"},
+		scoredObjectTypes(9.0, 4.5, 0.2, 0.1), config); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls := mockQuery.calls(); calls != 2 {
+		t.Errorf("expected 2 downstream queries for the 2 surviving object types, got %d", calls)
+	}
+}
+
+// The repeatable half of the performance claim: downstream request count stays one query per object
+// type (single channel here), and wall clock stays flat rather than summing them.
+func TestSemanticInstanceRetrieval_CostScalesWithObjectTypes(t *testing.T) {
+	const delay = 40 * time.Millisecond
+	for _, count := range []int{1, 3, 5, 10} {
+		count := count
+		t.Run(fmt.Sprintf("object_types=%d", count), func(t *testing.T) {
+			mockQuery := &mockOntologyQuery{
+				instancesFunc: func(req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+					time.Sleep(delay)
+					return rowsToResp([]map[string]any{instanceRow(req.OtID, 9)}), nil
+				},
+			}
+			svc := &localSearchImpl{logger: &mockLogger{}, ontologyQuery: mockQuery}
+			config := DefaultRetrievalConfig()
+			config.ConceptRetrieval.TopK = count
+
+			start := time.Now()
+			result, err := svc.semanticInstanceRetrieval(context.Background(),
+				&interfaces.KnSearchLocalRequest{KnID: "129", Query: "q"},
+				fanoutObjectTypes(count), config)
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			t.Logf("object_types=%2d downstream_queries=%2d elapsed=%v", count, mockQuery.calls(), elapsed)
+
+			if got := mockQuery.calls(); got != count {
+				t.Errorf("expected one downstream query per object type, got %d for %d types", got, count)
+			}
+			if len(result.Nodes) != count {
+				t.Errorf("expected one row per object type, got %d", len(result.Nodes))
+			}
+			// With a concurrency of 6, ten object types take two waves — nothing near ten delays.
+			waves := (count + DefaultSemanticInstanceRetrievalConfig().ObjectTypeConcurrency - 1) /
+				DefaultSemanticInstanceRetrievalConfig().ObjectTypeConcurrency
+			if budget := time.Duration(waves+1) * delay; elapsed > budget {
+				t.Errorf("elapsed %v exceeds %v for %d object types", elapsed, budget, count)
+			}
+		})
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_type_prefilter_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_type_prefilter_test.go
@@ -149,3 +149,56 @@ func TestSemanticInstanceRetrieval_CostScalesWithObjectTypes(t *testing.T) {
 		})
 	}
 }
+
+// Zero means concept recall never scored this object type, not that it scored badly. It reaches the
+// candidate set unscored in ordinary ways: concept search scores only what it matched, relation
+// endpoints are completed in afterwards, and object_types pinned by the caller are applied before
+// scoring runs. Dropping those would silently skip an object type the caller named by hand.
+func TestFilterObjectTypesByScore_KeepsUnscoredObjectTypes(t *testing.T) {
+	svc := &localSearchImpl{logger: &mockLogger{}}
+	types := scoredObjectTypes(5.0, 0, 0.2)
+	types[1].ConceptID = "shipment" // pulled in as a relation endpoint, never scored
+
+	kept := svc.filterObjectTypesByScore(context.Background(), types, 0.3)
+
+	var sawShipment bool
+	for _, objType := range kept {
+		if objType.ConceptID == "shipment" {
+			sawShipment = true
+		}
+	}
+	if !sawShipment {
+		t.Fatalf("an unscored object type was dropped as if it had scored low: %v", keptConceptIDs(kept))
+	}
+	// The genuinely low-scoring one still goes.
+	for _, objType := range kept {
+		if objType.ConceptID == "ot_02" {
+			t.Errorf("expected the scored-but-low object type to be dropped: %v", keptConceptIDs(kept))
+		}
+	}
+}
+
+// End to end: an unscored object type still gets its downstream query.
+func TestSemanticInstanceRetrieval_PreFilterQueriesUnscoredObjectTypes(t *testing.T) {
+	queried := map[string]bool{}
+	mockQuery := &mockOntologyQuery{
+		instancesFunc: func(req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+			queried[req.OtID] = true
+			return rowsToResp([]map[string]any{instanceRow(req.OtID, 9)}), nil
+		},
+	}
+	svc := &localSearchImpl{logger: &mockLogger{}, ontologyQuery: mockQuery}
+	config := DefaultRetrievalConfig()
+	config.SemanticInstanceRetrieval.MinObjectTypeScoreRatio = 0.3
+
+	types := scoredObjectTypes(5.0, 0)
+	types[1].ConceptID = "shipment"
+
+	if _, err := svc.semanticInstanceRetrieval(context.Background(),
+		&interfaces.KnSearchLocalRequest{KnID: "129", Query: "q"}, types, config); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !queried["shipment"] {
+		t.Fatal("no instance query was issued for the unscored object type")
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/relevance_gate_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/relevance_gate_test.go
@@ -34,8 +34,8 @@ func gatedNodes(scores ...float64) []*interfaces.KnSearchNode {
 	out := make([]*interfaces.KnSearchNode, 0, len(scores))
 	for i, score := range scores {
 		out = append(out, &interfaces.KnSearchNode{
-			InstanceName: string(rune('a' + i)),
-			Score:        1,
+			InstanceName:  string(rune('a' + i)),
+			Score:         1,
 			RerankerScore: score,
 		})
 	}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -14,6 +14,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,6 +67,14 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 
 	instanceConfig := config.SemanticInstanceRetrieval
 	propertyConfig := config.PropertyFilter
+
+	// Drop the object types the query has nothing to do with before paying for them. A request may
+	// override the deployment's calibrated ratio, the same way it may override the relevance gate.
+	objectTypeRatio := instanceConfig.MinObjectTypeScoreRatio
+	if objectTypeRatio <= 0 && s.config != nil {
+		objectTypeRatio = s.config.InstanceSearchConfig.MinObjectTypeScoreRatio
+	}
+	objectTypes = s.filterObjectTypesByScore(ctx, objectTypes, objectTypeRatio)
 
 	// Hold instance recall to the number of object types the caller asked for.
 	//
@@ -219,6 +228,77 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 	}
 
 	return result, nil
+}
+
+// filterObjectTypesByScore drops object types concept recall scored far below its best one.
+//
+// Every object type kept here costs at least one downstream query, and one embedding call where a
+// vector channel applies, so the cheapest instance query is the one never issued. The scores come
+// from BKN's concept search and have no fixed scale, which is why the threshold is a fraction of the
+// best score of the same recall rather than an absolute number: that is the one comparison this
+// signal supports.
+//
+// Two guards keep the filter from turning a narrow answer into no answer:
+//   - no scores at all (every object type at 0) means concept recall had no signal to give, not that
+//     nothing is relevant, so nothing is dropped;
+//   - the best-scoring object type is always kept, so the filter can narrow a query, never empty it.
+//
+// It logs what it saw either way: the spread between the best and worst object type is what a
+// deployment needs in order to choose a ratio, and it is not visible from the response.
+func (s *localSearchImpl) filterObjectTypesByScore(
+	ctx context.Context,
+	objectTypes []*interfaces.KnSearchObjectType,
+	ratio float64,
+) []*interfaces.KnSearchObjectType {
+	if len(objectTypes) <= 1 {
+		return objectTypes
+	}
+
+	best, worst := 0.0, math.Inf(1)
+	for _, objType := range objectTypes {
+		if objType == nil {
+			continue
+		}
+		if objType.Score > best {
+			best = objType.Score
+		}
+		if objType.Score < worst {
+			worst = objType.Score
+		}
+	}
+	if best <= 0 {
+		s.logger.WithContext(ctx).Debugf(
+			"[ObjectTypePreFilter] Concept recall scored no object type, keeping all %d", len(objectTypes))
+		return objectTypes
+	}
+	s.logger.WithContext(ctx).Debugf(
+		"[ObjectTypePreFilter] Object type scores across %d types: best=%.4f worst=%.4f ratio=%.4f",
+		len(objectTypes), best, worst, ratio)
+	if ratio <= 0 {
+		return objectTypes
+	}
+
+	threshold := best * ratio
+	kept := make([]*interfaces.KnSearchObjectType, 0, len(objectTypes))
+	dropped := make([]string, 0)
+	for _, objType := range objectTypes {
+		if objType == nil {
+			continue
+		}
+		// Keep the best one whatever the threshold says: a query that recalled something should not
+		// come back empty because every candidate sat just under the bar.
+		if objType.Score >= threshold || objType.Score == best {
+			kept = append(kept, objType)
+			continue
+		}
+		dropped = append(dropped, objType.ConceptID)
+	}
+	if len(dropped) > 0 {
+		s.logger.WithContext(ctx).Infof(
+			"[ObjectTypePreFilter] Skipped %d object types below %.4f (best=%.4f): %v",
+			len(dropped), threshold, best, dropped)
+	}
+	return kept
 }
 
 // conceptTopK reports how many object types the caller allowed into instance recall, or 0 when the

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -281,8 +281,19 @@ func (s *localSearchImpl) filterObjectTypesByScore(
 	threshold := best * ratio
 	kept := make([]*interfaces.KnSearchObjectType, 0, len(objectTypes))
 	dropped := make([]string, 0)
+	unscored := 0
 	for _, objType := range objectTypes {
 		if objType == nil {
+			continue
+		}
+		// Zero is not a low score, it is no score. An object type reaches the candidate set without
+		// ever being scored in several ordinary ways: concept search only scores what it matched, the
+		// endpoints of a selected relation are completed in afterwards, and object_types pinned by the
+		// caller are applied before scoring runs at all. Dropping those would silently skip the very
+		// object type a caller named by hand.
+		if objType.Score <= 0 {
+			unscored++
+			kept = append(kept, objType)
 			continue
 		}
 		// Keep the best one whatever the threshold says: a query that recalled something should not
@@ -292,6 +303,10 @@ func (s *localSearchImpl) filterObjectTypesByScore(
 			continue
 		}
 		dropped = append(dropped, objType.ConceptID)
+	}
+	if unscored > 0 {
+		s.logger.WithContext(ctx).Debugf(
+			"[ObjectTypePreFilter] Kept %d object types concept recall never scored", unscored)
 	}
 	if len(dropped) > 0 {
 		s.logger.WithContext(ctx).Infof(


### PR DESCRIPTION
Closes the remaining acceptance criteria of #1056. Stacked on #1069 — retarget to `main` once that lands.

## Skip object types the query has nothing to do with

The cheapest instance query is the one never issued. Every object type reaching instance recall costs at least one downstream query, plus an embedding call where a vector channel applies.

Concept recall already scores object types, but the local shape dropped that score on conversion, so instance recall could not tell them apart. The score now rides along — off the wire, since it is comparable only within one concept recall and publishing it would invite comparisons across queries that do not hold — and `min_object_type_score_ratio` skips object types scoring far below the best of the same recall.

Relative, not absolute: the score comes from BKN's concept search with no fixed scale, so a fraction of the same pass's best is the one comparison it supports.

Two guards keep a narrow answer from becoming no answer:

- **no scores at all** means concept recall had no signal to give, not that nothing is relevant — nothing is dropped;
- **the best-scoring object type is always kept**, so the filter can narrow a query, never empty it.

## Off by default, and here is why

Measured on two networks, the object types that survived concept recall spanned:

| network | best | worst | worst / best |
|---|---|---|---|
| yanfeng_ont_v14 (12 types) | 23.33 | 4.98 | 0.21 |
| worldcup (11 types) | 14.58 | 4.01 | 0.27 |

A ratio that trims the first barely touches the second. The narrowness is structural rather than bad luck: concept recall has already kept only its top matches, so what remains to trim is "less related among the best", not "obviously unrelated". Shipping a constant here would be fitting one deployment's data.

So the mechanism ships with the knob at 0, and the `[ObjectTypePreFilter]` debug line reports the spread it saw either way — that line is the calibration input, and it is not visible from the response. Same discipline as `min_reranker_score` in #1069.

Reachable from deployment config (`instance_search_config.min_object_type_score_ratio`) and per request through `kn_search`'s `retrieval_config`.

## The repeatable cost measurement

#1056 also asked for a benchmark over 1/3/5/10 object types recording downstream request count and elapsed time. Table-driven test, asserting one downstream query per object type and that wall clock follows the concurrency bound instead of the sum:

```
object_types= 1 downstream_queries= 1 elapsed=40.2ms
object_types= 3 downstream_queries= 3 elapsed=41.2ms
object_types= 5 downstream_queries= 5 elapsed=40.3ms
object_types=10 downstream_queries=10 elapsed=84.7ms   <- two waves at concurrency 6
```

## Tests

Pre-filter: drops the far-behind, keeps everything when there is no signal, always keeps the best whatever the threshold, off by default, and — end to end — issues downstream queries only for the survivors.

`go build ./...` and `go test ./... -race` green across the context-loader server.

## What #1056 looks like after this

Every acceptance criterion is covered. Two are worth naming for what they are: the absolute relevance gate (#1069) and this pre-filter both ship **off by default**, because in both cases the threshold proved not to travel between deployments — the mechanism and the calibration data are the deliverable, not a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
