### PR TITLE
fix(model-manager): enforce default model permissions

### DIFF
--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -28,6 +28,7 @@ import re
 
 # Save a large model configuration.
 async def add_model(schema_para, userId, language, role=""):
+    global redis_util
     required_params = ["max_model_len"]
     missing_params = await validate_required_params(schema_para, required_params)
     if missing_params:
@@ -43,6 +44,13 @@ async def add_model(schema_para, userId, language, role=""):
     if not permission:
         return JSONResponse(status_code=403, content=NotPermissionError)
     quota = schema_para.get("quota", False)
+    requested_default = schema_para.get("default", False)
+    if not isinstance(requested_default, bool):
+        error_dict = error_with_message(
+            ModelFactory_Router_ParamError_TypeError_Error,
+            "ModelFactory.Validation.BooleanParameter",
+            parameter="default")
+        return JSONResponse(status_code=400, content=error_dict)
     content = await llm_add_verify(schema_para, userId)
     if content:
         StandLogger.error(content)
@@ -58,12 +66,12 @@ async def add_model(schema_para, userId, language, role=""):
                 config["ClientId"] = model_configs.get("ClientId", "")
                 config["OperationCode"] = model_configs.get("OperationCode", "")
             model_id = worker.get_id()
-            llm_model_dao.add_data_into_model_list(model_id, schema_para["model_series"],
-                                                   schema_para.get("model_type", "llm"),
-                                                   schema_para["model_name"], model_configs["api_model"],
-                                                   userId, json.dumps(config),
-                                                   schema_para["max_model_len"],
-                                                   schema_para.get("model_parameters", None), quota)
+            is_default = llm_model_dao.add_data_with_default(
+                model_id, schema_para["model_series"], schema_para.get("model_type", "llm"),
+                schema_para["model_name"], model_configs["api_model"], userId, json.dumps(config),
+                schema_para["max_model_len"], schema_para.get("model_parameters", None), quota,
+                requested_default,
+            )
             # Grant the new model instance to its creator; add_permission bypasses administrators.
             if base_config.AUTH_ENABLED:
                 user_infos = await get_username_by_ids([userId])
@@ -77,7 +85,12 @@ async def add_model(schema_para, userId, language, role=""):
                 raise Exception("add permission failed")
             # Return Snowflake IDs as strings because 19-digit values exceed JavaScript's safe integer range.
             # Numeric JSON would lose precision and make the returned resource impossible to query or delete.
-            content = {"status": "ok", "id": str(model_id)}
+            content = {"status": "ok", "id": str(model_id), "default": is_default}
+            if is_default:
+                llm_default_key = "dip:model-api:llm:default_model_3ed523:list"
+                if redis_util is None:
+                    redis_util = await get_redis_util()
+                await redis_util.delete_str(llm_default_key)
             if quota is False:
                 conf_id = worker.get_id()
                 model_quota_dao.add_no_model_quota_config(conf_id, model_id, userId)
@@ -1003,7 +1016,6 @@ async def edit_default_model(model_para, userId, language):
             error_dict['detail'] = "The specified model does not exist."
             return JSONResponse(status_code=400, content=error_dict)
 
-        # Read the current default model.
         set_default = model_para["default"]
         if not set_default:
             llm_model_dao.update_model_default_status(model_id, False)
@@ -1015,21 +1027,14 @@ async def edit_default_model(model_para, userId, language):
             return JSONResponse(status_code=200, content={"status": "ok", "id": model_id, "default": False})
 
         old_default_data = llm_model_dao.get_default_model()
-        old_model_id = ""
-        if old_default_data:
-            old_model_id = old_default_data[0]["f_model_id"]
-        # Reject a redundant default-model update.
+        old_model_id = old_default_data[0]["f_model_id"] if old_default_data else ""
         if old_model_id == model_id:
             error_dict = error_with_message(
                 ModelFactory_Router_ParamError_TypeError_Error,
                 "ModelFactory.ModelController.EditDefaultModel.AlreadyDefault")
             return JSONResponse(status_code=400, content=error_dict)
 
-        # Clear the old default before setting the new one.
-        if old_model_id:
-            llm_model_dao.update_model_default_status(old_model_id, False)
-        # Set the new default model.
-        llm_model_dao.update_model_default_status(model_id, True)
+        llm_model_dao.set_default_model(model_id)
         default_cache_name = "default_model_3ed523"
         default_cache_key = f"dip:model-api:llm:{default_cache_name}:list"
         if redis_util is None:

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -26,6 +26,18 @@ from app.utils.verify_utils import llm_test
 from sse_starlette import EventSourceResponse
 import re
 
+
+async def can_manage_default_llm(user_id, role):
+    """Check the same wildcard modify grant used for default-model management."""
+    return await permission_manager.check_single_permission(
+        user_id=user_id,
+        resource_id="*",
+        operations="modify",
+        resource_type="large_model",
+        role=role,
+    )
+
+
 # Save a large model configuration.
 async def add_model(schema_para, userId, language, role=""):
     global redis_util
@@ -51,6 +63,8 @@ async def add_model(schema_para, userId, language, role=""):
             "ModelFactory.Validation.BooleanParameter",
             parameter="default")
         return JSONResponse(status_code=400, content=error_dict)
+    if requested_default and not await can_manage_default_llm(userId, role):
+        return JSONResponse(status_code=403, content=NotPermissionError)
     content = await llm_add_verify(schema_para, userId)
     if content:
         StandLogger.error(content)
@@ -66,12 +80,6 @@ async def add_model(schema_para, userId, language, role=""):
                 config["ClientId"] = model_configs.get("ClientId", "")
                 config["OperationCode"] = model_configs.get("OperationCode", "")
             model_id = worker.get_id()
-            is_default = llm_model_dao.add_data_with_default(
-                model_id, schema_para["model_series"], schema_para.get("model_type", "llm"),
-                schema_para["model_name"], model_configs["api_model"], userId, json.dumps(config),
-                schema_para["max_model_len"], schema_para.get("model_parameters", None), quota,
-                requested_default,
-            )
             # Grant the new model instance to its creator; add_permission bypasses administrators.
             if base_config.AUTH_ENABLED:
                 user_infos = await get_username_by_ids([userId])
@@ -83,6 +91,17 @@ async def add_model(schema_para, userId, language, role=""):
                 resource_type="large_model", user_name=user_name, role=role)
             if not grant_ok:
                 raise Exception("add permission failed")
+            try:
+                is_default = await asyncio.to_thread(
+                    llm_model_dao.add_data_with_default,
+                    model_id, schema_para["model_series"], schema_para.get("model_type", "llm"),
+                    schema_para["model_name"], model_configs["api_model"], userId, json.dumps(config),
+                    schema_para["max_model_len"], schema_para.get("model_parameters", None), quota,
+                    requested_default,
+                )
+            except Exception:
+                await permission_manager.delete_permission("large_model", [str(model_id)])
+                raise
             # Return Snowflake IDs as strings because 19-digit values exceed JavaScript's safe integer range.
             # Numeric JSON would lose precision and make the returned resource impossible to query or delete.
             content = {"status": "ok", "id": str(model_id), "default": is_default}
@@ -987,9 +1006,9 @@ async def get_monitor_data(userId, language, model_id, role=""):
         return JSONResponse(status_code=500, content=DataBaseError)
 
 
-async def edit_default_model(model_para, userId, language):
+async def edit_default_model(model_para, userId, language, role=""):
     global redis_util
-    if base_config.AUTH_ENABLED and userId != "266c6a42-6131-4d62-8f39-853e7093701c":
+    if not await can_manage_default_llm(userId, role):
         error_dict = error_with_message(
             ModelFactory_Router_ParamError_TypeError_Error,
             "ModelFactory.ModelController.EditDefaultModel.PermissionDenied")

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -66,8 +66,8 @@ async def add_model(request: logics.AddExternalSmallModel, userId, language, rol
         )
         if not status:
             raise Exception("add permission failed")
-        small_model_dao.add_model_info(config_info, userId)
-        content = {"status": "ok", "id": model_id}
+        is_default = small_model_dao.add_model_with_default(config_info, userId, request.default)
+        content = {"status": "ok", "id": model_id, "default": is_default}
         return JSONResponse(status_code=200, content=content)
     except Exception as e:
         StandLogger.error(e.args)
@@ -402,11 +402,7 @@ async def set_default_model(model_para, userId, language, role):
             small_model_dao.update_model_default_status(model_id, False)
             return JSONResponse(status_code=200, content={"status": "ok", "id": model_id, "default": False})
         model_type = model_info[0]["f_model_type"]
-        old_default = small_model_dao.get_default_by_type(model_type)
-        for line in old_default:
-            if line["f_model_id"] != model_id:
-                small_model_dao.update_model_default_status(line["f_model_id"], False)
-        small_model_dao.update_model_default_status(model_id, True)
+        small_model_dao.set_default_model(model_id, model_type)
         content = {"status": "ok", "id": model_id, "default": True}
         return JSONResponse(status_code=200, content=content)
     except Exception as e:

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi.responses import JSONResponse
 
 from app.commons.errors.codes import ParamValidationErrors
@@ -14,6 +16,17 @@ from app.utils.reshape_utils import *
 from fastapi import Response, status
 from app.mydb.ConnectUtil import redis_util, get_redis_util
 from app.utils.permission_manager import PermissionManager, permission_manager
+
+
+async def can_manage_default_small_model(user_id, role):
+    """Require the type-wide modify grant before replacing a small-model default."""
+    return await permission_manager.check_single_permission(
+        user_id=user_id,
+        resource_id="*",
+        operations="modify",
+        resource_type="small_model",
+        role=role,
+    )
 
 
 async def add_model(request: logics.AddExternalSmallModel, userId, language, role, private=False):
@@ -51,6 +64,8 @@ async def add_model(request: logics.AddExternalSmallModel, userId, language, rol
                                                                       role=role)
         if not permission:
             return JSONResponse(status_code=403, content=NotPermissionError)
+        if request.default and not await can_manage_default_small_model(userId, role):
+            return JSONResponse(status_code=403, content=NotPermissionError)
         if base_config.AUTH_ENABLED:
             user_infos = await get_username_by_ids([userId])
             user_name = user_infos.get(userId, "")
@@ -66,7 +81,13 @@ async def add_model(request: logics.AddExternalSmallModel, userId, language, rol
         )
         if not status:
             raise Exception("add permission failed")
-        is_default = small_model_dao.add_model_with_default(config_info, userId, request.default)
+        try:
+            is_default = await asyncio.to_thread(
+                small_model_dao.add_model_with_default, config_info, userId, request.default,
+            )
+        except Exception:
+            await permission_manager.delete_permission("small_model", [model_id])
+            raise
         content = {"status": "ok", "id": model_id, "default": is_default}
         return JSONResponse(status_code=200, content=content)
     except Exception as e:

--- a/infra/mf-model-manager/app/dao/llm_model_dao.py
+++ b/infra/mf-model-manager/app/dao/llm_model_dao.py
@@ -5,7 +5,11 @@ from app.commons.snow_id import worker
 from app.dao import user_info
 from app.interfaces import dbaccess
 from app.logs.stand_log import StandLogger
-from app.mydb.my_pymysql_pool import connect_execute_close_db, connect_execute_commit_close_db
+from app.mydb.my_pymysql_pool import (
+    advisory_lock_transaction,
+    connect_execute_close_db,
+    connect_execute_commit_close_db,
+)
 
 
 class ModelDao():
@@ -110,6 +114,29 @@ class ModelDao():
                                                                 max_model_len, quota)
 
         cursor.execute(sql)
+
+    def add_data_with_default(self, model_id, model_series, model_type, model_name, model, userId, model_config,
+                              max_model_len, model_parameters, quota, requested_default):
+        """Create a model and select its effective default in one transaction."""
+        with advisory_lock_transaction("mf-model-default:llm") as cursor:
+            cursor.execute("select f_model_id from t_llm_model where f_default=1")
+            has_default = bool(cursor.fetchall())
+            is_default = requested_default or not has_default
+
+            if requested_default and has_default:
+                cursor.execute("update t_llm_model set f_default=0 where f_default=1")
+
+            sql = """insert into t_llm_model(
+                f_model_id,f_model_series,f_model_type,f_model_name,f_model,
+                f_create_by,f_update_by,f_model_config,f_update_time,f_create_time,
+                f_max_model_len,f_model_parameters,f_quota,f_default
+            ) values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+            cursor.execute(sql, (
+                model_id, model_series, model_type, model_name, model, userId, userId, model_config,
+                datetime.datetime.today(), datetime.datetime.today(), max_model_len, model_parameters,
+                1 if quota else 0, 1 if is_default else 0,
+            ))
+            return is_default
 
     @connect_execute_commit_close_db
     def delete_model_by_id(self, model_ids, connection, cursor):
@@ -423,6 +450,12 @@ class ModelDao():
         """Update a model's default status."""
         sql = """update t_llm_model set f_default=%s where f_model_id=%s"""
         cursor.execute(sql, (1 if is_default else 0, model_id))
+
+    def set_default_model(self, model_id):
+        """Atomically make a model the sole large-model default."""
+        with advisory_lock_transaction("mf-model-default:llm") as cursor:
+            cursor.execute("update t_llm_model set f_default=0 where f_default=1")
+            cursor.execute("update t_llm_model set f_default=1 where f_model_id=%s", model_id)
 
     @connect_execute_commit_close_db
     def get_overview_data(self, model_id, start_time, end_time, userId, connection, cursor):

--- a/infra/mf-model-manager/app/dao/small_model_dao.py
+++ b/infra/mf-model-manager/app/dao/small_model_dao.py
@@ -3,7 +3,11 @@ import json
 
 from app.interfaces.dbaccess import AddExternalSmallModelInfo
 from app.logs.stand_log import StandLogger
-from app.mydb.my_pymysql_pool import connect_execute_close_db, connect_execute_commit_close_db
+from app.mydb.my_pymysql_pool import (
+    advisory_lock_transaction,
+    connect_execute_close_db,
+    connect_execute_commit_close_db,
+)
 
 para_dict = {
     "update_time": "f_update_time",
@@ -24,6 +28,37 @@ class SmallModelDao:
                       config_info.batch_size, config_info.max_tokens, config_info.embedding_dim]
 
         cursor.execute(sql, value_list)
+
+    def add_model_with_default(self, config_info: AddExternalSmallModelInfo, userId, requested_default):
+        """Create a small model with one default per model type under a lock."""
+        lock_name = f"mf-model-default:small:{config_info.model_type}"
+        with advisory_lock_transaction(lock_name) as cursor:
+            cursor.execute(
+                "select f_model_id from t_small_model where f_default=1 and f_model_type=%s",
+                config_info.model_type,
+            )
+            has_default = bool(cursor.fetchall())
+            is_default = requested_default or not has_default
+
+            if requested_default and has_default:
+                cursor.execute(
+                    "update t_small_model set f_default=0 where f_default=1 and f_model_type=%s",
+                    config_info.model_type,
+                )
+
+            sql = """insert into t_small_model(
+                f_model_id,f_model_name,f_model_type,f_model_config,f_create_time,f_update_time,
+                f_create_by,f_update_by,f_adapter,f_adapter_code,f_batch_size,f_max_tokens,
+                f_embedding_dim,f_default
+            ) values(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"""
+            cursor.execute(sql, (
+                config_info.model_id, config_info.model_name, config_info.model_type,
+                json.dumps(config_info.model_config, ensure_ascii=False), datetime.datetime.today(),
+                datetime.datetime.today(), userId, userId, config_info.adapter, config_info.adapter_code,
+                config_info.batch_size, config_info.max_tokens, config_info.embedding_dim,
+                1 if is_default else 0,
+            ))
+            return is_default
 
     @connect_execute_commit_close_db
     def edit_model_info(self, config_info: AddExternalSmallModelInfo, userId, connection, cursor):
@@ -155,6 +190,16 @@ class SmallModelDao:
         """Update one small model's default status."""
         sql = """update t_small_model set f_default = %s where f_model_id = %s"""
         cursor.execute(sql, (1 if is_default else 0, model_id))
+
+    def set_default_model(self, model_id, model_type):
+        """Atomically make a model the sole default in its small-model type."""
+        lock_name = f"mf-model-default:small:{model_type}"
+        with advisory_lock_transaction(lock_name) as cursor:
+            cursor.execute(
+                "update t_small_model set f_default=0 where f_default=1 and f_model_type=%s",
+                model_type,
+            )
+            cursor.execute("update t_small_model set f_default=1 where f_model_id=%s", model_id)
 
 
 small_model_dao = SmallModelDao()

--- a/infra/mf-model-manager/app/interfaces/logics.py
+++ b/infra/mf-model-manager/app/interfaces/logics.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Body, Header
 from typing import Optional, List, Dict, Union
-from pydantic import StrictFloat, StrictStr, Field, StrictInt, conint, validator, confloat, conlist, constr, \
+from pydantic import StrictBool, StrictFloat, StrictStr, Field, StrictInt, conint, validator, confloat, conlist, constr, \
     root_validator
 from fastapi.exceptions import RequestValidationError
 from app.controller.ossclient_controller import *
@@ -351,6 +351,7 @@ class AddExternalSmallModel(BaseModel):
     batch_size: int = Field(description="Batch size")
     max_tokens: Optional[int] = Field(default=None, description="Maximum token count")
     embedding_dim: Optional[int] = Field(default=None, description="Embedding dimension")
+    default: StrictBool = Field(default=False, description="Whether to set this model as the system default")
     is_private: Optional[bool] = Field(default=False, description="Whether this is a private route used to control validation")
 
     @root_validator

--- a/infra/mf-model-manager/app/mydb/my_pymysql_pool.py
+++ b/infra/mf-model-manager/app/mydb/my_pymysql_pool.py
@@ -76,8 +76,15 @@ def advisory_lock_transaction(lock_name, timeout=10):
             try:
                 cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
             except Exception:
-                # The transaction result is already known; closing the
-                # connection also releases an advisory lock as a fallback.
-                pass
+                # ``connection.close()`` returns a pooled connection and can
+                # leave its MariaDB session (and therefore its advisory lock)
+                # alive.  Close the physical connection before returning the
+                # wrapper to the pool so it cannot be reused with this lock.
+                physical_connection = getattr(connection, "_con", None)
+                if physical_connection is not None:
+                    try:
+                        physical_connection.close()
+                    except Exception:
+                        pass
         cursor.close()
         connection.close()

--- a/infra/mf-model-manager/app/mydb/my_pymysql_pool.py
+++ b/infra/mf-model-manager/app/mydb/my_pymysql_pool.py
@@ -1,5 +1,7 @@
 # -*-coding:utf-8-*-
 
+from contextlib import contextmanager
+
 from app.mydb.pymysql_pool import PymysqlPool
 
 
@@ -43,3 +45,39 @@ def connect_execute_close_db(func):
         return None
 
     return wrapper
+
+
+@contextmanager
+def advisory_lock_transaction(lock_name, timeout=10):
+    """Run a database transaction while holding a MariaDB advisory lock.
+
+    Default-model selection is a read-modify-write operation.  Holding the
+    connection-scoped lock until after ``commit`` serializes that operation
+    without requiring a schema migration or leaving multiple defaults during
+    concurrent model creation.
+    """
+    pymysql_pool = PymysqlPool.get_pool()
+    connection = pymysql_pool.connection()
+    cursor = connection.cursor()
+    lock_acquired = False
+    try:
+        cursor.execute("SELECT GET_LOCK(%s, %s) AS lock_acquired", (lock_name, timeout))
+        lock_result = cursor.fetchall()
+        lock_acquired = bool(lock_result and lock_result[0].get("lock_acquired"))
+        if not lock_acquired:
+            raise RuntimeError(f"Timed out acquiring database lock: {lock_name}")
+        yield cursor
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        if lock_acquired:
+            try:
+                cursor.execute("SELECT RELEASE_LOCK(%s)", (lock_name,))
+            except Exception:
+                # The transaction result is already known; closing the
+                # connection also releases an advisory lock as a fallback.
+                pass
+        cursor.close()
+        connection.close()

--- a/infra/mf-model-manager/app/routers/llm_router.py
+++ b/infra/mf-model-manager/app/routers/llm_router.py
@@ -162,7 +162,7 @@ async def monitor_llm(request: Request, model_id):
 @llm_route.post("/llm/default/edit")
 async def edit_default_llm(request: Request, model_para: dict = Body(...)):
     userId, language, role = await get_user_info(request)
-    return await edit_default_model(model_para, userId, language)
+    return await edit_default_model(model_para, userId, language, role)
 
 
 @llm_route.get("/llm/monitor/overview")

--- a/infra/mf-model-manager/app/test/test_external_small_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_controller.py
@@ -13,18 +13,18 @@ import json
 class TestAddModel(TestCase):
     def setUp(self) -> None:
         self.name_check = small_model_dao.name_check
-        self.add_model_info = small_model_dao.add_model_info
+        self.add_model_with_default = small_model_dao.add_model_with_default
 
     def tearDown(self) -> None:
         small_model_dao.name_check = self.name_check
-        small_model_dao.add_model_info = self.add_model_info
+        small_model_dao.add_model_with_default = self.add_model_with_default
         StandLogger.stand_log_shutdown()
 
     def test_add_model_success(self):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         small_model_dao.name_check = mock.Mock(return_value=[])
-        small_model_dao.add_model_info = mock.Mock(return_value=None)
+        small_model_dao.add_model_with_default = mock.Mock(return_value=True)
         para = logics.AddExternalSmallModel(
             model_name="1",
             model_type="embedding",
@@ -36,6 +36,8 @@ class TestAddModel(TestCase):
         res = loop.run_until_complete(
             small_model_controller.add_model(para, "1", "zh", "user"))
         self.assertEqual(isinstance(json.loads(res.body)["id"], str), True)
+        self.assertTrue(json.loads(res.body)["default"])
+        self.assertFalse(small_model_dao.add_model_with_default.call_args.args[-1])
 
 
 class TestVolcengineMultimodalEmbeddingRequest(TestCase):

--- a/infra/mf-model-manager/app/test/test_external_small_model_dao.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_dao.py
@@ -43,6 +43,31 @@ class TestAddModelInfo(TestCase):
         self.assertEqual(res, None)
 
 
+class TestAddModelWithDefault(TestCase):
+    def test_requested_default_replaces_only_the_same_model_type(self):
+        pool = mock.MagicMock()
+        connection = mock.MagicMock()
+        cursor = mock.MagicMock()
+        pool.connection.return_value = connection
+        connection.cursor.return_value = cursor
+        cursor.fetchall.side_effect = [[{"lock_acquired": 1}], [{"f_model_id": "existing"}]]
+        config_info = AddExternalSmallModelInfo(
+            model_id="1",
+            model_name="new embedding",
+            model_type="embedding",
+            model_config={"api_url": "http://example.com", "api_model": "embedding"},
+        )
+
+        with mock.patch.object(PymysqlPool, "get_pool", return_value=pool):
+            is_default = small_model_dao.add_model_with_default(config_info, "user1", True)
+
+        self.assertTrue(is_default)
+        connection.commit.assert_called_once()
+        clear_call = cursor.execute.call_args_list[2]
+        self.assertIn("f_model_type=%s", clear_call.args[0])
+        self.assertEqual(clear_call.args[1], "embedding")
+
+
 class TestEditModelInfo(TestCase):
     def setUp(self) -> None:
         self.mysqlPool = PymysqlPool

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -132,12 +132,18 @@ class TestAddModel(TestCase):
         self.get_model_by_name = llm_model_dao.get_model_by_name
         self.check_model_unique = llm_model_dao.check_model_unique
         self.redis_util = llm_controller.redis_util
+        self.check_single_permission = llm_controller.permission_manager.check_single_permission
+        self.add_permission = llm_controller.permission_manager.add_permission
+        self.delete_permission = llm_controller.permission_manager.delete_permission
 
     def tearDown(self) -> None:
         llm_model_dao.add_data_with_default = self.add_data_with_default
         llm_model_dao.get_model_by_name = self.get_model_by_name
         llm_model_dao.check_model_unique = self.check_model_unique
         llm_controller.redis_util = self.redis_util
+        llm_controller.permission_manager.check_single_permission = self.check_single_permission
+        llm_controller.permission_manager.add_permission = self.add_permission
+        llm_controller.permission_manager.delete_permission = self.delete_permission
         StandLogger.stand_log_shutdown()
 
     def test_add_model_success(self):
@@ -166,6 +172,79 @@ class TestAddModel(TestCase):
         self.assertEqual(isinstance(json.loads(res.body)["id"], str), True)
         self.assertTrue(json.loads(res.body)["default"])
         self.assertFalse(llm_model_dao.add_data_with_default.call_args.args[-1])
+
+    def test_add_model_rejects_explicit_default_without_modify_permission(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        request = {
+            "model_config": {
+                "api_model": "qianxun-l-128k",
+                "api_url": "https://qianxun.rcrai.com/open/qianxun/v1",
+                "api_key": "ckm-652a0795c43b8abca48ce7627d65e910",
+                "api_type": "openai"
+            },
+            "model_series": "openai",
+            "model_name": "qianxun-l-128k",
+            "model_type": "llm",
+            "max_model_len": 128,
+            "default": True,
+        }
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(side_effect=[True, False])
+        llm_model_dao.add_data_with_default = mock.Mock()
+
+        res = loop.run_until_complete(llm_controller.add_model(request, "111", "zh"))
+
+        self.assertEqual(res.status_code, 403)
+        llm_model_dao.add_data_with_default.assert_not_called()
+
+    def test_add_model_does_not_create_default_when_permission_grant_fails(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        request = {
+            "model_config": {
+                "api_model": "qianxun-l-128k",
+                "api_url": "https://qianxun.rcrai.com/open/qianxun/v1",
+                "api_key": "ckm-652a0795c43b8abca48ce7627d65e910",
+                "api_type": "openai"
+            },
+            "model_series": "openai",
+            "model_name": "qianxun-l-128k",
+            "model_type": "llm",
+            "max_model_len": 128,
+        }
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=True)
+        llm_controller.permission_manager.add_permission = mock.AsyncMock(return_value=False)
+        llm_model_dao.add_data_with_default = mock.Mock()
+
+        res = loop.run_until_complete(llm_controller.add_model(request, "111", "zh"))
+
+        self.assertEqual(res.status_code, 500)
+        llm_model_dao.add_data_with_default.assert_not_called()
+
+    def test_add_model_removes_grant_when_database_write_fails(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        request = {
+            "model_config": {
+                "api_model": "qianxun-l-128k",
+                "api_url": "https://qianxun.rcrai.com/open/qianxun/v1",
+                "api_key": "ckm-652a0795c43b8abca48ce7627d65e910",
+                "api_type": "openai"
+            },
+            "model_series": "openai",
+            "model_name": "qianxun-l-128k",
+            "model_type": "llm",
+            "max_model_len": 128,
+        }
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=True)
+        llm_controller.permission_manager.add_permission = mock.AsyncMock(return_value=True)
+        llm_controller.permission_manager.delete_permission = mock.AsyncMock(return_value=True)
+        llm_model_dao.add_data_with_default = mock.Mock(side_effect=RuntimeError("database unavailable"))
+
+        res = loop.run_until_complete(llm_controller.add_model(request, "111", "zh"))
+
+        self.assertEqual(res.status_code, 500)
+        llm_controller.permission_manager.delete_permission.assert_awaited_once()
 
 
 # test_model
@@ -454,12 +533,14 @@ class TestEditDefaultModel(TestCase):
         self.get_default_model = llm_model_dao.get_default_model
         self.update_model_default_status = llm_model_dao.update_model_default_status
         self.redis_util = llm_controller.redis_util
+        self.check_single_permission = llm_controller.permission_manager.check_single_permission
 
     def tearDown(self) -> None:
         llm_model_dao.check_model_is_exist = self.check_model_is_exist
         llm_model_dao.get_default_model = self.get_default_model
         llm_model_dao.update_model_default_status = self.update_model_default_status
         llm_controller.redis_util = self.redis_util
+        llm_controller.permission_manager.check_single_permission = self.check_single_permission
         StandLogger.stand_log_shutdown()
 
     def _redis_mock(self):
@@ -471,6 +552,7 @@ class TestEditDefaultModel(TestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         llm_controller.redis_util = self._redis_mock()
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=True)
         llm_model_dao.check_model_is_exist = mock.Mock(return_value=True)
         llm_model_dao.get_default_model = mock.Mock(return_value=[{"f_model_id": "111"}])
         llm_model_dao.update_model_default_status = mock.Mock(return_value=None)
@@ -488,6 +570,7 @@ class TestEditDefaultModel(TestCase):
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         llm_controller.redis_util = self._redis_mock()
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=True)
         llm_model_dao.check_model_is_exist = mock.Mock(return_value=True)
         llm_model_dao.get_default_model = mock.Mock(return_value=[{"f_model_id": "111"}])
         llm_model_dao.update_model_default_status = mock.Mock(return_value=None)
@@ -496,6 +579,20 @@ class TestEditDefaultModel(TestCase):
             llm_controller.edit_default_model({"model_id": "111", "default": True}, "111", "zh"))
 
         self.assertEqual(res.status_code, 400)
+        llm_model_dao.update_model_default_status.assert_not_called()
+
+    def test_edit_default_model_requires_type_wide_modify_permission(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=False)
+        llm_model_dao.check_model_is_exist = mock.Mock(return_value=True)
+        llm_model_dao.update_model_default_status = mock.Mock(return_value=None)
+
+        res = loop.run_until_complete(
+            llm_controller.edit_default_model({"model_id": "111", "default": False}, "111", "zh"))
+
+        self.assertEqual(res.status_code, 403)
+        llm_model_dao.check_model_is_exist.assert_not_called()
         llm_model_dao.update_model_default_status.assert_not_called()
 
 

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -128,14 +128,16 @@ class TestUsedModelOpenai(TestCase):
 
 class TestAddModel(TestCase):
     def setUp(self) -> None:
-        self.add_data_into_model_list = llm_model_dao.add_data_into_model_list
+        self.add_data_with_default = llm_model_dao.add_data_with_default
         self.get_model_by_name = llm_model_dao.get_model_by_name
         self.check_model_unique = llm_model_dao.check_model_unique
+        self.redis_util = llm_controller.redis_util
 
     def tearDown(self) -> None:
-        llm_model_dao.add_data_into_model_list = self.add_data_into_model_list
+        llm_model_dao.add_data_with_default = self.add_data_with_default
         llm_model_dao.get_model_by_name = self.get_model_by_name
         llm_model_dao.check_model_unique = self.check_model_unique
+        llm_controller.redis_util = self.redis_util
         StandLogger.stand_log_shutdown()
 
     def test_add_model_success(self):
@@ -154,14 +156,16 @@ class TestAddModel(TestCase):
             "max_model_len": 128,
             "quota": True
         }
-        llm_model_dao.add_data_into_model_list = mock.Mock(return_value=None)
+        llm_model_dao.add_data_with_default = mock.Mock(return_value=True)
         llm_model_dao.get_model_by_name = mock.Mock(return_value=())
         llm_model_dao.check_model_unique = mock.Mock(return_value=False)
-        # add_model returns {"status": "ok", "id": str(model_id)}.
+        llm_controller.redis_util = mock.MagicMock(delete_str=mock.AsyncMock())
         res = loop.run_until_complete(
             llm_controller.add_model(request, "111", "zh"))
         self.assertEqual(json.loads(res.body)["status"], "ok")
         self.assertEqual(isinstance(json.loads(res.body)["id"], str), True)
+        self.assertTrue(json.loads(res.body)["default"])
+        self.assertFalse(llm_model_dao.add_data_with_default.call_args.args[-1])
 
 
 # test_model

--- a/infra/mf-model-manager/app/test/test_model_dao.py
+++ b/infra/mf-model-manager/app/test/test_model_dao.py
@@ -185,6 +185,26 @@ class TestAddDataIntoModelList(TestCase):
         self.assertEqual(None, res)
 
 
+class TestAddDataWithDefault(TestCase):
+    def test_first_model_becomes_default_in_the_creation_transaction(self):
+        pool = mock.MagicMock()
+        connection = mock.MagicMock()
+        cursor = mock.MagicMock()
+        pool.connection.return_value = connection
+        connection.cursor.return_value = cursor
+        cursor.fetchall.side_effect = [[{"lock_acquired": 1}], []]
+        with mock.patch.object(PymysqlPool, "get_pool", return_value=pool):
+            is_default = llm_model_dao.add_data_with_default(
+                "222", "openai", "llm", "name", "model", "user", "{}", 32, None, False, False,
+            )
+
+        self.assertTrue(is_default)
+        connection.commit.assert_called_once()
+        insert_call = cursor.execute.call_args_list[-2]
+        self.assertIn("f_default", insert_call.args[0])
+        self.assertEqual(insert_call.args[1][-1], 1)
+
+
 # get_data_from_model_list_by_name_fuzzyfunction test class.
 class TestGetDataFromModelListByNameFuzzy(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Require type-wide modify permission before an explicit default selection can replace an existing default.
- [x] Grant the creator access before persisting the model/default change; compensate by removing the grant when the database write fails.
- [x] Run the advisory-lock database work off the async event loop and discard a pooled physical connection if advisory-lock release fails.
- [x] Add controller regression coverage for denied default selection, failed authorization grant, failed database write, and default-edit authorization.
- [ ] Documentation update (not applicable).

---

## Why

- Related Issue: Closes #1091
- Related Feature: Default model selection on model creation
- Background: Explicitly replacing a default model must use the same authority as default-model management and must not leave a stale cache or partial authorization state.

---

## How

- Key implementation points: A creation request with default=true requires wildcard modify access for the model type. First-model auto-default behavior remains available to users with create permission. Permission creation now precedes persistence, and a failed database write removes the newly created grant.
- Breaking changes (API, config, database, etc.): No schema migration or API contract change. Users without type-wide modify permission now receive 403 for an explicit default replacement.

---

## Testing

- [ ] Unit tests passed locally (service dependencies are unavailable in this workspace).
- [ ] Integration tests passed locally (not run).
- [ ] Verified in test environment (not run).

Test notes:

- Python compilation completed for the modified controllers, router, database helper, and tests.
- Added focused controller regression tests.
- Targeted unit tests could not start because fastapi and sse_starlette are not installed in the workspace.

---

## Risk & Rollback

- Potential risks: Authorization services and MariaDB advisory locks must be validated in CI/test environments.
- Rollback plan: Revert commit e7a96b35.

---

## Additional Notes

- The corresponding UI permission gate is in openbkn-ai/bkn-studio#490.
