### PR TITLE
fix(context-loader): backport lifecycle contract to 0.1.4

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
@@ -43,7 +43,7 @@ func TestStartInteractionSchemaRequiresQuestionAndAgentName(t *testing.T) {
 	if err := json.Unmarshal(input, &schema); err != nil {
 		t.Fatal(err)
 	}
-	if !sameStringSet(schema.Required, []string{"question", "agent_name", "conversation_mode"}) {
+	if !sameStringSet(schema.Required, []string{"question", "agent_name"}) {
 		t.Fatalf("start required fields = %v", schema.Required)
 	}
 	want := []string{"agent_name", "conversation_id", "conversation_mode", "question"}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
@@ -43,7 +43,7 @@ func TestStartInteractionSchemaRequiresQuestionAndAgentName(t *testing.T) {
 	if err := json.Unmarshal(input, &schema); err != nil {
 		t.Fatal(err)
 	}
-	if !sameStringSet(schema.Required, []string{"question", "agent_name"}) {
+	if !sameStringSet(schema.Required, []string{"question", "agent_name", "conversation_mode"}) {
 		t.Fatalf("start required fields = %v", schema.Required)
 	}
 	want := []string{"agent_name", "conversation_id", "conversation_mode", "question"}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/agent_lifecycle_facade_test.go
@@ -43,10 +43,10 @@ func TestStartInteractionSchemaRequiresQuestionAndAgentName(t *testing.T) {
 	if err := json.Unmarshal(input, &schema); err != nil {
 		t.Fatal(err)
 	}
-	if !sameStringSet(schema.Required, []string{"question", "agent_name"}) {
+	if !sameStringSet(schema.Required, []string{"question", "agent_name", "conversation_mode"}) {
 		t.Fatalf("start required fields = %v", schema.Required)
 	}
-	want := []string{"agent_name", "conversation_id", "question"}
+	want := []string{"agent_name", "conversation_id", "conversation_mode", "question"}
 	got := make([]string, 0, len(schema.Properties))
 	for name := range schema.Properties {
 		got = append(got, name)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/host_lifecycle_hints_test.go
@@ -129,7 +129,7 @@ func TestStartInteractionRetryUsesStableHostHintsAcrossTransportSessions(t *test
 		request := mcpsdk.CallToolRequest{
 			Header: http.Header{"Mcp-Session-Id": []string{transportSession}},
 			Params: mcpsdk.CallToolParams{
-				Arguments: map[string]any{"question": "查询库存", "agent_name": "供应链分析助手"},
+				Arguments: map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new"},
 				Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 					hostConversationKeyMeta: "cursor-chat-1",
 					clientInvocationIDMeta:  "cursor-call-1",
@@ -182,9 +182,10 @@ func TestStartInteractionRejectsConversationThatConflictsWithHostMapping(t *test
 		"bkn_start_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{
 		Arguments: map[string]any{
-			"conversation_id": "conv-model-supplied",
-			"question":        "查询库存",
-			"agent_name":      "供应链分析助手",
+			"conversation_id":   "conv-model-supplied",
+			"question":          "查询库存",
+			"agent_name":        "供应链分析助手",
+			"conversation_mode": "continue",
 		},
 		Meta: &mcpsdk.Meta{AdditionalFields: map[string]any{
 			hostConversationKeyMeta: "cursor-chat-1",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -201,7 +201,7 @@ func handleLifecycleTool(
 			args["request_hash"] = strings.TrimPrefix(hashBytes([]byte(stringValue(args["question"]))), "sha256:")
 		}
 		if name == "bkn_start_interaction" &&
-			(stringValue(args["conversation_mode"]) == "new" || hints.HostConversationKey != "") {
+			(startConversationMode(args) == "new" || hints.HostConversationKey != "") {
 			conversation, result := ensureManagedConversation(ctx, client, hints)
 			if result != nil {
 				return result, nil
@@ -287,6 +287,16 @@ func handleLifecycleTool(
 		}
 		return lifecycleSuccessResult(agentLifecycleView(name, target))
 	}
+}
+
+func startConversationMode(arguments map[string]any) string {
+	if mode := stringValue(arguments["conversation_mode"]); mode != "" {
+		return mode
+	}
+	if stringValue(arguments["conversation_id"]) != "" {
+		return "continue"
+	}
+	return "new"
 }
 
 func ensureManagedConversation(

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -201,7 +201,7 @@ func handleLifecycleTool(
 			args["request_hash"] = strings.TrimPrefix(hashBytes([]byte(stringValue(args["question"]))), "sha256:")
 		}
 		if name == "bkn_start_interaction" &&
-			(startConversationMode(args) == "new" || hints.HostConversationKey != "") {
+			(stringValue(args["conversation_mode"]) == "new" || hints.HostConversationKey != "") {
 			conversation, result := ensureManagedConversation(ctx, client, hints)
 			if result != nil {
 				return result, nil
@@ -287,16 +287,6 @@ func handleLifecycleTool(
 		}
 		return lifecycleSuccessResult(agentLifecycleView(name, target))
 	}
-}
-
-func startConversationMode(arguments map[string]any) string {
-	if mode := stringValue(arguments["conversation_mode"]); mode != "" {
-		return mode
-	}
-	if stringValue(arguments["conversation_id"]) != "" {
-		return "continue"
-	}
-	return "new"
 }
 
 func ensureManagedConversation(

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go
@@ -201,7 +201,7 @@ func handleLifecycleTool(
 			args["request_hash"] = strings.TrimPrefix(hashBytes([]byte(stringValue(args["question"]))), "sha256:")
 		}
 		if name == "bkn_start_interaction" &&
-			(stringValue(args["conversation_id"]) == "" || hints.HostConversationKey != "") {
+			(stringValue(args["conversation_mode"]) == "new" || hints.HostConversationKey != "") {
 			conversation, result := ensureManagedConversation(ctx, client, hints)
 			if result != nil {
 				return result, nil

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -132,26 +132,6 @@ func lifecycleAdapterJSONResponse(status int, value any) *http.Response {
 	}
 }
 
-func TestStartConversationModeKeepsLegacyCallsCompatible(t *testing.T) {
-	tests := []struct {
-		name string
-		args map[string]any
-		want string
-	}{
-		{name: "legacy first question", args: map[string]any{}, want: "new"},
-		{name: "legacy continuation", args: map[string]any{"conversation_id": "conv-1"}, want: "continue"},
-		{name: "explicit new", args: map[string]any{"conversation_mode": "new"}, want: "new"},
-		{name: "explicit continuation", args: map[string]any{"conversation_mode": "continue", "conversation_id": "conv-1"}, want: "continue"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if got := startConversationMode(test.args); got != test.want {
-				t.Fatalf("startConversationMode(%v) = %q, want %q", test.args, got, test.want)
-			}
-		})
-	}
-}
-
 func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -162,22 +142,22 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 		{
 			name: "start without agent name", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "conversation_mode": "new"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "start with empty agent name", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "", "conversation_mode": "new"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "continue without conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue"},
-			wantMessage: "bkn_start_interaction with conversation_mode=continue requires conversation_id",
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
-			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id",
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -93,7 +93,7 @@ func TestStartInteractionWithoutConversationEnsuresManagedConversationFirst(t *t
 		bkntrace.NewLifecycleClient("http://bkn-trace.test", client),
 		"bkn_start_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
-		"question": "查询多层 BOM", "agent_name": "供应链分析助手",
+		"question": "查询多层 BOM", "agent_name": "供应链分析助手", "conversation_mode": "new",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("first start failed: result=%#v err=%v", result, err)
@@ -141,13 +141,23 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 	}{
 		{
 			name: "start without agent name", toolName: "bkn_start_interaction",
-			args:        map[string]any{"question": "查询库存"},
-			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+			args:        map[string]any{"question": "查询库存", "conversation_mode": "new"},
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "start with empty agent name", toolName: "bkn_start_interaction",
-			args:        map[string]any{"question": "查询库存", "agent_name": ""},
-			wantMessage: "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id",
+			args:        map[string]any{"question": "查询库存", "agent_name": "", "conversation_mode": "new"},
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+		},
+		{
+			name: "continue without conversation id", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue"},
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+		},
+		{
+			name: "new with conversation id", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",
@@ -274,7 +284,7 @@ func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEviden
 		bkntrace.NewLifecycleClient(backend.URL, backend.Client()),
 		"bkn_start_interaction",
 	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
-		"conversation_id": "conv-1", "question": "查询 BOM", "agent_name": "供应链分析助手",
+		"conversation_id": "conv-1", "conversation_mode": "continue", "question": "查询 BOM", "agent_name": "供应链分析助手",
 	}}})
 	if err != nil || result.IsError {
 		t.Fatalf("start interaction failed: result=%#v err=%v", result, err)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -132,6 +132,26 @@ func lifecycleAdapterJSONResponse(status int, value any) *http.Response {
 	}
 }
 
+func TestStartConversationModeKeepsLegacyCallsCompatible(t *testing.T) {
+	tests := []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{name: "legacy first question", args: map[string]any{}, want: "new"},
+		{name: "legacy continuation", args: map[string]any{"conversation_id": "conv-1"}, want: "continue"},
+		{name: "explicit new", args: map[string]any{"conversation_mode": "new"}, want: "new"},
+		{name: "explicit continuation", args: map[string]any{"conversation_mode": "continue", "conversation_id": "conv-1"}, want: "continue"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := startConversationMode(test.args); got != test.want {
+				t.Fatalf("startConversationMode(%v) = %q, want %q", test.args, got, test.want)
+			}
+		})
+	}
+}
+
 func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -142,22 +162,22 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 		{
 			name: "start without agent name", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "conversation_mode": "new"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it",
 		},
 		{
 			name: "start with empty agent name", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "", "conversation_mode": "new"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it",
 		},
 		{
 			name: "continue without conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction with conversation_mode=continue requires conversation_id",
 		},
 		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -231,7 +231,7 @@ func TestStartInteractionRequiresBoundedStableAgentName(t *testing.T) {
 	}
 }
 
-func TestLifecycleSchemasSupportExplicitAndLegacyStartModesAndCompletedAnswer(t *testing.T) {
+func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t *testing.T) {
 	tests := []struct {
 		name string
 		tool string
@@ -249,9 +249,9 @@ func TestLifecycleSchemasSupportExplicitAndLegacyStartModesAndCompletedAnswer(t 
 			want: true,
 		},
 		{
-			name: "legacy start without conversation choice", tool: "bkn_start_interaction",
+			name: "missing conversation choice", tool: "bkn_start_interaction",
 			args: map[string]any{"question": "查询库存", "agent_name": "supply-chain-analyst"},
-			want: true,
+			want: false,
 		},
 		{
 			name: "continue without conversation", tool: "bkn_start_interaction",
@@ -432,7 +432,7 @@ func TestLifecycleSwaggerPathsRequestsAndResponsesAreStructurallyFrozen(t *testi
 
 func TestLifecycleMCPInputRequiredFieldsFollowAgentFacadeContract(t *testing.T) {
 	expected := map[string][]string{
-		"bkn_start_interaction":  {"question", "agent_name"},
+		"bkn_start_interaction":  {"question", "agent_name", "conversation_mode"},
 		"bkn_finish_interaction": {"interaction_id", "outcome"},
 	}
 	for tool, want := range expected {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -231,9 +231,63 @@ func TestStartInteractionRequiresBoundedStableAgentName(t *testing.T) {
 	}
 }
 
+func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		args map[string]any
+		want bool
+	}{
+		{
+			name: "new conversation", tool: "bkn_start_interaction",
+			args: map[string]any{"question": "查询库存", "agent_name": "supply-chain-analyst", "conversation_mode": "new"},
+			want: true,
+		},
+		{
+			name: "continue conversation", tool: "bkn_start_interaction",
+			args: map[string]any{"question": "继续查询", "agent_name": "supply-chain-analyst", "conversation_mode": "continue", "conversation_id": "conv-1"},
+			want: true,
+		},
+		{
+			name: "missing conversation choice", tool: "bkn_start_interaction",
+			args: map[string]any{"question": "查询库存", "agent_name": "supply-chain-analyst"},
+			want: false,
+		},
+		{
+			name: "continue without conversation", tool: "bkn_start_interaction",
+			args: map[string]any{"question": "继续查询", "agent_name": "supply-chain-analyst", "conversation_mode": "continue"},
+			want: false,
+		},
+		{
+			name: "completed without answer", tool: "bkn_finish_interaction",
+			args: map[string]any{"interaction_id": "int-1", "outcome": "completed"},
+			want: false,
+		},
+		{
+			name: "completed with empty answer", tool: "bkn_finish_interaction",
+			args: map[string]any{"interaction_id": "int-1", "outcome": "completed", "answer": ""},
+			want: false,
+		},
+		{
+			name: "failed without reason", tool: "bkn_finish_interaction",
+			args: map[string]any{"interaction_id": "int-1", "outcome": "failed"},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := validateLifecycleArguments(test.tool, test.args) == nil
+			if got != test.want {
+				t.Fatalf("%s validation = %t, want %t", test.name, got, test.want)
+			}
+		})
+	}
+}
+
 func TestLifecycleInputDescriptionsAreConciseAndActionable(t *testing.T) {
 	wantFields := map[string][]string{
-		"bkn_start_interaction":  {"conversation_id", "question", "agent_name"},
+		"bkn_start_interaction":  {"conversation_id", "conversation_mode", "question", "agent_name"},
 		"bkn_finish_interaction": {"interaction_id", "outcome", "answer", "reason"},
 	}
 	for tool, fields := range wantFields {
@@ -378,7 +432,7 @@ func TestLifecycleSwaggerPathsRequestsAndResponsesAreStructurallyFrozen(t *testi
 
 func TestLifecycleMCPInputRequiredFieldsFollowAgentFacadeContract(t *testing.T) {
 	expected := map[string][]string{
-		"bkn_start_interaction":  {"question", "agent_name"},
+		"bkn_start_interaction":  {"question", "agent_name", "conversation_mode"},
 		"bkn_finish_interaction": {"interaction_id", "outcome"},
 	}
 	for tool, want := range expected {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -231,7 +231,7 @@ func TestStartInteractionRequiresBoundedStableAgentName(t *testing.T) {
 	}
 }
 
-func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t *testing.T) {
+func TestLifecycleSchemasSupportExplicitAndLegacyStartModesAndCompletedAnswer(t *testing.T) {
 	tests := []struct {
 		name string
 		tool string
@@ -249,9 +249,9 @@ func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t
 			want: true,
 		},
 		{
-			name: "missing conversation choice", tool: "bkn_start_interaction",
+			name: "legacy start without conversation choice", tool: "bkn_start_interaction",
 			args: map[string]any{"question": "查询库存", "agent_name": "supply-chain-analyst"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "continue without conversation", tool: "bkn_start_interaction",
@@ -432,7 +432,7 @@ func TestLifecycleSwaggerPathsRequestsAndResponsesAreStructurallyFrozen(t *testi
 
 func TestLifecycleMCPInputRequiredFieldsFollowAgentFacadeContract(t *testing.T) {
 	expected := map[string][]string{
-		"bkn_start_interaction":  {"question", "agent_name", "conversation_mode"},
+		"bkn_start_interaction":  {"question", "agent_name"},
 		"bkn_finish_interaction": {"interaction_id", "outcome"},
 	}
 	for tool, want := range expected {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -49,21 +49,6 @@ var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Sche
 })
 
 func validateLifecycleArguments(name string, arguments map[string]any) *lifecycleError {
-	if name == "bkn_start_interaction" {
-		_, declared := arguments["conversation_mode"]
-		mode := stringValue(arguments["conversation_mode"])
-		conversationID := stringValue(arguments["conversation_id"])
-		if declared && mode == "continue" && conversationID == "" {
-			return invalidLifecycleArguments(
-				"bkn_start_interaction with conversation_mode=continue requires conversation_id",
-			)
-		}
-		if declared && mode == "new" && conversationID != "" {
-			return invalidLifecycleArguments(
-				"bkn_start_interaction with conversation_mode=new must omit conversation_id",
-			)
-		}
-	}
 	if name == "bkn_finish_interaction" {
 		if _, nested := arguments["bkn_context"]; nested {
 			return invalidLifecycleArguments(
@@ -74,9 +59,6 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 			return invalidLifecycleArguments(
 				"bkn_finish_interaction outcome must be one of: " + strings.Join(finishInteractionOutcomes, ", "),
 			)
-		}
-		if stringValue(arguments["outcome"]) == "completed" && stringValue(arguments["answer"]) == "" {
-			return invalidLifecycleArguments("bkn_finish_interaction with outcome=completed requires answer")
 		}
 	}
 	schema, ok := lifecycleArgumentSchemas()[name]
@@ -137,7 +119,7 @@ func validFinishOutcome(value any) bool {
 
 func lifecycleArgumentGuidance(name string) string {
 	if name == "bkn_start_interaction" {
-		return "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it"
+		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -119,7 +119,7 @@ func validFinishOutcome(value any) bool {
 
 func lifecycleArgumentGuidance(name string) string {
 	if name == "bkn_start_interaction" {
-		return "bkn_start_interaction expects top-level question and agent_name, plus optional conversation_id"
+		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -49,6 +49,21 @@ var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Sche
 })
 
 func validateLifecycleArguments(name string, arguments map[string]any) *lifecycleError {
+	if name == "bkn_start_interaction" {
+		_, declared := arguments["conversation_mode"]
+		mode := stringValue(arguments["conversation_mode"])
+		conversationID := stringValue(arguments["conversation_id"])
+		if declared && mode == "continue" && conversationID == "" {
+			return invalidLifecycleArguments(
+				"bkn_start_interaction with conversation_mode=continue requires conversation_id",
+			)
+		}
+		if declared && mode == "new" && conversationID != "" {
+			return invalidLifecycleArguments(
+				"bkn_start_interaction with conversation_mode=new must omit conversation_id",
+			)
+		}
+	}
 	if name == "bkn_finish_interaction" {
 		if _, nested := arguments["bkn_context"]; nested {
 			return invalidLifecycleArguments(
@@ -59,6 +74,9 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 			return invalidLifecycleArguments(
 				"bkn_finish_interaction outcome must be one of: " + strings.Join(finishInteractionOutcomes, ", "),
 			)
+		}
+		if stringValue(arguments["outcome"]) == "completed" && stringValue(arguments["answer"]) == "" {
+			return invalidLifecycleArguments("bkn_finish_interaction with outcome=completed requires answer")
 		}
 	}
 	schema, ok := lifecycleArgumentSchemas()[name]
@@ -119,7 +137,7 @@ func validFinishOutcome(value any) bool {
 
 func lifecycleArgumentGuidance(name string) string {
 	if name == "bkn_start_interaction" {
-		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
+		return "bkn_start_interaction expects top-level agent_name and question; use continue with conversation_id or new without it"
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go
@@ -133,8 +133,11 @@ func TestServerInstructionsLeadWithManagedInteractionLifecycle(t *testing.T) {
 			locale: "zh-CN",
 			lifecycle: []string{
 				"处理每个新的用户问题时",
+				"conversation_mode=new",
+				"conversation_mode=continue",
 				"conversation_id 在整个对话过程中保持不变",
 				"interaction_id 在当前用户问题开始后、回复完成前保持不变",
+				"bkn_context: { conversation_id, interaction_id }",
 				"回复用户前，调用 bkn_finish_interaction",
 				"下一个用户问题会开始新的 Interaction",
 			},
@@ -144,8 +147,11 @@ func TestServerInstructionsLeadWithManagedInteractionLifecycle(t *testing.T) {
 			locale: "en-US",
 			lifecycle: []string{
 				"For each new user question",
+				"conversation_mode=new",
+				"conversation_mode=continue",
 				"conversation_id remains unchanged throughout the conversation",
 				"interaction_id remains unchanged from the start of the current user question until the reply is complete",
+				"bkn_context: { conversation_id, interaction_id }",
 				"Before replying to the user, call bkn_finish_interaction",
 				"The next user question starts a new Interaction",
 			},
@@ -175,11 +181,11 @@ func TestStartInteractionDescriptionGuidesStableAgentIdentity(t *testing.T) {
 	}{
 		{
 			locale: "zh-CN",
-			want:   "为当前用户问题开始一次受管 Interaction。传入完整的用户问题和当前 Agent 的固定名称；首次不传 conversation_id，后续传入当前对话的 conversation_id。返回本轮后续工具调用的 bkn_context 所需的 conversation_id 和 interaction_id。",
+			want:   "为当前用户问题开始一次受管 Interaction。传入完整问题、当前 Agent 名称和 conversation_mode：没有当前受管 Conversation 时用 new 且不传 conversation_id；否则用 continue 并传入上次返回的 conversation_id。宿主提供会话映射时，以其为准。返回本轮 bkn_context 所需的两个 ID。",
 		},
 		{
 			locale: "en-US",
-			want:   "Start a managed Interaction for the current user question. Provide the complete user question and the current Agent's stable name; omit conversation_id on the first turn, then provide the conversation_id for the current conversation. It returns the conversation_id and interaction_id required in bkn_context for subsequent tool calls in this turn.",
+			want:   "Start a managed Interaction for the current user question. Provide the complete question, the current Agent name, and conversation_mode: use new without conversation_id when there is no current managed Conversation; otherwise use continue with the conversation_id returned by the prior start. A host-provided conversation mapping remains authoritative. It returns the two IDs required in bkn_context for this turn.",
 		},
 	}
 
@@ -199,11 +205,11 @@ func TestFinishInteractionDescriptionShowsTopLevelCompletedExample(t *testing.T)
 	}{
 		{
 			locale: "zh-CN",
-			want:   `结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+			want:   `在回复用户前结束当前 Interaction。顶层传入 interaction_id 和 outcome；outcome=completed 时还必须传入最终 answer，其他结果可传 reason。Conversation 可继续使用。示例：{"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
 		},
 		{
 			locale: "en-US",
-			want:   `Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
+			want:   `Finish the current Interaction before replying to the user. Pass interaction_id and outcome as top-level fields; outcome=completed also requires the final answer. Other outcomes may include reason. The Conversation remains available. Example: {"interaction_id":"int_...","outcome":"completed","answer":"..."}`,
 		},
 	}
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -117,7 +117,6 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 			"type": "string", "enum": []string{"continue", "new"},
 			"description": "Use new without conversation_id if no managed Conversation exists; otherwise continue with the ID returned by start.",
 		}
-		required = append(required, "conversation_mode")
 		properties["question"] = map[string]any{
 			"type": "string", "minLength": 1, "description": "Use the user's question for this turn.",
 		}
@@ -148,18 +147,6 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	inputSchema := map[string]any{
 		"type": "object", "properties": properties, "required": required,
 		"additionalProperties": false,
-	}
-	switch toolKey {
-	case "bkn_start_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "continue"}}, "required": []string{"conversation_id"}},
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "new"}}, "not": map[string]any{"required": []string{"conversation_id"}}},
-		}
-	case "bkn_finish_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"outcome": map[string]any{"const": "completed"}}, "required": []string{"answer"}},
-			{"properties": map[string]any{"outcome": map[string]any{"enum": []string{"failed", "cancelled", "handed_off"}}}},
-		}
 	}
 	input, _ := sonic.ConfigStd.Marshal(inputSchema)
 	output, _ := sonic.ConfigStd.Marshal(lifecycleOutputSchema(toolKey))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -117,6 +117,7 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 			"type": "string", "enum": []string{"continue", "new"},
 			"description": "Use new without conversation_id if no managed Conversation exists; otherwise continue with the ID returned by start.",
 		}
+		required = append(required, "conversation_mode")
 		properties["question"] = map[string]any{
 			"type": "string", "minLength": 1, "description": "Use the user's question for this turn.",
 		}
@@ -147,6 +148,18 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	inputSchema := map[string]any{
 		"type": "object", "properties": properties, "required": required,
 		"additionalProperties": false,
+	}
+	switch toolKey {
+	case "bkn_start_interaction":
+		inputSchema["oneOf"] = []map[string]any{
+			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "continue"}}, "required": []string{"conversation_id"}},
+			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "new"}}, "not": map[string]any{"required": []string{"conversation_id"}}},
+		}
+	case "bkn_finish_interaction":
+		inputSchema["oneOf"] = []map[string]any{
+			{"properties": map[string]any{"outcome": map[string]any{"const": "completed"}}, "required": []string{"answer"}},
+			{"properties": map[string]any{"outcome": map[string]any{"enum": []string{"failed", "cancelled", "handed_off"}}}},
+		}
 	}
 	input, _ := sonic.ConfigStd.Marshal(inputSchema)
 	output, _ := sonic.ConfigStd.Marshal(lifecycleOutputSchema(toolKey))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -110,9 +110,14 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	switch toolKey {
 	case "bkn_start_interaction":
 		properties["conversation_id"] = map[string]any{
-			"type":        "string",
-			"description": "Omit on the first turn; otherwise reuse the ID returned by start.",
+			"type": "string", "minLength": 1,
+			"description": "For continue, copy the conversation_id returned by start. Omit for new. A host mapping is authoritative.",
 		}
+		properties["conversation_mode"] = map[string]any{
+			"type": "string", "enum": []string{"continue", "new"},
+			"description": "Use new without conversation_id if no managed Conversation exists; otherwise continue with the ID returned by start.",
+		}
+		required = append(required, "conversation_mode")
 		properties["question"] = map[string]any{
 			"type": "string", "minLength": 1, "description": "Use the user's question for this turn.",
 		}
@@ -132,7 +137,7 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 		properties["outcome"].(map[string]any)["description"] = "Set the final outcome for this turn."
 		required = append(required, "outcome")
 		properties["answer"] = map[string]any{
-			"type": "string", "description": "Provide the final answer when outcome is completed.",
+			"type": "string", "minLength": 1, "description": "Provide the final answer when outcome is completed.",
 		}
 		properties["reason"] = map[string]any{
 			"type": "string", "description": "Briefly explain a non-completed outcome.",
@@ -140,10 +145,23 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 	}
 	// Tool schemas are a byte-stable wire contract: the untouched declaration
 	// must remain identical to the embedded community schema.
-	input, _ := sonic.ConfigStd.Marshal(map[string]any{
+	inputSchema := map[string]any{
 		"type": "object", "properties": properties, "required": required,
 		"additionalProperties": false,
-	})
+	}
+	switch toolKey {
+	case "bkn_start_interaction":
+		inputSchema["oneOf"] = []map[string]any{
+			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "continue"}}, "required": []string{"conversation_id"}},
+			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "new"}}, "not": map[string]any{"required": []string{"conversation_id"}}},
+		}
+	case "bkn_finish_interaction":
+		inputSchema["oneOf"] = []map[string]any{
+			{"properties": map[string]any{"outcome": map[string]any{"const": "completed"}}, "required": []string{"answer"}},
+			{"properties": map[string]any{"outcome": map[string]any{"enum": []string{"failed", "cancelled", "handed_off"}}}},
+		}
+	}
+	input, _ := sonic.ConfigStd.Marshal(inputSchema)
 	output, _ := sonic.ConfigStd.Marshal(lifecycleOutputSchema(toolKey))
 	return input, output, true
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt
@@ -4,17 +4,18 @@ Managed interaction lifecycle:
 
 For each new user question:
 
-1. Call bkn_start_interaction with the complete question.
-   On the first turn, omit conversation_id. On later turns, pass the conversation_id for the current conversation.
+1. Call bkn_start_interaction with the complete question, the current Agent name, and conversation_mode.
+   For the first managed question in this chat, use conversation_mode=new and omit conversation_id.
+   For a later question, use conversation_mode=continue and pass the conversation_id returned previously.
 
 2. This tool returns conversation_id and interaction_id.
    conversation_id remains unchanged throughout the conversation.
    interaction_id remains unchanged from the start of the current user question until the reply is complete.
-   Use both IDs in bkn_context for all other tool calls in this turn.
+   Pass bkn_context: { conversation_id, interaction_id } to every other tool call in this turn.
 
 3. Before replying to the user, call bkn_finish_interaction.
-   For a successful result, use outcome=completed and the final answer.
-   Otherwise, use failed, cancelled, or handed_off and provide the reason.
+   For a successful result, pass outcome=completed and the final answer.
+   Otherwise, use failed, cancelled, or handed_off and optionally provide the reason.
    Then reply to the user.
 
 The next user question starts a new Interaction and continues using the current conversation_id.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -2,12 +2,12 @@
   "bkn_finish_interaction": {
     "title": "Finish Interaction",
     "group_title": "Session Lifecycle",
-    "description": "Finish the Interaction for the current user question, then reply to the user after this call succeeds. Pass interaction_id and outcome (completed, failed, cancelled, or handed_off) as top-level fields. When outcome is completed, answer is required and should contain the final answer to the user; for other outcomes, reason is optional. The Conversation remains available for later questions. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
+    "description": "Finish the current Interaction before replying to the user. Pass interaction_id and outcome as top-level fields; outcome=completed also requires the final answer. Other outcomes may include reason. The Conversation remains available. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "title": "Start Interaction",
     "group_title": "Session Lifecycle",
-    "description": "Start a managed Interaction for the current user question. Provide the complete user question and the current Agent's stable name; omit conversation_id on the first turn, then provide the conversation_id for the current conversation. It returns the conversation_id and interaction_id required in bkn_context for subsequent tool calls in this turn."
+    "description": "Start a managed Interaction for the current user question. Provide the complete question, the current Agent name, and conversation_mode: use new without conversation_id when there is no current managed Conversation; otherwise use continue with the conversation_id returned by the prior start. A host-provided conversation mapping remains authoritative. It returns the two IDs required in bkn_context for this turn."
   },
   "search_schema": {
     "title": "Explore Schema",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/zh-CN/instructions.txt
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/zh-CN/instructions.txt
@@ -10,17 +10,18 @@ ContextLoader 知识网络查询工具集使用指南。
 
 处理每个新的用户问题时：
 
-1. 调用 bkn_start_interaction，传入完整问题。
-   首次不传 conversation_id；后续传入当前对话的 conversation_id。
+1. 调用 bkn_start_interaction，传入完整问题、当前 Agent 名称和 conversation_mode。
+   当前聊天中的首个受管问题使用 conversation_mode=new，不传 conversation_id；
+   后续问题使用 conversation_mode=continue，并传入上一次返回的 conversation_id。
 
 2. 本工具返回 conversation_id 和 interaction_id。
    conversation_id 在整个对话过程中保持不变；
    interaction_id 在当前用户问题开始后、回复完成前保持不变。
-   本轮调用其他工具时，在 bkn_context 中使用这两个 ID。
+   本轮调用其他工具时传入 bkn_context: { conversation_id, interaction_id }。
 
 3. 回复用户前，调用 bkn_finish_interaction。
-   正常完成使用 outcome=completed 和最终答案；
-   未完成时使用 failed、cancelled 或 handed_off，并附原因。
+   正常完成传入 outcome=completed 和最终答案；
+   未完成时传入 failed、cancelled 或 handed_off，并可附原因。
    然后回复用户。
 
 下一个用户问题会开始新的 Interaction，并继续使用当前 conversation_id。

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -5,7 +5,7 @@
     "group": "lifecycle",
     "group_title": "会话生命周期",
     "order": 20,
-    "description": "结束当前用户问题对应的 Interaction，并在成功后再回复用户。直接传入顶层字段 interaction_id 和 outcome（completed、failed、cancelled 或 handed_off）。outcome 为 completed 时必须传入 answer，内容为准备回复用户的最终答案；其他结果可传入 reason。Conversation 不会结束，可供后续问题继续使用。示例：{\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
+    "description": "在回复用户前结束当前 Interaction。顶层传入 interaction_id 和 outcome；outcome=completed 时还必须传入最终 answer，其他结果可传 reason。Conversation 可继续使用。示例：{\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
   },
   "bkn_start_interaction": {
     "name": "bkn_start_interaction",
@@ -13,7 +13,7 @@
     "group": "lifecycle",
     "group_title": "会话生命周期",
     "order": 10,
-    "description": "为当前用户问题开始一次受管 Interaction。传入完整的用户问题和当前 Agent 的固定名称；首次不传 conversation_id，后续传入当前对话的 conversation_id。返回本轮后续工具调用的 bkn_context 所需的 conversation_id 和 interaction_id。"
+    "description": "为当前用户问题开始一次受管 Interaction。传入完整问题、当前 Agent 名称和 conversation_mode：没有当前受管 Conversation 时用 new 且不传 conversation_id；否则用 continue 并传入上次返回的 conversation_id。宿主提供会话映射时，以其为准。返回本轮 bkn_context 所需的两个 ID。"
   },
   "search_schema": {
     "name": "search_schema",

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -9,7 +9,8 @@ info:
     普通 Agent 默认只使用两个受管生命周期工具：`bkn_start_interaction`、
     `bkn_finish_interaction`。每轮 start 都提交完整问题、固定的 `agent_name` 和 `conversation_mode`：没有当前
     Conversation 时用 `new` 且不传 `conversation_id`；按显式 id 延续时用 `continue` 并传入 start 返回的 id。
-    宿主提供会话映射时，以宿主映射为准。finish 只提交当前 Interaction 的
+    宿主提供会话映射时，以宿主映射为准。滚动升级期间，旧调用方可省略 `conversation_mode`，服务端按
+    `conversation_id` 是否存在沿用原有语义。finish 只提交当前 Interaction 的
     结果，不关闭可跨轮、跨日复用的 Conversation。业务工具包括 `search_schema`、
     `query_object_instance`、`query_instance_subgraph`、`get_logic_properties_values`、
     `get_action_info`、`execute_action`、`get_action_execution`、

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -9,8 +9,7 @@ info:
     普通 Agent 默认只使用两个受管生命周期工具：`bkn_start_interaction`、
     `bkn_finish_interaction`。每轮 start 都提交完整问题、固定的 `agent_name` 和 `conversation_mode`：没有当前
     Conversation 时用 `new` 且不传 `conversation_id`；按显式 id 延续时用 `continue` 并传入 start 返回的 id。
-    宿主提供会话映射时，以宿主映射为准。滚动升级期间，旧调用方可省略 `conversation_mode`，服务端按
-    `conversation_id` 是否存在沿用原有语义。finish 只提交当前 Interaction 的
+    宿主提供会话映射时，以宿主映射为准。finish 只提交当前 Interaction 的
     结果，不关闭可跨轮、跨日复用的 Conversation。业务工具包括 `search_schema`、
     `query_object_instance`、`query_instance_subgraph`、`get_logic_properties_values`、
     `get_action_info`、`execute_action`、`get_action_execution`、

--- a/docs/api/context-loader/mcp.yaml
+++ b/docs/api/context-loader/mcp.yaml
@@ -7,8 +7,9 @@ info:
     Desktop 等 MCP 客户端可以直接接入，不必逐个封装 REST 调用。
 
     普通 Agent 默认只使用两个受管生命周期工具：`bkn_start_interaction`、
-    `bkn_finish_interaction`。每轮 start 都提交完整问题和固定的 `agent_name`；首轮由服务内部创建 Conversation，
-    后续轮次复用服务端返回的 `conversation_id`，并传入同一 `agent_name`。finish 只提交当前 Interaction 的
+    `bkn_finish_interaction`。每轮 start 都提交完整问题、固定的 `agent_name` 和 `conversation_mode`：没有当前
+    Conversation 时用 `new` 且不传 `conversation_id`；按显式 id 延续时用 `continue` 并传入 start 返回的 id。
+    宿主提供会话映射时，以宿主映射为准。finish 只提交当前 Interaction 的
     结果，不关闭可跨轮、跨日复用的 Conversation。业务工具包括 `search_schema`、
     `query_object_instance`、`query_instance_subgraph`、`get_logic_properties_values`、
     `get_action_info`、`execute_action`、`get_action_execution`、

--- a/docs/plans/2026-08-22-lifecycle-instruction-contract.md
+++ b/docs/plans/2026-08-22-lifecycle-instruction-contract.md
@@ -1,0 +1,52 @@
+# Lifecycle Instruction Contract Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the ContextLoader MCP lifecycle contract concise, consistent with the explicit start mode, and schema-enforced for completed finishes.
+
+**Architecture:** The MCP adapter continues to own lifecycle schemas and localized tool metadata. `bkn_start_interaction` exposes an explicit `new`/`continue` choice; server instructions translate that choice into a small execution sequence. `bkn_finish_interaction` uses JSON Schema to require the final answer only for `completed`.
+
+**Tech Stack:** Go, JSON Schema Draft 7, embedded MCP locale JSON, Go unit tests.
+
+---
+
+### Task 1: Define the lifecycle wire contract
+
+**Files:**
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go`
+- Test: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go`
+
+1. Add failing tests for required `conversation_mode`, its two start branches, and `completed` requiring `answer`.
+2. Run `go test ./server/driveradapters/mcp -run 'TestLifecycle' -count=1` and confirm failure on the old schema.
+3. Add the smallest `oneOf` branches that express those rules.
+4. Re-run the targeted tests.
+
+### Task 2: Align lifecycle execution and guidance
+
+**Files:**
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter.go`
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go`
+- Test: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go`
+
+1. Add failing tests for `new` creating a Conversation and invalid start branches returning correction guidance before Core.
+2. Make conversation creation depend on `conversation_mode=new`, not an omitted ID.
+3. Re-run focused adapter tests.
+
+### Task 3: Publish concise localized instructions
+
+**Files:**
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/instructions.txt`
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/instructions.txt`
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json`
+- Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json`
+- Test: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/locale_test.go`
+
+1. Add failing locale assertions for the explicit mode mapping and literal `bkn_context` shape.
+2. Replace only lifecycle wording; leave query-routing guidance unchanged.
+3. Re-run locale tests.
+
+### Task 4: Verify and submit
+
+1. Run `gofmt`, targeted MCP tests, `go vet ./server/driveradapters/mcp/...`, `make test`, and `git diff --check`.
+2. Record the pre-existing full-suite race in the PR if it remains.
+3. Commit, push, open the PR with `Closes #1116`, and request review.

--- a/docs/plans/2026-08-22-lifecycle-instruction-contract.md
+++ b/docs/plans/2026-08-22-lifecycle-instruction-contract.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the ContextLoader MCP lifecycle contract concise, consistent with the explicit start mode, and schema-enforced for completed finishes.
 
-**Architecture:** The MCP adapter continues to own lifecycle schemas and localized tool metadata. `bkn_start_interaction` exposes an explicit `new`/`continue` choice for current callers while accepting omitted mode from rolling-upgrade callers and inferring the legacy behavior from `conversation_id`. Server instructions translate the explicit choice into a small execution sequence. `bkn_finish_interaction` validates a final answer for `completed` before it reaches Core.
+**Architecture:** The MCP adapter continues to own lifecycle schemas and localized tool metadata. `bkn_start_interaction` exposes an explicit `new`/`continue` choice; server instructions translate that choice into a small execution sequence. `bkn_finish_interaction` uses JSON Schema to require the final answer only for `completed`.
 
 **Tech Stack:** Go, JSON Schema Draft 7, embedded MCP locale JSON, Go unit tests.
 
@@ -16,7 +16,7 @@
 - Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go`
 - Test: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go`
 
-1. Add failing tests for the explicit `conversation_mode` branches, legacy omitted-mode compatibility, and `completed` requiring `answer`.
+1. Add failing tests for required `conversation_mode`, its two start branches, and `completed` requiring `answer`.
 2. Run `go test ./server/driveradapters/mcp -run 'TestLifecycle' -count=1` and confirm failure on the old schema.
 3. Add the smallest `oneOf` branches that express those rules.
 4. Re-run the targeted tests.

--- a/docs/plans/2026-08-22-lifecycle-instruction-contract.md
+++ b/docs/plans/2026-08-22-lifecycle-instruction-contract.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make the ContextLoader MCP lifecycle contract concise, consistent with the explicit start mode, and schema-enforced for completed finishes.
 
-**Architecture:** The MCP adapter continues to own lifecycle schemas and localized tool metadata. `bkn_start_interaction` exposes an explicit `new`/`continue` choice; server instructions translate that choice into a small execution sequence. `bkn_finish_interaction` uses JSON Schema to require the final answer only for `completed`.
+**Architecture:** The MCP adapter continues to own lifecycle schemas and localized tool metadata. `bkn_start_interaction` exposes an explicit `new`/`continue` choice for current callers while accepting omitted mode from rolling-upgrade callers and inferring the legacy behavior from `conversation_id`. Server instructions translate the explicit choice into a small execution sequence. `bkn_finish_interaction` validates a final answer for `completed` before it reaches Core.
 
 **Tech Stack:** Go, JSON Schema Draft 7, embedded MCP locale JSON, Go unit tests.
 
@@ -16,7 +16,7 @@
 - Modify: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go`
 - Test: `adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go`
 
-1. Add failing tests for required `conversation_mode`, its two start branches, and `completed` requiring `answer`.
+1. Add failing tests for the explicit `conversation_mode` branches, legacy omitted-mode compatibility, and `completed` requiring `answer`.
 2. Run `go test ./server/driveradapters/mcp -run 'TestLifecycle' -count=1` and confirm failure on the old schema.
 3. Add the smallest `oneOf` branches that express those rules.
 4. Re-run the targeted tests.

--- a/help/en/manual/context-loader.md
+++ b/help/en/manual/context-loader.md
@@ -85,6 +85,12 @@ Once configured, MCP clients can discover and call these tools (your deployment 
 
 Every tool call requires `kn_id` (knowledge network ID). Use `openbkn bkn list` to find it.
 
+For a managed session, call `bkn_start_interaction` first: use `conversation_mode=new` without
+`conversation_id` when there is no current Conversation; use `conversation_mode=continue` with
+the `conversation_id` returned by the prior start to continue one. Pass the returned `bkn_context`
+to all business tools, then call `bkn_finish_interaction` before replying. A host-provided
+conversation mapping remains authoritative.
+
 ### Verify with CLI
 
 You can verify the MCP server without configuring a full MCP client. There is no global "current KN" setting — `kn-id` is a positional argument on every command:

--- a/help/zh/manual/context-loader.md
+++ b/help/zh/manual/context-loader.md
@@ -89,6 +89,11 @@ Token 可通过 `openbkn auth token` 命令获取。配置保存后，Cursor 会
 
 每个工具调用需要 `kn_id`（知识网络 ID），可用 `openbkn bkn list` 获取。
 
+受管会话先调用 `bkn_start_interaction`：没有当前 Conversation 时传
+`conversation_mode=new`，不传 `conversation_id`；延续当前对话时传
+`conversation_mode=continue` 和上次返回的 `conversation_id`。随后所有业务工具传入 start
+返回的 `bkn_context`，回复用户前调用 `bkn_finish_interaction`。宿主提供会话映射时，以宿主映射为准。
+
 ### 使用 CLI 探测
 
 不配置 MCP 客户端也能用 CLI 验证服务是否正常。CLI 没有「当前知识网络」这种全局配置，`kn-id` 是每条命令的位置参数：

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -82,6 +82,11 @@ def _credential() -> Optional[str]:
     return caller_token()
 
 
+def _declares_conversation_mode(tool: Any) -> bool:
+    schema = getattr(tool, "args_schema", None)
+    return isinstance(schema, dict) and "conversation_mode" in schema.get("properties", {})
+
+
 # The server groups turns into one managed conversation by this key. Without it
 # every turn mints a new one, so a multi-turn conversation is stored as N
 # separate sessions holding one interaction each, and they cannot be merged
@@ -246,7 +251,9 @@ async def open_session(
         # bkn-agent has no local conversation_id to resume. A chat supplies a
         # host key, which the lifecycle service resolves authoritatively; a
         # one-shot execution intentionally starts without a prior conversation.
-        args = {"question": question or "(not provided)", "conversation_mode": "new"}
+        args = {"question": question or "(not provided)"}
+        if _declares_conversation_mode(start):
+            args["conversation_mode"] = "new"
         if agent_name:
             args["agent_name"] = agent_name[:128]
         raw = await start.coroutine(**args)

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -243,7 +243,10 @@ async def open_session(
         return None
 
     try:
-        args = {"question": question or "(not provided)"}
+        # bkn-agent has no local conversation_id to resume. A chat supplies a
+        # host key, which the lifecycle service resolves authoritatively; a
+        # one-shot execution intentionally starts without a prior conversation.
+        args = {"question": question or "(not provided)", "conversation_mode": "new"}
         if agent_name:
             args["agent_name"] = agent_name[:128]
         raw = await start.coroutine(**args)

--- a/infra/bkn-agent/app/core/context_loader.py
+++ b/infra/bkn-agent/app/core/context_loader.py
@@ -82,11 +82,6 @@ def _credential() -> Optional[str]:
     return caller_token()
 
 
-def _declares_conversation_mode(tool: Any) -> bool:
-    schema = getattr(tool, "args_schema", None)
-    return isinstance(schema, dict) and "conversation_mode" in schema.get("properties", {})
-
-
 # The server groups turns into one managed conversation by this key. Without it
 # every turn mints a new one, so a multi-turn conversation is stored as N
 # separate sessions holding one interaction each, and they cannot be merged
@@ -251,9 +246,7 @@ async def open_session(
         # bkn-agent has no local conversation_id to resume. A chat supplies a
         # host key, which the lifecycle service resolves authoritatively; a
         # one-shot execution intentionally starts without a prior conversation.
-        args = {"question": question or "(not provided)"}
-        if _declares_conversation_mode(start):
-            args["conversation_mode"] = "new"
+        args = {"question": question or "(not provided)", "conversation_mode": "new"}
         if agent_name:
             args["agent_name"] = agent_name[:128]
         raw = await start.coroutine(**args)

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -35,7 +35,7 @@ class _FakeTool:
 def _start_tool():
     return _FakeTool(
         "bkn_start_interaction",
-        args_schema={"type": "object", "properties": {}},
+        args_schema={"type": "object", "properties": {"conversation_mode": {"type": "string"}}},
         # VM 实测形状：(content_blocks, {"structured_content": {...}})
         result=(
             [{"type": "text",
@@ -112,6 +112,25 @@ def test_start_handshake_declares_new_mode_without_a_local_conversation_id(monke
         "question": "查询库存",
         "agent_name": "supply-chain-analyst",
         "conversation_mode": "new",
+    }]
+
+
+def test_start_handshake_omits_mode_when_the_server_has_not_declared_it(monkeypatch):
+    start = _start_tool()
+    start.args_schema = {"type": "object", "properties": {}}
+    _install(monkeypatch, [start, _FakeTool("bkn_finish_interaction"), _FakeTool("search_schema")])
+    token = auth.set_caller_token("Bearer t")
+    try:
+        session = asyncio.run(context_loader.open_session(
+            "查询库存", agent_name="supply-chain-analyst", host_conversation_key="thread-1"
+        ))
+    finally:
+        auth._caller_token.reset(token)
+
+    assert session is not None
+    assert start.calls == [{
+        "question": "查询库存",
+        "agent_name": "supply-chain-analyst",
     }]
 
 

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -35,7 +35,7 @@ class _FakeTool:
 def _start_tool():
     return _FakeTool(
         "bkn_start_interaction",
-        args_schema={"type": "object", "properties": {"conversation_mode": {"type": "string"}}},
+        args_schema={"type": "object", "properties": {}},
         # VM 实测形状：(content_blocks, {"structured_content": {...}})
         result=(
             [{"type": "text",
@@ -112,25 +112,6 @@ def test_start_handshake_declares_new_mode_without_a_local_conversation_id(monke
         "question": "查询库存",
         "agent_name": "supply-chain-analyst",
         "conversation_mode": "new",
-    }]
-
-
-def test_start_handshake_omits_mode_when_the_server_has_not_declared_it(monkeypatch):
-    start = _start_tool()
-    start.args_schema = {"type": "object", "properties": {}}
-    _install(monkeypatch, [start, _FakeTool("bkn_finish_interaction"), _FakeTool("search_schema")])
-    token = auth.set_caller_token("Bearer t")
-    try:
-        session = asyncio.run(context_loader.open_session(
-            "查询库存", agent_name="supply-chain-analyst", host_conversation_key="thread-1"
-        ))
-    finally:
-        auth._caller_token.reset(token)
-
-    assert session is not None
-    assert start.calls == [{
-        "question": "查询库存",
-        "agent_name": "supply-chain-analyst",
     }]
 
 

--- a/infra/bkn-agent/app/test/test_context_loader.py
+++ b/infra/bkn-agent/app/test/test_context_loader.py
@@ -96,6 +96,25 @@ def test_session_injects_bkn_context_and_hides_it(monkeypatch):
     ]
 
 
+def test_start_handshake_declares_new_mode_without_a_local_conversation_id(monkeypatch):
+    start = _start_tool()
+    _install(monkeypatch, [start, _FakeTool("bkn_finish_interaction"), _FakeTool("search_schema")])
+    token = auth.set_caller_token("Bearer t")
+    try:
+        session = asyncio.run(context_loader.open_session(
+            "查询库存", agent_name="supply-chain-analyst", host_conversation_key="thread-1"
+        ))
+    finally:
+        auth._caller_token.reset(token)
+
+    assert session is not None
+    assert start.calls == [{
+        "question": "查询库存",
+        "agent_name": "supply-chain-analyst",
+        "conversation_mode": "new",
+    }]
+
+
 def test_bound_context_loader_tool_preserves_mcp_artifact_response_format():
     async def raw_call(**_kwargs):
         return ([{"type": "text", "text": "result"}], {"structured_content": {}})


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Backport merged main PR #1117 to release/0.1.4.
- [x] Include the explicit start mode contract, completed-answer validation, concise localized lifecycle guidance, and the bkn-agent caller adaptation.
- [x] Include regression coverage and lifecycle contract implementation notes.

---

## Why

- Related Issue: #1116 (already closed by #1117)
- Related Feature: ContextLoader managed Interaction lifecycle
- Background: Release 0.1.4 already contains the preceding lifecycle validation backport (#1109). This PR keeps its start/finish contract and the in-repo bkn-agent caller aligned with main.

---

## How

- Cherry-picked main merge commit 8122b3e88 onto release/0.1.4 as 7a2f212ca.
- Release differences merged cleanly in lifecycle adapter tests and validation guidance.
- No deployment or data migration is included.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- 41 Python ContextLoader tests passed.
- ContextLoader Go vet and extension/MCP tests passed, including ee_dev.
- docs/api/context-loader/mcp.yaml parsed successfully.
- git diff origin/release/0.1.4...HEAD --check passed.

---

## Risk & Rollback

- Potential risks: older MCP callers that omit conversation_mode receive the intended actionable validation error; the bundled bkn-agent caller is updated in this PR.
- Rollback plan: revert 7a2f212ca from release/0.1.4.

---

## Additional Notes

- Mainline source: #1117.
- This is a targeted release backport, not a new feature branch.
