### PR TITLE
fix(release): backport trace persistence and timestamp repairs to 0.1.4

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: {{ .Values.opensearch.traceIndex | quote }}
             - name: OPENSEARCH_LOG_INDEX
               value: {{ .Values.opensearch.logIndex | quote }}
+            - name: OPENSEARCH_TRACE_TIMESTAMP_PIPELINE
+              value: {{ .Values.opensearch.traceTimestampPipeline | quote }}
             - name: OPENSEARCH_EVIDENCE_INDEX
               value: {{ .Values.evidence.index | quote }}
             - name: BKN_TRACE_EVIDENCE_STORE

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -153,6 +153,9 @@ opensearch:
   # Keep these aligned with the bundled Collector's ss4o dataset/namespace.
   traceIndex: ss4o_traces-default-namespace
   logIndex: ss4o_logs-default-namespace
+  # Empty for standalone use. The product installer supplies the compatibility
+  # pipeline before it configures the Collector to require it.
+  traceTimestampPipeline: ""
   auth:
     enabled: false
     existingSecret: ""

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -103,6 +103,11 @@ func NewApp() (*App, error) {
 		},
 		openSearchConfig.Timeout,
 	)
+	if err := openSearchClient.EnsureTraceTimestampPipeline(
+		context.Background(), openSearchConfig.TraceTimestampPipeline,
+	); err != nil {
+		return nil, fmt.Errorf("initialize trace timestamp pipeline: %w", err)
+	}
 	traceDetailClient := opensearchtraceaccess.New(openSearchClient, openSearchConfig.TraceIndex)
 	traceQueryService := tracesvc.New(traceDetailClient)
 	var evidenceStore ievidencestore.EvidenceStorePort = evidencestore.New()

--- a/bkn-trace/agent-observability/src/conf/opensearch.go
+++ b/bkn-trace/agent-observability/src/conf/opensearch.go
@@ -11,12 +11,13 @@ import (
 )
 
 type OpenSearchConfig struct {
-	Endpoint      string
-	TraceIndex    string
-	EvidenceIndex string
-	LogIndex      string
-	Timeout       time.Duration
-	Auth          OpenSearchAuthConfig
+	Endpoint               string
+	TraceIndex             string
+	EvidenceIndex          string
+	LogIndex               string
+	TraceTimestampPipeline string
+	Timeout                time.Duration
+	Auth                   OpenSearchAuthConfig
 }
 
 type OpenSearchAuthConfig struct {
@@ -47,11 +48,12 @@ func NewOpenSearchConfig() OpenSearchConfig {
 	}
 
 	return OpenSearchConfig{
-		Endpoint:      endpoint,
-		TraceIndex:    traceIndex,
-		EvidenceIndex: evidenceIndex,
-		LogIndex:      logIndex,
-		Timeout:       3 * time.Second,
+		Endpoint:               endpoint,
+		TraceIndex:             traceIndex,
+		EvidenceIndex:          evidenceIndex,
+		LogIndex:               logIndex,
+		TraceTimestampPipeline: os.Getenv("OPENSEARCH_TRACE_TIMESTAMP_PIPELINE"),
+		Timeout:                3 * time.Second,
 		Auth: OpenSearchAuthConfig{
 			Enabled:  os.Getenv("OPENSEARCH_AUTH_ENABLED") == "true",
 			Username: os.Getenv("OPENSEARCH_AUTH_USERNAME"),

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -93,6 +93,52 @@ func NewWithHTTPClient(baseURL string, auth AuthConfig, httpClient *http.Client)
 	}
 }
 
+// EnsureTraceTimestampPipeline installs the OpenSearch-side compatibility
+// repair for the Collector's SS4O trace encoder. The affected upstream encoder
+// serializes @timestamp as Go's zero time while retaining span startTime. The
+// condition deliberately requires a traceId, so logs never enter this path.
+func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{
+		"description": "Repair zero @timestamp on OpenTelemetry SS4O trace spans from startTime.",
+		"processors": []map[string]any{{
+			"script": map[string]any{
+				"lang":   "painless",
+				"if":     "ctx.containsKey('traceId') && ctx.containsKey('startTime') && ctx.startTime != null && (!ctx.containsKey('@timestamp') || ctx['@timestamp'] == null || ctx['@timestamp'] == '0001-01-01T00:00:00Z')",
+				"source": "ctx['@timestamp'] = ctx.startTime",
+			},
+		}},
+	})
+	if err != nil {
+		return fmt.Errorf("encode trace timestamp pipeline: %w", err)
+	}
+	requestURL := fmt.Sprintf("%s/_ingest/pipeline/%s", c.baseURL, url.PathEscape(name))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create trace timestamp pipeline request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute trace timestamp pipeline request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read trace timestamp pipeline response: %w", err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch trace timestamp pipeline failed with status %d: %s", resp.StatusCode, string(responseBody))
+	}
+	return nil
+}
+
 func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte, error) {
 	url := fmt.Sprintf("%s/%s/_search", c.baseURL, strings.TrimLeft(index, "/"))
 

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package opensearch
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/_ingest/pipeline/bkn-trace-span-timestamp-v1" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		content := string(body)
+		if !strings.Contains(content, "startTime") || !strings.Contains(content, "0001-01-01T00:00:00Z") {
+			t.Fatalf("pipeline must repair only zero trace timestamps: %s", content)
+		}
+		if !strings.Contains(content, "ctx.containsKey('traceId')") {
+			t.Fatalf("pipeline must not alter log records: %s", content)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New(server.URL, AuthConfig{}, time.Second)
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1"); err != nil {
+		t.Fatalf("ensure timestamp pipeline: %v", err)
+	}
+}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
@@ -46,6 +46,9 @@ metadata:
 {{- if .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- $_ := set $opensearch "traces_index_time_format" .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- end }}
+{{- if .Values.opensearchExporter.pipeline }}
+{{- $_ := set $opensearch "pipeline" .Values.opensearchExporter.pipeline }}
+{{- end }}
 {{- $mapping := dict "mode" .Values.opensearchExporter.mapping.mode }}
 {{- if .Values.opensearchExporter.mapping.timestampField }}
 {{- $_ := set $mapping "timestamp_field" .Values.opensearchExporter.mapping.timestampField }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -97,6 +97,9 @@ opensearchExporter:
   tracesIndex: ""
   tracesIndexFallback: unknown
   tracesIndexTimeFormat: ""
+  # Optional OpenSearch ingest pipeline applied by the exporter. The full
+  # OpenBKN installer sets its trace timestamp repair pipeline explicitly.
+  pipeline: ""
   mapping:
     mode: ss4o
     timestampField: ""

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
@@ -15,6 +15,7 @@ checksum() {
 
 baseline="$(checksum)"
 changed_exporter="$(checksum --set opensearchExporter.http.endpoint=http://example.invalid:9200)"
+timestamp_pipeline_rendered="$(helm template otelcol-contrib "${chart_dir}" --set opensearchExporter.pipeline=bkn-trace-span-timestamp-v1)"
 unchanged="$(checksum)"
 
 if [[ -z "${baseline}" ]]; then
@@ -29,6 +30,11 @@ fi
 
 if [[ "${baseline}" != "${unchanged}" ]]; then
   echo "collector config checksum changed without a configuration change" >&2
+  exit 1
+fi
+
+if ! grep -Fq "pipeline: bkn-trace-span-timestamp-v1" <<<"${timestamp_pipeline_rendered}"; then
+  echo "collector must pass the configured OpenSearch ingest pipeline to its exporter" >&2
   exit 1
 fi
 

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -962,6 +962,98 @@ _openbkn_release_extra_sets() {
     fi
 }
 
+# Chart version equality alone is not sufficient for agent-observability: the
+# product installer supplies its durable Trace profile as Helm values, while
+# the standalone chart deliberately defaults to in-memory stores. Reconcile a
+# release that was installed directly (or before the profile existed) so a
+# later normal install cannot leave conversations volatile after a Pod restart.
+_openbkn_agent_observability_has_durable_profile() {
+    local namespace="$1"
+    local values
+    if ! values="$(helm get values agent-observability -n "${namespace}" --all -o json 2>/dev/null)"; then
+        return 2
+    fi
+    python3 -c '
+import json, sys
+try:
+    values = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError):
+    sys.exit(2)
+core = values.get("core", {})
+evidence = values.get("evidence", {})
+durable = (
+    core.get("store") == "mariadb"
+    and core.get("projection", {}).get("enabled") is True
+    and evidence.get("store") == "opensearch"
+    and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
+)
+sys.exit(0 if durable else 1)
+' <<<"${values}"
+}
+
+_openbkn_agent_observability_profile_is_explicitly_volatile() {
+    local key value
+    local -a set_values=("${CORE_SET_VALUES[@]-}")
+    for key in core.store core.projection.enabled evidence.store evidence.ingestAuth.existingSecret; do
+        value="$(_openbkn_last_set_value "${key}" "${set_values[@]}")" || continue
+        case "${key}:${value}" in
+            core.store:mariadb|core.projection.enabled:true|evidence.store:opensearch)
+                ;;
+            evidence.ingestAuth.existingSecret:*)
+                [[ -n "${value}" ]] || return 0
+                ;;
+            *) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+_openbkn_last_set_value() {
+    local key="$1"
+    shift
+    local item value="" found=false
+    for item in "$@"; do
+        if [[ "${item}" == "${key}="* ]]; then
+            value="${item#*=}"
+            found=true
+        fi
+    done
+    if [[ "${found}" == true ]]; then
+        printf '%s\n' "${value}"
+        return 0
+    fi
+    return 1
+}
+
+_openbkn_should_skip_upgrade() {
+    local release_name="$1"
+    local namespace="$2"
+    local chart_name="$3"
+    local target_version="$4"
+
+    if ! should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+        return 1
+    fi
+    if [[ "${release_name}" == "agent-observability" ]]; then
+        _openbkn_agent_observability_has_durable_profile "${namespace}"
+        case "$?" in
+            0) ;;
+            1)
+                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
+                    return 0
+                fi
+                log_info "Reconcile agent-observability: installed runtime profile is not durable."
+                return 1
+                ;;
+            *)
+                log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
+                return 0
+                ;;
+        esac
+    fi
+    return 0
+}
+
 # Install a single bkn-foundry release from a local .tgz
 _install_openbkn_release_local() {
     local release_name="$1"
@@ -991,7 +1083,7 @@ _install_openbkn_release_local() {
     if [[ -z "${target_version}" ]]; then
         target_version="$(get_local_chart_version "${chart_tgz}")"
     fi
-    if should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+    if _openbkn_should_skip_upgrade "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
         return 0
     fi
 
@@ -1037,7 +1129,7 @@ _install_openbkn_release_repo() {
         target_version=$(get_repo_chart_latest_version "${helm_repo_name}" "${chart_name}")
     fi
 
-    if should_skip_upgrade_same_chart_version "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
+    if _openbkn_should_skip_upgrade "${release_name}" "${namespace}" "${chart_name}" "${target_version}"; then
         return 0
     fi
 

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -476,6 +476,7 @@ _openbkn_trace_profile_sets() {
                 "evidence.ingestAuth.secretKey=token"
                 "opensearch.traceIndex=ss4o_traces-default-namespace"
                 "opensearch.logIndex=ss4o_logs-default-namespace"
+                "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
             )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
@@ -486,6 +487,9 @@ _openbkn_trace_profile_sets() {
             fi
             ;;
         otelcol-contrib)
+            CORE_RELEASE_EXTRA_SETS+=(
+                "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
+            )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
                     "opensearchExporter.http.endpoint=$(_openbkn_trace_opensearch_endpoint)"
@@ -991,6 +995,33 @@ sys.exit(0 if durable else 1)
 ' <<<"${values}"
 }
 
+# The Collector chart has an independent same-version skip. Reconcile its
+# rendered values as well: otherwise an already-installed Collector never
+# receives the trace timestamp pipeline even though agent-observability has
+# created it successfully.
+_openbkn_collector_has_trace_timestamp_pipeline() {
+    local namespace="$1"
+    local values
+    if ! values="$(helm get values otelcol-contrib -n "${namespace}" --all -o json 2>/dev/null)"; then
+        return 2
+    fi
+    python3 -c '
+import json, sys
+try:
+    values = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError):
+    sys.exit(2)
+pipeline = values.get("opensearchExporter", {}).get("pipeline")
+sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
+' <<<"${values}"
+}
+
+_openbkn_collector_pipeline_is_explicitly_overridden() {
+    local value
+    value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
+    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
+}
+
 _openbkn_agent_observability_profile_is_explicitly_volatile() {
     local key value
     local -a set_values=("${CORE_SET_VALUES[@]-}")
@@ -1047,6 +1078,22 @@ _openbkn_should_skip_upgrade() {
                 ;;
             *)
                 log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
+                return 0
+                ;;
+        esac
+    elif [[ "${release_name}" == "otelcol-contrib" ]]; then
+        _openbkn_collector_has_trace_timestamp_pipeline "${namespace}"
+        case "$?" in
+            0) ;;
+            1)
+                if _openbkn_collector_pipeline_is_explicitly_overridden; then
+                    return 0
+                fi
+                log_info "Reconcile otelcol-contrib: installed Collector has no trace timestamp pipeline."
+                return 1
+                ;;
+            *)
+                log_warn "Cannot read otelcol-contrib Helm values; preserving the version-skip decision to avoid an unverified rollout."
                 return 0
                 ;;
         esac

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -985,11 +985,13 @@ except (json.JSONDecodeError, TypeError):
     sys.exit(2)
 core = values.get("core", {})
 evidence = values.get("evidence", {})
+opensearch = values.get("opensearch", {})
 durable = (
     core.get("store") == "mariadb"
     and core.get("projection", {}).get("enabled") is True
     and evidence.get("store") == "opensearch"
     and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
+    and opensearch.get("traceTimestampPipeline") == "bkn-trace-span-timestamp-v1"
 )
 sys.exit(0 if durable else 1)
 ' <<<"${values}"
@@ -1019,6 +1021,12 @@ sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
 _openbkn_collector_pipeline_is_explicitly_overridden() {
     local value
     value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
+    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
+}
+
+_openbkn_agent_observability_pipeline_is_explicitly_overridden() {
+    local value
+    value="$(_openbkn_last_set_value "opensearch.traceTimestampPipeline" "${CORE_SET_VALUES[@]-}")" || return 1
     [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
 }
 
@@ -1070,7 +1078,8 @@ _openbkn_should_skip_upgrade() {
         case "$?" in
             0) ;;
             1)
-                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
+                if _openbkn_agent_observability_profile_is_explicitly_volatile ||
+                   _openbkn_agent_observability_pipeline_is_explicitly_overridden; then
                     return 0
                 fi
                 log_info "Reconcile agent-observability: installed runtime profile is not durable."

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -991,7 +991,7 @@ durable = (
     and core.get("projection", {}).get("enabled") is True
     and evidence.get("store") == "opensearch"
     and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
-    and opensearch.get("traceTimestampPipeline") == "bkn-trace-span-timestamp-v1"
+    and bool(opensearch.get("traceTimestampPipeline"))
 )
 sys.exit(0 if durable else 1)
 ' <<<"${values}"
@@ -1021,12 +1021,6 @@ sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
 _openbkn_collector_pipeline_is_explicitly_overridden() {
     local value
     value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
-    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
-}
-
-_openbkn_agent_observability_pipeline_is_explicitly_overridden() {
-    local value
-    value="$(_openbkn_last_set_value "opensearch.traceTimestampPipeline" "${CORE_SET_VALUES[@]-}")" || return 1
     [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
 }
 
@@ -1078,8 +1072,7 @@ _openbkn_should_skip_upgrade() {
         case "$?" in
             0) ;;
             1)
-                if _openbkn_agent_observability_profile_is_explicitly_volatile ||
-                   _openbkn_agent_observability_pipeline_is_explicitly_overridden; then
+                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
                     return 0
                 fi
                 log_info "Reconcile agent-observability: installed runtime profile is not durable."

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -56,6 +56,7 @@ contains "AO uses durable Core" "${ao_sets}" "core.store=mariadb"
 contains "AO requires Core DSN Secret" "${ao_sets}" "core.mariadb.existingSecret=bkn-trace-core-mariadb"
 contains "AO persists evidence" "${ao_sets}" "evidence.store=opensearch"
 contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
+contains "AO creates the Collector timestamp repair pipeline first" "${ao_sets}" "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
@@ -67,7 +68,7 @@ should_skip_upgrade_same_chart_version() { return 0; }
 HELM_VALUES=''
 HELM_GET_VALUES_EXIT=0
 helm() {
-    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" ]]; then
+    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" || "$*" == "get values otelcol-contrib -n openbkn --all -o json" ]]; then
         if [[ "${HELM_GET_VALUES_EXIT}" -ne 0 ]]; then
             return "${HELM_GET_VALUES_EXIT}"
         fi
@@ -121,6 +122,28 @@ else
     fail "a failed Helm values read must preserve the version-skip decision"
 fi
 HELM_GET_VALUES_EXIT=0
+
+CORE_SET_VALUES=()
+HELM_VALUES='{"opensearchExporter":{"pipeline":""}}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    fail "installer must reconcile a Collector without the timestamp repair pipeline"
+else
+    ok
+fi
+
+HELM_VALUES='{"opensearchExporter":{"pipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    ok
+else
+    fail "installer should retain the version-skip optimization for a reconciled Collector"
+fi
+
+HELM_VALUES='{not-json}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    ok
+else
+    fail "invalid Collector Helm values must preserve the version-skip decision"
+fi
 
 CORE_SET_VALUES=("core.store=memory" "core.store=mariadb")
 HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
@@ -194,6 +217,7 @@ not_contains "secure AO never forwards an OpenSearch password to Helm" "${secure
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_trace_profile_sets otelcol-contrib
 secure_collector_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
+contains "Collector routes spans through the timestamp repair pipeline" "${secure_collector_sets}" "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
 contains "secure Collector uses the OpenSearch endpoint from config" "${secure_collector_sets}" "opensearchExporter.http.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
 contains "secure Collector verifies the OpenSearch TLS peer" "${secure_collector_sets}" "opensearchExporter.http.tls.insecure=false"
 contains "secure Collector enables OpenSearch auth" "${secure_collector_sets}" "opensearchExporter.auth.enabled=true"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -95,9 +95,16 @@ fi
 
 HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
 if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a durable profile that lacks the timestamp pipeline"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
     ok
 else
-    fail "installer should retain the version-skip optimization for a durable runtime profile"
+    fail "installer should retain the version-skip optimization for a fully reconciled runtime profile"
 fi
 
 CORE_SET_VALUES=("core.store=memory")
@@ -180,7 +187,7 @@ else
     fail "repository installer must upgrade a volatile runtime profile"
 fi
 
-HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
 _install_openbkn_release_local agent-observability /tmp openbkn
 _install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
 if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -16,6 +16,7 @@ not_contains() {
     if [[ "${value}" != *"${unexpected}"* ]]; then ok; else fail "${label}: unexpected [${unexpected}] in [${value}]"; fi
 }
 log_info() { :; }
+log_warn() { :; }
 get_set_value() {
     local key="$1"
     shift
@@ -58,6 +59,122 @@ contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
+
+# The installer must not silently retain Chart defaults when the chart version
+# is unchanged. That is precisely when a previously direct-installed release
+# would otherwise keep its volatile Core store through a later normal install.
+should_skip_upgrade_same_chart_version() { return 0; }
+HELM_VALUES=''
+HELM_GET_VALUES_EXIT=0
+helm() {
+    if [[ "$*" == "get values agent-observability -n openbkn --all -o json" ]]; then
+        if [[ "${HELM_GET_VALUES_EXIT}" -ne 0 ]]; then
+            return "${HELM_GET_VALUES_EXIT}"
+        fi
+        printf '%s\n' "${HELM_VALUES}"
+        return 0
+    fi
+    return 0
+}
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if ! declare -F _openbkn_should_skip_upgrade >/dev/null; then
+    fail "installer must expose a runtime-profile reconciliation guard"
+elif _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a volatile agent-observability runtime profile"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":""}}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a profile without the evidence ingest Secret"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "installer should retain the version-skip optimization for a durable runtime profile"
+fi
+
+CORE_SET_VALUES=("core.store=memory")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "an explicit volatile override must retain the normal version-skip decision"
+fi
+CORE_SET_VALUES=("")
+
+HELM_VALUES='{not-json}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "invalid Helm values must preserve the version-skip decision"
+fi
+HELM_GET_VALUES_EXIT=1
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    ok
+else
+    fail "a failed Helm values read must preserve the version-skip decision"
+fi
+HELM_GET_VALUES_EXIT=0
+
+CORE_SET_VALUES=("core.store=memory" "core.store=mariadb")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "the last explicit --set value must decide whether a volatile profile is intentional"
+else
+    ok
+fi
+CORE_SET_VALUES=("")
+
+# Both installer paths must use the reconciliation guard. Keep this test
+# cluster-free by stubbing only the final Helm upgrade operation.
+UPGRADE_CALLS=0
+CONFIG_YAML_PATH="${CONFIG_REGISTRY_FILE}"
+ORIGINAL_RELEASE_EXTRA_SETS="$(declare -f _openbkn_release_extra_sets)"
+_openbkn_helm_upgrade_release() { UPGRADE_CALLS=$((UPGRADE_CALLS + 1)); }
+_openbkn_release_extra_sets() { CORE_RELEASE_EXTRA_SETS=("test.profile=true"); CORE_RELEASE_EXTRA_SET_STRINGS=(""); }
+_openbkn_resolve_release_version() { printf '%s' '0.1.4'; }
+_openbkn_resolve_chart_name() { printf '%s' "$1"; }
+build_chart_ref() { printf '%s' "$1/$2"; }
+find_cached_chart_tgz_by_version() { printf '%s' '/tmp/agent-observability-0.1.4.tgz'; }
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"}}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+if [[ "${UPGRADE_CALLS}" -eq 1 ]]; then
+    ok
+else
+    fail "local installer must upgrade a volatile runtime profile"
+fi
+
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "repository installer must upgrade a volatile runtime profile"
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "durable runtime profiles must skip both installer paths"
+fi
+
+HELM_VALUES='{not-json}'
+_install_openbkn_release_local agent-observability /tmp openbkn
+_install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
+if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then
+    ok
+else
+    fail "unreadable Helm values must not roll out either installer path"
+fi
+eval "${ORIGINAL_RELEASE_EXTRA_SETS}"
 
 cat >"${CONFIG_REGISTRY_FILE}" <<'EOF'
 depServices:

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -114,6 +114,13 @@ if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 
 else
     fail "an explicit volatile override must retain the normal version-skip decision"
 fi
+CORE_SET_VALUES=("opensearch.traceTimestampPipeline=custom-trace-pipeline")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"},"opensearch":{"traceTimestampPipeline":"custom-trace-pipeline"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "a custom timestamp pipeline must not bypass durable Core profile reconciliation"
+else
+    ok
+fi
 CORE_SET_VALUES=("")
 
 HELM_VALUES='{not-json}'


### PR DESCRIPTION
## What Changed

- [x] Backport #1127: reconcile the durable BKN Trace profile on same-version upgrades.
- [x] Backport #1129: repair Collector trace `@timestamp` values through a span-only ingest pipeline.

---

## Why

- Related mainline PRs: #1127, #1129
- Release branch `release/0.1.4` did not yet contain #1127, which #1129 depends on for same-version Collector configuration reconciliation.

---

## How

- Cherry-picked only the two merged mainline commits in dependency order: `305a56ef9` then `3505e457c`.
- No unrelated mainline changes included.
- Breaking changes: none. Historical trace documents are not rewritten.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (not required; no external dependency added)
- [ ] Verified in test environment (requires deploy confirmation)

Test notes:

- `openbkn_trace_profile_test.sh` — 87 checks
- `openbkn_trace_prerequisites_test.sh` — 33 checks
- Collector rollout regression, both Helm lints
- Core Go package tests and `go vet ./...`

---

## Risk & Rollback

- Potential risks: deployment creates an OpenSearch ingest pipeline and rolls existing Collector configuration forward.
- Rollback plan: revert this PR; no historical data is modified.

---

## Additional Notes

- Deployment remains gated by the repository confirmation process.