### PR TITLE
fix(vega): sync discovered source descriptions

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access.go
@@ -1012,6 +1012,7 @@ func (ra *resourceAccess) UpdateDiscoveryMetadata(ctx context.Context,
 	}
 
 	builder := sq.Update(RESOURCE_TABLE_NAME).
+		Set("f_description", resource.Description).
 		Set("f_status_message", resource.StatusMessage).
 		Set("f_source_metadata", string(sourceMetadataBytes)).
 		Set("f_schema_definition", string(schemaDefinitionBytes)).

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -453,8 +453,9 @@ func TestResourceAccessUpdateDiscoveryMetadata(t *testing.T) {
 	resource.LastDiscoverStatus = interfaces.DiscoverStatusUpdated
 	expectedUpdateTime := resource.UpdateTime - 1
 
-	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_status_message = ?, f_source_metadata = ?, f_schema_definition = ?, f_last_discover_status = ?, f_updater = ?, f_updater_type = ?, f_update_time = ? WHERE f_id = ? AND f_update_time = ?")).
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE t_resource SET f_description = ?, f_status_message = ?, f_source_metadata = ?, f_schema_definition = ?, f_last_discover_status = ?, f_updater = ?, f_updater_type = ?, f_update_time = ? WHERE f_id = ? AND f_update_time = ?")).
 		WithArgs(
+			resource.Description,
 			resource.StatusMessage,
 			`{"properties":{"row_count":42}}`,
 			`[{"name":"id","display_name":"","type":"integer","description":"","original_name":"","original_type":"","original_description":"","features":null,"attributes":null}]`,

--- a/adp/vega/vega-backend/server/interfaces/connector.go
+++ b/adp/vega/vega-backend/server/interfaces/connector.go
@@ -115,18 +115,21 @@ type MetricValue struct {
 
 // IndexMeta represents search index metadata.
 type IndexMeta struct {
-	Name       string                    `json:"name"`
-	Properties map[string]any            `json:"properties"`
-	Mapping    map[string]IndexFieldMeta `json:"mapping"`
+	Name        string                    `json:"name"`
+	Description string                    `json:"description"`
+	Properties  map[string]any            `json:"properties"`
+	Mapping     map[string]IndexFieldMeta `json:"mapping"`
+	MappingMeta map[string]any            `json:"mapping_meta"`
 }
 
 // IndexFieldMeta represents index field metadata.
 type IndexFieldMeta struct {
-	Name       string         `json:"name"`
-	Type       string         `json:"type"`
-	Analyzer   string         `json:"analyzer,omitempty"`
-	Searchable bool           `json:"searchable"`
-	Attributes map[string]any `json:"attributes"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Type        string         `json:"type"`
+	Analyzer    string         `json:"analyzer,omitempty"`
+	Searchable  bool           `json:"searchable"`
+	Attributes  map[string]any `json:"attributes"`
 	// SubFields (multi-fields) are arranged in alphabetical order by Name to ensure stable serialization
 	SubFields []IndexSubFieldMeta `json:"sub_fields,omitempty"`
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_discover.go
@@ -100,7 +100,9 @@ func (c *OpenSearchConnector) ListIndexes(ctx context.Context) ([]*interfaces.In
 		}
 
 		indices = append(indices, &interfaces.IndexMeta{
-			Name: idx.Index,
+			Name:        idx.Index,
+			Description: "",
+			MappingMeta: map[string]any{},
 			Properties: map[string]any{
 				"docs.count": idx.DocsCount,
 				"store.size": idx.StoreSize,
@@ -110,33 +112,22 @@ func (c *OpenSearchConnector) ListIndexes(ctx context.Context) ([]*interfaces.In
 	return indices, nil
 }
 
-// GetIndexMeta retrieves index metadata (mappings, settings).
-// GetIndexMeta obtains the metadata information of the specified index, including mapping and Settings
-// Parameter
-//
-//	-ctx: Context information, used to control the timeout and cancellation of requests
-//	-index: A pointer to the interface IndexMeta, used to store the obtained metadata
-//
-// Return value:
-//
-//	-error: If an error occurs during the operation, return an error message
+// GetIndexMeta retrieves an index's mappings and settings.
 func (c *OpenSearchConnector) GetIndexMeta(ctx context.Context, index *interfaces.IndexMeta) error {
-	// First, make sure the connector is connected to the OpenSearch service
 	if err := c.Connect(ctx); err != nil {
 		return err
 	}
 
-	// Check if the attribute mapping of the index is empty. If it is empty, initialize an empty map
 	if index.Properties == nil {
 		index.Properties = make(map[string]any)
 	}
+	index.Description = ""
+	index.MappingMeta = make(map[string]any)
 
-	// 1. Get Mappings
 	if err := c.fetchMappings(ctx, index); err != nil {
 		return fmt.Errorf("failed to fetch mappings: %w", err)
 	}
 
-	// 2. Get Settings
 	if err := c.fetchSettings(ctx, index); err != nil {
 		return fmt.Errorf("failed to fetch settings: %w", err)
 	}
@@ -158,48 +149,28 @@ func (c *OpenSearchConnector) fetchMappings(ctx context.Context, index *interfac
 	if resp.IsError() {
 		return fmt.Errorf("opensearch API error: %s", resp.String())
 	}
-	//{
-	//	"product_index" : {
-	//	"mappings" : {
-	//		"properties" : {
-	//			"age" : {
-	//				"type" : "integer"
-	//			},
-	//			"create_time" : {
-	//				"type" : "date"
-	//			},
-	//			"description" : {
-	//				"type" : "text",
-	//				"fields" : {
-	//					"keyword" : {
-	//						"type" : "keyword",
-	//						"ignore_above" : 256
-	//					}
-	//				}
-	//			}
-	//		}
-	//	}
-	//}
-	//}
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	// Mapping structure definition
 	var dataMapping map[string]struct {
 		Mappings struct {
+			Meta       map[string]any      `json:"_meta"`
 			Properties map[string]Property `json:"properties"`
 		} `json:"mappings"`
 	}
-	// Parse JSON
 	err = sonic.Unmarshal(bodyBytes, &dataMapping)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to parse mappings: %w", err)
 	}
 
 	fieldMap := make(map[string]interfaces.IndexFieldMeta)
+	index.MappingMeta = make(map[string]any)
 	if idxData, ok := dataMapping[index.Name]; ok {
+		if idxData.Mappings.Meta != nil {
+			index.MappingMeta = idxData.Mappings.Meta
+		}
 		parseProperties("", idxData.Mappings.Properties, fieldMap)
 	}
 	index.Mapping = fieldMap
@@ -217,23 +188,20 @@ type Property struct {
 
 // UnmarshalJSON custom deserialization method
 func (p *Property) UnmarshalJSON(data []byte) error {
-	// Parse all fields to a temporary map
 	var raw map[string]any
 	if err := sonic.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 
-	// Initialize Attributes
 	if p.Attributes == nil {
 		p.Attributes = make(map[string]any)
 	}
 
-	// Handle the "type" field
 	if typeVal, ok := raw["type"]; ok {
 		p.Type = fmt.Sprintf("%v", typeVal)
 	}
 
-	// Copy all fields except type, properties, and Fields to Attributes
+	// Preserve mapping parameters other than nested and multi-field definitions.
 	for key, value := range raw {
 		switch key {
 		case "properties", "fields":
@@ -242,7 +210,6 @@ func (p *Property) UnmarshalJSON(data []byte) error {
 			p.Attributes[key] = value
 		}
 	}
-	// Handle the properties field (recursive parsing)
 	if propsVal, ok := raw["properties"].(map[string]any); ok {
 		p.Properties = make(map[string]Property)
 		for propName, propValue := range propsVal {
@@ -253,7 +220,6 @@ func (p *Property) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
-	// Handle the fields field (recursive parsing)
 	if fieldsVal, ok := raw["fields"].(map[string]any); ok {
 		p.Fields = make(map[string]Property)
 		for fieldName, fieldValue := range fieldsVal {
@@ -268,33 +234,44 @@ func (p *Property) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Recursively parse the field: Flatten the nested object into a dot path and directly produce the IndexFieldMeta;
-// multi-fields SubFields are attached to the subfields of their parent fields in alphabetical order. Silently skip non-Object fields without type.
+// parseProperties flattens nested objects and retains multi-fields on their parent fields.
 func parseProperties(parentPath string, props map[string]Property, out map[string]interfaces.IndexFieldMeta) {
 	for name, prop := range props {
 		currentPath := name
 		if parentPath != "" {
 			currentPath = parentPath + "." + name
 		}
-		// Only fields that are not object but have a type will result
 		if prop.Type != "object" && prop.Type != "" {
 			out[currentPath] = interfaces.IndexFieldMeta{
-				Name:       currentPath,
-				Type:       prop.Type,
-				Searchable: true,
-				Attributes: prop.Attributes,
-				SubFields:  collectSubFields(prop),
+				Name:        currentPath,
+				Description: descriptionFromFieldMeta(prop.Attributes),
+				Type:        prop.Type,
+				Searchable:  isSearchable(prop.Attributes),
+				Attributes:  prop.Attributes,
+				SubFields:   collectSubFields(prop),
 			}
 		}
-		// Recursively parse nested fields of object
 		if len(prop.Properties) > 0 {
 			parseProperties(currentPath, prop.Properties, out)
 		}
 	}
 }
 
-// collectSubFields extracts the multi-fields subfields in alphabetical order of Name into IndexSubfield meta slices.
-// type is stripped from Attributes and inserted into the Type field.
+func descriptionFromFieldMeta(attributes map[string]any) string {
+	meta, ok := attributes["meta"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	description, _ := meta["description"].(string)
+	return description
+}
+
+func isSearchable(attributes map[string]any) bool {
+	searchable, ok := attributes["index"].(bool)
+	return !ok || searchable
+}
+
+// collectSubFields returns multi-fields in name order for stable serialization.
 func collectSubFields(p Property) []interfaces.IndexSubFieldMeta {
 	if len(p.Fields) == 0 {
 		return nil

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_discover_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_discover_test.go
@@ -1,9 +1,13 @@
 package opensearch
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,7 +20,9 @@ func TestPropertyUnmarshalJSON(t *testing.T) {
 
 		err := sonic.Unmarshal([]byte(`{
 			"type": "text",
+			"index": false,
 			"analyzer": "ik_max_word",
+			"meta": {"description": "商品标题"},
 			"fields": {
 				"keyword": {"type": "keyword", "ignore_above": 256}
 			},
@@ -27,7 +33,13 @@ func TestPropertyUnmarshalJSON(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "text", prop.Type)
+		assert.Equal(t, false, prop.Attributes["index"])
 		assert.Equal(t, "ik_max_word", prop.Attributes["analyzer"])
+		assert.Equal(t, map[string]any{"description": "商品标题"}, prop.Attributes["meta"])
+		out := map[string]interfaces.IndexFieldMeta{}
+		parseProperties("", map[string]Property{"title": prop}, out)
+		assert.Equal(t, "商品标题", out["title"].Description)
+		assert.False(t, out["title"].Searchable)
 		require.Contains(t, prop.Fields, "keyword")
 		assert.Equal(t, "keyword", prop.Fields["keyword"].Type)
 		assert.Equal(t, float64(256), prop.Fields["keyword"].Attributes["ignore_above"])
@@ -49,8 +61,11 @@ func TestParseProperties(t *testing.T) {
 		out := map[string]interfaces.IndexFieldMeta{}
 		parseProperties("", map[string]Property{
 			"description": {
-				Type:       "text",
-				Attributes: map[string]any{"analyzer": "ik_max_word"},
+				Type: "text",
+				Attributes: map[string]any{
+					"analyzer": "ik_max_word",
+					"meta":     map[string]any{"description": "商品标题", "owner": "catalog-team"},
+				},
 				Fields: map[string]Property{
 					"keyword": {Type: "keyword", Attributes: map[string]any{"ignore_above": 256}},
 				},
@@ -61,11 +76,16 @@ func TestParseProperties(t *testing.T) {
 					"age": {Type: "integer", Attributes: map[string]any{"doc_values": true}},
 				},
 			},
+			"not_searchable": {
+				Type:       "keyword",
+				Attributes: map[string]any{"index": false},
+			},
 			"ignored": {},
 		}, out)
 
 		require.Contains(t, out, "description")
 		assert.Equal(t, "description", out["description"].Name)
+		assert.Equal(t, "商品标题", out["description"].Description)
 		assert.Equal(t, "text", out["description"].Type)
 		assert.True(t, out["description"].Searchable)
 		require.Len(t, out["description"].SubFields, 1)
@@ -73,9 +93,91 @@ func TestParseProperties(t *testing.T) {
 		assert.Equal(t, "keyword", out["description"].SubFields[0].Type)
 		require.Contains(t, out, "profile.age")
 		assert.Equal(t, "integer", out["profile.age"].Type)
+		assert.False(t, out["not_searchable"].Searchable)
 		assert.NotContains(t, out, "profile")
 		assert.NotContains(t, out, "ignored")
 	})
+}
+
+func TestDescriptionFromFieldMeta(t *testing.T) {
+	assert.Equal(t, "字段说明", descriptionFromFieldMeta(map[string]any{
+		"meta": map[string]any{"description": "字段说明"},
+	}))
+	assert.Empty(t, descriptionFromFieldMeta(map[string]any{"meta": map[string]any{"description": 1}}))
+	assert.Empty(t, descriptionFromFieldMeta(map[string]any{"meta": "invalid"}))
+}
+
+func TestIsSearchable(t *testing.T) {
+	assert.True(t, isSearchable(nil))
+	assert.True(t, isSearchable(map[string]any{"index": true}))
+	assert.False(t, isSearchable(map[string]any{"index": false}))
+	assert.True(t, isSearchable(map[string]any{"index": "false"}))
+}
+
+func TestFetchMappingsExtractsMappingMeta(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/products/_mapping", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{
+			"products": {
+				"mappings": {
+					"_meta": {"description": "产品索引", "version": "1.0", "owner": {"team": "search"}},
+					"properties": {"title": {"type": "text"}}
+				}
+			}
+		}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{client: client}
+	index := &interfaces.IndexMeta{Name: "products", Description: "索引描述", MappingMeta: map[string]any{"old": true}}
+
+	require.NoError(t, connector.fetchMappings(context.Background(), index))
+	assert.Equal(t, "索引描述", index.Description)
+	assert.Equal(t, map[string]any{
+		"description": "产品索引",
+		"version":     "1.0",
+		"owner":       map[string]any{"team": "search"},
+	}, index.MappingMeta)
+	require.Contains(t, index.Mapping, "title")
+}
+
+func TestFetchMappingsDefaultsMissingMappingMetaToEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"products":{"mappings":{"properties":{}}}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{client: client}
+	index := &interfaces.IndexMeta{Name: "products", Description: "索引描述", MappingMeta: map[string]any{"old": true}}
+
+	require.NoError(t, connector.fetchMappings(context.Background(), index))
+	assert.Equal(t, "索引描述", index.Description)
+	assert.Empty(t, index.MappingMeta)
+}
+
+func TestFetchMappingsReturnsErrorForInvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{client: client}
+
+	err = connector.fetchMappings(context.Background(), &interfaces.IndexMeta{Name: "products"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse mappings")
 }
 
 func TestCollectSubFields(t *testing.T) {

--- a/adp/vega/vega-backend/server/worker/discover_index.go
+++ b/adp/vega/vega-backend/server/worker/discover_index.go
@@ -241,7 +241,7 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *in
 			if existing, ok := existingProperties[field.Name]; ok {
 				property.DisplayName = existing.DisplayName
 				property.Description = resolveSourceDescription(existing.Description, existing.OriginalDescription, field.Description)
-				property.Features = existing.Features
+				property.Features = mergeIndexFeatures(existing.Features, property.Features)
 			}
 			props = append(props, property)
 		}
@@ -285,6 +285,21 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *in
 		}
 	}
 	return nil
+}
+
+// mergeIndexFeatures preserves business features and refreshes native features from the source mapping.
+func mergeIndexFeatures(existing, native []interfaces.PropertyFeature) []interfaces.PropertyFeature {
+	features := make([]interfaces.PropertyFeature, 0, len(existing)+len(native))
+	for _, feature := range existing {
+		if !feature.IsNative {
+			features = append(features, feature)
+		}
+	}
+	features = append(features, native...)
+	if len(features) == 0 {
+		return nil
+	}
+	return features
 }
 
 // osSubFieldTypeToFeatureType maps supported OpenSearch multi-field types to VEGA feature types.

--- a/adp/vega/vega-backend/server/worker/discover_index.go
+++ b/adp/vega/vega-backend/server/worker/discover_index.go
@@ -22,29 +22,15 @@ type indexDiscoverItem struct {
 	markAfterEnrich bool
 }
 
-// discoverIndexResources discovers index resources from an index connector.
-// discoverIndexResources obtains and discovers indexes from the connector.
-// Then coordinate with the existing resources and finally enrich the metadata information of the index
-// Parameter
-//
-//	-ctx: Context information, used to control the timeout and cancellation of requests
-//	-catalog: Catalog interface, containing relevant information about the catalog
-//	- connector: Connector interface, used for interacting with data sources
-//
-// Return value:
-//   - * interfaces. DiscoverResult: findings, including a new resource, outdated and not change resources statistics
-//     -error: Error message, returned if an error occurs during the discovery process
 func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context,
 	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, connector interfaces.Connector,
 	progress *discoverTaskReconcileProgress) (*interfaces.DiscoverResult, error) {
 
-	// Check whether the connector implements the IndexConnector interface
 	indexConnector, ok := connector.(interfaces.IndexConnector)
 	if !ok {
 		return nil, fmt.Errorf("connector does not support index discover")
 	}
 
-	// Step 1: List Indices: Obtain all indices
 	sourceIndices, err := indexConnector.ListIndexes(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list indices: %w", err)
@@ -56,14 +42,12 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context,
 	}
 	logger.Infof("Discovered %d indices from source", len(sourceIndices))
 
-	// Step 2: Get Existing Resources: Find out if the db already exists and then do the comparison
 	existingResources, err := dtw.rs.GetByCatalogID(ctx, catalog.ID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get existing resources: %w", err)
 	}
 	logger.Infof("Loaded %d existing resources for index discovery", len(existingResources))
 
-	// Step 3: Reconcile: get the index data and insert it:
 	result, items, err := dtw.reconcileIndexResources(ctx, task, catalog, sourceIndices, existingResources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to reconcile resources: %w", err)
@@ -75,7 +59,6 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context,
 	}
 	logger.Infof("Reconciled %d index resources", len(items))
 
-	// Step 4: Enrich: Enrich the metadata information for index entries
 	if err := dtw.enrichIndexMetadata(ctx, task, indexConnector, items, result, progress); err != nil {
 		return nil, fmt.Errorf("failed to enrich index metadata: %w", err)
 	}
@@ -92,33 +75,18 @@ func (dtw *DiscoverTaskWorker) discoverIndexResources(ctx context.Context,
 	return result, nil
 }
 
-// reconcileIndexResources reconciles source indices with existing resources.
-// reconcileIndexResources coordinates index resources and handles new resources, existing resources, and expired resources
-// Parameter
-//
-//	-ctx: Context information, used to control the timeout and cancellation of requests
-//	-catalog: Directory information, including metadata such as ID
-//	-sourceIndices: List of source index metadata
-//	-Existing Resources: A list of existingResources
-//
-// Return value:
-//   - * interfaces. DiscoverResult: findings, including the directory ID and the statistics of all kinds of resources
-//   - []indexDiscoverItem: A list of indexDiscoveritems, including resources and index metadata
-//     -error: Error message, returned if an error occurs during processing
-func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, task *interfaces.DiscoverTask,
-	catalog *interfaces.Catalog, sourceIndices []*interfaces.IndexMeta,
+func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, sourceIndices []*interfaces.IndexMeta,
 	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []indexDiscoverItem, error) {
 
 	actions := task.DiscoverActions
 
-	// Initialize the discovery results and set the directory ID
 	result := &interfaces.DiscoverResult{
 		CatalogID: catalog.ID,
 	}
 
-	var items []indexDiscoverItem // Index to discover the list of items
+	var items []indexDiscoverItem
 
-	// Create a mapping of an existing resource with the source identifier as the key
 	existingMap := make(map[string]*interfaces.Resource)
 	for _, r := range existingResources {
 		if r.Category != interfaces.ResourceCategoryIndex {
@@ -126,15 +94,14 @@ func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, task
 		}
 		existingMap[r.SourceIdentifier] = r
 	}
-	// Create a source index mapping and name the index as the key
+
 	sourceMap := make(map[string]*interfaces.IndexMeta)
 	for _, idx := range sourceIndices {
 		sourceMap[idx.Name] = idx
 	}
 
-	// Handle new and existing
 	for _, idx := range sourceIndices {
-		sourceIdentifier := idx.Name //test-index
+		sourceIdentifier := idx.Name
 
 		if resource, ok := existingMap[sourceIdentifier]; ok {
 			if actions != nil && actions.Refresh {
@@ -174,7 +141,6 @@ func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, task
 		}
 	}
 
-	// Handle stale
 	if actions != nil && actions.MarkStale {
 		for sourceIdentifier, existing := range existingMap {
 			if _, ok := sourceMap[sourceIdentifier]; !ok {
@@ -193,17 +159,19 @@ func (dtw *DiscoverTaskWorker) reconcileIndexResources(ctx context.Context, task
 }
 
 // createIndexResource creates a new resource for an index.
-func (dtw *DiscoverTaskWorker) createIndexResource(ctx context.Context, catalog *interfaces.Catalog, index *interfaces.IndexMeta) (*interfaces.Resource, error) {
+func (dtw *DiscoverTaskWorker) createIndexResource(ctx context.Context,
+	catalog *interfaces.Catalog, index *interfaces.IndexMeta) (*interfaces.Resource, error) {
 
 	req := &interfaces.ResourceRequest{
 		CatalogID:        catalog.ID,
 		Name:             index.Name,
+		Description:      index.Description,
 		Category:         interfaces.ResourceCategoryIndex,
 		Status:           interfaces.ResourceStatusActive,
 		SourceIdentifier: index.Name,
 		SourceMetadata: map[string]any{
 			"original_name":        index.Name,
-			"original_description": "",
+			"original_description": index.Description,
 		},
 	}
 	resource, err := dtw.rs.Create(ctx, req)
@@ -214,65 +182,82 @@ func (dtw *DiscoverTaskWorker) createIndexResource(ctx context.Context, catalog 
 	return resource, nil
 }
 
-// enrichIndexMetadata enriches index resources with detailed metadata.
-// enriches the metadata information for index entries
-// Parameter
-//
-//	-ctx: Context information, used to control the timeout and cancellation of requests
-//	-indexConnector: Index connector, used to obtain the metadata of the index
-//	-items: List of index items that require rich metadata
-//
-// Return value:
-//
-//	-error: If an error occurs during processing, return an error message
+// enrichIndexMetadata refreshes source metadata while preserving business metadata.
 func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *interfaces.DiscoverTask,
 	indexConnector interfaces.IndexConnector, items []indexDiscoverItem, result *interfaces.DiscoverResult,
 	progress *discoverTaskReconcileProgress) error {
+
 	progress.SetMetadataTotal(len(items))
 
-	// Traverse all the index entries that need to be processed
 	for _, item := range items {
 		idx := item.indexMeta
 		resource := item.resource
 		beforeHash := sourceSnapshotHash(resource)
 
-		// Get detailed metadata (mappings) : Obtain detailed information about the index
 		if err := indexConnector.GetIndexMeta(ctx, idx); err != nil {
 			logger.Warnf("Failed to get metadata for index %s: %v", idx.Name, err)
-			return err
+			resource.LastDiscoverStatus = interfaces.DiscoverStatusError
+			resource.StatusMessage = fmt.Sprintf("discover metadata failed: %v", err)
+			updateDiscoverResultForEnrichStatus(result, interfaces.DiscoverStatusError)
+			expectedUpdateTime := resource.UpdateTime
+			resource.Updater = task.Creator
+			resource.UpdateTime = time.Now().UnixMilli()
+			if updateErr := dtw.rs.InternalUpdateDiscoveryMetadata(ctx, nil, resource, expectedUpdateTime); updateErr != nil {
+				logger.Errorf("Failed to update discover error for index %s: %v", idx.Name, updateErr)
+				return updateErr
+			}
+			if current, changed := progress.AdvanceMetadata(); changed {
+				message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
+				if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
+					return err
+				}
+			}
+			continue
 		}
 
-		// Map fields to SchemaDefinition
-		var columns []*interfaces.Property
+		existingProperties := make(map[string]*interfaces.Property, len(resource.SchemaDefinition))
+		for _, property := range resource.SchemaDefinition {
+			if property != nil {
+				existingProperties[property.Name] = property
+			}
+		}
+
+		var props []*interfaces.Property
 		for _, field := range idx.Mapping {
-			// For {"ignore_above":256,"type":"keyword"}, remove type.
 			delete(field.Attributes, "type")
 
-			columns = append(columns, &interfaces.Property{
+			property := &interfaces.Property{
 				Name:        field.Name,
 				DisplayName: field.Name,
-				Type:        field.Type,
-				Description: "",
+				Type:        indexConnector.MapType(field.Type),
+				Description: field.Description,
 
 				OriginalName:        field.Name,
 				OriginalType:        field.Type,
-				OriginalDescription: "",
+				OriginalDescription: field.Description,
 				Attributes:          field.Attributes,
 				Features:            buildSubFieldFeatures(field.Name, field.SubFields),
-			})
+			}
+			if existing, ok := existingProperties[field.Name]; ok {
+				property.DisplayName = existing.DisplayName
+				property.Description = resolveSourceDescription(existing.Description, existing.OriginalDescription, field.Description)
+				property.Features = existing.Features
+			}
+			props = append(props, property)
 		}
-		resource.SchemaDefinition = columns
+		resource.SchemaDefinition = props
 
-		// Populate SourceMetadata
+		resource.Description = resolveSourceDescription(resource.Description, sourceOriginalDescription(resource.SourceMetadata), idx.Description)
+
 		sourceMetadata := make(map[string]any)
 		if resource.SourceMetadata != nil {
 			sourceMetadata = resource.SourceMetadata
 		}
-
+		sourceMetadata["original_name"] = idx.Name
+		sourceMetadata["original_description"] = idx.Description
 		sourceMetadata["properties"] = idx.Properties
 		sourceMetadata["mapping"] = idx.Mapping
-		sourceMetadata["original_name"] = idx.Name
-		sourceMetadata["original_description"] = ""
+		sourceMetadata["mapping_meta"] = idx.MappingMeta
 		resource.SourceMetadata = sourceMetadata
 
 		discoverStatus := resource.LastDiscoverStatus
@@ -281,8 +266,8 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *in
 			updateDiscoverResultForEnrichStatus(result, discoverStatus)
 		}
 
-		// Update Resource
 		resource.LastDiscoverStatus = discoverStatus
+		resource.StatusMessage = ""
 		expectedUpdateTime := resource.UpdateTime
 		resource.Updater = task.Creator
 		resource.UpdateTime = time.Now().UnixMilli()
@@ -291,9 +276,7 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *in
 			return err
 		}
 
-		// Wait a bit to avoid overwhelming the server? No, it's fine for now.
-		// Just logging
-		logger.Infof("Enriched index %s: fields=%d", idx.Name, len(columns))
+		logger.Debugf("Enriched index %s: fields=%d", idx.Name, len(props))
 		if current, changed := progress.AdvanceMetadata(); changed {
 			message := fmt.Sprintf("resource metadata enriched: %d/%d", progress.metadataProcessed, progress.metadataTotal)
 			if err := dtw.updateProgress(ctx, task.ID, current, message); err != nil {
@@ -304,8 +287,7 @@ func (dtw *DiscoverTaskWorker) enrichIndexMetadata(ctx context.Context, task *in
 	return nil
 }
 
-// osSubFieldTypeToFeatureType maps OpenSearch multi-field type to VEGA PropertyFeature type.
-// If no other type is recognized and an empty string is returned, the caller should skip it and mark it as warn.
+// osSubFieldTypeToFeatureType maps supported OpenSearch multi-field types to VEGA feature types.
 func osSubFieldTypeToFeatureType(osType string) string {
 	switch osType {
 	case "keyword":
@@ -319,8 +301,7 @@ func osSubFieldTypeToFeatureType(osType string) string {
 	}
 }
 
-// buildSubFieldFeatures converts OpenSearch multi-field subfields to VEGA PropertyFeature.
-// parentName: The full name of the parent field (such as "user.name"); subFields: Metadata of subfields that have been arranged in alphabetical order by Name.
+// buildSubFieldFeatures converts OpenSearch multi-fields to VEGA property features.
 func buildSubFieldFeatures(parentName string, subFields []interfaces.IndexSubFieldMeta) []interfaces.PropertyFeature {
 	if len(subFields) == 0 {
 		return nil

--- a/adp/vega/vega-backend/server/worker/discover_index_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_index_test.go
@@ -7,6 +7,8 @@ package worker
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,4 +118,166 @@ func TestReconcileIndexResources(t *testing.T) {
 		assert.Equal(t, 1, result.StaleCount)
 		assert.Empty(t, items)
 	})
+}
+
+func TestEnrichIndexMetadataContinuesWhenOneIndexFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	inaccessible := &interfaces.Resource{ID: "r1", SourceIdentifier: "unavailable", LastDiscoverStatus: interfaces.DiscoverStatusNew}
+	accessible := &interfaces.Resource{
+		ID:                 "r2",
+		SourceIdentifier:   "products",
+		LastDiscoverStatus: interfaces.DiscoverStatusNew,
+		StatusMessage:      "discover metadata failed: previous failure",
+		SourceMetadata:     map[string]any{"original_name": "products"},
+	}
+	connector := vmock.NewMockIndexConnector(ctrl)
+	connector.EXPECT().
+		GetIndexMeta(gomock.Any(), &interfaces.IndexMeta{Name: "unavailable"}).
+		Return(errors.New("permission denied"))
+	connector.EXPECT().
+		GetIndexMeta(gomock.Any(), &interfaces.IndexMeta{Name: "products"}).
+		DoAndReturn(func(_ context.Context, index *interfaces.IndexMeta) error {
+			index.Mapping = map[string]interfaces.IndexFieldMeta{
+				"id": {Name: "id", Type: "long"},
+			}
+			return nil
+		})
+	connector.EXPECT().MapType("long").Return(interfaces.DataType_Integer)
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, resource *interfaces.Resource, _ int64) error {
+			assert.Equal(t, "r1", resource.ID)
+			assert.Equal(t, interfaces.DiscoverStatusError, resource.LastDiscoverStatus)
+			assert.NotEmpty(t, resource.StatusMessage)
+			return nil
+		})
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, resource *interfaces.Resource, _ int64) error {
+			assert.Equal(t, "r2", resource.ID)
+			require.Len(t, resource.SchemaDefinition, 1)
+			assert.Equal(t, "id", resource.SchemaDefinition[0].Name)
+			assert.Equal(t, interfaces.DataType_Integer, resource.SchemaDefinition[0].Type)
+			assert.Empty(t, resource.StatusMessage)
+			return nil
+		})
+
+	result := &interfaces.DiscoverResult{}
+	err := dh.enrichIndexMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []indexDiscoverItem{
+		{resource: inaccessible, indexMeta: &interfaces.IndexMeta{Name: "unavailable"}},
+		{resource: accessible, indexMeta: &interfaces.IndexMeta{Name: "products"}},
+	}, result, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.FailedCount)
+}
+
+func TestEnrichIndexMetadataPreservesBusinessMetadata(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	resource := &interfaces.Resource{
+		ID:               "r1",
+		SourceIdentifier: "products",
+		SchemaDefinition: []*interfaces.Property{{
+			Name:        "title",
+			DisplayName: "商品标题",
+			Description: "人工字段说明",
+			Features: []interfaces.PropertyFeature{{
+				FeatureName: "fulltext",
+				FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			}},
+		}},
+	}
+	connector := vmock.NewMockIndexConnector(ctrl)
+	connector.EXPECT().
+		GetIndexMeta(gomock.Any(), &interfaces.IndexMeta{Name: "products"}).
+		DoAndReturn(func(_ context.Context, index *interfaces.IndexMeta) error {
+			index.Mapping = map[string]interfaces.IndexFieldMeta{
+				"title": {
+					Name:       "title",
+					Type:       "text",
+					Attributes: map[string]any{"type": "text", "analyzer": "standard"},
+				},
+			}
+			return nil
+		})
+	connector.EXPECT().MapType("text").Return(interfaces.DataType_Text)
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
+			require.Len(t, updated.SchemaDefinition, 1)
+			field := updated.SchemaDefinition[0]
+			assert.Equal(t, "商品标题", field.DisplayName)
+			assert.Equal(t, "人工字段说明", field.Description)
+			assert.Equal(t, interfaces.DataType_Text, field.Type)
+			assert.Equal(t, "text", field.OriginalType)
+			assert.Equal(t, map[string]any{"analyzer": "standard"}, field.Attributes)
+			assert.Equal(t, []interfaces.PropertyFeature{{
+				FeatureName: "fulltext",
+				FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			}}, field.Features)
+			return nil
+		})
+
+	err := dh.enrichIndexMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []indexDiscoverItem{{
+		resource:  resource,
+		indexMeta: &interfaces.IndexMeta{Name: "products"},
+	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
+}
+
+func TestEnrichIndexMetadataSynchronizesSourceDescriptions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	resource := &interfaces.Resource{
+		ID:          "r1",
+		Description: "旧索引说明",
+		SourceMetadata: map[string]any{
+			"original_description": "旧索引说明",
+		},
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "empty", Description: ""},
+			{Name: "source", Description: "旧字段说明", OriginalDescription: "旧字段说明"},
+			{Name: "manual", Description: "人工字段说明", OriginalDescription: "旧字段说明"},
+		},
+	}
+	connector := vmock.NewMockIndexConnector(ctrl)
+	connector.EXPECT().
+		GetIndexMeta(gomock.Any(), &interfaces.IndexMeta{Name: "products"}).
+		DoAndReturn(func(_ context.Context, index *interfaces.IndexMeta) error {
+			index.Description = "新索引说明"
+			index.MappingMeta = map[string]any{"description": "新 mapping 说明", "owner": "search-team"}
+			index.Mapping = map[string]interfaces.IndexFieldMeta{
+				"empty":  {Name: "empty", Type: "keyword", Description: "新字段说明"},
+				"source": {Name: "source", Type: "keyword", Description: "新字段说明"},
+				"manual": {Name: "manual", Type: "keyword", Description: "新字段说明"},
+			}
+			return nil
+		})
+	connector.EXPECT().MapType("keyword").Return(interfaces.DataType_String).Times(3)
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
+			assert.Equal(t, "新索引说明", updated.Description)
+			assert.Equal(t, "新索引说明", updated.SourceMetadata["original_description"])
+			assert.Equal(t, map[string]any{"description": "新 mapping 说明", "owner": "search-team"}, updated.SourceMetadata["mapping_meta"])
+			fields := make(map[string]*interfaces.Property, len(updated.SchemaDefinition))
+			for _, field := range updated.SchemaDefinition {
+				fields[field.Name] = field
+			}
+			assert.Equal(t, "新字段说明", fields["empty"].Description)
+			assert.Equal(t, "新字段说明", fields["source"].Description)
+			assert.Equal(t, "新字段说明", fields["source"].OriginalDescription)
+			assert.Equal(t, "人工字段说明", fields["manual"].Description)
+			assert.Equal(t, "新字段说明", fields["manual"].OriginalDescription)
+			return nil
+		})
+
+	err := dh.enrichIndexMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []indexDiscoverItem{{
+		resource:  resource,
+		indexMeta: &interfaces.IndexMeta{Name: "products"},
+	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
 }

--- a/adp/vega/vega-backend/server/worker/discover_index_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_index_test.go
@@ -227,15 +227,15 @@ func TestEnrichIndexMetadataPreservesBusinessMetadata(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEnrichIndexMetadataSynchronizesSourceDescriptions(t *testing.T) {
+func TestEnrichIndexMetadataSynchronizesFieldDescriptions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rs := vmock.NewMockResourceService(ctrl)
 	dh := &DiscoverTaskWorker{rs: rs}
 	resource := &interfaces.Resource{
 		ID:          "r1",
-		Description: "旧索引说明",
+		Description: "人工索引说明",
 		SourceMetadata: map[string]any{
-			"original_description": "旧索引说明",
+			"original_description": "",
 		},
 		SchemaDefinition: []*interfaces.Property{
 			{Name: "empty", Description: ""},
@@ -247,7 +247,6 @@ func TestEnrichIndexMetadataSynchronizesSourceDescriptions(t *testing.T) {
 	connector.EXPECT().
 		GetIndexMeta(gomock.Any(), &interfaces.IndexMeta{Name: "products"}).
 		DoAndReturn(func(_ context.Context, index *interfaces.IndexMeta) error {
-			index.Description = "新索引说明"
 			index.MappingMeta = map[string]any{"description": "新 mapping 说明", "owner": "search-team"}
 			index.Mapping = map[string]interfaces.IndexFieldMeta{
 				"empty":  {Name: "empty", Type: "keyword", Description: "新字段说明"},
@@ -259,8 +258,8 @@ func TestEnrichIndexMetadataSynchronizesSourceDescriptions(t *testing.T) {
 	connector.EXPECT().MapType("keyword").Return(interfaces.DataType_String).Times(3)
 	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
-			assert.Equal(t, "新索引说明", updated.Description)
-			assert.Equal(t, "新索引说明", updated.SourceMetadata["original_description"])
+			assert.Equal(t, "人工索引说明", updated.Description)
+			assert.Equal(t, "", updated.SourceMetadata["original_description"])
 			assert.Equal(t, map[string]any{"description": "新 mapping 说明", "owner": "search-team"}, updated.SourceMetadata["mapping_meta"])
 			fields := make(map[string]*interfaces.Property, len(updated.SchemaDefinition))
 			for _, field := range updated.SchemaDefinition {

--- a/adp/vega/vega-backend/server/worker/discover_index_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_index_test.go
@@ -186,6 +186,10 @@ func TestEnrichIndexMetadataPreservesBusinessMetadata(t *testing.T) {
 			Features: []interfaces.PropertyFeature{{
 				FeatureName: "fulltext",
 				FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			}, {
+				FeatureName: "title.legacy",
+				FeatureType: interfaces.PropertyFeatureType_Keyword,
+				IsNative:    true,
 			}},
 		}},
 	}
@@ -198,6 +202,11 @@ func TestEnrichIndexMetadataPreservesBusinessMetadata(t *testing.T) {
 					Name:       "title",
 					Type:       "text",
 					Attributes: map[string]any{"type": "text", "analyzer": "standard"},
+					SubFields: []interfaces.IndexSubFieldMeta{{
+						Name:       "keyword",
+						Type:       "keyword",
+						Attributes: map[string]any{"ignore_above": 256},
+					}},
 				},
 			}
 			return nil
@@ -215,6 +224,12 @@ func TestEnrichIndexMetadataPreservesBusinessMetadata(t *testing.T) {
 			assert.Equal(t, []interfaces.PropertyFeature{{
 				FeatureName: "fulltext",
 				FeatureType: interfaces.PropertyFeatureType_Fulltext,
+			}, {
+				FeatureName: "title.keyword",
+				DisplayName: "title.keyword",
+				FeatureType: interfaces.PropertyFeatureType_Keyword,
+				IsNative:    true,
+				Config:      map[string]any{"ignore_above": 256},
 			}}, field.Features)
 			return nil
 		})

--- a/adp/vega/vega-backend/server/worker/discover_table.go
+++ b/adp/vega/vega-backend/server/worker/discover_table.go
@@ -81,6 +81,124 @@ func (dtw *DiscoverTaskWorker) discoverTableResources(ctx context.Context,
 	return result, nil
 }
 
+// reconcileTableResources reconciles source tables with existing resources.
+func (dtw *DiscoverTaskWorker) reconcileTableResources(ctx context.Context,
+	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, sourceTables []*interfaces.TableMeta,
+	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []tableDiscoverItem, error) {
+
+	actions := task.DiscoverActions
+
+	result := &interfaces.DiscoverResult{
+		CatalogID: catalog.ID,
+	}
+
+	// Used for returning Discover Items
+	var items []tableDiscoverItem
+
+	// Build a map of the existing resources (indexed by SourceIdentifier)
+	existingMap := make(map[string]*interfaces.Resource)
+	for _, r := range existingResources {
+		if r.Category != interfaces.ResourceCategoryTable {
+			continue
+		}
+		existingMap[r.SourceIdentifier] = r
+	}
+
+	// Build the map of the source table
+	sourceMap := make(map[string]*interfaces.TableMeta)
+	for _, t := range sourceTables {
+		sourceIdentifier := dtw.buildSourceIdentifier(t)
+		sourceMap[sourceIdentifier] = t
+	}
+
+	// Handle newly added and retained resources
+	for _, table := range sourceTables {
+		sourceIdentifier := dtw.buildSourceIdentifier(table)
+
+		if resource, ok := existingMap[sourceIdentifier]; ok {
+			// Existing. Check the status
+			if actions != nil && actions.Refresh {
+				markAfterEnrich := true
+				if resource.Status == interfaces.ResourceStatusStale {
+					// Previously marked as stale, now reactivated
+					if err := dtw.rs.UpdateStatus(ctx, resource.ID, interfaces.ResourceStatusActive, ""); err != nil {
+						logger.Errorf("Failed to reactivate resource %s: %v", resource.ID, err)
+					} else {
+						dtw.markDiscover(ctx, resource.ID, interfaces.DiscoverStatusRestored)
+						resource.Status = interfaces.ResourceStatusActive
+						resource.LastDiscoverStatus = interfaces.DiscoverStatusRestored
+						result.RestoredCount++
+						markAfterEnrich = false
+					}
+				}
+				items = append(items, tableDiscoverItem{
+					resource:        resource,
+					tableMeta:       table,
+					markAfterEnrich: markAfterEnrich,
+				})
+			}
+		} else {
+			// New resources - Only processed when the policy allows create
+			if actions != nil && actions.Create {
+				resource, err := dtw.createTableResource(ctx, catalog, table, sourceIdentifier)
+				if err != nil {
+					logger.Errorf("Failed to create resource %s: %v", sourceIdentifier, err)
+				} else {
+					dtw.markDiscover(ctx, resource.ID, interfaces.DiscoverStatusNew)
+					resource.LastDiscoverStatus = interfaces.DiscoverStatusNew
+					result.NewCount++
+					items = append(items, tableDiscoverItem{
+						resource:  resource,
+						tableMeta: table,
+					})
+				}
+			}
+		}
+	}
+
+	// Handle deleted resources (marked as stale) - only handle when the policy allows mark_stale
+	if actions != nil && actions.MarkStale {
+		for sourceIdentifier, existing := range existingMap {
+			if _, ok := sourceMap[sourceIdentifier]; !ok {
+				dtw.markDiscover(ctx, existing.ID, interfaces.DiscoverStatusMissing)
+				if existing.Status == interfaces.ResourceStatusActive {
+					if err := dtw.rs.UpdateStatus(ctx, existing.ID, interfaces.ResourceStatusStale, ""); err != nil {
+						logger.Errorf("Failed to mark resource %s as stale: %v", existing.ID, err)
+					} else {
+						result.StaleCount++
+					}
+				}
+			}
+		}
+	}
+	return result, items, nil
+}
+
+// createTableResource creates a new resource.
+func (dtw *DiscoverTaskWorker) createTableResource(ctx context.Context, catalog *interfaces.Catalog,
+	table *interfaces.TableMeta, sourceIdentifier string) (*interfaces.Resource, error) {
+
+	req := &interfaces.ResourceRequest{
+		CatalogID:        catalog.ID,
+		Name:             sourceIdentifier,
+		Description:      table.Description,
+		Category:         interfaces.ResourceCategoryTable,
+		Status:           interfaces.ResourceStatusActive,
+		Schema:           table.Schema,
+		SourceIdentifier: sourceIdentifier,
+		SourceMetadata: map[string]any{
+			"original_name":        sourceIdentifier,
+			"original_description": table.Description,
+		},
+	}
+	resource, err := dtw.rs.Create(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
 // add details to the table metadata
 // Parameter
 //
@@ -104,8 +222,7 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, task *in
 		beforeHash := sourceSnapshotHash(resource)
 
 		// Obtain detailed metadata
-		err := tableConnector.GetTableMeta(ctx, table)
-		if err != nil {
+		if err := tableConnector.GetTableMeta(ctx, table); err != nil {
 			logger.Warnf("Failed to get metadata for table %s: %v", table.Name, err)
 			resource.LastDiscoverStatus = interfaces.DiscoverStatusError
 			resource.StatusMessage = fmt.Sprintf("discover metadata failed: %v", err)
@@ -134,7 +251,8 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, task *in
 				existingProperties[property.Name] = property
 			}
 		}
-		resource.SchemaDefinition = make([]*interfaces.Property, 0, len(table.Columns))
+
+		var props []*interfaces.Property
 		for _, column := range table.Columns {
 			property := &interfaces.Property{
 				Name:        column.Name,
@@ -147,22 +265,24 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, task *in
 				OriginalDescription: column.Description,
 			}
 			if existing, ok := existingProperties[column.Name]; ok {
-				// display_name, description and features can all be maintained by users or semantic understanding.
-				// Probing only refreshes the physical metadata at the source end and cannot overwrite these business metadata.
 				property.DisplayName = existing.DisplayName
-				property.Description = existing.Description
+				property.Description = resolveSourceDescription(existing.Description, existing.OriginalDescription, column.Description)
 				property.Features = existing.Features
 			}
-			resource.SchemaDefinition = append(resource.SchemaDefinition, property)
+			props = append(props, property)
 		}
+		resource.SchemaDefinition = props
+
+		resource.Description = resolveSourceDescription(resource.Description, sourceOriginalDescription(resource.SourceMetadata), table.Description)
+
 		// Fill in the Resource metadata: source_metadata field
 		sourceMetadata := make(map[string]any)
 		if resource.SourceMetadata != nil {
 			sourceMetadata = resource.SourceMetadata
 		}
-		sourceMetadata["columns"] = table.Columns
 		sourceMetadata["original_name"] = resource.SourceIdentifier
 		sourceMetadata["original_description"] = table.Description
+		sourceMetadata["columns"] = table.Columns
 		if table.TableType != "" {
 			sourceMetadata["table_type"] = table.TableType
 		}
@@ -208,97 +328,6 @@ func (dtw *DiscoverTaskWorker) enrichTableMetadata(ctx context.Context, task *in
 	return nil
 }
 
-// reconcileTableResources reconciles source tables with existing resources.
-func (dtw *DiscoverTaskWorker) reconcileTableResources(ctx context.Context,
-	task *interfaces.DiscoverTask, catalog *interfaces.Catalog, sourceTables []*interfaces.TableMeta,
-	existingResources []*interfaces.Resource) (*interfaces.DiscoverResult, []tableDiscoverItem, error) {
-
-	actions := task.DiscoverActions
-	result := &interfaces.DiscoverResult{
-		CatalogID: catalog.ID,
-	}
-
-	// Used for returning Discover Items
-	var items []tableDiscoverItem
-
-	// Build a map of the existing resources (indexed by SourceIdentifier)
-	existingMap := make(map[string]*interfaces.Resource)
-	for _, r := range existingResources {
-		if r.Category != interfaces.ResourceCategoryTable {
-			continue
-		}
-		existingMap[r.SourceIdentifier] = r
-	}
-
-	// Build the map of the source table
-	sourceMap := make(map[string]*interfaces.TableMeta)
-	for _, t := range sourceTables {
-		sourceIdentifier := dtw.buildSourceIdentifier(t)
-		sourceMap[sourceIdentifier] = t
-	}
-	// Handle newly added and retained resources
-	for _, table := range sourceTables {
-		sourceIdentifier := dtw.buildSourceIdentifier(table)
-
-		if resource, ok := existingMap[sourceIdentifier]; ok {
-			// Existing. Check the status
-			if actions != nil && actions.Refresh {
-				markAfterEnrich := true
-				if resource.Status == interfaces.ResourceStatusStale {
-					// Previously marked as stale, now reactivated
-					if err := dtw.rs.UpdateStatus(ctx, resource.ID, interfaces.ResourceStatusActive, ""); err != nil {
-						logger.Errorf("Failed to reactivate resource %s: %v", resource.ID, err)
-					} else {
-						dtw.markDiscover(ctx, resource.ID, interfaces.DiscoverStatusRestored)
-						resource.Status = interfaces.ResourceStatusActive
-						resource.LastDiscoverStatus = interfaces.DiscoverStatusRestored
-						result.RestoredCount++
-						markAfterEnrich = false
-					}
-				}
-				items = append(items, tableDiscoverItem{
-					resource:        resource,
-					tableMeta:       table,
-					markAfterEnrich: markAfterEnrich,
-				})
-			}
-		} else {
-			// New resources - Only processed when the policy allows create
-			if actions != nil && actions.Create {
-				resource, err := dtw.createResource(ctx, catalog, table, sourceIdentifier)
-				if err != nil {
-					logger.Errorf("Failed to create resource %s: %v", sourceIdentifier, err)
-				} else {
-					dtw.markDiscover(ctx, resource.ID, interfaces.DiscoverStatusNew)
-					resource.LastDiscoverStatus = interfaces.DiscoverStatusNew
-					result.NewCount++
-					items = append(items, tableDiscoverItem{
-						resource:  resource,
-						tableMeta: table,
-					})
-				}
-			}
-		}
-	}
-
-	// Handle deleted resources (marked as stale) - only handle when the policy allows mark_stale
-	if actions != nil && actions.MarkStale {
-		for sourceIdentifier, existing := range existingMap {
-			if _, ok := sourceMap[sourceIdentifier]; !ok {
-				dtw.markDiscover(ctx, existing.ID, interfaces.DiscoverStatusMissing)
-				if existing.Status == interfaces.ResourceStatusActive {
-					if err := dtw.rs.UpdateStatus(ctx, existing.ID, interfaces.ResourceStatusStale, ""); err != nil {
-						logger.Errorf("Failed to mark resource %s as stale: %v", existing.ID, err)
-					} else {
-						result.StaleCount++
-					}
-				}
-			}
-		}
-	}
-	return result, items, nil
-}
-
 // buildSourceIdentifier builds the source identifier for a table.
 func (dtw *DiscoverTaskWorker) buildSourceIdentifier(table *interfaces.TableMeta) string {
 	identifier := table.Name
@@ -311,26 +340,10 @@ func (dtw *DiscoverTaskWorker) buildSourceIdentifier(table *interfaces.TableMeta
 	return identifier
 }
 
-// createResource creates a new resource.
-func (dtw *DiscoverTaskWorker) createResource(ctx context.Context, catalog *interfaces.Catalog, table *interfaces.TableMeta, sourceIdentifier string) (*interfaces.Resource, error) {
-
-	req := &interfaces.ResourceRequest{
-		CatalogID:        catalog.ID,
-		Name:             sourceIdentifier,
-		Description:      table.Description,
-		Category:         interfaces.ResourceCategoryTable,
-		Status:           interfaces.ResourceStatusActive,
-		Schema:           table.Schema,
-		SourceIdentifier: sourceIdentifier,
-		SourceMetadata: map[string]any{
-			"original_name":        sourceIdentifier,
-			"original_description": table.Description,
-		},
+// resolveSourceDescription keeps a business description unless it is absent or still matches the previous source description.
+func resolveSourceDescription(description, originalDescription, discoveredDescription string) string {
+	if description == "" || description == originalDescription {
+		return discoveredDescription
 	}
-	resource, err := dtw.rs.Create(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	return resource, nil
+	return description
 }

--- a/adp/vega/vega-backend/server/worker/discover_table_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_table_test.go
@@ -281,10 +281,10 @@ func TestEnrichTableMetadataSynchronizesSourceDescriptions(t *testing.T) {
 	dh := &DiscoverTaskWorker{rs: rs}
 	resource := &interfaces.Resource{
 		ID:               "r1",
-		Description:      "",
+		Description:      "旧源端表注释",
 		SourceIdentifier: "public.departments",
 		SourceMetadata: map[string]any{
-			"original_description": "",
+			"original_description": "旧源端表注释",
 		},
 		SchemaDefinition: []*interfaces.Property{
 			{Name: "empty_description", Description: "", OriginalDescription: ""},

--- a/adp/vega/vega-backend/server/worker/discover_table_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_table_test.go
@@ -207,7 +207,11 @@ func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
 	dh := &DiscoverTaskWorker{rs: rs}
 	resource := &interfaces.Resource{
 		ID:               "r1",
+		Description:      "人工资源说明",
 		SourceIdentifier: "public.departments",
+		SourceMetadata: map[string]any{
+			"original_description": "旧源端表注释",
+		},
 		SchemaDefinition: []*interfaces.Property{
 			{
 				Name:                "department_id",
@@ -227,6 +231,7 @@ func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
 	connector.EXPECT().
 		GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "departments", Schema: "public"}).
 		DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
+			table.Description = "最新源端表注释"
 			table.Columns = []interfaces.TableColumnMeta{
 				{Name: "department_id", Type: "varchar", Description: "源端最新部门编号注释"},
 				{Name: "department_name", Type: "varchar", Description: "部门名称"},
@@ -236,6 +241,7 @@ func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
 	connector.EXPECT().MapType("varchar").Return(interfaces.DataType_String).Times(2)
 	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
+			assert.Equal(t, "人工资源说明", updated.Description)
 			require.Len(t, updated.SchemaDefinition, 2)
 
 			existing := updated.SchemaDefinition[0]
@@ -267,4 +273,76 @@ func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
 	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
 
 	require.NoError(t, err)
+}
+
+func TestEnrichTableMetadataSynchronizesSourceDescriptions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	resource := &interfaces.Resource{
+		ID:               "r1",
+		Description:      "",
+		SourceIdentifier: "public.departments",
+		SourceMetadata: map[string]any{
+			"original_description": "",
+		},
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "empty_description", Description: "", OriginalDescription: ""},
+			{Name: "source_description", Description: "旧源端字段注释", OriginalDescription: "旧源端字段注释"},
+			{Name: "business_description", Description: "人工字段说明", OriginalDescription: "旧源端字段注释"},
+		},
+	}
+	connector := vmock.NewMockTableConnector(ctrl)
+	connector.EXPECT().
+		GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "departments", Schema: "public"}).
+		DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
+			table.Description = "最新源端表注释"
+			table.Columns = []interfaces.TableColumnMeta{
+				{Name: "empty_description", Type: "varchar", Description: "最新空字段注释"},
+				{Name: "source_description", Type: "varchar", Description: "最新源端字段注释"},
+				{Name: "business_description", Type: "varchar", Description: "最新源端字段注释"},
+			}
+			return nil
+		})
+	connector.EXPECT().MapType("varchar").Return(interfaces.DataType_String).Times(3)
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
+			assert.Equal(t, "最新源端表注释", updated.Description)
+			assert.Equal(t, "最新源端表注释", updated.SourceMetadata["original_description"])
+			require.Len(t, updated.SchemaDefinition, 3)
+			assert.Equal(t, "最新空字段注释", updated.SchemaDefinition[0].Description)
+			assert.Equal(t, "最新源端字段注释", updated.SchemaDefinition[1].Description)
+			assert.Equal(t, "人工字段说明", updated.SchemaDefinition[2].Description)
+			for _, property := range updated.SchemaDefinition {
+				assert.NotEmpty(t, property.OriginalDescription)
+			}
+			return nil
+		})
+
+	err := dh.enrichTableMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []tableDiscoverItem{{
+		resource: resource,
+		tableMeta: &interfaces.TableMeta{
+			Name: "departments", Schema: "public",
+		},
+	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
+}
+
+func TestResolveSourceDescription(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		description           string
+		originalDescription   string
+		discoveredDescription string
+		want                  string
+	}{
+		{name: "empty business description", description: "", originalDescription: "旧源端注释", discoveredDescription: "新源端注释", want: "新源端注释"},
+		{name: "unchanged source description", description: "旧源端注释", originalDescription: "旧源端注释", discoveredDescription: "新源端注释", want: "新源端注释"},
+		{name: "manual business description", description: "人工说明", originalDescription: "旧源端注释", discoveredDescription: "新源端注释", want: "人工说明"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveSourceDescription(tc.description, tc.originalDescription, tc.discoveredDescription))
+		})
+	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Synchronize source-derived descriptions for discovered table and index resources while preserving business descriptions.
- [x] Preserve OpenSearch mapping `_meta`, map field `meta.description`, and parse field `index` into `Searchable`.
- [x] Make index metadata failures resource-scoped and add regression coverage.
- [ ] Docs/doc 1 — N/A: no user-facing API or configuration change.

---

## Why

- Related Issue: Closes openbkn-ai/bkn-studio#479
- Related Feature: N/A
- Background: repeated discovery did not persist refreshed source descriptions and could overwrite or lose metadata semantics.

---

## How

- Key implementation points: persist resource descriptions during discovery; retain the previous source description to distinguish source-derived and business descriptions; normalize index field types; preserve mapping metadata; return mapping parse errors instead of panicking.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A: no real OpenSearch or SQL Server environment was used.
- [ ] Verified in test environment — N/A: local code change only.

Test notes:

- `make ci` (golangci-lint, full test suite, coverage gate)

---

## Risk & Rollback

- Potential risks: source-derived descriptions now refresh on rediscovery; manual business descriptions remain preserved by comparison with the prior source description.
- Rollback plan: revert commit `9b4ff5a5e`.

---

## Additional Notes

- No screenshots or external service logs.
