### PR TITLE
fix(trace): preserve initial conversation intent

### DIFF
--- a/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent-design.md
+++ b/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent-design.md
@@ -14,9 +14,11 @@ conversation-wide fallback.
   non-empty; use interaction ID as the deterministic timestamp tie-breaker.
 - Return both previews from that same interaction. Its result may be empty.
 - If no interaction has a question, return empty question and result previews.
+- If the whole conversation predates interaction IDs, retain its legacy
+  request-level preview. A mixed conversation still uses only identified
+  interactions, so it cannot combine artifacts across interactions.
 
 ## Scope
 
 Change only the Foundry conversation-summary selection helper and its tests. Do
 not change APIs, persistence, lifecycle state, pagination, EE routes, or UI.
-

--- a/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent-design.md
+++ b/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent-design.md
@@ -1,0 +1,22 @@
+# Conversation Initial Intent Preview Design
+
+## Problem
+
+Conversation summaries currently skip the earliest interaction when it has a
+question but no result. They may therefore display a later continuation prompt,
+or combine a question and result from different interactions through the
+conversation-wide fallback.
+
+## Contract
+
+- Group request facts by interaction.
+- Select the chronologically earliest interaction whose aggregated question is
+  non-empty; use interaction ID as the deterministic timestamp tie-breaker.
+- Return both previews from that same interaction. Its result may be empty.
+- If no interaction has a question, return empty question and result previews.
+
+## Scope
+
+Change only the Foundry conversation-summary selection helper and its tests. Do
+not change APIs, persistence, lifecycle state, pagination, EE routes, or UI.
+

--- a/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent.md
+++ b/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent.md
@@ -1,0 +1,11 @@
+# Conversation Initial Intent Preview Implementation Plan
+
+1. Add a regression test where the first interaction has the user's initial
+   question but no result, and a later interaction is complete.
+2. Add a regression test proving a result-only later interaction is not paired
+   with the first interaction's question.
+3. Run the focused tests and confirm the current implementation fails.
+4. Select the earliest interaction with a non-empty question and remove the
+   conversation-wide fallback.
+5. Run focused and full `evidencesvc` package tests, formatting, and diff checks.
+

--- a/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent.md
+++ b/bkn-trace/agent-observability/docs/plans/2026-08-20-conversation-initial-intent.md
@@ -4,8 +4,11 @@
    question but no result, and a later interaction is complete.
 2. Add a regression test proving a result-only later interaction is not paired
    with the first interaction's question.
-3. Run the focused tests and confirm the current implementation fails.
-4. Select the earliest interaction with a non-empty question and remove the
+3. Add a compatibility regression test for a legacy conversation with no
+   interaction IDs.
+4. Run the focused tests and confirm the current implementation fails.
+5. Select the earliest interaction with a non-empty question and remove the
    conversation-wide fallback.
-5. Run focused and full `evidencesvc` package tests, formatting, and diff checks.
-
+6. Retain the request-level fallback only when every request lacks an
+   interaction ID, then run focused and full `evidencesvc` package tests,
+   formatting, and diff checks.

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -393,10 +393,9 @@ func firstConversationInteractionPreview(requests []evidencevo.RequestSummary) (
 	var question, result, firstAt, firstID string
 	for interactionID, interactionRequests := range byInteraction {
 		summary, _ := aggregateRequestGroup(interactionRequests)
-		// A list preview must remain a usable question/result pair. If the
-		// earliest interaction lost either artifact, prefer the next complete
-		// interaction; aggregateRequestGroup remains the all-incomplete fallback.
-		if summary.QuestionPreview == "" || summary.ResultPreview == "" {
+		// The question represents the user's intent. Keep its result scoped to
+		// the same interaction even when that result is unavailable.
+		if summary.QuestionPreview == "" {
 			continue
 		}
 		at := firstPresentSummary(summary.StartedAt, summary.CompletedAt)
@@ -407,8 +406,7 @@ func firstConversationInteractionPreview(requests []evidencevo.RequestSummary) (
 	if firstID != "" {
 		return question, result
 	}
-	base, _ := aggregateRequestGroup(requests)
-	return base.QuestionPreview, base.ResultPreview
+	return "", ""
 }
 
 // assignInteractionRoundNumbers preserves chronological meaning independently

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -389,6 +389,13 @@ func firstConversationInteractionPreview(requests []evidencevo.RequestSummary) (
 			byInteraction[request.InteractionID] = append(byInteraction[request.InteractionID], request)
 		}
 	}
+	// Contract versions before interaction IDs were mandatory still contribute a
+	// coherent request-level preview. Do not use this fallback once any
+	// interaction exists, because that would reintroduce cross-interaction pairs.
+	if len(byInteraction) == 0 {
+		base, _ := aggregateRequestGroup(requests)
+		return base.QuestionPreview, base.ResultPreview
+	}
 
 	var question, result, firstAt, firstID string
 	for interactionID, interactionRequests := range byInteraction {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -464,6 +464,20 @@ func TestBuildConversationSummaryDoesNotPairInitialQuestionWithLaterResultOnlyIn
 	}
 }
 
+func TestBuildConversationSummaryUsesLegacyPreviewWhenNoInteractionIDExists(t *testing.T) {
+	summary := buildConversationSummary("conversation_legacy", []evidencevo.RequestSummary{
+		{
+			RequestID: "req_legacy", StartedAt: "2026-08-07T08:00:00Z", CompletedAt: "2026-08-07T08:00:01Z",
+			Status: "completed", EvidenceCompleteness: "complete",
+			QuestionPreview: "存量会话的问题", ResultPreview: "存量会话的结果",
+		},
+	})
+
+	if summary.QuestionPreview != "存量会话的问题" || summary.ResultPreview != "存量会话的结果" {
+		t.Fatalf("legacy requests without interaction IDs must retain their existing preview: %+v", summary)
+	}
+}
+
 func TestBuildConversationSummarySkipsUnavailableFirstInteractionPreview(t *testing.T) {
 	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
 		{

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -422,6 +422,48 @@ func TestBuildConversationSummaryUsesFirstCoherentInteractionAndHidesChildCallEr
 	}
 }
 
+func TestBuildConversationSummaryKeepsInitialQuestionWhenItsResultIsUnavailable(t *testing.T) {
+	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
+		{
+			RequestID: "req_initial", InteractionID: "interaction_initial",
+			StartedAt: "2026-08-07T08:00:00Z", CompletedAt: "2026-08-07T08:00:01Z",
+			Status: "error", EvidenceCompleteness: "partial",
+			InteractionQuestion: "分析 6 月份的需求满足情况",
+		},
+		{
+			RequestID: "req_continue", InteractionID: "interaction_continue",
+			StartedAt: "2026-08-07T08:02:00Z", CompletedAt: "2026-08-07T08:02:01Z",
+			Status: "completed", EvidenceCompleteness: "complete",
+			InteractionQuestion: "请继续", InteractionResult: "后续分析已完成",
+		},
+	})
+
+	if summary.QuestionPreview != "分析 6 月份的需求满足情况" || summary.ResultPreview != "" {
+		t.Fatalf("conversation preview must preserve the initial intent without borrowing a later result: %+v", summary)
+	}
+}
+
+func TestBuildConversationSummaryDoesNotPairInitialQuestionWithLaterResultOnlyInteraction(t *testing.T) {
+	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
+		{
+			RequestID: "req_initial", InteractionID: "interaction_initial",
+			StartedAt: "2026-08-07T08:00:00Z", CompletedAt: "2026-08-07T08:00:01Z",
+			Status: "completed", EvidenceCompleteness: "partial",
+			InteractionQuestion: "分析 6 月份的需求满足情况",
+		},
+		{
+			RequestID: "req_result", InteractionID: "interaction_result",
+			StartedAt: "2026-08-07T08:02:00Z", CompletedAt: "2026-08-07T08:02:01Z",
+			Status: "completed", EvidenceCompleteness: "partial",
+			InteractionResult: "这是另一轮产生的结果",
+		},
+	})
+
+	if summary.QuestionPreview != "分析 6 月份的需求满足情况" || summary.ResultPreview != "" {
+		t.Fatalf("conversation preview must keep question and result in the same interaction: %+v", summary)
+	}
+}
+
 func TestBuildConversationSummarySkipsUnavailableFirstInteractionPreview(t *testing.T) {
 	summary := buildConversationSummary("conversation_supply", []evidencevo.RequestSummary{
 		{


### PR DESCRIPTION
## Summary

- select the earliest interaction that contains a user question for the conversation preview
- keep question and result previews scoped to the same interaction, allowing an unavailable result to remain empty
- remove the conversation-wide fallback that could replace initial intent or combine artifacts from different interactions

## Test plan

- env GOCACHE=/tmp/codex-bkn-foundry-go-cache go test ./... -count=1 from bkn-trace/agent-observability
- git diff --check

Addresses openbkn-ai/openbkn-ee#32.

## Integration note

The enterprise build must consume a Foundry revision containing this change before the issue can be considered deployed.

