### PR TITLE
fix(trace): accept public receipt event IDs

### DIFF
--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchruntimeaudit/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchruntimeaudit/source.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	sourceID  = "bkn-trace-runtime"
-	logPrefix = sourceID + ":"
+	sourceID    = "bkn-trace-runtime"
+	logPrefix   = sourceID + ":"
+	eventPrefix = "operation.executed:"
 )
 
 type searchClient interface {
@@ -68,8 +69,8 @@ func (source *Source) Search(ctx context.Context, query observabilityvo.LogQuery
 }
 
 func (source *Source) Get(ctx context.Context, logID string) (observabilityvo.LogRecord, bool, error) {
-	receiptID := strings.TrimPrefix(logID, logPrefix)
-	if receiptID == logID || receiptID == "" {
+	receiptID, supported := receiptIDFromIdentifier(logID)
+	if !supported {
 		return observabilityvo.LogRecord{}, false, nil
 	}
 	scope := observabilityvo.SourceAccessScopeFromContext(ctx)
@@ -82,10 +83,19 @@ func (source *Source) Get(ctx context.Context, logID string) (observabilityvo.Lo
 	if err != nil || len(page.Records) == 0 {
 		return observabilityvo.LogRecord{}, false, err
 	}
-	if page.Records[0].LogID != logID {
-		return observabilityvo.LogRecord{}, false, fmt.Errorf("receipt log detail returned mismatched log_id")
+	if page.Records[0].SourceLogID != receiptID {
+		return observabilityvo.LogRecord{}, false, fmt.Errorf("receipt log detail returned mismatched receipt_id")
 	}
 	return page.Records[0], true, nil
+}
+
+func receiptIDFromIdentifier(identifier string) (string, bool) {
+	for _, prefix := range []string{eventPrefix, logPrefix} {
+		if receiptID := strings.TrimPrefix(identifier, prefix); receiptID != identifier && receiptID != "" {
+			return receiptID, true
+		}
+	}
+	return "", false
 }
 
 func (source *Source) search(ctx context.Context, query map[string]any) (observabilityvo.SourcePage, error) {
@@ -232,7 +242,7 @@ func projectReceipt(document sessionvo.ReceiptProjectionDocument) observabilityv
 	}
 	targetName := firstNonEmpty(document.ToolName, document.OperationID)
 	return observabilityvo.LogRecord{
-		EventID: "operation.executed:" + document.ID, EventTime: timestamp, RecordedAt: timestamp,
+		EventID: eventPrefix + document.ID, EventTime: timestamp, RecordedAt: timestamp,
 		ActorNameSnapshot: document.Owner.EffectiveSubjectID, ActorType: actorType(document.Owner.EffectiveSubjectType),
 		AuthMethod: "unknown", SourceChannel: "api", BusinessModule: "domain_knowledge_network", Action: "execute",
 		TargetType: "operation", TargetID: document.OperationID, TargetNameSnapshot: targetName,

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchruntimeaudit/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchruntimeaudit/source_test.go
@@ -100,13 +100,10 @@ func TestSearchMarksCountPartialWhenFreeTextNeedsLocalFiltering(t *testing.T) {
 	}
 }
 
-func TestGetUsesScopedReceiptLookup(t *testing.T) {
+func TestGetAcceptsPublicOperationEventID(t *testing.T) {
 	terminalAt := time.Date(2026, 8, 20, 12, 1, 0, 0, time.UTC)
 	client := &fakeClient{result: searchPayload(t, "eq", terminalAt, nil)}
-	ctx := observabilityvo.WithSourceAccessScope(context.Background(), observabilityvo.SourceAccessScope{
-		TenantID: "tenant", BusinessDomain: "domain",
-	})
-	record, found, err := New(client, "projection").Get(ctx, "bkn-trace-runtime:receipt")
+	record, found, err := New(client, "projection").Get(scopedContext(), "operation.executed:receipt")
 	if err != nil || !found || record.SourceLogID != "receipt" {
 		t.Fatalf("record=%+v found=%v err=%v", record, found, err)
 	}
@@ -115,17 +112,70 @@ func TestGetUsesScopedReceiptLookup(t *testing.T) {
 			t.Errorf("detail query missing %s: %s", expected, client.body)
 		}
 	}
-
-	if _, found, err := New(client, "projection").Get(ctx, "other:receipt"); err != nil || found || client.calls != 1 {
-		t.Fatalf("foreign id should not query: found=%v calls=%d err=%v", found, client.calls, err)
+	if record.EventID != "operation.executed:receipt" {
+		t.Fatalf("event_id=%q", record.EventID)
 	}
+}
+
+func TestGetRetainsInternalLogIDCompatibility(t *testing.T) {
+	terminalAt := time.Date(2026, 8, 20, 12, 1, 0, 0, time.UTC)
+	client := &fakeClient{result: searchPayload(t, "eq", terminalAt, nil)}
+	record, found, err := New(client, "projection").Get(scopedContext(), "bkn-trace-runtime:receipt")
+	if err != nil || !found || record.SourceLogID != "receipt" || client.calls != 1 {
+		t.Fatalf("record=%+v found=%v calls=%d err=%v", record, found, client.calls, err)
+	}
+}
+
+func TestGetRejectsUnsupportedIdentifierWithoutQuerying(t *testing.T) {
+	client := &fakeClient{}
+	_, found, err := New(client, "projection").Get(scopedContext(), "other:receipt")
+	if err != nil || found || client.calls != 0 {
+		t.Fatalf("found=%v calls=%d err=%v", found, client.calls, err)
+	}
+}
+
+func TestGetRejectsMismatchedReceiptProjection(t *testing.T) {
+	terminalAt := time.Date(2026, 8, 20, 12, 1, 0, 0, time.UTC)
+	client := &fakeClient{result: searchPayloadForReceipt(t, "other", "eq", terminalAt, nil)}
+	_, found, err := New(client, "projection").Get(scopedContext(), "operation.executed:receipt")
+	if err == nil || found || client.calls != 1 {
+		t.Fatalf("found=%v calls=%d err=%v", found, client.calls, err)
+	}
+}
+
+func TestSearchPublicEventIDRoundTripsToDetailLookup(t *testing.T) {
+	terminalAt := time.Date(2026, 8, 20, 12, 1, 0, 0, time.UTC)
+	client := &fakeClient{result: searchPayload(t, "eq", terminalAt, nil)}
+	source := New(client, "projection")
+	page, err := source.Search(context.Background(), observabilityvo.LogQuery{
+		AuthorizedTenantID: "tenant", AuthorizedBusinessDomain: "domain",
+	})
+	if err != nil || len(page.Records) != 1 {
+		t.Fatalf("page=%+v err=%v", page, err)
+	}
+
+	record, found, err := source.Get(scopedContext(), page.Records[0].EventID)
+	if err != nil || !found || record.SourceLogID != page.Records[0].SourceLogID {
+		t.Fatalf("record=%+v found=%v err=%v", record, found, err)
+	}
+}
+
+func scopedContext() context.Context {
+	return observabilityvo.WithSourceAccessScope(context.Background(), observabilityvo.SourceAccessScope{
+		TenantID: "tenant", BusinessDomain: "domain",
+	})
 }
 
 func searchPayload(t *testing.T, relation string, terminalAt time.Time, sortValues []any) []byte {
 	t.Helper()
+	return searchPayloadForReceipt(t, "receipt", relation, terminalAt, sortValues)
+}
+
+func searchPayloadForReceipt(t *testing.T, receiptID, relation string, terminalAt time.Time, sortValues []any) []byte {
+	t.Helper()
 	hit := map[string]any{"_source": map[string]any{
 		"owner":        map[string]any{"tenant_id": "tenant", "business_domain_id": "domain", "effective_subject_type": "service", "effective_subject_id": "user", "application_principal_id": "app"},
-		"operation_id": "operation-a", "attempt": 1, "receipt_id": "receipt", "conversation_id": "conversation-a",
+		"operation_id": "operation-a", "attempt": 1, "receipt_id": receiptID, "conversation_id": "conversation-a",
 		"interaction_id": "interaction-a", "request_id": "request-a", "trace_id": "trace-a", "tool_name": "run_sql",
 		"receipt_status": "completed", "issued_at": terminalAt.Add(-time.Minute).Format(time.RFC3339Nano), "terminal_at": terminalAt.Format(time.RFC3339Nano),
 	}}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Accept public `operation.executed:<receipt_id>` identifiers in runtime log detail lookup
- [x] Preserve existing `bkn-trace-runtime:<receipt_id>` compatibility and scoped receipt lookup
- [x] Add focused regression coverage for public/internal IDs, unsupported IDs, list-to-detail round-trip, and mismatched receipt projections

---

## Why

- Related Issue: Closes #1101
- Related Feature: Operation audit log detail drilldown
- Background: commit `8b5957b1` exposed a public runtime event ID that the runtime detail source did not recognize, so every visible `operation.executed` row returned 404 when opened.

---

## How

- Key implementation points: normalize only the two supported identifier prefixes to the receipt ID; retain tenant and business-domain filters; validate the returned projection through `SourceLogID` rather than comparing the internal `LogID` with a public caller ID.
- Breaking changes (API, config, database, etc.): none. No frontend, OpenSearch mapping/index, database schema, configuration, or API contract changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; the change is isolated to identifier normalization and uses a mocked OpenSearch client
- [ ] Verified in test environment — not run; requires a deployed environment with runtime receipt projections

Test notes:

- `go test ./src/drivenadapter/httpaccess/opensearchruntimeaudit -count=1`
- `make test`
- `make lint`
- `make build`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: low. The source accepts one additional public prefix, but still requires trusted tenant/business-domain scope and an exact receipt ID match. Unsupported prefixes do not query OpenSearch.
- Rollback plan: revert commit `0b569eb34`; no data or schema rollback is required.

---

## Additional Notes

- Independent local review found no blocking correctness or security issues.
- The fix intentionally remains in the backend source adapter; clients do not construct or depend on internal log IDs.
