### PR TITLE
fix(context-loader): validate lifecycle tool arguments

### DIFF
--- a/adp/context-loader/agent-retrieval/go.mod
+++ b/adp/context-loader/agent-retrieval/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.3
 	github.com/openbkn-ai/licverify v0.5.0
 	github.com/pkg/errors v0.9.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/viper v1.21.0
 	github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c
@@ -25,7 +26,6 @@ require (
 
 require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 )
 
 require (

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
@@ -129,7 +129,7 @@ func TestStartInteractionRetryUsesStableHostHintsAcrossTransportSessions(t *test
 		request := mcpsdk.CallToolRequest{
 			Header: http.Header{"Mcp-Session-Id": []string{transportSession}},
 			Params: mcpsdk.CallToolParams{
-				Arguments: map[string]any{"question": "查询库存"},
+				Arguments: map[string]any{"question": "查询库存", "agent_name": "供应链分析助手"},
 				Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 					hostConversationKeyMeta: "cursor-chat-1",
 					clientInvocationIDMeta:  "cursor-call-1",
@@ -184,6 +184,7 @@ func TestStartInteractionRejectsConversationThatConflictsWithHostMapping(t *test
 		Arguments: map[string]any{
 			"conversation_id": "conv-model-supplied",
 			"question":        "查询库存",
+			"agent_name":      "供应链分析助手",
 		},
 		Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 			hostConversationKeyMeta: "cursor-chat-1",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -401,7 +401,7 @@ func lifecycleRequest(name string, args map[string]any) (string, string, map[str
 	case "bkn_start_interaction":
 		conversationID := url.PathEscape(stringValue(args["conversation_id"]))
 		return http.MethodPost, "/conversations/" + conversationID + "/interactions",
-			copyArgs(args, "idempotency_key", "request_hash", "agent_name", "lease_seconds")
+			copyArgs(args, "idempotency_key", "request_hash", "agent_name")
 	case "bkn_finish_interaction":
 		interactionID := url.PathEscape(stringValue(args["interaction_id"]))
 		return http.MethodPost, "/interactions/" + interactionID + "/finish",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -193,6 +193,9 @@ func handleLifecycleTool(
 			}), nil
 		}
 		args := req.GetArguments()
+		if validationErr := validateLifecycleArguments(name, args); validationErr != nil {
+			return lifecycleToolError(*validationErr), nil
+		}
 		ensureLifecycleIdempotency(ctx, name, args, hints)
 		if name == "bkn_start_interaction" {
 			args["request_hash"] = strings.TrimPrefix(hashBytes([]byte(stringValue(args["question"]))), "sha256:")

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -162,11 +162,19 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 		{
 			name: "finish with unsupported outcome", toolName: "bkn_finish_interaction",
 			args:        map[string]any{"interaction_id": "int-1", "outcome": "abandoned"},
-			wantMessage: "bkn_finish_interaction outcome must be completed, failed, cancelled, or handed_off",
+			wantMessage: "bkn_finish_interaction outcome must be one of: completed, failed, cancelled, handed_off",
 		},
 		{
 			name: "finish with empty interaction id", toolName: "bkn_finish_interaction",
 			args:        map[string]any{"interaction_id": "", "outcome": "failed"},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+		{
+			name: "finish with caller-owned claims", toolName: "bkn_finish_interaction",
+			args: map[string]any{
+				"interaction_id": "int-1", "outcome": "completed", "answer": "库存充足",
+				"claims": []any{map[string]any{"claim_id": "caller-owned"}},
+			},
 			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
 		},
 	}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -132,6 +132,89 @@ func lifecycleAdapterJSONResponse(status int, value any) *http.Response {
 	}
 }
 
+func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
+	tests := []struct {
+		name        string
+		toolName    string
+		args        map[string]any
+		wantMessage string
+	}{
+		{
+			name: "start without agent name", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存"},
+			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+		},
+		{
+			name: "start with empty agent name", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": ""},
+			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+		},
+		{
+			name: "finish with lifecycle IDs nested in bkn context", toolName: "bkn_finish_interaction",
+			args: map[string]any{
+				"bkn_context": map[string]any{
+					"conversation_id": "conv-1", "interaction_id": "int-1",
+				},
+				"outcome": "completed", "answer": "库存充足",
+			},
+			wantMessage: "bkn_finish_interaction requires interaction_id as a top-level field; remove bkn_context and retry",
+		},
+		{
+			name: "finish with unsupported outcome", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "abandoned"},
+			wantMessage: "bkn_finish_interaction outcome must be completed, failed, cancelled, or handed_off",
+		},
+		{
+			name: "finish with empty interaction id", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "", "outcome": "failed"},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coreCalls := 0
+			client := &http.Client{Transport: lifecycleAdapterRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				coreCalls++
+				return lifecycleAdapterJSONResponse(http.StatusInternalServerError, map[string]any{}), nil
+			})}
+			ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{
+				RequestID: "req-invalid-lifecycle-arguments", TenantID: "tenant-1", BusinessDomain: "domain-1",
+			})
+			ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+				AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+			})
+
+			result, err := handleLifecycleTool(
+				bkntrace.NewLifecycleClient("http://bkn-trace.test", client), test.toolName,
+			)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: test.args}})
+			if err != nil {
+				t.Fatalf("invalid lifecycle arguments returned handler error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("invalid lifecycle arguments unexpectedly succeeded: %#v", result)
+			}
+			if coreCalls != 0 {
+				t.Fatalf("invalid lifecycle arguments reached Core %d times", coreCalls)
+			}
+			textContent, ok := mcpsdk.AsTextContent(result.Content[0])
+			if !ok {
+				t.Fatalf("invalid lifecycle error is not text: %#v", result.Content)
+			}
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(textContent.Text), &envelope); err != nil {
+				t.Fatalf("decode invalid lifecycle error: %v", err)
+			}
+			errorValue := envelope["error"].(map[string]any)
+			if errorValue["code"] != "invalid_params" ||
+				errorValue["required_action"] != "correct_tool_arguments" ||
+				errorValue["message"] != test.wantMessage {
+				t.Fatalf("invalid lifecycle error lacks correction guidance: %#v", errorValue)
+			}
+		})
+	}
+}
+
 func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEvidence(t *testing.T) {
 	createdAt := time.Date(2026, 8, 3, 6, 30, 0, 123000000, time.UTC)
 	var artifact map[string]any
@@ -176,7 +259,7 @@ func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEviden
 		bkntrace.NewLifecycleClient(backend.URL, backend.Client()),
 		"bkn_start_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
-		"conversation_id": "conv-1", "question": "查询 BOM",
+		"conversation_id": "conv-1", "question": "查询 BOM", "agent_name": "供应链分析助手",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("start interaction failed: result=%#v err=%v", result, err)
@@ -243,17 +326,13 @@ func TestFinishInteractionUsesCoreUpdatedAtForServerOwnedResultEvidence(t *testi
 		"bkn_finish_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
 		"interaction_id": "int-1", "outcome": "completed",
-		"idempotency_key": "complete-1", "answer": "BOM 查询完成",
-		"claims": []any{map[string]any{"claim_id": "caller-owned"}},
+		"answer": "BOM 查询完成",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("complete interaction failed: result=%#v err=%v", result, err)
 	}
 	if got := artifact["observed_at"]; got != updatedAt.Format(time.RFC3339Nano) {
 		t.Fatalf("result artifact observed_at=%v, want Core updated_at %s", got, updatedAt.Format(time.RFC3339Nano))
-	}
-	if _, forwarded := finishBody["claims"]; forwarded {
-		t.Fatalf("ordinary MCP finish forwarded caller-owned claims: %#v", finishBody)
 	}
 }
 
@@ -303,7 +382,7 @@ func TestFinishInteractionRetryReusesCommittedResultArtifact(t *testing.T) {
 		"bkn_finish_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
 		"interaction_id": "int-1", "outcome": "completed",
-		"idempotency_key": "complete-1", "answer": "BOM 查询完成",
+		"answer": "BOM 查询完成",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("terminal retry failed: result=%#v err=%v", result, err)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -17,6 +17,8 @@ package mcp
 
 import (
 	"encoding/json"
+	"slices"
+	"strings"
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -53,7 +55,7 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 		}
 		if outcome, present := arguments["outcome"]; present && !validFinishOutcome(outcome) {
 			return invalidLifecycleArguments(
-				"bkn_finish_interaction outcome must be completed, failed, cancelled, or handed_off",
+				"bkn_finish_interaction outcome must be one of: " + strings.Join(finishInteractionOutcomes, ", "),
 			)
 		}
 	}
@@ -80,12 +82,7 @@ func validFinishOutcome(value any) bool {
 	if !ok {
 		return false
 	}
-	switch outcome {
-	case "completed", "failed", "cancelled", "handed_off":
-		return true
-	default:
-		return false
-	}
+	return slices.Contains(finishInteractionOutcomes, outcome)
 }
 
 func lifecycleArgumentGuidance(name string) string {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -1,0 +1,96 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Schema {
+	result := make(map[string]*jsonschema.Schema, len(lifecycleToolNames))
+	for name := range lifecycleToolNames {
+		input, _ := loadToolSchemas(name)
+		var document any
+		if err := json.Unmarshal(input, &document); err != nil {
+			panic("invalid lifecycle input schema for " + name + ": " + err.Error())
+		}
+		compiler := jsonschema.NewCompiler()
+		compiler.DefaultDraft(jsonschema.Draft7)
+		if err := compiler.AddResource("schema.json", document); err != nil {
+			panic("cannot register lifecycle input schema for " + name + ": " + err.Error())
+		}
+		schema, err := compiler.Compile("schema.json")
+		if err != nil {
+			panic("cannot compile lifecycle input schema for " + name + ": " + err.Error())
+		}
+		result[name] = schema
+	}
+	return result
+})
+
+func validateLifecycleArguments(name string, arguments map[string]any) *lifecycleError {
+	if name == "bkn_finish_interaction" {
+		if _, nested := arguments["bkn_context"]; nested {
+			return invalidLifecycleArguments(
+				"bkn_finish_interaction requires interaction_id as a top-level field; remove bkn_context and retry",
+			)
+		}
+		if outcome, present := arguments["outcome"]; present && !validFinishOutcome(outcome) {
+			return invalidLifecycleArguments(
+				"bkn_finish_interaction outcome must be completed, failed, cancelled, or handed_off",
+			)
+		}
+	}
+	schema, ok := lifecycleArgumentSchemas()[name]
+	if !ok {
+		return nil
+	}
+	if err := schema.Validate(arguments); err == nil {
+		return nil
+	}
+	return invalidLifecycleArguments(lifecycleArgumentGuidance(name))
+}
+
+func invalidLifecycleArguments(message string) *lifecycleError {
+	return &lifecycleError{
+		Code:           "invalid_params",
+		Message:        message,
+		RequiredAction: "correct_tool_arguments",
+	}
+}
+
+func validFinishOutcome(value any) bool {
+	outcome, ok := value.(string)
+	if !ok {
+		return false
+	}
+	switch outcome {
+	case "completed", "failed", "cancelled", "handed_off":
+		return true
+	default:
+		return false
+	}
+}
+
+func lifecycleArgumentGuidance(name string) string {
+	if name == "bkn_start_interaction" {
+		return "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id"
+	}
+	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -192,6 +192,30 @@ func TestStartInteractionDescriptionGuidesStableAgentIdentity(t *testing.T) {
 	}
 }
 
+func TestFinishInteractionDescriptionShowsTopLevelCompletedExample(t *testing.T) {
+	tests := []struct {
+		locale string
+		want   string
+	}{
+		{
+			locale: "zh-CN",
+			want:   `结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+		},
+		{
+			locale: "en-US",
+			want:   `Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.locale, func(t *testing.T) {
+			if got := loadMCPLocaleBundle(test.locale).ToolMeta("bkn_finish_interaction").Description; got != test.want {
+				t.Fatalf("finish description for %s = %q, want %q", test.locale, got, test.want)
+			}
+		})
+	}
+}
+
 func getNestedString(root map[string]any, path []string) (string, bool) {
 	var current any = root
 	for _, segment := range path {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -99,6 +99,8 @@ func loadToolSchemas(toolKey string) (input, output json.RawMessage) {
 	return wrapper.InputSchema, wrapper.OutputSchema
 }
 
+var finishInteractionOutcomes = []string{"completed", "failed", "cancelled", "handed_off"}
+
 func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, bool) {
 	if _, ok := lifecycleToolNames[toolKey]; !ok {
 		return nil, nil, false
@@ -126,7 +128,7 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 			"description": "Use the exact interaction_id returned by start.",
 		}
 		required = append(required, "interaction_id")
-		properties["outcome"] = enumSchema("completed", "failed", "cancelled", "handed_off")
+		properties["outcome"] = enumSchema(finishInteractionOutcomes...)
 		properties["outcome"].(map[string]any)["description"] = "Set the final outcome for this turn."
 		required = append(required, "outcome")
 		properties["answer"] = map[string]any{

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -108,20 +108,22 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	switch toolKey {
 	case "bkn_start_interaction":
 		properties["conversation_id"] = map[string]any{
-			"type": "string", "description": "Omit on the first turn; otherwise reuse the ID returned by start.",
+			"type":        "string",
+			"description": "Omit on the first turn; otherwise reuse the ID returned by start.",
 		}
 		properties["question"] = map[string]any{
-			"type": "string", "description": "Use the user's question for this turn.",
+			"type": "string", "minLength": 1, "description": "Use the user's question for this turn.",
 		}
 		required = append(required, "question")
 		properties["agent_name"] = map[string]any{
-			"type": "string", "maxLength": 128,
+			"type": "string", "minLength": 1, "maxLength": 128,
 			"description": "The current Agent's stable name. Provide the same value on every call in the same conversation_id.",
 		}
 		required = append(required, "agent_name")
 	case "bkn_finish_interaction":
 		properties["interaction_id"] = map[string]any{
-			"type": "string", "description": "Use the exact interaction_id returned by start.",
+			"type": "string", "minLength": 1,
+			"description": "Use the exact interaction_id returned by start.",
 		}
 		required = append(required, "interaction_id")
 		properties["outcome"] = enumSchema("completed", "failed", "cancelled", "handed_off")

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -1,7 +1,8 @@
 {
   "bkn_finish_interaction": {
     "title": "Finish Interaction",
-    "group_title": "Session Lifecycle"
+    "group_title": "Session Lifecycle",
+    "description": "Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "title": "Start Interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -5,7 +5,7 @@
     "group": "lifecycle",
     "group_title": "会话生命周期",
     "order": 20,
-    "description": "Submit the current Interaction result and final answer. This does not close the Conversation."
+    "description": "结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "name": "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -835,13 +835,14 @@ func TestLifecycleRequestDropsCallerSuppliedOwnerIdentity(t *testing.T) {
 	_, _, body := lifecycleRequest("bkn_start_interaction", map[string]any{
 		"conversation_id":          "conversation-1",
 		"idempotency_key":          "create-1",
+		"lease_seconds":            600,
 		"tenant_id":                "forged-tenant",
 		"business_domain_id":       "forged-domain",
 		"application_principal_id": "forged-app",
 		"effective_subject_id":     "forged-user",
 	})
 	for _, field := range []string{
-		"tenant_id", "business_domain_id", "application_principal_id", "effective_subject_id",
+		"lease_seconds", "tenant_id", "business_domain_id", "application_principal_id", "effective_subject_id",
 	} {
 		if _, exists := body[field]; exists {
 			t.Fatalf("caller-supplied trusted field %s leaked into Core JSON: %#v", field, body)


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Execute the published lifecycle JSON Schema before calling BKN Trace Core.
- [x] Improve `bkn_finish_interaction` descriptions in zh-CN and en-US.
- [x] Add regression tests for invalid arguments, correction guidance, and localized descriptions.

This is a focused follow-up to #1068. It does not change Conversation/Interaction semantics; it makes the existing MCP contract executable and easier for third-party Agents to follow.

## Why

Cursor's three-round trace for Conversation `conv_1c5efeb9b759db1f62c295a26b8b27d8` exposed a gap between the published lifecycle schemas and runtime behavior:

- Query tools carry IDs inside `bkn_context`, while `bkn_finish_interaction` accepts lifecycle fields at the top level.
- Cursor copied the query-tool shape into five finish calls. Those calls failed, but the adapter did not reject the malformed input before routing toward Core.
- All observed start calls also omitted `agent_name`, even though #1068 made it required in the public schema.
- The abandoned terminal state was caused by the existing five-minute TTL, not by malformed finish mutating the Interaction. This PR therefore does not change TTL, force termination, or terminal idempotency.

## Contract Comparison

| Area | Before | After |
| --- | --- | --- |
| Lifecycle input schema | Exposed to MCP clients, but not executed by the lifecycle adapter. | The same schema is compiled once and executed before idempotency generation or any Core request. |
| Invalid required values | Missing/empty `agent_name` or `interaction_id` could reach later processing. | Missing fields, empty required strings, invalid types, invalid enum values, and unsupported fields return `invalid_params` before Core. |
| Misplaced finish context | A copied `bkn_context` shape produced indirect routing errors. | When `bkn_context` is actually supplied to finish, the error says to remove it and pass `interaction_id` as a top-level field. |
| Invalid outcome | Generic downstream failure; the correction path was unclear. | The error lists the four accepted values: `completed`, `failed`, `cancelled`, and `handed_off`. |
| Finish description | Generic English baseline; no complete parameter structure or example. | zh-CN and en-US descriptions positively define top-level fields, outcome values, the conditional `answer` requirement, reply ordering, Conversation lifetime, and one completed example. |

Current zh-CN description:

> 结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{"interaction_id":"int_...","outcome":"completed","answer":"..."}

The normal description intentionally does not mention `bkn_context`: it gives only the correct positive structure. The historical mistake appears only in the targeted error returned when that mistake is present.

## How

- Reuse the existing `github.com/santhosh-tekuri/jsonschema/v6` dependency and promote it from indirect to direct.
- Compile the two lifecycle input schemas once with `sync.OnceValue`.
- Validate arguments immediately after host lifecycle hints and before generated idempotency fields or Core calls.
- Keep the existing `completed`-requires-`answer` business check and all lifecycle semantics unchanged.

Deliberately out of scope:

- accepting both top-level fields and `bkn_context`;
- `force` termination or TTL changes;
- terminal idempotency changes;
- making `reason` mandatory;
- multiple examples for every outcome.

## Testing

- [x] `make test` — complete `agent-retrieval` module passed.
- [x] `go test ./server/driveradapters/mcp -count=1` — passed again after applying the commit to the latest `origin/main`.
- [x] `go vet ./server/driveradapters/mcp/...` — passed.
- [x] `git diff --check origin/main...HEAD` — passed.
- [ ] `golangci-lint` — not installed in the local environment; CI remains authoritative.

Regression coverage proves invalid lifecycle arguments return before any Core HTTP call and locks the exact correction messages and localized finish descriptions.

## Risk & Rollback

- Potential risk: callers that previously relied on the runtime ignoring the published `additionalProperties: false` contract will now receive `invalid_params`. The error is non-mutating and retryable by correcting the call shape.
- Rollback: revert commit `285841bc8`; no database, Core API, TTL, or persisted-state migration is involved.

## Additional Notes

- Independent code review found no Critical, Important, or Minor blocking issues.
- The implementation is intentionally limited to the MCP lifecycle adapter; it does not modify BKN modeling, query tools, or BKN Trace Core.
