### PR TITLE
fix(context-loader): backport lifecycle argument validation to 0.1.4

### DIFF
--- a/adp/context-loader/agent-retrieval/go.mod
+++ b/adp/context-loader/agent-retrieval/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.3
 	github.com/openbkn-ai/licverify v0.5.0
 	github.com/pkg/errors v0.9.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/viper v1.21.0
 	github.com/toon-format/toon-go v0.0.0-20251202084852-7ca0e27c4e8c
@@ -25,7 +26,6 @@ require (
 
 require (
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 )
 
 require (

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
@@ -129,7 +129,7 @@ func TestStartInteractionRetryUsesStableHostHintsAcrossTransportSessions(t *test
 		request := mcpsdk.CallToolRequest{
 			Header: http.Header{"Mcp-Session-Id": []string{transportSession}},
 			Params: mcpsdk.CallToolParams{
-				Arguments: map[string]any{"question": "查询库存"},
+				Arguments: map[string]any{"question": "查询库存", "agent_name": "供应链分析助手"},
 				Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 					hostConversationKeyMeta: "cursor-chat-1",
 					clientInvocationIDMeta:  "cursor-call-1",
@@ -184,6 +184,7 @@ func TestStartInteractionRejectsConversationThatConflictsWithHostMapping(t *test
 		Arguments: map[string]any{
 			"conversation_id": "conv-model-supplied",
 			"question":        "查询库存",
+			"agent_name":      "供应链分析助手",
 		},
 		Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 			hostConversationKeyMeta: "cursor-chat-1",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -193,6 +193,9 @@ func handleLifecycleTool(
 			}), nil
 		}
 		args := req.GetArguments()
+		if validationErr := validateLifecycleArguments(name, args); validationErr != nil {
+			return lifecycleToolError(*validationErr), nil
+		}
 		ensureLifecycleIdempotency(ctx, name, args, hints)
 		if name == "bkn_start_interaction" {
 			args["request_hash"] = strings.TrimPrefix(hashBytes([]byte(stringValue(args["question"]))), "sha256:")
@@ -398,7 +401,7 @@ func lifecycleRequest(name string, args map[string]any) (string, string, map[str
 	case "bkn_start_interaction":
 		conversationID := url.PathEscape(stringValue(args["conversation_id"]))
 		return http.MethodPost, "/conversations/" + conversationID + "/interactions",
-			copyArgs(args, "idempotency_key", "request_hash", "agent_name", "lease_seconds")
+			copyArgs(args, "idempotency_key", "request_hash", "agent_name")
 	case "bkn_finish_interaction":
 		interactionID := url.PathEscape(stringValue(args["interaction_id"]))
 		return http.MethodPost, "/interactions/" + interactionID + "/finish",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -132,6 +132,97 @@ func lifecycleAdapterJSONResponse(status int, value any) *http.Response {
 	}
 }
 
+func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
+	tests := []struct {
+		name        string
+		toolName    string
+		args        map[string]any
+		wantMessage string
+	}{
+		{
+			name: "start without agent name", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存"},
+			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+		},
+		{
+			name: "start with empty agent name", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": ""},
+			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+		},
+		{
+			name: "finish with lifecycle IDs nested in bkn context", toolName: "bkn_finish_interaction",
+			args: map[string]any{
+				"bkn_context": map[string]any{
+					"conversation_id": "conv-1", "interaction_id": "int-1",
+				},
+				"outcome": "completed", "answer": "库存充足",
+			},
+			wantMessage: "bkn_finish_interaction requires interaction_id as a top-level field; remove bkn_context and retry",
+		},
+		{
+			name: "finish with unsupported outcome", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "abandoned"},
+			wantMessage: "bkn_finish_interaction outcome must be one of: completed, failed, cancelled, handed_off",
+		},
+		{
+			name: "finish with empty interaction id", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "", "outcome": "failed"},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+		{
+			name: "finish with caller-owned claims", toolName: "bkn_finish_interaction",
+			args: map[string]any{
+				"interaction_id": "int-1", "outcome": "completed", "answer": "库存充足",
+				"claims": []any{map[string]any{"claim_id": "caller-owned"}},
+			},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coreCalls := 0
+			client := &http.Client{Transport: lifecycleAdapterRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				coreCalls++
+				return lifecycleAdapterJSONResponse(http.StatusInternalServerError, map[string]any{}), nil
+			})}
+			ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{
+				RequestID: "req-invalid-lifecycle-arguments", TenantID: "tenant-1", BusinessDomain: "domain-1",
+			})
+			ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+				AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+			})
+
+			result, err := handleLifecycleTool(
+				bkntrace.NewLifecycleClient("http://bkn-trace.test", client), test.toolName,
+			)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: test.args}})
+			if err != nil {
+				t.Fatalf("invalid lifecycle arguments returned handler error: %v", err)
+			}
+			if !result.IsError {
+				t.Fatalf("invalid lifecycle arguments unexpectedly succeeded: %#v", result)
+			}
+			if coreCalls != 0 {
+				t.Fatalf("invalid lifecycle arguments reached Core %d times", coreCalls)
+			}
+			textContent, ok := mcpsdk.AsTextContent(result.Content[0])
+			if !ok {
+				t.Fatalf("invalid lifecycle error is not text: %#v", result.Content)
+			}
+			var envelope map[string]any
+			if err := json.Unmarshal([]byte(textContent.Text), &envelope); err != nil {
+				t.Fatalf("decode invalid lifecycle error: %v", err)
+			}
+			errorValue := envelope["error"].(map[string]any)
+			if errorValue["code"] != "invalid_params" ||
+				errorValue["required_action"] != "correct_tool_arguments" ||
+				errorValue["message"] != test.wantMessage {
+				t.Fatalf("invalid lifecycle error lacks correction guidance: %#v", errorValue)
+			}
+		})
+	}
+}
+
 func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEvidence(t *testing.T) {
 	createdAt := time.Date(2026, 8, 3, 6, 30, 0, 123000000, time.UTC)
 	var artifact map[string]any
@@ -176,7 +267,7 @@ func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEviden
 		bkntrace.NewLifecycleClient(backend.URL, backend.Client()),
 		"bkn_start_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
-		"conversation_id": "conv-1", "question": "查询 BOM",
+		"conversation_id": "conv-1", "question": "查询 BOM", "agent_name": "供应链分析助手",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("start interaction failed: result=%#v err=%v", result, err)
@@ -243,17 +334,13 @@ func TestFinishInteractionUsesCoreUpdatedAtForServerOwnedResultEvidence(t *testi
 		"bkn_finish_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
 		"interaction_id": "int-1", "outcome": "completed",
-		"idempotency_key": "complete-1", "answer": "BOM 查询完成",
-		"claims": []any{map[string]any{"claim_id": "caller-owned"}},
+		"answer": "BOM 查询完成",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("complete interaction failed: result=%#v err=%v", result, err)
 	}
 	if got := artifact["observed_at"]; got != updatedAt.Format(time.RFC3339Nano) {
 		t.Fatalf("result artifact observed_at=%v, want Core updated_at %s", got, updatedAt.Format(time.RFC3339Nano))
-	}
-	if _, forwarded := finishBody["claims"]; forwarded {
-		t.Fatalf("ordinary MCP finish forwarded caller-owned claims: %#v", finishBody)
 	}
 }
 
@@ -303,7 +390,7 @@ func TestFinishInteractionRetryReusesCommittedResultArtifact(t *testing.T) {
 		"bkn_finish_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
 		"interaction_id": "int-1", "outcome": "completed",
-		"idempotency_key": "complete-1", "answer": "BOM 查询完成",
+		"answer": "BOM 查询完成",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("terminal retry failed: result=%#v err=%v", result, err)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -150,6 +150,13 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
 		},
 		{
+			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",
+			args: map[string]any{
+				"question": "查询库存", "agent_name": "供应链分析助手", "lease_seconds": 600,
+			},
+			wantMessage: "bkn_start_interaction received unsupported field(s): lease_seconds. Remove them and retry",
+		},
+		{
 			name: "finish with lifecycle IDs nested in bkn context", toolName: "bkn_finish_interaction",
 			args: map[string]any{
 				"bkn_context": map[string]any{
@@ -175,7 +182,7 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 				"interaction_id": "int-1", "outcome": "completed", "answer": "库存充足",
 				"claims": []any{map[string]any{"claim_id": "caller-owned"}},
 			},
-			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+			wantMessage: "bkn_finish_interaction received unsupported field(s): claims. Remove them and retry",
 		},
 	}
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -1,0 +1,93 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mcp
+
+import (
+	"encoding/json"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Schema {
+	result := make(map[string]*jsonschema.Schema, len(lifecycleToolNames))
+	for name := range lifecycleToolNames {
+		input, _ := loadToolSchemas(name)
+		var document any
+		if err := json.Unmarshal(input, &document); err != nil {
+			panic("invalid lifecycle input schema for " + name + ": " + err.Error())
+		}
+		compiler := jsonschema.NewCompiler()
+		compiler.DefaultDraft(jsonschema.Draft7)
+		if err := compiler.AddResource("schema.json", document); err != nil {
+			panic("cannot register lifecycle input schema for " + name + ": " + err.Error())
+		}
+		schema, err := compiler.Compile("schema.json")
+		if err != nil {
+			panic("cannot compile lifecycle input schema for " + name + ": " + err.Error())
+		}
+		result[name] = schema
+	}
+	return result
+})
+
+func validateLifecycleArguments(name string, arguments map[string]any) *lifecycleError {
+	if name == "bkn_finish_interaction" {
+		if _, nested := arguments["bkn_context"]; nested {
+			return invalidLifecycleArguments(
+				"bkn_finish_interaction requires interaction_id as a top-level field; remove bkn_context and retry",
+			)
+		}
+		if outcome, present := arguments["outcome"]; present && !validFinishOutcome(outcome) {
+			return invalidLifecycleArguments(
+				"bkn_finish_interaction outcome must be one of: " + strings.Join(finishInteractionOutcomes, ", "),
+			)
+		}
+	}
+	schema, ok := lifecycleArgumentSchemas()[name]
+	if !ok {
+		return nil
+	}
+	if err := schema.Validate(arguments); err == nil {
+		return nil
+	}
+	return invalidLifecycleArguments(lifecycleArgumentGuidance(name))
+}
+
+func invalidLifecycleArguments(message string) *lifecycleError {
+	return &lifecycleError{
+		Code:           "invalid_params",
+		Message:        message,
+		RequiredAction: "correct_tool_arguments",
+	}
+}
+
+func validFinishOutcome(value any) bool {
+	outcome, ok := value.(string)
+	if !ok {
+		return false
+	}
+	return slices.Contains(finishInteractionOutcomes, outcome)
+}
+
+func lifecycleArgumentGuidance(name string) string {
+	if name == "bkn_start_interaction" {
+		return "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id"
+	}
+	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -17,11 +17,13 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 )
 
 var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Schema {
@@ -65,8 +67,38 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 	}
 	if err := schema.Validate(arguments); err == nil {
 		return nil
+	} else if fields := unsupportedLifecycleArgumentFields(err); len(fields) > 0 {
+		return invalidLifecycleArguments(
+			name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
+		)
 	}
 	return invalidLifecycleArguments(lifecycleArgumentGuidance(name))
+}
+
+func unsupportedLifecycleArgumentFields(err error) []string {
+	var root *jsonschema.ValidationError
+	if !errors.As(err, &root) {
+		return nil
+	}
+	fields := make(map[string]struct{})
+	var visit func(*jsonschema.ValidationError)
+	visit = func(validationErr *jsonschema.ValidationError) {
+		if additional, ok := validationErr.ErrorKind.(*kind.AdditionalProperties); ok {
+			for _, field := range additional.Properties {
+				fields[field] = struct{}{}
+			}
+		}
+		for _, cause := range validationErr.Causes {
+			visit(cause)
+		}
+	}
+	visit(root)
+	result := make([]string, 0, len(fields))
+	for field := range fields {
+		result = append(result, field)
+	}
+	slices.Sort(result)
+	return result
 }
 
 func invalidLifecycleArguments(message string) *lifecycleError {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -192,6 +192,30 @@ func TestStartInteractionDescriptionGuidesStableAgentIdentity(t *testing.T) {
 	}
 }
 
+func TestFinishInteractionDescriptionShowsTopLevelCompletedExample(t *testing.T) {
+	tests := []struct {
+		locale string
+		want   string
+	}{
+		{
+			locale: "zh-CN",
+			want:   `结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+		},
+		{
+			locale: "en-US",
+			want:   `Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.locale, func(t *testing.T) {
+			if got := loadMCPLocaleBundle(test.locale).ToolMeta("bkn_finish_interaction").Description; got != test.want {
+				t.Fatalf("finish description for %s = %q, want %q", test.locale, got, test.want)
+			}
+		})
+	}
+}
+
 func getNestedString(root map[string]any, path []string) (string, bool) {
 	var current any = root
 	for _, segment := range path {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -99,6 +99,8 @@ func loadToolSchemas(toolKey string) (input, output json.RawMessage) {
 	return wrapper.InputSchema, wrapper.OutputSchema
 }
 
+var finishInteractionOutcomes = []string{"completed", "failed", "cancelled", "handed_off"}
+
 func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, bool) {
 	if _, ok := lifecycleToolNames[toolKey]; !ok {
 		return nil, nil, false
@@ -108,23 +110,25 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	switch toolKey {
 	case "bkn_start_interaction":
 		properties["conversation_id"] = map[string]any{
-			"type": "string", "description": "Omit on the first turn; otherwise reuse the ID returned by start.",
+			"type":        "string",
+			"description": "Omit on the first turn; otherwise reuse the ID returned by start.",
 		}
 		properties["question"] = map[string]any{
-			"type": "string", "description": "Use the user's question for this turn.",
+			"type": "string", "minLength": 1, "description": "Use the user's question for this turn.",
 		}
 		required = append(required, "question")
 		properties["agent_name"] = map[string]any{
-			"type": "string", "maxLength": 128,
+			"type": "string", "minLength": 1, "maxLength": 128,
 			"description": "The current Agent's stable name. Provide the same value on every call in the same conversation_id.",
 		}
 		required = append(required, "agent_name")
 	case "bkn_finish_interaction":
 		properties["interaction_id"] = map[string]any{
-			"type": "string", "description": "Use the exact interaction_id returned by start.",
+			"type": "string", "minLength": 1,
+			"description": "Use the exact interaction_id returned by start.",
 		}
 		required = append(required, "interaction_id")
-		properties["outcome"] = enumSchema("completed", "failed", "cancelled", "handed_off")
+		properties["outcome"] = enumSchema(finishInteractionOutcomes...)
 		properties["outcome"].(map[string]any)["description"] = "Set the final outcome for this turn."
 		required = append(required, "outcome")
 		properties["answer"] = map[string]any{

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -1,7 +1,8 @@
 {
   "bkn_finish_interaction": {
     "title": "Finish Interaction",
-    "group_title": "Session Lifecycle"
+    "group_title": "Session Lifecycle",
+    "description": "Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "title": "Start Interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -5,7 +5,7 @@
     "group": "lifecycle",
     "group_title": "会话生命周期",
     "order": 20,
-    "description": "Submit the current Interaction result and final answer. This does not close the Conversation."
+    "description": "结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "name": "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -835,13 +835,14 @@ func TestLifecycleRequestDropsCallerSuppliedOwnerIdentity(t *testing.T) {
 	_, _, body := lifecycleRequest("bkn_start_interaction", map[string]any{
 		"conversation_id":          "conversation-1",
 		"idempotency_key":          "create-1",
+		"lease_seconds":            600,
 		"tenant_id":                "forged-tenant",
 		"business_domain_id":       "forged-domain",
 		"application_principal_id": "forged-app",
 		"effective_subject_id":     "forged-user",
 	})
 	for _, field := range []string{
-		"tenant_id", "business_domain_id", "application_principal_id", "effective_subject_id",
+		"lease_seconds", "tenant_id", "business_domain_id", "application_principal_id", "effective_subject_id",
 	} {
 		if _, exists := body[field]; exists {
 			t.Fatalf("caller-supplied trusted field %s leaked into Core JSON: %#v", field, body)


### PR DESCRIPTION
## What Changed

- [x] Backport the merged #1108 lifecycle argument validation to release/0.1.4.

## Why

release/0.1.4 was cut at 2026-08-21 23:30 CST; #1108 merged at 2026-08-22 07:40 CST, so this release branch does not contain the fix.

## How

- Cherry-picked the final merged #1108 commit onto origin/release/0.1.4.
- The release branch already contains #1068, the required lifecycle-instruction predecessor.

## Testing

- [x] go test ./server/driveradapters/mcp -count=1
- [x] make test (agent-retrieval)
- [x] go vet ./server/driveradapters/mcp/...
- [x] git diff --check origin/release/0.1.4...HEAD

## Risk & Rollback

- Same intentional MCP input-contract tightening as #1108; no database or schema migration.
- Revert the single backport commit to roll back.
