### PR TITLE
feat(context-loader): let the reranker decide which object types a query means

### DIFF
--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -175,6 +175,11 @@ type KnInstanceSearchConfig struct {
 	// Those two numbers were measured when the concept-recall score was raw BM25. It is the
 	// reranker's 0..1 relevance now, so a deployment that did calibrate this value has to measure
 	// again — the ratios are not comparable across the two scales.
+	//
+	// Worse, both scales can reach this threshold in one deployment: enable_rerank=false leaves
+	// object types on the coarse BM25 score and enable_rerank=true replaces it with the reranker's,
+	// so the same ratio filters the two request paths with different strength. Calibrate against the
+	// path the callers actually use.
 	MinObjectTypeScoreRatio float64 `yaml:"min_object_type_score_ratio"`
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -171,6 +171,10 @@ type KnInstanceSearchConfig struct {
 	// Off by default for want of a portable value: concept recall has already kept only its best
 	// matches, so the spread among survivors is narrow — the worst one scored 0.21 and 0.27 of the
 	// best on two of our own networks. A ratio that trims one of them barely touches the other.
+	//
+	// Those two numbers were measured when the concept-recall score was raw BM25. It is the
+	// reranker's 0..1 relevance now, so a deployment that did calibrate this value has to measure
+	// again — the ratios are not comparable across the two scales.
 	MinObjectTypeScoreRatio float64 `yaml:"min_object_type_score_ratio"`
 }
 

--- a/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/kn_search_local.go
@@ -58,6 +58,15 @@ type KnSearchConceptRetrievalConfig struct {
 	EnablePropertyBrief    *bool    `json:"enable_property_brief" default:"true"`
 	PerObjectPropertyTopK  int      `json:"per_object_property_top_k" default:"8"`
 	GlobalPropertyTopK     int      `json:"global_property_top_k" default:"30"`
+	// ObjectRerankCandidateLimit caps how many object types the concept rerank call carries, best
+	// coarse score first. It bounds one model call, not the response: everything below the cut keeps
+	// its place in the schema, it just cannot outrank a reranked object type. 0 turns object
+	// reranking off and leaves object types on the coarse BM25/kNN score.
+	//
+	// Deliberately not on the wire: retrieval_config is documented as a compatibility shim that
+	// absorbs only top_k and schema_brief, so a caller-settable field here would advertise a knob
+	// the contract says does nothing. It is a safety cap for pathological networks, not a tunable.
+	ObjectRerankCandidateLimit int `json:"-" default:"200"`
 }
 
 // KnSearchSemanticInstanceRetrievalConfig semantic instance recall configuration parameters.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -697,32 +697,40 @@ func (s *localSearchImpl) rankConcepts(
 
 	// Call the Rerank service; model is the default reranker checked in the empty model management (#842)
 	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
-	if err != nil {
-		// Graceful downgrade: Relevance is not lost when the reranker is unavailable (not registered/NameNotExist).
-		// Prioritize sorting by coarse recall BM25 _score (existing correlation signal, zero additional delay);
-		// Only fall back to pure name matching if _score is all 0 (if coarse recall is not enabled).
-		// Object types keep whatever the coarse pass gave them, which is the pre-rerank behaviour.
+	if err != nil || rerankResp == nil {
 		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank unavailable (%v); degrading to coarse-recall _score order", err)
-		if ranked, ok := rankRelationTypesByScore(relations, topK); ok {
-			return ranked
-		}
-		s.logger.WithContext(ctx).Warnf("[RankConcepts] coarse-recall _score all zero; falling back to simple name match")
-		return s.rankRelationTypesBySimpleMatch(query, relations, topK)
+		return s.degradeRelationRanking(ctx, query, relations, topK)
 	}
 
 	objectScores := make([]float64, objectDocCount)
 	relationScores := make([]float64, len(relations))
+	objectApplied, relationApplied := 0, 0
 	for _, result := range rerankResp.Results {
 		switch {
 		case result.Index < 0 || result.Index >= len(documents):
 		case result.Index < objectDocCount:
 			objectScores[result.Index] = result.RelevanceScore
+			objectApplied++
 		default:
 			relationScores[result.Index-objectDocCount] = result.RelevanceScore
+			relationApplied++
 		}
 	}
 
-	if objectDocCount > 0 {
+	// A 200 carrying no usable index is the reranker being unavailable in a way that never surfaces
+	// as an error - an unregistered model answered through an error envelope, a vendor that returned
+	// an empty list. Taking it at face value would clear every coarse score and leave nothing in its
+	// place, which is strictly worse than not having called the model at all. Instance reranking
+	// guards this the same way.
+	if objectApplied == 0 && relationApplied == 0 {
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank returned no usable index; degrading to coarse-recall _score order")
+		return s.degradeRelationRanking(ctx, query, relations, topK)
+	}
+
+	// Write back per category, and only where the model actually answered. A vendor that returns
+	// only its top N can come back with relation scores and no object score at all; zeroing the
+	// object types on the strength of that would bury them for a reason the model never gave.
+	if objectApplied > 0 {
 		// The rerank score replaces the coarse score instead of blending with it: the two are not on
 		// one scale (BM25 is unbounded, the reranker answers in 0..1), so an object type still holding
 		// a coarse score would sort above every reranked one. Object types that missed the candidate
@@ -735,12 +743,36 @@ func (s *localSearchImpl) rankConcepts(
 		for i, obj := range objectCandidates {
 			obj.Score = objectScores[i]
 		}
-		s.logger.WithContext(ctx).Debugf("[RankConcepts] Reranked %d/%d object types", objectDocCount, len(objectTypes))
+		s.logger.WithContext(ctx).Debugf("[RankConcepts] Reranked %d/%d object types", objectApplied, len(objectTypes))
+	} else if objectDocCount > 0 {
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank scored no object type; keeping coarse-recall order for %d", objectDocCount)
+	}
+
+	if relationApplied == 0 && len(relations) > 0 {
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank scored no relation type; keeping recall order for %d", len(relations))
 	}
 
 	ranked := rankRelationsByScores(relations, relationScores, topK)
 	s.logger.WithContext(ctx).Debugf("[RankConcepts] Rerank completed, top_k=%d", len(ranked))
 	return ranked
+}
+
+// degradeRelationRanking is the relation ranking used whenever the reranker gives nothing usable.
+// Relevance is not lost when the reranker is unavailable (not registered / NameNotExist): sort by
+// the coarse recall BM25 _score first, which is an existing signal at zero extra latency, and fall
+// back to pure name matching only when _score is all zero (coarse recall off). Object types keep
+// whatever the coarse pass gave them, which is the pre-rerank behaviour.
+func (s *localSearchImpl) degradeRelationRanking(
+	ctx context.Context,
+	query string,
+	relations []*interfaces.RelationType,
+	topK int,
+) []*interfaces.RelationType {
+	if ranked, ok := rankRelationTypesByScore(relations, topK); ok {
+		return ranked
+	}
+	s.logger.WithContext(ctx).Warnf("[RankConcepts] coarse-recall _score all zero; falling back to simple name match")
+	return s.rankRelationTypesBySimpleMatch(query, relations, topK)
 }
 
 // objectRerankCandidates picks the object types that go into the rerank call, best coarse score

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -79,15 +79,18 @@ func (s *localSearchImpl) conceptRetrieval(
 		}
 	}
 
-	// 3. Object class correlation scoring. Coarse recall only works in very large networks (relationship number >= CoarseMinRelationCount)
-	// Triggered, most real networks cannot reach it, and there is no query signal on the object side, and can only be passively brought out by the relationship endpoint.
-	// This channel is added here so that the correlation of object types can independently participate in subsequent sorting.
+	// 3. Coarse object type scoring (BM25 + kNN). Coarse recall only fires on very large networks
+	// (relation count >= CoarseMinRelationCount) and most real networks never reach it, so without
+	// this channel object types carry no query signal at all and can only be brought out passively
+	// by a relation endpoint. It is also the first stage of the two-stage object ranking: it decides
+	// which object types are worth handing to the reranker in step 4.
 	if !coarseScored {
 		s.scoreObjectTypes(ctx, req.KnID, req.Query, networkDetail.ObjectTypes, config)
 	}
 
-	// 4. Sort relationship types (based on semantic relevance) and select Top-K.
-	rankedRelations := s.rankRelationTypes(ctx, req.Query, networkDetail.ObjectTypes, networkDetail.RelationTypes, config.TopK, req.EnableRerank, req.RerankModel)
+	// 4. Rank relation types and score object types against the query, in one rerank call.
+	rankedRelations := s.rankConcepts(ctx, req.Query, networkDetail.ObjectTypes, networkDetail.RelationTypes,
+		config.TopK, req.EnableRerank, req.RerankModel, config.ObjectRerankCandidateLimit)
 	s.logger.WithContext(ctx).Debugf("[ConceptRetrieval] Ranked relations: %d -> top_k=%d", len(networkDetail.RelationTypes), len(rankedRelations))
 
 	// 5. Object type selection: Sort by self-relevance, relationship endpoints are incorporated as schema self-consistent constraints.
@@ -199,7 +202,8 @@ func (s *localSearchImpl) conceptRetrievalByGroups(
 	relations, actions = scope.applyToConcepts(objects, relations, actions)
 	s.logScopeOutcome(ctx, "[Groups]", scope, objects, unmatchedObjectTypes)
 
-	rankedRelations := s.rankRelationTypes(ctx, req.Query, objects, relations, config.TopK, req.EnableRerank, req.RerankModel)
+	rankedRelations := s.rankConcepts(ctx, req.Query, objects, relations,
+		config.TopK, req.EnableRerank, req.RerankModel, config.ObjectRerankCandidateLimit)
 	selectedObjects := s.selectObjectTypesForConceptRetrieval(objects, rankedRelations, config.TopK)
 
 	brief := boolValue(config.SchemaBrief)
@@ -629,7 +633,7 @@ func (s *localSearchImpl) buildCoarseRecallQuery(knID, query string, limit int, 
 }
 
 // rankRelationTypes semantically ranks relationship types and takes Top-K.
-// Semantic ranking using the Rerank service.
+// Semantic ranking using the Rerank service. Object types keep their coarse score.
 func (s *localSearchImpl) rankRelationTypes(
 	ctx context.Context,
 	query string,
@@ -639,18 +643,129 @@ func (s *localSearchImpl) rankRelationTypes(
 	enableRerank bool,
 	rerankModel string,
 ) []*interfaces.RelationType {
-	if len(relations) == 0 {
+	return s.rankConcepts(ctx, query, objectTypes, relations, topK, enableRerank, rerankModel, 0)
+}
+
+// rankConcepts ranks relation types and scores object types against the query in a single rerank
+// call. Both concept recall paths enter here.
+//
+// Object types used to reach the response on their coarse score alone, and that score cannot carry
+// the job: it is BM25 over ten equally weighted fields summed with a kNN channel whose 0..1 score
+// is dwarfed by unbounded BM25, so lexical noise decides the order and the vector channel cannot
+// correct it. A query carrying schema meta-words ("<entity> object type field") therefore ranked a
+// long-commented object type above the one actually named after the entity. The reranker is the
+// only component in this pipeline that can tell a meta-word from a business term, so object types
+// now go through it too.
+//
+// The two categories share one call instead of paying for two round trips, and sharing buys a
+// second property: scores from one rerank invocation are comparable, so an object type and a
+// relation type can be reasoned about on the same scale.
+//
+// objectCandidateLimit caps how many object types enter the call; 0 leaves object types on their
+// coarse score, which is what the relation-only entry point wants.
+//
+// Relation ranking keeps its contract exactly: same Top-K cut, same downgrade chain.
+func (s *localSearchImpl) rankConcepts(
+	ctx context.Context,
+	query string,
+	objectTypes []*interfaces.ObjectType,
+	relations []*interfaces.RelationType,
+	topK int,
+	enableRerank bool,
+	rerankModel string,
+	objectCandidateLimit int,
+) []*interfaces.RelationType {
+	objectCandidates := objectRerankCandidates(objectTypes, objectCandidateLimit)
+
+	if len(relations) == 0 && len(objectCandidates) == 0 {
 		return relations
 	}
 
-	// When Rerank is not enabled: keep original order, only truncate Top-K (for alignment with Python's current concept recall behavior)
+	// When Rerank is not enabled: keep original order, only truncate Top-K (for alignment with
+	// Python's current concept recall behavior). Object types keep their coarse score for the same
+	// reason - the caller opted out of paying for the model.
 	if !enableRerank {
-		if topK <= 0 || topK >= len(relations) {
-			return relations
-		}
-		return relations[:topK]
+		return truncateRelations(relations, topK)
 	}
 
+	documents := make([]string, 0, len(objectCandidates)+len(relations))
+	for _, obj := range objectCandidates {
+		documents = append(documents, buildObjectText(obj))
+	}
+	objectDocCount := len(documents)
+	documents = append(documents, s.buildRelationDocuments(objectTypes, relations)...)
+
+	// Call the Rerank service; model is the default reranker checked in the empty model management (#842)
+	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
+	if err != nil {
+		// Graceful downgrade: Relevance is not lost when the reranker is unavailable (not registered/NameNotExist).
+		// Prioritize sorting by coarse recall BM25 _score (existing correlation signal, zero additional delay);
+		// Only fall back to pure name matching if _score is all 0 (if coarse recall is not enabled).
+		// Object types keep whatever the coarse pass gave them, which is the pre-rerank behaviour.
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank unavailable (%v); degrading to coarse-recall _score order", err)
+		if ranked, ok := rankRelationTypesByScore(relations, topK); ok {
+			return ranked
+		}
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] coarse-recall _score all zero; falling back to simple name match")
+		return s.rankRelationTypesBySimpleMatch(query, relations, topK)
+	}
+
+	objectScores := make([]float64, objectDocCount)
+	relationScores := make([]float64, len(relations))
+	for _, result := range rerankResp.Results {
+		switch {
+		case result.Index < 0 || result.Index >= len(documents):
+		case result.Index < objectDocCount:
+			objectScores[result.Index] = result.RelevanceScore
+		default:
+			relationScores[result.Index-objectDocCount] = result.RelevanceScore
+		}
+	}
+
+	if objectDocCount > 0 {
+		// The rerank score replaces the coarse score instead of blending with it: the two are not on
+		// one scale (BM25 is unbounded, the reranker answers in 0..1), so an object type still holding
+		// a coarse score would sort above every reranked one. Object types that missed the candidate
+		// cut are zeroed for that same reason - they already lost on the coarse signal.
+		for _, obj := range objectTypes {
+			if obj != nil {
+				obj.Score = 0
+			}
+		}
+		for i, obj := range objectCandidates {
+			obj.Score = objectScores[i]
+		}
+		s.logger.WithContext(ctx).Debugf("[RankConcepts] Reranked %d/%d object types", objectDocCount, len(objectTypes))
+	}
+
+	ranked := rankRelationsByScores(relations, relationScores, topK)
+	s.logger.WithContext(ctx).Debugf("[RankConcepts] Rerank completed, top_k=%d", len(ranked))
+	return ranked
+}
+
+// objectRerankCandidates picks the object types that go into the rerank call, best coarse score
+// first. The coarse BM25/kNN pass stays in front of the model as the cheap first stage: reranking
+// every object type of a large network would blow the model's input budget, and the coarse score is
+// the only signal available to choose the candidates with. Object types the coarse pass never
+// scored still ride along while there is room, so a network whose coarse recall returned nothing at
+// all is reranked whole rather than not at all.
+func objectRerankCandidates(objectTypes []*interfaces.ObjectType, limit int) []*interfaces.ObjectType {
+	if limit <= 0 || len(objectTypes) == 0 {
+		return nil
+	}
+	ranked := sortObjectTypesByScore(objectTypes)
+	if len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+	return ranked
+}
+
+// buildRelationDocuments renders each relation for the reranker, holding index alignment with the
+// input slice: a nil relation still occupies its slot.
+func (s *localSearchImpl) buildRelationDocuments(
+	objectTypes []*interfaces.ObjectType,
+	relations []*interfaces.RelationType,
+) []string {
 	objectNameByID := make(map[string]string, len(objectTypes))
 	for _, obj := range objectTypes {
 		if obj == nil || obj.ID == "" {
@@ -676,22 +791,15 @@ func (s *localSearchImpl) rankRelationTypes(
 		}
 		documents[i] = buildRelationText(sourceName, relationName, targetName, rel.Comment)
 	}
+	return documents
+}
 
-	// Call the Rerank service; model is the default reranker checked in the empty model management (#842)
-	rerankResp, err := s.rerankClient.Rerank(ctx, query, documents, rerankModel)
-	if err != nil {
-		// Graceful downgrade: Relevance is not lost when the reranker is unavailable (not registered/NameNotExist).
-		// Prioritize sorting by coarse recall BM25 _score (existing correlation signal, zero additional delay);
-		// Only fall back to pure name matching if _score is all 0 (if coarse recall is not enabled).
-		s.logger.WithContext(ctx).Warnf("[RankRelationTypes] Rerank unavailable (%v); degrading to coarse-recall _score order", err)
-		if ranked, ok := rankRelationTypesByScore(relations, topK); ok {
-			return ranked
-		}
-		s.logger.WithContext(ctx).Warnf("[RankRelationTypes] coarse-recall _score all zero; falling back to simple name match")
-		return s.rankRelationTypesBySimpleMatch(query, relations, topK)
+// rankRelationsByScores orders relations by the given per-index scores and takes Top-K.
+func rankRelationsByScores(relations []*interfaces.RelationType, scores []float64, topK int) []*interfaces.RelationType {
+	if len(relations) == 0 {
+		return relations
 	}
 
-	// Sort by Rerank score.
 	type scoredRelation struct {
 		relation *interfaces.RelationType
 		score    float64
@@ -699,22 +807,17 @@ func (s *localSearchImpl) rankRelationTypes(
 
 	scored := make([]scoredRelation, len(relations))
 	for i, rel := range relations {
-		scored[i] = scoredRelation{
-			relation: rel,
-			score:    0,
+		score := 0.0
+		if i < len(scores) {
+			score = scores[i]
 		}
-	}
-	for _, result := range rerankResp.Results {
-		if result.Index >= 0 && result.Index < len(relations) {
-			scored[result.Index].score = result.RelevanceScore
-		}
+		scored[i] = scoredRelation{relation: rel, score: score}
 	}
 
 	sort.SliceStable(scored, func(i, j int) bool {
 		return scored[i].score > scored[j].score
 	})
 
-	// Take Top-K.
 	if topK > len(scored) {
 		topK = len(scored)
 	}
@@ -723,10 +826,33 @@ func (s *localSearchImpl) rankRelationTypes(
 	for i := 0; i < topK; i++ {
 		result[i] = scored[i].relation
 	}
-
-	s.logger.WithContext(ctx).Debugf("[RankRelationTypes] Rerank completed, top_k=%d", len(result))
-
 	return result
+}
+
+// truncateRelations keeps the incoming order and cuts to Top-K.
+func truncateRelations(relations []*interfaces.RelationType, topK int) []*interfaces.RelationType {
+	if topK <= 0 || topK >= len(relations) {
+		return relations
+	}
+	return relations[:topK]
+}
+
+// buildObjectText renders an object type for the reranker. The name carries the identity and the
+// comment carries what it is for; properties are left out on purpose - they multiply the document
+// by the width of the table for a signal the name and comment already carry.
+func buildObjectText(obj *interfaces.ObjectType) string {
+	if obj == nil {
+		return ""
+	}
+	name := strings.TrimSpace(obj.Name)
+	if name == "" {
+		name = obj.ID
+	}
+	comment := strings.TrimSpace(obj.Comment)
+	if comment == "" {
+		return name
+	}
+	return name + "，" + comment
 }
 
 func buildRelationText(sourceName, relationName, targetName, relationComment string) string {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval_test.go
@@ -3,6 +3,7 @@ package knsearch
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
@@ -97,11 +98,19 @@ func TestConceptRetrieval_MainFlow(t *testing.T) {
 			}(),
 			mockSetup: func(m *mockBknBackend, r *mockRerankClient) {
 				m.networkDetail = mockDetail
-				r.rerankResp = &interfaces.RerankResp{
-					Results: []interfaces.RerankResult{
-						{Index: 0, RelevanceScore: 0.1},
-						{Index: 1, RelevanceScore: 0.9},
-					},
+				// Score by document content rather than a fixed index. The rerank call carries
+				// object type documents ahead of the relation ones, so a hardcoded index names
+				// whichever slot the layout happens to put there, not the relation under test.
+				r.rerankFunc = func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+					resp := &interfaces.RerankResp{}
+					for i, doc := range documents {
+						score := 0.1
+						if strings.Contains(doc, "关系_1") {
+							score = 0.9
+						}
+						resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
+					}
+					return resp, nil
 				}
 			},
 			checkResult: func(t *testing.T, res *interfaces.KnSearchConceptResult, err error) {

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/config.go
@@ -23,6 +23,10 @@ func DefaultConceptRetrievalConfig() *interfaces.KnSearchConceptRetrievalConfig 
 		EnablePropertyBrief:    boolPtr(true),
 		PerObjectPropertyTopK:  8,
 		GlobalPropertyTopK:     30,
+		// 200 is well above any network we have seen (the largest is a few dozen object types), so in
+		// practice every object type is reranked; it exists to keep a pathological network from
+		// sending an unbounded document list to the model.
+		ObjectRerankCandidateLimit: 200,
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
@@ -53,7 +53,12 @@ func buildObjectRankingNetwork() *interfaces.KnowledgeNetworkDetail {
 	return detail
 }
 
-// objectRankingRerank ranks the relationship with "employee" to the bottom.
+// objectRankingRerank ranks the relation hanging off "employee" to the bottom while keeping the
+// employee object type itself at the top - which is the whole point of the scenario: the query is
+// about employees, and relation ranking must not be able to bury the object type the query names.
+//
+// The two document kinds are told apart by the "-" in every relation name of this fixture; the
+// reranker only ever sees flat strings, so the fixture has to carry the distinction itself.
 type objectRankingRerank struct{}
 
 func (d *objectRankingRerank) Rerank(ctx context.Context, query string, documents []string, model string) (*interfaces.RerankResp, error) {
@@ -61,7 +66,11 @@ func (d *objectRankingRerank) Rerank(ctx context.Context, query string, document
 	for i, doc := range documents {
 		score := 0.9 - float64(i)*0.01
 		if strings.Contains(doc, "员工") {
-			score = 0.5
+			if strings.Contains(doc, "-") {
+				score = 0.5 // the lone relation on 员工: least relevant of all relations
+			} else {
+				score = 0.99 // the 员工 object type: what the query is actually about
+			}
 		}
 		resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
 	}
@@ -240,8 +249,13 @@ func buildEndpointsLastNetwork() *interfaces.KnowledgeNetworkDetail {
 	return detail
 }
 
-// When scoring is unavailable (BKN retrieval fails), it must be degraded gracefully: no error is reported, no null is returned,
-// And the order returns to the "relationship endpoint first" before the repair, and cannot be changed to the definition order out of thin air.
+// When no relevance signal is available at all - the BKN coarse pass fails AND the reranker is
+// down - it must degrade gracefully: no error, no null, and the order falls back to the
+// "relation endpoints first" behaviour that predates #778 rather than to definition order.
+//
+// Both sources have to be knocked out for this to be the degraded path: object types are reranked
+// now, so a working reranker still yields relevance when the coarse pass fails. That laddering is
+// asserted by TestObjectRelevanceSurvivesCoarseFailure.
 func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	net := buildEndpointsLastNetwork()
 	backend := &mockBknBackend{
@@ -251,7 +265,7 @@ func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	svc := &localSearchImpl{
 		logger:       &mockLogger{},
 		bknBackend:   backend,
-		rerankClient: &objectRankingRerank{},
+		rerankClient: &mockRerankClient{rerankError: fmt.Errorf("reranker unavailable")},
 	}
 
 	cfg := DefaultConceptRetrievalConfig()

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_rerank_test.go
@@ -89,6 +89,11 @@ func metaWordAwareRerank() *mockRerankClient {
 
 func runMetaWordQuery(t *testing.T, enableRerank bool) []string {
 	t.Helper()
+	return runMetaWordQueryWith(t, metaWordAwareRerank(), enableRerank)
+}
+
+func runMetaWordQueryWith(t *testing.T, rerank interfaces.DrivenMFModelAPIClient, enableRerank bool) []string {
+	t.Helper()
 
 	net := buildMetaWordQueryNetwork()
 	svc := &localSearchImpl{
@@ -98,7 +103,7 @@ func runMetaWordQuery(t *testing.T, enableRerank bool) []string {
 			objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: coarseScoresFavouringDecoy(net)},
 			relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
 		},
-		rerankClient: metaWordAwareRerank(),
+		rerankClient: rerank,
 	}
 
 	cfg := DefaultConceptRetrievalConfig()
@@ -283,5 +288,62 @@ func TestObjectRerankCandidateLimitBoundsDocuments(t *testing.T) {
 	if len(docs) != want {
 		t.Errorf("expected %d documents (%d object candidates + %d relation types), got %d",
 			want, cfg.ObjectRerankCandidateLimit, len(net.RelationTypes), len(docs))
+	}
+}
+
+// A reranker can fail without returning an error: an unregistered model answered through an error
+// envelope, a vendor that came back with an empty list. Taking that at face value would clear every
+// coarse score and put nothing in its place, leaving object types worse ordered than if the model
+// had never been called - the #778 regression, reintroduced through a success path.
+func TestRerankReturningNoUsableIndexKeepsCoarseOrder(t *testing.T) {
+	cases := []struct {
+		name   string
+		client *mockRerankClient
+	}{
+		{"empty results", &mockRerankClient{rerankResp: &interfaces.RerankResp{}}},
+		{"nil response", &mockRerankClient{}},
+		{"every index out of range", &mockRerankClient{rerankResp: &interfaces.RerankResp{
+			Results: []interfaces.RerankResult{{Index: 999, RelevanceScore: 0.9}, {Index: -1, RelevanceScore: 0.9}},
+		}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := runMetaWordQueryWith(t, tc.client, true)
+			t.Logf("%s -> %v", tc.name, names)
+			if len(names) == 0 {
+				t.Fatalf("expected object types, got none")
+			}
+			// Coarse order is what BM25 gave: the decoy first. Worse than a working reranker, but it
+			// is the honest answer and it is what the caller got before this change.
+			if names[0] != decoyObjectName {
+				t.Errorf("expected coarse order preserved (%q first), got %v", decoyObjectName, names)
+			}
+		})
+	}
+}
+
+// Vendors that return only their top N can answer with relation scores and no object score at all.
+// Zeroing the object types on the strength of that would bury them for a reason the model never
+// gave, so each category is written back only where the model actually answered.
+func TestRerankScoringOnlyRelationsKeepsObjectCoarseOrder(t *testing.T) {
+	net := buildMetaWordQueryNetwork()
+	objectCount := len(net.ObjectTypes)
+	client := &mockRerankClient{
+		rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+			resp := &interfaces.RerankResp{}
+			for i := objectCount; i < len(documents); i++ {
+				resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: 0.7})
+			}
+			return resp, nil
+		},
+	}
+
+	names := runMetaWordQueryWith(t, client, true)
+	t.Logf("relations-only rerank -> %v", names)
+	if len(names) == 0 {
+		t.Fatalf("expected object types, got none")
+	}
+	if names[0] != decoyObjectName {
+		t.Errorf("expected object coarse order preserved (%q first), got %v", decoyObjectName, names)
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_rerank_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_rerank_test.go
@@ -1,0 +1,287 @@
+package knsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// Regression for the reported "企业对象类字段" case.
+//
+// The coarse pass is BM25 over ten equally weighted fields, and the BKN concept index tokenizes
+// Chinese per character, so a query carrying schema meta-words ("企业 对象类 字段") scores a long
+// dispatch-record object type - whose comment happens to repeat 企业 three times - above the object
+// type actually named 企业. With max_concepts=1 that one slot went to the decoy and the answer the
+// caller wanted never appeared. The reranker is the only stage that can tell 字段 is a meta-word.
+
+const (
+	decoyObjectName  = "企业派单记录"
+	targetObjectName = "企业"
+)
+
+func buildMetaWordQueryNetwork() *interfaces.KnowledgeNetworkDetail {
+	detail := &interfaces.KnowledgeNetworkDetail{ID: "kn_meta_word"}
+	objects := []struct{ id, name, comment string }{
+		{"met_coal_share", decoyObjectName, "企业派单记录是表示企业给司机派活、找车、找司机的一次任务记录，包含。分享企业、分享张数、收货信息id"},
+		{"met_coal_company", targetObjectName, "企业主体信息"},
+		{"met_coal_used_info", "司机拉运记录", "司机每次接了企业派单拉运任务的详细信息"},
+		{"met_coal_road", "路线", "平台司机常跑的路线，起点是煤矿，终点是卸货地点"},
+	}
+	for _, o := range objects {
+		detail.ObjectTypes = append(detail.ObjectTypes, &interfaces.ObjectType{
+			ID: o.id, Name: o.name, Comment: o.comment,
+		})
+	}
+	detail.RelationTypes = append(detail.RelationTypes, &interfaces.RelationType{
+		ID:                 "rel_road",
+		Name:               "司机拉运记录和路线的关系",
+		Comment:            "一条拉运记录跑在一条路线上",
+		SourceObjectTypeID: "met_coal_used_info",
+		TargetObjectTypeID: "met_coal_road",
+	})
+	return detail
+}
+
+// coarseScoresFavouringDecoy is what BM25 actually returned for this network: the decoy far ahead
+// of every other object type, the object type the query names down with the rest.
+func coarseScoresFavouringDecoy(net *interfaces.KnowledgeNetworkDetail) []*interfaces.ObjectType {
+	entries := make([]*interfaces.ObjectType, 0, len(net.ObjectTypes))
+	for _, o := range net.ObjectTypes {
+		cp := *o
+		cp.Score = 1.0
+		if cp.Name == decoyObjectName {
+			cp.Score = 12.5
+		}
+		entries = append(entries, &cp)
+	}
+	return entries
+}
+
+// conceptNameOf pulls the leading name out of a rerank document. buildObjectText writes
+// "name，comment"; a relation document is space-joined and never matches a bare object name.
+func conceptNameOf(doc string) string {
+	if i := strings.Index(doc, "，"); i >= 0 {
+		return doc[:i]
+	}
+	return doc
+}
+
+// metaWordAwareRerank stands in for a semantic reranker: it recognises that the query is about
+// 企业 and is not fooled by a comment that merely repeats the word.
+func metaWordAwareRerank() *mockRerankClient {
+	return &mockRerankClient{
+		rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+			resp := &interfaces.RerankResp{}
+			for i, doc := range documents {
+				score := 0.2
+				if conceptNameOf(doc) == targetObjectName {
+					score = 0.95
+				}
+				resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
+			}
+			return resp, nil
+		},
+	}
+}
+
+func runMetaWordQuery(t *testing.T, enableRerank bool) []string {
+	t.Helper()
+
+	net := buildMetaWordQueryNetwork()
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:     net,
+			objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: coarseScoresFavouringDecoy(net)},
+			relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
+		},
+		rerankClient: metaWordAwareRerank(),
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 1
+
+	req := &interfaces.KnSearchLocalRequest{
+		KnID:         "kn_meta_word",
+		Query:        "企业 对象类 字段",
+		EnableRerank: enableRerank,
+	}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	// Go through the response filter the MCP tool uses, so the assertion is on what the caller sees.
+	knResp := &interfaces.KnSearchResp{ObjectTypes: res.ObjectTypes, RelationTypes: res.RelationTypes}
+	scope := SearchSchemaScope{IncludeObjectTypes: true, IncludeRelationTypes: true}
+	filtered := FilterSearchSchemaResp(knResp, nil, scope, cfg.TopK)
+
+	names := make([]string, 0, len(filtered.ObjectTypes))
+	for _, o := range filtered.ObjectTypes {
+		if m, ok := o.(map[string]any); ok {
+			if n, ok := m["concept_name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+	}
+	return names
+}
+
+func TestMetaWordQueryReachesTheObjectTypeItNames(t *testing.T) {
+	names := runMetaWordQuery(t, true)
+	t.Logf("with rerank -> %v", names)
+
+	if len(names) == 0 || names[0] != targetObjectName {
+		t.Fatalf("expected %q ranked first, got %v", targetObjectName, names)
+	}
+	for _, n := range names {
+		if n == decoyObjectName {
+			t.Errorf("the decoy %q must not take the single max_concepts slot, got %v", decoyObjectName, names)
+		}
+	}
+}
+
+// The coarse-only behaviour is kept verbatim behind enable_rerank=false, and it is also the
+// evidence that the fixture reproduces the reported failure rather than assuming it.
+func TestMetaWordQueryWithoutRerankStillPicksTheDecoy(t *testing.T) {
+	names := runMetaWordQuery(t, false)
+	t.Logf("without rerank -> %v", names)
+
+	if len(names) == 0 || names[0] != decoyObjectName {
+		t.Fatalf("coarse-only path should still rank the BM25 winner %q first, got %v", decoyObjectName, names)
+	}
+}
+
+// Coarse scoring failing no longer costs object relevance: the reranker is a second, independent
+// source of it. Only losing both drops to the endpoint-first order asserted by
+// TestObjectScoringDegradesWhenBackendFails.
+func TestObjectRelevanceSurvivesCoarseFailure(t *testing.T) {
+	net := buildEndpointsLastNetwork()
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:    net,
+			objectTypesError: fmt.Errorf("backend unavailable"),
+		},
+		rerankClient: &mockRerankClient{
+			rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+				resp := &interfaces.RerankResp{}
+				for i, doc := range documents {
+					score := 0.1
+					if conceptNameOf(doc) == "对象_0" {
+						score = 0.99
+					}
+					resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
+				}
+				return resp, nil
+			},
+		},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 5
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: "对象_0", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("expected graceful degradation, got error: %v", err)
+	}
+	if len(res.ObjectTypes) == 0 {
+		t.Fatalf("expected object types, got none")
+	}
+	// obj_0 hangs off no relation in this fixture, so ranking it first can only come from relevance.
+	if res.ObjectTypes[0].ConceptID != "obj_0" {
+		got := make([]string, 0, len(res.ObjectTypes))
+		for _, o := range res.ObjectTypes {
+			got = append(got, o.ConceptID)
+		}
+		t.Errorf("expected obj_0 first on reranker-only relevance, got %v", got)
+	}
+}
+
+// Both concept categories ride one rerank call: two would double the latency of every schema
+// search, and scores from separate invocations are not comparable with each other.
+func TestConceptRerankIssuesOneCallCarryingBothCategories(t *testing.T) {
+	net := buildMetaWordQueryNetwork()
+	rerank := metaWordAwareRerank()
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:     net,
+			objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: coarseScoresFavouringDecoy(net)},
+			relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
+		},
+		rerankClient: rerank,
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 3
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_meta_word", Query: "企业", EnableRerank: true}
+	if _, err := svc.conceptRetrieval(context.Background(), req, cfg); err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	if got := rerank.callCount(); got != 1 {
+		t.Errorf("expected exactly 1 rerank call, got %d", got)
+	}
+	docs := rerank.documents()
+	want := len(net.ObjectTypes) + len(net.RelationTypes)
+	if len(docs) != want {
+		t.Fatalf("expected %d documents (%d object types + %d relation types), got %d: %v",
+			want, len(net.ObjectTypes), len(net.RelationTypes), len(docs), docs)
+	}
+	// Object documents come first; the split point is what the score demux relies on.
+	for i := 0; i < len(net.ObjectTypes); i++ {
+		if strings.Contains(docs[i], " ") {
+			t.Errorf("document %d should be an object type, got a relation-shaped one: %q", i, docs[i])
+		}
+	}
+}
+
+// The candidate cap bounds one model call. Object types below the cut stay in the schema; they
+// just cannot outrank a reranked one, which is why their score is cleared rather than left on the
+// coarse scale.
+func TestObjectRerankCandidateLimitBoundsDocuments(t *testing.T) {
+	net := buildObjectRankingNetwork()
+	rerank := &mockRerankClient{
+		rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+			resp := &interfaces.RerankResp{}
+			for i := range documents {
+				resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: 0.5})
+			}
+			return resp, nil
+		},
+	}
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:     net,
+			objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: buildScoredObjectEntries(net, "员工")},
+			relationTypesResp: &interfaces.RelationTypeConcepts{Entries: net.RelationTypes},
+		},
+		rerankClient: rerank,
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 5
+	cfg.ObjectRerankCandidateLimit = 2
+
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_demo", Query: "员工 性别", EnableRerank: true}
+	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+	if len(res.ObjectTypes) == 0 {
+		t.Fatalf("expected object types, got none")
+	}
+
+	docs := rerank.documents()
+	want := cfg.ObjectRerankCandidateLimit + len(net.RelationTypes)
+	if len(docs) != want {
+		t.Errorf("expected %d documents (%d object candidates + %d relation types), got %d",
+			want, cfg.ObjectRerankCandidateLimit, len(net.RelationTypes), len(docs))
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -291,6 +291,12 @@ func (s *localSearchImpl) filterObjectTypesByScore(
 		// endpoints of a selected relation are completed in afterwards, and object_types pinned by the
 		// caller are applied before scoring runs at all. Dropping those would silently skip the very
 		// object type a caller named by hand.
+		//
+		// Narrower than it used to be: concept recall reranks every object type it carries, so an
+		// endpoint-completed or caller-pinned one now arrives with a real relevance score and is
+		// filtered on it like any other. This branch is what is left when the reranker was
+		// unavailable - and a pinned object type can then be dropped on relevance alone, which is
+		// worth revisiting for whoever turns this ratio on.
 		if objType.Score <= 0 {
 			unscored++
 			kept = append(kept, objType)


### PR DESCRIPTION
## What broke

Concept recall ranked object types on their coarse score alone, and that score cannot carry the job:

```
bool.should[
  knn(_vector, k=2000),                        // cosine, 0..1
  multi_match(10 fields, best_fields, no boost) // BM25, unbounded
]
```

`bool.should` **sums**, so the kNN channel is dwarfed by BM25 and cannot correct a lexical mistake. On top of that the BKN concept index pins its full-text fields to the `standard` analyzer, which tokenizes Chinese per character — our own `deploy/images/opensearch/README.md` says so. A query becomes a bag of single characters, and every extra word in it moves the scores.

Reported from the field: searching a coal-logistics network for the enterprise object type returned a dispatch-record object type instead, purely because its long comment repeats the word. Dropping two schema meta-words from the query fixed it — the tell that the query text, not the network, decided the answer. With `max_concepts=1` the single object slot went to the decoy and the object type the caller asked for never appeared.

## What this changes

Object types now go through the reranker — the only stage in this pipeline that can tell a meta-word from a business term.

It shares the call that already ranks relation types. Two calls would double the latency of every schema search, and scores from separate rerank invocations are not comparable with each other, while scores from one are.

The coarse pass keeps its place as the cheap first stage that picks the candidates: reranking every object type of a pathological network would blow the model's input budget. `ObjectRerankCandidateLimit` (200, internal — not on the wire, since `retrieval_config` is documented as a compatibility shim) bounds one model call, not the response. Everything below the cut stays in the schema; it just cannot outrank a reranked object type.

Object types below the cut have their score **cleared** rather than left on the coarse scale: BM25 and a 0..1 relevance do not share a scale, and a leftover coarse score would sort above every reranked one. Object types the coarse pass never scored still ride along while there is room, so a network whose coarse recall returned nothing is reranked whole rather than not at all.

## What does not change

- Relation ranking: same Top-K cut, same downgrade chain (rerank → coarse `_score` → name match).
- `enable_rerank=false` leaves both categories on the coarse score, exactly as before.
- Losing the coarse pass no longer costs object relevance — the reranker is a second, independent source. Only losing **both** drops to the endpoint-first order that predates #778, and that ladder is now asserted by two tests instead of assumed.

## Calibration note

`min_object_type_score_ratio` (#1079) compares concept-recall scores. That score is the reranker's 0..1 relevance now, not raw BM25, so the two numbers recorded in its doc comment are no longer comparable and a deployment that calibrated the ratio has to measure again. It is **off by default**, so nothing changes for anyone who did not opt in. The comment now says this.

## Tests

`object_rerank_test.go` reproduces the reported case with a fixture whose coarse scores favour the decoy exactly as BM25 did:

- `TestMetaWordQueryReachesTheObjectTypeItNames` — the object type the query names wins the single `max_concepts` slot, and the decoy is absent.
- `TestMetaWordQueryWithoutRerankStillPicksTheDecoy` — the same fixture under `enable_rerank=false` still picks the decoy, which is the evidence the fixture reproduces the failure rather than assuming it.
- `TestObjectRelevanceSurvivesCoarseFailure` — coarse pass down, reranker up: relevance still drives the order.
- `TestConceptRerankIssuesOneCallCarryingBothCategories` — one call, both categories, object documents first.
- `TestObjectRerankCandidateLimitBoundsDocuments` — the cap bounds the document list.

Two existing mocks scored by fixed document index or by "any document mentioning 员工"; both assumptions were only ever about a relations-only document list, and they now score by content and by document kind.

Full `agent-retrieval` suite green.

## Not in this PR

Three related defects stay open, none of which this one depends on:

1. The concept index `standard` → `ik_max_word` switch. The IK image is on `main` already, but `GetBKNConceptSchemaDefinition` still asks for `standard`, and changing it trips `deepCompareSchemas` into deleting and recreating the dataset — that needs its own upgrade-path verification.
2. kNN and BM25 still fuse by raw sum in concept recall. Instance recall already has `fuseByRRF`; concept recall should get the same treatment.
3. `multi_match` still gives `name` the same weight as a 50-character `comment`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)