### PR TITLE
fix(context-loader): make every digest #1092 touched reproducible again

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
@@ -271,7 +271,11 @@ func normalizedHTTPInputHash(input map[string]any, businessContext bkntrace.Busi
 			"causation_event_ids": causationIDs,
 		},
 	}
-	raw, _ := sonic.Marshal(value)
+	// ConfigStd, because value is a map and the default sonic config does not sort map keys: with Go
+	// randomising map iteration order this "normalized" hash came out different on every call, and
+	// so did the operation key built from it, so the same request retried looked like a new
+	// operation every time. Same root cause as #1098, one subsystem over.
+	raw, _ := sonic.ConfigStd.Marshal(value)
 	return hashLifecyclePayload(raw)
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_operation_key_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_operation_key_test.go
@@ -1,0 +1,63 @@
+package driveradapters
+
+import (
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+)
+
+// Regression for the second instance of #1098's root cause.
+//
+// normalizedHTTPInputHash exists to give identical input an identical digest — it even sorts
+// causation ids by hand to get there. It then marshals a map[string]any with the default sonic
+// config, which does not sort map keys, and Go randomises map iteration order. So the "normalized"
+// hash came out different on every call, and the operation key built from it with it.
+//
+// The input needs several keys for the bug to show: with one key there is no order to get wrong.
+func lifecycleHashFixture() (map[string]any, bkntrace.BusinessContext) {
+	input := map[string]any{
+		"query":         "供应商 对象类 字段",
+		"kn_id":         "kn_probe",
+		"max_concepts":  10,
+		"schema_brief":  true,
+		"enable_rerank": true,
+		"zebra_key":     "sorts last",
+		"alpha_key":     "sorts first",
+	}
+	businessContext := bkntrace.BusinessContext{
+		ConversationID:    "conv_1",
+		InteractionID:     "int_1",
+		ParentOperationID: "op_parent",
+		CausationEventIDs: []string{"evt_b", "evt_a"},
+	}
+	return input, businessContext
+}
+
+func TestNormalizedHTTPInputHashIsStable(t *testing.T) {
+	input, businessContext := lifecycleHashFixture()
+
+	want := normalizedHTTPInputHash(input, businessContext)
+	for i := 0; i < 64; i++ {
+		if got := normalizedHTTPInputHash(input, businessContext); got != want {
+			t.Fatalf("normalized input hash changed between calls (call %d):\n  %s\n  %s", i, got, want)
+		}
+	}
+}
+
+// The hash is not an end in itself: it is the identity half of the HTTP operation key, so an
+// unstable hash makes the same request look like a different operation on every retry.
+func TestHTTPOperationKeyIsStable(t *testing.T) {
+	input, businessContext := lifecycleHashFixture()
+
+	key := func() string {
+		return hashHTTPOperationKey("http-request", businessContext, "search_schema",
+			"req_1\x00"+normalizedHTTPInputHash(input, businessContext))
+	}
+
+	want := key()
+	for i := 0; i < 64; i++ {
+		if got := key(); got != want {
+			t.Fatalf("operation key changed between calls (call %d): %s != %s", i, got, want)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/canonical_hash_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/canonical_hash_test.go
@@ -1,0 +1,126 @@
+package bkntrace
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+// Regression for #1098.
+//
+// agent-observability admits an evidence event only if it can recompute payload_hash from the
+// envelope, and it does that with encoding/json (ledgervo.CanonicalPayloadHash). So whatever this
+// package hashes has to be encoding/json's exact bytes. The default sonic config is not: it neither
+// sorts map keys nor escapes HTML, and Go randomises map iteration order, so the sender produced a
+// different envelope - and a different hash - on every single call. Every event was rejected, which
+// took bkn_start_interaction down, which took every MCP tool that carries a bkn_context with it.
+//
+// A map with several keys is the whole point of these fixtures: with one key there is no order to
+// get wrong, and the bug hides.
+func canonicalEventFixture() Event {
+	return Event{
+		"event_id":        "evt_9f3c",
+		"event_type":      "context.search_schema",
+		"interaction_id":  "int_7c9d",
+		"operation_id":    "op_1a2b",
+		"attempt":         1,
+		"observed_at":     "2026-08-21T09:00:00Z",
+		"emitted_at":      "2026-08-21T09:00:01Z",
+		"zebra_last_key":  "sorts after everything else",
+		"alpha_first_key": "sorts before everything else",
+		"html_payload":    `a<b&c>d`,
+	}
+}
+
+// receiverCanonicalHash mirrors ledgervo.CanonicalPayloadHash. It lives in bkn-trace, a separate
+// module this one cannot import, so the contract is restated here rather than asserted against the
+// real function - if that canonicalisation ever changes, this test is the thing that has to be
+// updated in step with it.
+func receiverCanonicalHash(t *testing.T, envelope []byte) string {
+	t.Helper()
+	var decoded any
+	if err := json.Unmarshal(envelope, &decoded); err == nil {
+		if canonical, err := json.Marshal(decoded); err == nil {
+			envelope = canonical
+		}
+	}
+	sum := sha256.Sum256(envelope)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestEvidenceEnvelopeHashMatchesReceiverCanonicalisation(t *testing.T) {
+	event := canonicalEventFixture()
+
+	built, err := trace30EvidenceEvent(map[string]any{
+		"bkn.conversation.id": "conv_1",
+		"bkn.request.id":      "req_1",
+		"trace_id":            "trace_1",
+	}, event, nil)
+	if err != nil {
+		t.Fatalf("trace30EvidenceEvent failed: %v", err)
+	}
+
+	envelope, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	want := receiverCanonicalHash(t, envelope)
+
+	if built.PayloadHash != want {
+		t.Errorf("payload_hash would be rejected by agent-observability:\n  sent     = %s\n  receiver = %s",
+			built.PayloadHash, want)
+	}
+}
+
+// The failure that made this so hard to spot from a single log line: it is not deterministic. Two
+// calls on the same input disagreed, so the same event hashed differently on every retry.
+func TestEvidenceEnvelopeHashIsStableAcrossCalls(t *testing.T) {
+	traceBlock := map[string]any{"bkn.conversation.id": "conv_1", "trace_id": "trace_1"}
+
+	first, err := trace30EvidenceEvent(traceBlock, canonicalEventFixture(), nil)
+	if err != nil {
+		t.Fatalf("trace30EvidenceEvent failed: %v", err)
+	}
+	for i := 0; i < 32; i++ {
+		again, err := trace30EvidenceEvent(traceBlock, canonicalEventFixture(), nil)
+		if err != nil {
+			t.Fatalf("trace30EvidenceEvent failed on call %d: %v", i, err)
+		}
+		if again.PayloadHash != first.PayloadHash {
+			t.Fatalf("payload_hash changed between calls (call %d): %s != %s",
+				i, again.PayloadHash, first.PayloadHash)
+		}
+	}
+}
+
+// HashValue is exported and takes any, so a map reaches it the moment a caller passes one - and an
+// identity that changes per call is worse than a wrong one, because nothing downstream can match on
+// it. vega's copy of this function already used ConfigStd; this one had been left on the default.
+func TestHashValueIsStableAndMatchesEncodingJSON(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"map with several keys", map[string]any{"zebra": 1, "alpha": 2, "mid": 3, "beta": 4, "yak": 5}},
+		{"string carrying HTML", `a<b&c>d`},
+		{"nested map", map[string]any{"outer": map[string]any{"z": 1, "a": 2}, "list": []any{"b", "a"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(tc.value)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			sum := sha256.Sum256(raw)
+			want := "sha256:" + hex.EncodeToString(sum[:])
+
+			for i := 0; i < 32; i++ {
+				if got := HashValue(tc.value); got != want {
+					t.Fatalf("HashValue diverged from encoding/json on call %d:\n  got  = %s\n  want = %s",
+						i, got, want)
+				}
+			}
+		})
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -746,7 +746,13 @@ func postBatch(ingestURL string, timeout time.Duration, payload batch) error {
 		if err != nil {
 			return err
 		}
-		body, err := sonic.Marshal(requestPayload)
+		// Same config that hashed the envelope. Envelope holds the live Event map rather than the
+		// bytes that were hashed, so marshalling it here with a different config ships bytes the
+		// digest was not taken over. It survives today only because the receiver canonicalises what
+		// it gets before comparing - the moment a value stops round-tripping through that step
+		// unchanged (an int above 2^53, a json.Number, a struct), the two drift apart again and
+		// every event is rejected exactly as in #1098.
+		body, err := sonic.ConfigStd.Marshal(requestPayload)
 		if err != nil {
 			return err
 		}

--- a/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
+++ b/adp/context-loader/agent-retrieval/server/infra/bkntrace/evidence.go
@@ -120,8 +120,12 @@ type eventContext struct {
 	observedAt       string
 }
 
+// HashValue is ConfigStd, not the default sonic config, and the difference is not cosmetic: the
+// default config neither sorts map keys nor escapes HTML, so hashing a map returns a different
+// digest on every call - Go randomises map iteration order. ConfigStd reproduces encoding/json
+// byte for byte, which is what every peer that recomputes one of these digests still uses.
 func HashValue(value any) string {
-	raw, err := sonic.Marshal(value)
+	raw, err := sonic.ConfigStd.Marshal(value)
 	if err != nil {
 		raw = []byte(fmt.Sprintf("%v", value))
 	}
@@ -834,7 +838,14 @@ type trace30OperationEdge struct {
 }
 
 func trace30EvidenceEvent(traceBlock map[string]any, event Event, declaredRefs []BusinessRef) (trace30Event, error) {
-	envelope, err := sonic.Marshal(event)
+	// ConfigStd, because agent-observability recomputes this digest to admit the event and does it
+	// with encoding/json (ledgervo.CanonicalPayloadHash). Event is a map[string]any, and the default
+	// sonic config does not sort map keys, so the two sides agreed on nothing: Go randomises map
+	// iteration order, so the sender produced a different envelope - and a different hash - on every
+	// call, and every event was rejected with "payload_hash does not match canonical envelope".
+	// That rejection blocks bkn_start_interaction, which gates every MCP tool that takes a
+	// bkn_context, so the whole MCP surface goes down with it.
+	envelope, err := sonic.ConfigStd.Marshal(event)
 	if err != nil {
 		return trace30Event{}, err
 	}


### PR DESCRIPTION
Closes #1098. **Main has been broken for every MCP client since #1092 merged this afternoon** — this restores it, and sweeps the rest of that PR's surface for the same mistake.

## What happens on main today

```
$ openbkn context tool-call <kn> bkn_start_interaction --args '{"question":"probe","agent_name":"probe"}'
{"error":{"code":"evidence_capture_failed",
          "message":"payload_hash does not match canonical envelope"}}
```

That guard gates every MCP tool carrying a `bkn_context`, `search_schema` included. Every call, every time.

Everything before #1092 (`c8b2697d`, 2026-08-21 14:33) is fine, released 0.1.3 included — which is why nobody has reported it.

## Root cause

`sonic.Marshal` uses the default config, which **does not sort map keys**. `encoding/json` does. Go randomises map iteration order, so hashing a map through default sonic returns a different digest on every call:

```
sonic default: {"zebra":1,"alpha":2,"mid":3,...}   ← different order each call
encoding/json: {"alpha":2,"beta":4,"cat":6,...}    ← always sorted
```

#1092 replaced `encoding/json` with sonic across 80 files. Most sites correctly use `sonic.ConfigStd` — which reproduces `encoding/json` byte for byte, ordering and HTML escaping included, while keeping what that PR came for:

```
bigint  std={"ts":1755769626123456789}  sonicStd={"ts":1755769626123456789}  equal=true
```

Four sites in context-loader were left on the default config. These are those four.

## The four

| site | what it feeds | symptom |
|---|---|---|
| `evidence.go:837` envelope hash | agent-observability recomputes it with `encoding/json` (`ledgervo.CanonicalPayloadHash`) | **every evidence event rejected; MCP surface down** |
| `evidence.go:124` `HashValue` | exported, takes `any`, so a map reaches it as soon as a caller passes one | identity changes per call — worse than wrong, nothing can match on it |
| `evidence.go:745` `postBatch` | ships the envelope | digest covers one serialisation, wire carries another; survives only because the receiver re-canonicalises |
| `lifecycle_middleware.go:274` `normalizedHTTPInputHash` | the identity half of the HTTP operation key | `http:84ede0e2...` != `http:02a0aeb5...` on two consecutive calls with identical input — a retry looks like a new operation |

The last one is worth its own line: the function sorts causation ids by hand to be deterministic, then hands a `map[string]any` to the unsorted marshaller. The name says `normalized`.

## What the audit cleared

Every `sonic.Marshal` #1092 introduced in context-loader, checked for whether its bytes feed a digest or an identity. The rest stay as they are:

- **marshal-then-unmarshal round trips**, where order cannot matter — `session_guard` `operationIdentity` and receipt status, `utils.AnyToObject`, `toAnySlice`, retrieval config conversion
- **HTTP request bodies and payload fields nobody digests** — `lifecycle` postJSON, evidence artifact upload, `guardPayloadJSON`
- **text shown to a caller** — tool results, error envelopes
- `propertiesFingerprint` sorts its own keys and never touches sonic

## Tests

Each one fails on the unfixed code — checked by reverting the source and leaving the tests:

```
--- FAIL: TestEvidenceEnvelopeHashMatchesReceiverCanonicalisation
--- FAIL: TestEvidenceEnvelopeHashIsStableAcrossCalls
    payload_hash changed between calls (call 0):
      47d3a6b6d641f7e3cb5054a345e09470575d7066ece3ea07cdb24a5fc958867c !=
      e654e120af0d6c907838be2ddccdc12e5e97e58eca0bbdd9d4ff3a6146d7d3ae
--- FAIL: TestHashValueIsStableAndMatchesEncodingJSON
--- FAIL: TestNormalizedHTTPInputHashIsStable
--- FAIL: TestHTTPOperationKeyIsStable
    operation key changed between calls (call 1):
      http:84ede0e2d8f4c352c0eac6fa9074e0b3 != http:02a0aeb5209f6ecca4c0b420a8bfc155
```

Every fixture uses a map with several keys deliberately: with one key there is no order to get wrong and the bug hides.

`receiverCanonicalHash` restates `ledgervo.CanonicalPayloadHash` rather than calling it — bkn-trace is a separate module this one cannot import. If that canonicalisation changes, this test is what has to change with it, and the comment says so.

## Verified on the VM

Built and deployed against an **unmodified** agent-observability, which is what proves the sender was the broken half:

- `bkn_start_interaction` returns a `conversation_id` again
- `search_schema` with a working reranker returns its relation types
- with `rerank_model` pointed at a model that does not exist, `relation_types` comes back empty — #1097's behaviour, unaffected

## Left for later

The receiver's canonicalisation decodes into `any`, which degrades every number to `float64`, so an envelope carrying an integer above 2^53 still fails to match. That **predates #1092** and needs both sides moved together — recorded on #1098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)