### PR TITLE
fix(vega): gate single-document reads on query_data

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -373,6 +373,17 @@ func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor, 
 	if !ok {
 		return
 	}
+
+	// Reading one document is reading rows, so it needs query_data for the same
+	// reason the paged query does (#571): loading the resource only proves the
+	// caller may see the table's structure, and this endpoint hands back its
+	// contents.
+	if err := r.rs.CheckResourcePermission(ctx, resource.ID, interfaces.OPERATION_TYPE_QUERY_DATA); err != nil {
+		otellog.LogError(ctx, "Get resource data document denied", err)
+		rest.ReplyError(c, err)
+		return
+	}
+
 	warning, err := resourcelogic.EnsureResourceQueryable(ctx, resource)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,6 +29,17 @@ func setupResourceDataHandlerTest(
 	t *testing.T,
 ) (*gin.Engine, *vmock.MockResourceService, *vmock.MockDatasetService, *vmock.MockResourceDataService) {
 	t.Helper()
+	// 取数要 query_data（#571）；这些用例验的是查询本身，统一放行。
+	return setupResourceDataHandlerTestWithPermission(t, nil)
+}
+
+// setupResourceDataHandlerTestWithPermission builds the same harness with the
+// query_data check answering permErr, so a test can drive the endpoint as a
+// caller who may see the table but not read its rows.
+func setupResourceDataHandlerTestWithPermission(
+	t *testing.T, permErr error,
+) (*gin.Engine, *vmock.MockResourceService, *vmock.MockDatasetService, *vmock.MockResourceDataService) {
+	t.Helper()
 
 	engine := gin.New()
 	engine.Use(gin.Recovery())
@@ -36,9 +48,8 @@ func setupResourceDataHandlerTest(
 	t.Cleanup(mockCtrl.Finish)
 
 	rs := vmock.NewMockResourceService(mockCtrl)
-	// 取数要 query_data（#571）；这些用例验的是查询本身，统一放行。
-	rs.EXPECT().CheckResourcePermission(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil).AnyTimes()
+	rs.EXPECT().CheckResourcePermission(gomock.Any(), gomock.Any(), interfaces.OPERATION_TYPE_QUERY_DATA).
+		Return(permErr).AnyTimes()
 	ds := vmock.NewMockDatasetService(mockCtrl)
 	rds := vmock.NewMockResourceDataService(mockCtrl)
 	handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, rs, nil, ds, nil, nil, nil, rds)
@@ -274,6 +285,25 @@ func Test_ResourceDataRestHandler_GetResourceDataDoc(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), `"id":"doc-1"`)
+	})
+
+	t.Run("rejects document read without query_data", func(t *testing.T) {
+		// The document endpoint hands back row contents, so view_detail on the
+		// table is not enough on its own: it only says the caller may see the
+		// structure. Without this the split introduced by #801 decides nothing
+		// on this route even though the paged query already honours it.
+		engine, rs, _, _ := setupResourceDataHandlerTestWithPermission(t,
+			rest.NewHTTPError(context.Background(), http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails("Access denied: insufficient permissions for[query_data]"))
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(sampleDatasetResource(), nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-1/data/doc-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "query_data")
 	})
 
 	t.Run("returns not found for nil document", func(t *testing.T) {


### PR DESCRIPTION
Closes #1120

## Problem

`query_data` was split from `view_detail` in #801 so that "may see the table's structure" and "may read its rows" could differ, and #977 made the paged data query honour that split. The per-document route was left behind.

`getResourceDataDoc` (`GET /api/vega-backend/v1/resources/:id/data/:doc_id`) only calls `requireDatasetResource`, which loads the resource and therefore judges `view_detail`. It then returns the document's full contents. An account holding `view_detail` alone is refused by the paged route and handed the same rows by this one — one dataset, two routes, two answers.

## Change

Ask `CheckResourcePermission` for `query_data` before fetching the document, the same call the paged query makes on line 128 of the same file. That call already carries the catalog fallback (#817) and the internal-catalog S2S exemption, so internal callers reading platform datasets over `/in/` are unaffected.

No new permission point, no change to the enforcement engine, no migration.

## Compatibility

The gate itself shipped in #977; this only extends it to the route that missed it. Seeded `network_builder` grants carry `query_data` on both `catalog` and `resource`, so the default roles see no change. The accounts affected are those with a hand-made object grant of `view_detail` only — and those were already refused on the paged route once #977 landed, so this closes a gap rather than tightening a live contract.

## Testing

- `go test ./driveradapters/... -count=1` — passes.
- New case `rejects document read without query_data` drives the harness with a refusing verdict and asserts 403; without the fix the request reaches `GetDocument`, which the test does not expect.
- The harness now takes the permission verdict as a parameter; existing cases keep the allow answer they had.

## Out of scope

The data write routes (`createResourceData`, `putResourceData`, `putResourceDataDoc`, `deleteResourceData`, `deleteResourceDataByQuery`) are still judged by `view_detail` alone, so "may see the structure" currently implies "may write and delete rows". Which verb should govern them is a product decision and is recorded in #1120 for a separate issue.

## Pre-merge checklist

- [x] Unit tests pass
- [x] No schema or config change
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
