### PR TITLE
fix(trace): let Core own provenance schema initialization

### DIFF
--- a/bkn-trace/CHANGELOG.md
+++ b/bkn-trace/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Trace Core now owns creation of `bkn_trace_ee_provenance_analyses` in the versioned MariaDB migration manifest, so Community and Enterprise images initialize the same schema before optional Enterprise routes use it.
 - Renamed the module directory from `trace-ai/` to `bkn-trace/` to align with the platform-wide `bkn-*` naming (display name: BKN Trace). The Go module path changed to `github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability`; CI/release workflows, CODEOWNERS, and issue routing were updated accordingly. Image and chart names (`agent-observability`, `otelcol-contrib`) are unchanged.
 - Complete OpenBKN installations persist Trace Core in the fixed `bkn_trace` MariaDB database and Evidence in OpenSearch. Offline installations mirror the Evidence index hook image into the configured offline registry; online installations keep the chart registry unless explicitly overridden.
 - Managed lifecycle writes remain available through the cluster-internal `8081` Service and are now also exposed on public port `8080` for OAuth-authenticated SDK clients. Public writes derive owner identity server-side and are restricted to the deployment-approved tenant and business domain. Evidence Event/Artifact writes remain on public port `8080` and use the independent ingest token.

--- a/bkn-trace/CHANGELOG.zh.md
+++ b/bkn-trace/CHANGELOG.zh.md
@@ -6,6 +6,7 @@
 
 ### 变更
 
+- Trace Core 现在通过带版本的 MariaDB Migration 统一创建 `bkn_trace_ee_provenance_analyses`，使社区版与企业版镜像都会先完成相同 Schema 初始化，再由可选企业路由使用该表。
 - 模块目录由 `trace-ai/` 改名为 `bkn-trace/`，与平台 `bkn-*` 命名统一（展示名：BKN Trace）。Go module path 变更为 `github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability`；CI/发布流程、CODEOWNERS、Issue 路由同步更新。镜像与 Chart 名（`agent-observability`、`otelcol-contrib`）不变。
 - 完整 OpenBKN 安装将 Trace Core 持久化到固定的 `bkn_trace` MariaDB 数据库，并将 Evidence 持久化到 OpenSearch；离线安装会把 Evidence 索引 Hook 镜像同步到离线仓库，在线安装保持 Chart 默认仓库，除非显式覆盖。
 - 受管生命周期写入继续通过集群内部 `8081` Service 开放，并新增公开 `8080` 端口供 OAuth 鉴权后的 SDK 客户端调用。公开写入的 owner 身份由服务端派生，且仅允许部署方批准的租户与业务域；Evidence Event/Artifact 继续通过公开 `8080` 端口和独立 ingest token 写入。

--- a/bkn-trace/agent-observability/migrations/mariadb/v017/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v017/init.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS bkn_trace_ee_provenance_analyses (
+    analysis_id VARCHAR(64) NOT NULL,
+    interaction_id VARCHAR(64) NOT NULL,
+    markdown_snapshot LONGTEXT NOT NULL,
+    agent_id VARCHAR(128) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    result_payload LONGTEXT NULL,
+    failure_code VARCHAR(64) NULL,
+    failure_message VARCHAR(512) NULL,
+    started_at DATETIME(6) NOT NULL,
+    finished_at DATETIME(6) NULL,
+    PRIMARY KEY (analysis_id),
+    INDEX idx_provenance_analysis_interaction (interaction_id, started_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/bkn-trace/agent-observability/migrations/mariadb/v017/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v017/schema.go
@@ -1,0 +1,8 @@
+package v017
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string { return schemaSQL }

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -9,6 +9,7 @@ import (
 	v014 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v014"
 	v015 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v015"
 	v016 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v016"
+	v017 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v017"
 )
 
 // Migration is immutable once released. Every statement in SQL must be safe to
@@ -29,6 +30,7 @@ func Migrations() []Migration {
 		{version: "014", sql: v014.SchemaSQL()},
 		{version: "015", sql: v015.SchemaSQL()},
 		{version: "016", sql: v016.SchemaSQL()},
+		{version: "017", sql: v017.SchemaSQL()},
 	})
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -36,6 +36,8 @@ func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
 		"bkn_trace_log_source_coverage",
 		"PRIMARY KEY (source_id, deployment_id)",
 		"dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0",
+		"bkn_trace_ee_provenance_analyses",
+		"idx_provenance_analysis_interaction",
 	}
 	for _, fragment := range required {
 		if !strings.Contains(schema, fragment) {
@@ -50,6 +52,7 @@ func TestMigrationsAreOrderedAndChecksumProtected(t *testing.T) {
 		"014": "12ada5e84e6c1154dcb7e522804480d6a2c5d4cb2313c2a0883179d076e765e6",
 		"015": "408e6cb3445f6116995da9852116f1795563f5ea17a65da667b6ec42a33dec2e",
 		"016": "869da02928bed7950e7d0b2b3e609c806334a3839342e57631548f57b3ac1be4",
+		"017": "f47e2ee9f70f0089c2cd225f5d28cc612b2f0c105d5ba001d55771636c02e349",
 	}
 	migrations := sessionstore.Migrations()
 	if len(migrations) != len(expectedChecksums) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_integration_test.go
@@ -109,6 +109,14 @@ func TestMigrateIsIdempotentAndRecordsVersionLedger(t *testing.T) {
 	if ledgerRows != len(sessionstore.Migrations()) {
 		t.Fatalf("expected %d migration ledger rows, got %d", len(sessionstore.Migrations()), ledgerRows)
 	}
+	var provenanceTableRows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM information_schema.tables
+		WHERE table_schema = DATABASE() AND table_name = 'bkn_trace_ee_provenance_analyses'`).Scan(&provenanceTableRows); err != nil {
+		t.Fatalf("check provenance analysis table: %v", err)
+	}
+	if provenanceTableRows != 1 {
+		t.Fatalf("expected Core migration to create provenance analysis table, got %d", provenanceTableRows)
+	}
 }
 
 func TestSourceCoverageSurvivesStoreRestart(t *testing.T) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -47,6 +47,21 @@ func TestMigrationPlanReturnsOnlyUnappliedVersions(t *testing.T) {
 	}
 }
 
+func TestMigrationPlanUpgradesExistingCoreSchemaWithProvenanceTable(t *testing.T) {
+	migrations := Migrations()
+	applied := make(map[string]string, len(migrations)-1)
+	for _, migration := range migrations[:len(migrations)-1] {
+		applied[migration.Version] = migration.Checksum
+	}
+	plan, err := migrationPlan(migrations, applied)
+	if err != nil {
+		t.Fatalf("plan provenance schema migration: %v", err)
+	}
+	if len(plan) != 1 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") {
+		t.Fatalf("unexpected provenance schema plan: %#v", plan)
+	}
+}
+
 func TestMigrationPlanRejectsAppliedVersionGap(t *testing.T) {
 	migrations := Migrations()
 	applied := map[string]string{


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added MariaDB migration `017` so Trace Core owns creation of `bkn_trace_ee_provenance_analyses`.
- [x] Added migration manifest, checksum, upgrade-plan, and table-creation regression coverage.
- [x] Documented the shared Community/Enterprise schema ownership change in both changelogs.

---

## Why

- Related Issue: Closes #1096
- Related Feature: BKN Trace business provenance analysis history
- Background: The Enterprise assembly previously created its analysis-history table before Trace Core initialized `bkn_trace_schema_migrations`. On a clean database, Core then observed a non-empty schema without a ledger and refused startup. Community and Enterprise images must initialize the same Core-owned schema before optional Enterprise routes use it.

---

## How

- Key implementation points:
  - Added immutable migration `017` with `CREATE TABLE IF NOT EXISTS bkn_trace_ee_provenance_analyses`.
  - Registered `017` after migrations `013` through `016` in the checksum-protected manifest.
  - Verified that an existing `013`-`016` ledger plans only migration `017`.
  - Verified that idempotent migration creates the provenance analysis table.
- Breaking changes (API, config, database, etc.):
  - No API or configuration changes.
  - Database change: adds one table through the existing Trace Core migration ledger. Existing tables and data are not modified or dropped.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Passed: `go test ./src/drivenadapter/dbaccess/mariadb/sessionstore -count=1`
- The MariaDB-tagged integration suite was not run because no local integration database was available. The existing integration test was extended to assert that Core creates the new table.
- `git diff --check` passed.

---

## Risk & Rollback

- Potential risks:
  - Community installations will contain an otherwise dormant Enterprise analysis-history table.
  - Community and Enterprise images must use the same Core migration manifest; an older image will correctly reject a ledger containing migration `017` as newer than itself.
- Rollback plan:
  - Before rollout, revert this PR.
  - After migration `017` has been applied, roll back only to an image that contains the same migration manifest. Leave the additive table in place; do not drop it if Enterprise analysis history may have been written.

---

## Additional Notes

- The paired Enterprise change removes pre-Core DDL and pins the Enterprise build to this Core commit.
- Core commit: `aac41de5d91861cb3011198049fa67b20d5f0388`