### PR TITLE
fix(deploy): reconcile Trace persistence profile on same-version installs

### DIFF
--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -962,6 +962,98 @@ _openbkn_release_extra_sets() {
     fi
 }
 
+# Chart version equality alone is not sufficient for agent-observability: the
+# product installer supplies its durable Trace profile as Helm values, while
+# the standalone chart deliberately defaults to in-memory stores. Reconcile a
+# release that was installed directly (or before the profile existed) so a
+# later normal install cannot leave conversations volatile after a Pod restart.
+_openbkn_agent_observability_has_durable_profile() {
+    local namespace="$1"
+    local values
+    if ! values="$(helm get values agent-observability -n "${namespace}" --all -o json 2>/dev/null)"; then
+        return 2
+    fi
+    python3 -c '
+import json, sys
+try:
+    values = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError):
+    sys.exit(2)
+core = values.get("core", {})
+evidence = values.get("evidence", {})
+durable = (
+    core.get("store") == "mariadb"
+    and core.get("projection", {}).get("enabled") is True
+    and evidence.get("store") == "opensearch"
+    and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
+)
+sys.exit(0 if durable else 1)
+' <<<"${values}"
+}
+
+_openbkn_agent_observability_profile_is_explicitly_volatile() {
+    local key value
+    local -a set_values=("${CORE_SET_VALUES[@]-}")
+    for key in core.store core.projection.enabled evidence.store evidence.ingestAuth.existingSecret; do
+        value="$(_openbkn_last_set_value "${key}" "${set_values[@]}")" || continue
+        case "${key}:${value}" in
+            core.store:mariadb|core.projection.enabled:true|evidence.store:opensearch)
+                ;;
+            evidence.ingestAuth.existingSecret:*)
+                [[ -n "${value}" ]] || return 0
+                ;;
+            *) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+_openbkn_last_set_value() {
+    local key="$1"
+    shift
+    local item value="" found=false
+    for item in "$@"; do
+        if [[ "${item}" == "${key}="* ]]; then
+            value="${item#*=}"
+            found=true
+        fi
+    done
+    if [[ "${found}" == true ]]; then
+        printf '%s\n' "${value}"
+        return 0
+    fi
+    return 1
+}
+
+_openbkn_should_skip_upgrade() {
+    local release_name="$1"
+    local namespace="$2"
+    local chart_name="$3"
+    local target_version="$4"
+
+    if ! should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+        return 1
+    fi
+    if [[ "${release_name}" == "agent-observability" ]]; then
+        _openbkn_agent_observability_has_durable_profile "${namespace}"
+        case "$?" in
+            0) ;;
+            1)
+                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
+                    return 0
+                fi
+                log_info "Reconcile agent-observability: installed runtime profile is not durable."
+                return 1
+                ;;
+            *)
+                log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
+                return 0
+                ;;
+        esac
+    fi
+    return 0
+}
+
 # Install a single bkn-foundry release from a local .tgz
 _install_openbkn_release_local() {
     local release_name="$1"
@@ -991,7 +1083,7 @@ _install_openbkn_release_local() {
     if [[ -z "${target_version}" ]]; then
         target_version="$(get_local_chart_version "${chart_tgz}")"
     fi
-    if should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+    if _openbkn_should_skip_upgrade "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
         return 0
     fi
 
@@ -1037,7 +1129,7 @@ _install_openbkn_release_repo() {
         target_version=$(get_repo_chart_latest_version "${helm_repo_name}" "${chart_name}")
     fi
 
-    if should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+    if _openbkn_should_skip_upgrade "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
         return 0
     fi
 

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -16,6 +16,7 @@ not_contains() {
     if [[ "${value}" != *"${unexpected}"* ]]; then ok; else fail "${label}: unexpected [${unexpected}] in [${value}]"; fi
 }
 log_info() { :; }
+log_warn() { :; }
 get_set_value() {
     local key="$1"
     shift
@@ -58,6 +59,122 @@ contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
+
+# The installer must not silently retain Chart defaults when the chart version
+# is unchanged. That is precisely when a previously direct-installed release
+# would otherwise keep its volatile Core store through a later normal install.
+should_skip_upgrade_same_chart_version() { return 0; }
+HELM_VALUES=''
+HELM_GET_VALUES_EXIT=0
+helm() {
+    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" ]]; then
+        if [[ "${HELM_GET_VALUES_EXIT}" -ne 0 ]]; then
+            return "${HELM_GET_VALUES_EXIT}"
+        fi
+        printf '%s\n' "${HELM_VALUES}"
+        return 0
+    fi
+    return 0
+}
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if ! declare -F _openbkn_should_skip_upgrade >/dev/null; then
+    fail "installer must expose a runtime-profile reconciliation guard"
+elif _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a volatile agent-observability runtime profile"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":""}}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a profile without the evidence ingest Secret"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "installer should retain the version-skip optimization for a durable runtime profile"
+fi
+
+CORE_SET_VALUES=("core.store=memory")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "an explicit volatile override must retain the normal version-skip decision"
+fi
+CORE_SET_VALUES=("")
+
+HELM_VALUES='{not-json}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "invalid Helm values must preserve the version-skip decision"
+fi
+HELM_GET_VALUES_EXIT=1
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "a failed Helm values read must preserve the version-skip decision"
+fi
+HELM_GET_VALUES_EXIT=0
+
+CORE_SET_VALUES=("core.store=memory" "core.store=mariadb")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "the last explicit --set value must decide whether a volatile profile is intentional"
+else
+    ok
+fi
+CORE_SET_VALUES=("")
+
+# Both installer paths must use the reconciliation guard. Keep this test
+# cluster-free by stubbing only the final Helm upgrade operation.
+UPGRADE_CALLS=0
+CONFIG_YAML_PATH="${CONFIG_REGISTRY_FILE}"
+ORIGINAL_RELEASE_EXTRA_SETS="$(declare -f _openbkn_release_extra_sets)"
+_openbkn_helm_upgrade_release() { UPGRADE_CALLS=$((UPGRADE_CALLS + 1)); }
+_openbkn_release_extra_sets() { CORE_RELEASE_EXTRA_SETS=("test.profile=true"); CORE_RELEASE_EXTRA_SET_STRINGS=(""); }
+_openbkn_resolve_release_version() { printf '%s' '0.1.4'; }
+_openbkn_resolve_chart_name() { printf '%s' "$1"; }
+build_chart_ref() { printf '%s' "$1/$2"; }
+find_cached_chart_tgz_by_version() { printf '%s' '/tmp/agent-observability-0.1.4.tgz'; }
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+if [[ "${UPGRADE_CALLS}" -eq 1 ]]; then
+    ok
+else
+    fail "local installer must upgrade a volatile runtime profile"
+fi
+
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "repository installer must upgrade a volatile runtime profile"
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "durable runtime profiles must skip both installer paths"
+fi
+
+HELM_VALUES='{not-json}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "unreadable Helm values must not roll out either installer path"
+fi
+eval "${ORIGINAL_RELEASE_EXTRA_SETS}"
 
 cat >"${CONFIG_REGISTRY_FILE}" <<'EOF'
 depServices:


### PR DESCRIPTION
## What Changed

- [x] Reconcile `agent-observability` when an installed same-version release still has a volatile Trace runtime profile.
- [x] Add regression coverage for volatile/durable profiles, explicit overrides, failed values reads, and local/repository install paths.
- [ ] Docs/doc 1 — not applicable; installer behavior is covered by inline contract comments and regression tests.

---

## Why

- Related Issue: Closes #1126
- Related Feature: N/A — deployment regression fix.
- Background: Chart defaults intentionally use in-memory stores for standalone use, while the OpenBKN installer supplies persistent overrides. The same-version skip could preserve a directly installed/default profile, so a Pod restart cleared visible sessions and business-provenance summaries.

---

## How

- Check the installed Helm values as JSON before taking the same-version skip for `agent-observability`.
- Reconcile only confirmed profile drift; unreadable values preserve the skip to avoid an unverified rollout.
- Honor the final explicit `--set` value, matching Helm precedence.
- Breaking changes (API, config, database, etc.): none.

---

## Testing

- [x] Unit tests passed locally (`openbkn_trace_profile_test.sh`: 82 checks).
- [x] Integration tests passed locally (`openbkn_trace_prerequisites_test.sh`, `mariadb_trace_database_test.sh`).
- [ ] Verified in test environment — requires merge and a controlled deployment.

Test notes:

- `bash -n deploy/scripts/services/openbkn.sh`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: the next matching install upgrades only an `agent-observability` release confirmed to be volatile.
- Rollback plan: revert this commit; existing Helm values and persisted MariaDB/OpenSearch data are unchanged.

---

## Additional Notes

- Local diagnosis: `bkn-trace-core` still aliases 402 historical receipt documents; the running service was configured with `BKN_TRACE_CORE_STORE=memory` and disabled projection.
- The independent Collector `@timestamp` zero-value observation is deliberately out of scope for this deployment-profile PR.