### PR TITLE
fix(trace): require public lifecycle domains in chart

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - name: BKN_TRACE_DEPLOYMENT_TENANT_ID
               value: {{ required "evidence.queryAuth.deploymentTenantID is required" .Values.evidence.queryAuth.deploymentTenantID | quote }}
             - name: BKN_TRACE_PUBLIC_LIFECYCLE_BUSINESS_DOMAINS
-              value: {{ required "evidence.queryAuth.publicLifecycleBusinessDomains is required" .Values.evidence.queryAuth.publicLifecycleBusinessDomains | join "," | quote }}
+              value: {{ required "evidence.queryAuth.publicLifecycleBusinessDomains must be non-empty" (.Values.evidence.queryAuth.publicLifecycleBusinessDomains | join ",") | quote }}
             {{- if .Values.businessResolver.enabled }}
             - name: BKN_TRACE_BKN_RESOLVER_URL
               value: {{ .Values.businessResolver.bknBaseURL | quote }}

--- a/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
+++ b/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
@@ -109,8 +109,13 @@ if ! grep -A1 -Fq 'name: BKN_TRACE_DEPLOYMENT_TENANT_ID
   echo "single-tenant deployments must inject the trusted deployment tenant" >&2
   exit 1
 fi
-if ! grep -A1 -Fq 'name: BKN_TRACE_PUBLIC_LIFECYCLE_BUSINESS_DOMAINS
-              value: "bd_public"' <<<"${default_rendered}"; then
+if ! awk '
+  $0 == "            - name: BKN_TRACE_PUBLIC_LIFECYCLE_BUSINESS_DOMAINS" {
+    getline
+    if ($0 == "              value: \"bd_public\"") found = 1
+  }
+  END { exit !found }
+' <<<"${default_rendered}"; then
   echo "public lifecycle business domains must be rendered" >&2
   exit 1
 fi

--- a/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
+++ b/bkn-trace/agent-observability/scripts/test_evidence_index_governance.sh
@@ -109,6 +109,16 @@ if ! grep -A1 -Fq 'name: BKN_TRACE_DEPLOYMENT_TENANT_ID
   echo "single-tenant deployments must inject the trusted deployment tenant" >&2
   exit 1
 fi
+if ! grep -A1 -Fq 'name: BKN_TRACE_PUBLIC_LIFECYCLE_BUSINESS_DOMAINS
+              value: "bd_public"' <<<"${default_rendered}"; then
+  echo "public lifecycle business domains must be rendered" >&2
+  exit 1
+fi
+if helm template agent-observability "${chart_dir}" \
+  --set-json 'evidence.queryAuth.publicLifecycleBusinessDomains=[]' >/dev/null 2>&1; then
+  echo "public lifecycle business domains must be required and non-empty" >&2
+  exit 1
+fi
 
 legacy_rendered="$(render_chart agent-observability "${chart_dir}" \
   --set evidence.store=opensearch \


### PR DESCRIPTION
## Summary
- reject an empty public lifecycle domain allowlist during Helm rendering
- add chart regression coverage for the default bd_public scope and empty-list rejection

## Test plan
- [x] make helm-lint
- [x] make lint test build