### PR TITLE
fix(context-loader): return no relation type rather than an unvouched-for one

### DIFF
--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -749,7 +749,11 @@ func (s *localSearchImpl) rankConcepts(
 	}
 
 	if relationApplied == 0 && len(relations) > 0 {
-		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank scored no relation type; keeping recall order for %d", len(relations))
+		// The model answered, but not about a single relation - a vendor returning only its top N can
+		// do this. Recall order is not relevance, so handing back its head would be the #788 failure
+		// through a success path. Take the same ladder an unavailable reranker takes.
+		s.logger.WithContext(ctx).Warnf("[RankConcepts] Rerank scored no relation type; degrading for %d", len(relations))
+		return s.degradeRelationRanking(ctx, query, relations, topK)
 	}
 
 	ranked := rankRelationsByScores(relations, relationScores, topK)
@@ -826,15 +830,47 @@ func (s *localSearchImpl) buildRelationDocuments(
 	return documents
 }
 
-// rankRelationsByScores orders relations by the given per-index scores and takes Top-K.
+// scoredRelation pairs a relation type with whatever relevance the current scorer gave it.
+type scoredRelation struct {
+	relation *interfaces.RelationType
+	score    float64
+}
+
+// takeRelevantRelations orders by score, drops everything the scorer found no relevance in, and
+// cuts to Top-K.
+//
+// Dropping rather than ranking is the point (#788). Every scorer on this path can come back with
+// nothing relevant at all: the reranker is not registered, coarse recall is off so every _score is
+// zero, the literal name match finds no substring in a multi-word query. A Top-K taken from an
+// all-zero list is a relation picked by nothing but slice order - and it does not stop there,
+// because relation endpoint completion then pulls its two object types into the response. One
+// meaningless row becomes three, and the caller cannot tell them from real hits. An empty list is
+// the honest answer, and an empty list also leaves object_types clean.
+//
+// Stable sort, so relations the scorer rated equally keep recall order.
+func takeRelevantRelations(scored []scoredRelation, topK int) []*interfaces.RelationType {
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
+	})
+
+	result := make([]*interfaces.RelationType, 0, len(scored))
+	for _, item := range scored {
+		if item.score <= 0 {
+			// Sorted descending: the first non-positive score ends the relevant run.
+			break
+		}
+		if topK > 0 && len(result) >= topK {
+			break
+		}
+		result = append(result, item.relation)
+	}
+	return result
+}
+
+// rankRelationsByScores orders relations by the given per-index scores and takes the relevant Top-K.
 func rankRelationsByScores(relations []*interfaces.RelationType, scores []float64, topK int) []*interfaces.RelationType {
 	if len(relations) == 0 {
 		return relations
-	}
-
-	type scoredRelation struct {
-		relation *interfaces.RelationType
-		score    float64
 	}
 
 	scored := make([]scoredRelation, len(relations))
@@ -845,20 +881,7 @@ func rankRelationsByScores(relations []*interfaces.RelationType, scores []float6
 		}
 		scored[i] = scoredRelation{relation: rel, score: score}
 	}
-
-	sort.SliceStable(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
-	})
-
-	if topK > len(scored) {
-		topK = len(scored)
-	}
-
-	result := make([]*interfaces.RelationType, topK)
-	for i := 0; i < topK; i++ {
-		result[i] = scored[i].relation
-	}
-	return result
+	return takeRelevantRelations(scored, topK)
 }
 
 // truncateRelations keeps the incoming order and cuts to Top-K.
@@ -920,16 +943,16 @@ func rankRelationTypesByScore(relations []*interfaces.RelationType, topK int) ([
 		return nil, false
 	}
 
-	sorted := make([]*interfaces.RelationType, len(relations))
-	copy(sorted, relations)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].Score > sorted[j].Score
-	})
-
-	if topK <= 0 || topK > len(sorted) {
-		topK = len(sorted)
+	scored := make([]scoredRelation, 0, len(relations))
+	for _, rel := range relations {
+		if rel == nil {
+			continue
+		}
+		scored = append(scored, scoredRelation{relation: rel, score: rel.Score})
 	}
-	return sorted[:topK], true
+	// ok=true only says coarse recall had a signal to offer; the cut still drops the relations that
+	// signal did not reach, so a network where one relation scored does not drag Top-K-1 zeros along.
+	return takeRelevantRelations(scored, topK), true
 }
 
 // rankRelationTypesBySimpleMatch uses simple matching to sort (fallback when Rerank fails)
@@ -939,33 +962,16 @@ func (s *localSearchImpl) rankRelationTypesBySimpleMatch(
 	topK int,
 ) []*interfaces.RelationType {
 	// Simple relevance scoring (based on name matching)
-	type scoredRelation struct {
-		relation *interfaces.RelationType
-		score    float64
-	}
-
 	scored := make([]scoredRelation, len(relations))
 	for i, rel := range relations {
 		score := s.calculateRelevanceScore(query, rel.Name, rel.Comment)
 		scored[i] = scoredRelation{relation: rel, score: score}
 	}
 
-	// Sort by score descending.
-	sort.Slice(scored, func(i, j int) bool {
-		return scored[i].score > scored[j].score
-	})
-
-	// Take Top-K.
-	if topK > len(scored) {
-		topK = len(scored)
-	}
-
-	result := make([]*interfaces.RelationType, topK)
-	for i := 0; i < topK; i++ {
-		result[i] = scored[i].relation
-	}
-
-	return result
+	// calculateRelevanceScore is literal substring matching, so a multi-word query scores zero
+	// against every relation far more often than not. This is the last rung of the ladder: whatever
+	// it cannot vouch for, nothing downstream can.
+	return takeRelevantRelations(scored, topK)
 }
 
 // calculateRelevanceScore calculates the relevance score between Query and concept.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/object_recall_ranking_test.go
@@ -256,6 +256,11 @@ func buildEndpointsLastNetwork() *interfaces.KnowledgeNetworkDetail {
 // Both sources have to be knocked out for this to be the degraded path: object types are reranked
 // now, so a working reranker still yields relevance when the coarse pass fails. That laddering is
 // asserted by TestObjectRelevanceSurvivesCoarseFailure.
+//
+// The query has to be one the literal name matcher can actually score, or there are no relations to
+// take endpoints from and the assertion has nothing to bite on - since #788 a relation the last
+// rung cannot vouch for is dropped rather than ranked. TestNoRelevantRelationYieldsEmptyList covers
+// that other half.
 func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	net := buildEndpointsLastNetwork()
 	backend := &mockBknBackend{
@@ -271,7 +276,7 @@ func TestObjectScoringDegradesWhenBackendFails(t *testing.T) {
 	cfg := DefaultConceptRetrievalConfig()
 	cfg.TopK = 5
 
-	req := &interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: "对象", EnableRerank: true}
+	req := &interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: "关系_A", EnableRerank: true}
 	res, err := svc.conceptRetrieval(context.Background(), req, cfg)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/relation_relevance_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/relation_relevance_test.go
@@ -1,0 +1,189 @@
+package knsearch
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// Regression for #788.
+//
+// Every scorer on the relation path can come back with nothing relevant: the reranker is not
+// registered, coarse recall is off so every _score is zero, the literal name matcher finds no
+// substring in a multi-word query. The old code still cut Top-K out of that all-zero list, so a
+// relation nothing had vouched for reached the caller - and relation endpoint completion then
+// pulled its two object types in behind it, turning one meaningless row into three that the caller
+// could not tell from real hits.
+
+// irrelevantQuery matches no relation name or comment in buildEndpointsLastNetwork, so the literal
+// matcher - the last rung of the ladder - scores every one of them zero.
+const irrelevantQuery = "完全不相干的问题 对象类 字段"
+
+func relationNames(relations []*interfaces.KnSearchRelationType) []string {
+	out := make([]string, 0, len(relations))
+	for _, rel := range relations {
+		out = append(out, rel.ConceptName)
+	}
+	return out
+}
+
+func objectIDs(objects []*interfaces.KnSearchObjectType) []string {
+	out := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		out = append(out, obj.ConceptID)
+	}
+	return out
+}
+
+// endpointIDs are the object types reachable only as relation endpoints in this fixture: the
+// relations hang off obj_6..obj_9, which sit at the tail of definition order. If one of them shows
+// up while relation_types is empty, endpoint completion leaked.
+func endpointIDs() map[string]struct{} {
+	return map[string]struct{}{"obj_6": {}, "obj_7": {}, "obj_8": {}, "obj_9": {}}
+}
+
+func runRelationRelevanceCase(
+	t *testing.T,
+	query string,
+	rerank interfaces.DrivenMFModelAPIClient,
+	coarseObjectScores bool,
+	relationScores map[string]float64,
+) *interfaces.KnSearchConceptResult {
+	t.Helper()
+
+	net := buildEndpointsLastNetwork()
+	for _, rel := range net.RelationTypes {
+		rel.Score = relationScores[rel.ID]
+	}
+
+	backend := &mockBknBackend{networkDetail: net}
+	if coarseObjectScores {
+		backend.objectTypesResp = &interfaces.ObjectTypeConcepts{
+			Entries: buildScoredObjectEntries(net, "对象_0"),
+		}
+	} else {
+		backend.objectTypesError = fmt.Errorf("backend unavailable")
+	}
+
+	svc := &localSearchImpl{logger: &mockLogger{}, bknBackend: backend, rerankClient: rerank}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 1
+
+	res, err := svc.conceptRetrieval(context.Background(),
+		&interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: query, EnableRerank: true}, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+	return res
+}
+
+// The reported failure: no reranker, no coarse signal, nothing the literal matcher can vouch for.
+func TestNoRelevantRelationYieldsEmptyList(t *testing.T) {
+	res := runRelationRelevanceCase(t, irrelevantQuery,
+		&mockRerankClient{rerankError: fmt.Errorf("ModelFactory.ExternalSmallModel.Used.NameNotExist")},
+		true, nil)
+
+	if got := relationNames(res.RelationTypes); len(got) != 0 {
+		t.Errorf("expected no relation type when nothing scored above zero, got %v", got)
+	}
+	// The second half of the bug: an unvouched-for relation used to drag its endpoints in with it.
+	leaked := endpointIDs()
+	for _, id := range objectIDs(res.ObjectTypes) {
+		if _, isEndpoint := leaked[id]; isEndpoint {
+			t.Errorf("relation endpoint %s leaked into object_types with no relation returned: %v",
+				id, objectIDs(res.ObjectTypes))
+		}
+	}
+	if len(res.ObjectTypes) == 0 {
+		t.Error("object types must still be returned; only the unvouched-for relations go away")
+	}
+}
+
+// The ladder's middle rung: coarse recall scored some relations and not others. ok=true must not
+// license dragging the unscored ones along to fill Top-K.
+func TestCoarseScoreFallbackDropsUnscoredRelations(t *testing.T) {
+	res := runRelationRelevanceCase(t, irrelevantQuery,
+		&mockRerankClient{rerankError: fmt.Errorf("reranker unavailable")},
+		true, map[string]float64{"rel_1": 2.5})
+
+	got := relationNames(res.RelationTypes)
+	if len(got) != 1 || got[0] != "关系_B" {
+		t.Fatalf("expected only the coarse-scored relation, got %v", got)
+	}
+}
+
+// All coarse _scores zero drops to the literal matcher, which cannot vouch for anything here.
+func TestSimpleMatchFallbackAllZeroYieldsEmptyList(t *testing.T) {
+	res := runRelationRelevanceCase(t, irrelevantQuery,
+		&mockRerankClient{rerankError: fmt.Errorf("reranker unavailable")},
+		true, nil)
+
+	if got := relationNames(res.RelationTypes); len(got) != 0 {
+		t.Errorf("expected empty relation list from the literal matcher, got %v", got)
+	}
+}
+
+// A working reranker still answers, and only with what it rated above zero.
+func TestRerankKeepsOnlyRelationsItRated(t *testing.T) {
+	rerank := &mockRerankClient{
+		rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+			resp := &interfaces.RerankResp{}
+			for i, doc := range documents {
+				score := 0.0
+				if strings.Contains(doc, "关系_B") {
+					score = 0.88
+				}
+				resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: score})
+			}
+			return resp, nil
+		},
+	}
+
+	cfg := DefaultConceptRetrievalConfig()
+	cfg.TopK = 3
+	net := buildEndpointsLastNetwork()
+	svc := &localSearchImpl{
+		logger: &mockLogger{},
+		bknBackend: &mockBknBackend{
+			networkDetail:   net,
+			objectTypesResp: &interfaces.ObjectTypeConcepts{Entries: buildScoredObjectEntries(net, "对象_0")},
+		},
+		rerankClient: rerank,
+	}
+
+	res, err := svc.conceptRetrieval(context.Background(),
+		&interfaces.KnSearchLocalRequest{KnID: "kn_endpoints_last", Query: "关系_B", EnableRerank: true}, cfg)
+	if err != nil {
+		t.Fatalf("conceptRetrieval failed: %v", err)
+	}
+
+	got := relationNames(res.RelationTypes)
+	if len(got) != 1 || got[0] != "关系_B" {
+		t.Fatalf("expected only the relation the reranker rated, got %v", got)
+	}
+}
+
+// A vendor that returns only its top N can answer without scoring a single relation. Recall order
+// is not relevance, so handing back its head would reintroduce the bug through a success path.
+func TestRerankScoringNoRelationTakesTheDegradeLadder(t *testing.T) {
+	net := buildEndpointsLastNetwork()
+	objectCount := len(net.ObjectTypes)
+	rerank := &mockRerankClient{
+		rerankFunc: func(query string, documents []string, model string) (*interfaces.RerankResp, error) {
+			resp := &interfaces.RerankResp{}
+			for i := 0; i < objectCount && i < len(documents); i++ {
+				resp.Results = append(resp.Results, interfaces.RerankResult{Index: i, RelevanceScore: 0.6})
+			}
+			return resp, nil
+		},
+	}
+
+	res := runRelationRelevanceCase(t, irrelevantQuery, rerank, true, nil)
+	if got := relationNames(res.RelationTypes); len(got) != 0 {
+		t.Errorf("expected the degrade ladder to yield nothing, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #788.

## The bug

Every scorer on the relation path can come back with nothing relevant to offer:

- the reranker is not registered and answers `ModelFactory.ExternalSmallModel.Used.NameNotExist`;
- coarse recall is off, so every `_score` is zero;
- the last rung is `calculateRelevanceScore`, literal substring matching — a multi-word query scores zero against every relation far more often than not.

The code still cut Top-K out of that all-zero list, so a relation **nothing had vouched for** reached the caller.

It did not stop there. Relation endpoint completion then pulled that relation's two object types into the response as a schema self-consistency guarantee. One meaningless row became three, indistinguishable from real hits — which is how a `max_concepts=1` query spends its single object slot on an object type the query never asked about.

## The fix

Order by score, **drop what scored zero**, then cut to Top-K. All three rungs of the ladder go through one `takeRelevantRelations`, so none of them can reintroduce the unconditional cut on its own.

An empty relation list also leaves `object_types` clean: with no relation selected there is no endpoint to complete. That is acceptance criterion 4 falling out of criterion 3 rather than needing its own guard.

One **success** path fed the same failure and is fixed too: a vendor that returns only its top N can answer without scoring a single relation, and the code handed back recall order in that case. Recall order is not relevance, so it now takes the same degrade ladder an unavailable reranker takes.

## Acceptance criteria

| | |
|---|---|
| 配置有效 Rerank 模型时返回语义相关的 Relation Type | already fixed by #857 — an empty `model` now resolves the factory's default small model instead of guessing the name `reranker`; covered here by `TestRerankKeepsOnlyRelationsItRated` |
| Rerank 模型不存在时不返回任意零分 Relation Type | `TestNoRelevantRelationYieldsEmptyList` |
| 所有候选相关性为 0 时 `relation_types` 为空 | `TestSimpleMatchFallbackAllZeroYieldsEmptyList` |
| 无关 Relation Type 的端点不会进入 `object_types` | asserted in `TestNoRelevantRelationYieldsEmptyList` (the fixture hangs its relations off the tail of definition order, so a leaked endpoint is detectable) |
| 覆盖 Rerank 成功 / 模型不存在 / 粗召回全零 / 简单匹配全零 | the five tests in `relation_relevance_test.go`, plus `TestCoarseScoreFallbackDropsUnscoredRelations` for the partially-scored middle rung |
| 日志或指标能够区分正常 Rerank 与各类降级结果 | already landed in #1090: `Rerank unavailable` / `returned no usable index` / `scored no relation type` / `coarse-recall _score all zero` are four distinct lines |

## Deliberately not in scope

The **minimum-relevance threshold** #788 also suggests. Zero is unambiguous — the scorer had its chance and found nothing. A threshold discards relations that *did* score, and the number does not travel between deployments: `min_reranker_score` carries exactly this warning in its doc comment, having measured "clearly relevant" topping out near 0.16 on one of our environments and 0.74 on another. That belongs in its own change, behind a default-off knob with a shadow-logging period to see what it would cut.

## Note on a changed test

`TestObjectScoringDegradesWhenBackendFails` now queries something the literal matcher can score. Its subject is the endpoint-first ordering of the fully degraded path, and with no relation surviving there are no endpoints left to order — the test's own precondition (`fixture must yield relation endpoints`) started failing, which is the fix working. `TestNoRelevantRelationYieldsEmptyList` covers the other half.

## Unrelated finding

`go test -race` fails on `TestSemanticInstanceRetrieval_PreFilterQueriesUnscoredObjectTypes` with an unsynchronised write at `object_type_prefilter_test.go:186`, reached through the six-way object type fan-out. **It reproduces on `origin/main` untouched** — pre-existing, test-only, and not fixed here to keep this change to one subject. CI does not run `-race`, which is why it has stayed hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)