### PR TITLE
feat(deploy): add bkn-foundry 0.1.4 release manifest

### DIFF
--- a/deploy/release-manifests/0.1.4/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.4/bkn-foundry.yaml
@@ -1,0 +1,58 @@
+# Release lockfile for bkn-foundry 0.1.4 — pins the chart version of every
+# component that makes up the product. Consumed by:
+#     deploy.sh openbkn install --version=0.1.4
+# All charts are published at 0.1.4 by the v0.1.4 tag build.
+apiVersion: deploy.openbkn.ai/v0.1.4
+kind: VersionSet
+product: bkn-foundry
+version: 0.1.4
+source:
+  type: oci
+  registry: oci://ghcr.io/openbkn-ai/charts
+releases:
+  core-data-migrator:
+    chart: core-data-migrator
+    version: 0.1.4-release
+    stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: 0.1.4-release
+  mf-model-manager:
+    chart: mf-model-manager
+    version: 0.1.4-release
+  mf-model-api:
+    chart: mf-model-api
+    version: 0.1.4-release
+  vega-backend:
+    chart: vega-backend
+    version: 0.1.4-release
+  bkn-backend:
+    chart: bkn-backend
+    version: 0.1.4-release
+  ontology-query:
+    chart: ontology-query
+    version: 0.1.4-release
+  agent-operator-integration:
+    chart: agent-operator-integration
+    version: 0.1.4-release
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: 0.1.4-release
+  sandbox:
+    chart: sandbox
+    version: 0.1.4-release
+  agent-retrieval:
+    chart: agent-retrieval
+    version: 0.1.4-release
+  bkn-agent:
+    chart: bkn-agent
+    version: 0.1.4-release
+  agent-observability:
+    chart: agent-observability
+    version: 0.1.4-release
+  otelcol-contrib:
+    chart: otelcol-contrib
+    version: 0.1.4-release
+  bkn-studio:
+    chart: bkn-studio
+    version: 0.1.4-release


### PR DESCRIPTION
Add the 0.1.4 release lockfile for bkn-foundry deployment.

- Pin all product charts to version 0.1.4-release
- Register the 0.1.4 VersionSet and OCI chart registry
- Include bkn-studio in the release composition

# Pull Request

## What Changed

Add the release manifest for bkn-foundry version 0.1.4.

- [x] Add the bkn-foundry 0.1.4 release lockfile
- [x] Pin product charts to version 0.1.4-release
- [x] Include bkn-studio in the release composition
- [ ] Docs/doc 1

---

## Why

- Related Issue: N/A — release preparation
- Related Feature: BKN Foundry 0.1.4 Release
- Background: Provide a versioned deployment manifest for installing the 0.1.4 release from the OCI chart registry.

---

## How

- Key implementation points:
  - Add `deploy/release-manifests/0.1.4/bkn-foundry.yaml`.
  - Define the 0.1.4 `VersionSet`.
  - Pin all component charts to `0.1.4-release`.
  - Configure the OCI registry as the chart source.
- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Not run; this change only adds a release configuration manifest.

---

## Risk & Rollback

- Potential risks:
  - Installation may fail if one of the pinned `0.1.4-release` charts is unavailable or incorrectly published.
- Rollback plan:
  - Remove the `0.1.4` release manifest or use the previous `0.1.3` release manifest.

---

## Additional Notes

- This PR should be labeled `by-agent`.