### PR TITLE
fix(bkn-trace): repair Collector trace timestamps

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: {{ .Values.opensearch.traceIndex | quote }}
             - name: OPENSEARCH_LOG_INDEX
               value: {{ .Values.opensearch.logIndex | quote }}
+            - name: OPENSEARCH_TRACE_TIMESTAMP_PIPELINE
+              value: {{ .Values.opensearch.traceTimestampPipeline | quote }}
             - name: OPENSEARCH_EVIDENCE_INDEX
               value: {{ .Values.evidence.index | quote }}
             - name: BKN_TRACE_EVIDENCE_STORE

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -153,6 +153,9 @@ opensearch:
   # Keep these aligned with the bundled Collector's ss4o dataset/namespace.
   traceIndex: ss4o_traces-default-namespace
   logIndex: ss4o_logs-default-namespace
+  # Empty for standalone use. The product installer supplies the compatibility
+  # pipeline before it configures the Collector to require it.
+  traceTimestampPipeline: ""
   auth:
     enabled: false
     existingSecret: ""

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -103,6 +103,11 @@ func NewApp() (*App, error) {
 		},
 		openSearchConfig.Timeout,
 	)
+	if err := openSearchClient.EnsureTraceTimestampPipeline(
+		context.Background(), openSearchConfig.TraceTimestampPipeline,
+	); err != nil {
+		return nil, fmt.Errorf("initialize trace timestamp pipeline: %w", err)
+	}
 	traceDetailClient := opensearchtraceaccess.New(openSearchClient, openSearchConfig.TraceIndex)
 	traceQueryService := tracesvc.New(traceDetailClient)
 	var evidenceStore ievidencestore.EvidenceStorePort = evidencestore.New()

--- a/bkn-trace/agent-observability/src/conf/opensearch.go
+++ b/bkn-trace/agent-observability/src/conf/opensearch.go
@@ -11,12 +11,13 @@ import (
 )
 
 type OpenSearchConfig struct {
-	Endpoint      string
-	TraceIndex    string
-	EvidenceIndex string
-	LogIndex      string
-	Timeout       time.Duration
-	Auth          OpenSearchAuthConfig
+	Endpoint               string
+	TraceIndex             string
+	EvidenceIndex          string
+	LogIndex               string
+	TraceTimestampPipeline string
+	Timeout                time.Duration
+	Auth                   OpenSearchAuthConfig
 }
 
 type OpenSearchAuthConfig struct {
@@ -47,11 +48,12 @@ func NewOpenSearchConfig() OpenSearchConfig {
 	}
 
 	return OpenSearchConfig{
-		Endpoint:      endpoint,
-		TraceIndex:    traceIndex,
-		EvidenceIndex: evidenceIndex,
-		LogIndex:      logIndex,
-		Timeout:       3 * time.Second,
+		Endpoint:               endpoint,
+		TraceIndex:             traceIndex,
+		EvidenceIndex:          evidenceIndex,
+		LogIndex:               logIndex,
+		TraceTimestampPipeline: os.Getenv("OPENSEARCH_TRACE_TIMESTAMP_PIPELINE"),
+		Timeout:                3 * time.Second,
 		Auth: OpenSearchAuthConfig{
 			Enabled:  os.Getenv("OPENSEARCH_AUTH_ENABLED") == "true",
 			Username: os.Getenv("OPENSEARCH_AUTH_USERNAME"),

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -93,6 +93,52 @@ func NewWithHTTPClient(baseURL string, auth AuthConfig, httpClient *http.Client)
 	}
 }
 
+// EnsureTraceTimestampPipeline installs the OpenSearch-side compatibility
+// repair for the Collector's SS4O trace encoder. The affected upstream encoder
+// serializes @timestamp as Go's zero time while retaining span startTime. The
+// condition deliberately requires a traceId, so logs never enter this path.
+func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{
+		"description": "Repair zero @timestamp on OpenTelemetry SS4O trace spans from startTime.",
+		"processors": []map[string]any{{
+			"script": map[string]any{
+				"lang":   "painless",
+				"if":     "ctx.containsKey('traceId') && ctx.containsKey('startTime') && ctx.startTime != null && (!ctx.containsKey('@timestamp') || ctx['@timestamp'] == null || ctx['@timestamp'] == '0001-01-01T00:00:00Z')",
+				"source": "ctx['@timestamp'] = ctx.startTime",
+			},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("encode trace timestamp pipeline: %w", err)
+	}
+	requestURL := fmt.Sprintf("%s/_ingest/pipeline/%s", c.baseURL, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create trace timestamp pipeline request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute trace timestamp pipeline request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read trace timestamp pipeline response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch trace timestamp pipeline failed with status %d: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
+}
+
 func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s/_search", c.baseURL, strings.TrimLeft(index, "/"))
 

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package opensearch
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/_ingest/pipeline/bkn-trace-span-timestamp-v1" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(body)
+		if !strings.Contains(content, "startTime") || !strings.Contains(content, "0001-01-01T00:00:00Z") {
+			t.Fatalf("pipeline must repair only zero trace timestamps: %s", content)
+		}
+		if !strings.Contains(content, "ctx.containsKey('traceId')") {
+			t.Fatalf("pipeline must not alter log records: %s", content)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(server.URL, AuthConfig{}, time.Second)
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1"); err != nil {
+		t.Fatalf("ensure timestamp pipeline: %v", err)
+	}
+}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
@@ -46,6 +46,9 @@ metadata:
 {{- if .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- $_ := set $opensearch "traces_index_time_format" .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- end }}
+{{- if .Values.opensearchExporter.pipeline }}
+{{- $_ := set $opensearch "pipeline" .Values.opensearchExporter.pipeline }}
+{{- end }}
 {{- $mapping := dict "mode" .Values.opensearchExporter.mapping.mode }}
 {{- if .Values.opensearchExporter.mapping.timestampField }}
 {{- $_ := set $mapping "timestamp_field" .Values.opensearchExporter.mapping.timestampField }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -97,6 +97,9 @@ opensearchExporter:
   tracesIndex: ""
   tracesIndexFallback: unknown
   tracesIndexTimeFormat: ""
+  # Optional OpenSearch ingest pipeline applied by the exporter. The full
+  # OpenBKN installer sets its trace timestamp repair pipeline explicitly.
+  pipeline: ""
   mapping:
     mode: ss4o
     timestampField: ""

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
@@ -15,6 +15,7 @@ checksum() {
 
 baseline="$(checksum)"
 changed_exporter="$(checksum --set opensearchExporter.http.endpoint=http://example.invalid:9200)"
+timestamp_pipeline_rendered="$(helm template otelcol-contrib "${chart_dir}" --set opensearchExporter.pipeline=bkn-trace-span-timestamp-v1)"
 unchanged="$(checksum)"
 
 if [[ -z "${baseline}" ]]; then
@@ -29,6 +30,11 @@ fi
 
 if [[ "${baseline}" != "${unchanged}" ]]; then
   echo "collector config checksum changed without a configuration change" >&2
+  exit 1
+fi
+
+if ! grep -Fq "pipeline: bkn-trace-span-timestamp-v1" <<<"${timestamp_pipeline_rendered}"; then
+  echo "collector must pass the configured OpenSearch ingest pipeline to its exporter" >&2
   exit 1
 fi
 

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -476,6 +476,7 @@ _openbkn_trace_profile_sets() {
                 "evidence.ingestAuth.secretKey=token"
                 "opensearch.traceIndex=ss4o_traces-default-namespace"
                 "opensearch.logIndex=ss4o_logs-default-namespace"
+                "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
             )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
@@ -486,6 +487,9 @@ _openbkn_trace_profile_sets() {
             fi
             ;;
         otelcol-contrib)
+            CORE_RELEASE_EXTRA_SETS+=(
+                "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
+            )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
                     "opensearchExporter.http.endpoint=$(_openbkn_trace_opensearch_endpoint)"
@@ -991,6 +995,33 @@ sys.exit(0 if durable else 1)
 ' <<<"${values}"
 }
 
+# The Collector chart has an independent same-version skip. Reconcile its
+# rendered values as well: otherwise an already-installed Collector never
+# receives the trace timestamp pipeline even though agent-observability has
+# created it successfully.
+_openbkn_collector_has_trace_timestamp_pipeline() {
+    local namespace="$1"
+    local values
+    if ! values="$(helm get values otelcol-contrib -n "${namespace}" --all -o json 2>/dev/null)"; then
+        return 2
+    fi
+    python3 -c '
+import json, sys
+try:
+    values = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError):
+    sys.exit(2)
+pipeline = values.get("opensearchExporter", {}).get("pipeline")
+sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
+' <<<"${values}"
+}
+
+_openbkn_collector_pipeline_is_explicitly_overridden() {
+    local value
+    value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
+    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
+}
+
 _openbkn_agent_observability_profile_is_explicitly_volatile() {
     local key value
     local -a set_values=("${CORE_SET_VALUES[@]-}")
@@ -1047,6 +1078,22 @@ _openbkn_should_skip_upgrade() {
                 ;;
             *)
                 log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
+                return 0
+                ;;
+        esac
+    elif [[ "${release_name}" == "otelcol-contrib" ]]; then
+        _openbkn_collector_has_trace_timestamp_pipeline "${namespace}"
+        case "$?" in
+            0) ;;
+            1)
+                if _openbkn_collector_pipeline_is_explicitly_overridden; then
+                    return 0
+                fi
+                log_info "Reconcile otelcol-contrib: installed Collector has no trace timestamp pipeline."
+                return 1
+                ;;
+            *)
+                log_warn "Cannot read otelcol-contrib Helm values; preserving the version-skip decision to avoid an unverified rollout."
                 return 0
                 ;;
         esac

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -56,6 +56,7 @@ contains "AO uses durable Core" "${ao_sets}" "core.store=mariadb"
 contains "AO requires Core DSN Secret" "${ao_sets}" "core.mariadb.existingSecret=bkn-trace-core-mariadb"
 contains "AO persists evidence" "${ao_sets}" "evidence.store=opensearch"
 contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
+contains "AO creates the Collector timestamp repair pipeline first" "${ao_sets}" "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
@@ -67,7 +68,7 @@ should_skip_upgrade_same_chart_version() { return 0; }
 HELM_VALUES=''
 HELM_GET_VALUES_EXIT=0
 helm() {
-    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" ]]; then
+    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" || "$*" == "get values otelcol-contrib -n openbkn --all -o json" ]]; then
         if [[ "${HELM_GET_VALUES_EXIT}" -ne 0 ]]; then
             return "${HELM_GET_VALUES_EXIT}"
         fi
@@ -121,6 +122,28 @@ else
     fail "a failed Helm values read must preserve the version-skip decision"
 fi
 HELM_GET_VALUES_EXIT=0
+
+CORE_SET_VALUES=()
+HELM_VALUES='{"opensearchExporter":{"pipeline":""}}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    fail "installer must reconcile a Collector without the timestamp repair pipeline"
+else
+    ok
+fi
+
+HELM_VALUES='{"opensearchExporter":{"pipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    ok
+else
+    fail "installer should retain the version-skip optimization for a reconciled Collector"
+fi
+
+HELM_VALUES='{not-json}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    ok
+else
+    fail "invalid Collector Helm values must preserve the version-skip decision"
+fi
 
 CORE_SET_VALUES=("core.store=memory" "core.store=mariadb")
 HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
@@ -194,6 +217,7 @@ not_contains "secure AO never forwards an OpenSearch password to Helm" "${secure
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_trace_profile_sets otelcol-contrib
 secure_collector_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "Collector routes spans through the timestamp repair pipeline" "${secure_collector_sets}" "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
 contains "secure Collector uses the OpenSearch endpoint from config" "${secure_collector_sets}" "opensearchExporter.http.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
 contains "secure Collector verifies the OpenSearch TLS peer" "${secure_collector_sets}" "opensearchExporter.http.tls.insecure=false"
 contains "secure Collector enables OpenSearch auth" "${secure_collector_sets}" "opensearchExporter.auth.enabled=true"


### PR DESCRIPTION
## What Changed

- [x] Create the `bkn-trace-span-timestamp-v1` OpenSearch ingest pipeline through the existing Trace OpenSearch client.
- [x] Wire the pipeline into the full-product Trace and Collector install profiles.
- [x] Reconcile same-version Collector releases when the pipeline setting is absent.
- [x] Add focused Go and Helm/installer regression coverage.

---

## Why

- Related Issue: Closes #1128
- Background: the upstream Collector OpenSearch SS4O trace encoder writes `startTime` but serializes `@timestamp` as `0001-01-01T00:00:00Z`. Generic time-range queries consequently omit current traces.

---

## How

- The pipeline copies `startTime` only when a document has `traceId` and its `@timestamp` is missing or zero; logs and valid timestamps are left untouched.
- Agent Observability creates the pipeline before becoming ready; the collector uses it for subsequent writes.
- Existing Collector releases are upgraded even at the same chart version if the pipeline value is absent; unreadable Helm values retain the conservative skip.
- Breaking changes: no API, schema, or historical-data changes.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (not required; no external dependency added)
- [ ] Verified in test environment (requires deploy confirmation)

Test notes:

- `go test ./... -count=1` (agent-observability)
- `go vet ./...` (agent-observability)
- `bash deploy/scripts/services/openbkn_trace_profile_test.sh` (87 checks)
- `bash deploy/scripts/services/openbkn_trace_prerequisites_test.sh` (33 checks)
- Collector config-rollout, secure OpenSearch contract, and both Helm lints

---

## Risk & Rollback

- Potential risks: secure OpenSearch credentials need ingest-pipeline management permission; failure intentionally keeps Trace service unready rather than allowing invalid timestamps.
- Rollback plan: revert this PR and rerun the installer; the named ingest pipeline is isolated and does not alter historical documents.

---

## Additional Notes

- Historical documents are not automatically rewritten; trace graph reads continue to use `startTime`.
- Deployment changes OpenSearch cluster configuration and will follow the repository confirmation gate.