### PR TITLE
fix(vega): backport single-document query_data gate to 0.1.4

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -373,6 +373,17 @@ func (r *restHandler) getResourceDataDoc(c *gin.Context, visitor hydra.Visitor, 
 	if !ok {
 		return
 	}
+
+	// Reading one document is reading rows, so it needs query_data for the same
+	// reason the paged query does (#571): loading the resource only proves the
+	// caller may see the table's structure, and this endpoint hands back its
+	// contents.
+	if err := r.rs.CheckResourcePermission(ctx, resource.ID, interfaces.OPERATION_TYPE_QUERY_DATA); err != nil {
+		otellog.LogError(ctx, "Get resource data document denied", err)
+		rest.ReplyError(c, err)
+		return
+	}
+
 	warning, err := resourcelogic.EnsureResourceQueryable(ctx, resource)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,6 +29,17 @@ func setupResourceDataHandlerTest(
 	t *testing.T,
 ) (*gin.Engine, *vmock.MockResourceService, *vmock.MockDatasetService, *vmock.MockResourceDataService) {
 	t.Helper()
+	// 取数要 query_data（#571）；这些用例验的是查询本身，统一放行。
+	return setupResourceDataHandlerTestWithPermission(t, nil)
+}
+
+// setupResourceDataHandlerTestWithPermission builds the same harness with the
+// query_data check answering permErr, so a test can drive the endpoint as a
+// caller who may see the table but not read its rows.
+func setupResourceDataHandlerTestWithPermission(
+	t *testing.T, permErr error,
+) (*gin.Engine, *vmock.MockResourceService, *vmock.MockDatasetService, *vmock.MockResourceDataService) {
+	t.Helper()
 
 	engine := gin.New()
 	engine.Use(gin.Recovery())
@@ -36,9 +48,8 @@ func setupResourceDataHandlerTest(
 	t.Cleanup(mockCtrl.Finish)
 
 	rs := vmock.NewMockResourceService(mockCtrl)
-	// 取数要 query_data（#571）；这些用例验的是查询本身，统一放行。
-	rs.EXPECT().CheckResourcePermission(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(nil).AnyTimes()
+	rs.EXPECT().CheckResourcePermission(gomock.Any(), gomock.Any(), interfaces.OPERATION_TYPE_QUERY_DATA).
+		Return(permErr).AnyTimes()
 	ds := vmock.NewMockDatasetService(mockCtrl)
 	rds := vmock.NewMockResourceDataService(mockCtrl)
 	handler := MockNewRestHandler(&common.AppSetting{}, nil, nil, rs, nil, ds, nil, nil, nil, rds)
@@ -274,6 +285,25 @@ func Test_ResourceDataRestHandler_GetResourceDataDoc(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), `"id":"doc-1"`)
+	})
+
+	t.Run("rejects document read without query_data", func(t *testing.T) {
+		// The document endpoint hands back row contents, so view_detail on the
+		// table is not enough on its own: it only says the caller may see the
+		// structure. Without this the split introduced by #801 decides nothing
+		// on this route even though the paged query already honours it.
+		engine, rs, _, _ := setupResourceDataHandlerTestWithPermission(t,
+			rest.NewHTTPError(context.Background(), http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails("Access denied: insufficient permissions for[query_data]"))
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(sampleDatasetResource(), nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/vega-backend/in/v1/resources/res-1/data/doc-1", nil)
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusForbidden, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "query_data")
 	})
 
 	t.Run("returns not found for nil document", func(t *testing.T) {


### PR DESCRIPTION
Backport of #1122 to `release/0.1.4`. Refs #1120.

`release/0.1.4` already carries #977, which gated the paged data query on `query_data`. The per-document route was left behind on that branch too: `getResourceDataDoc` only calls `requireDatasetResource`, which judges `view_detail`, and then returns the document's contents. An account holding `view_detail` alone is refused by the paged route and handed the same rows by this one.

Cherry-pick of `29b90308`, clean — no conflicts, no adaptation.

## Testing

- `go build ./... && go test ./driveradapters/... -count=1` on this branch — passes.
- Verified end to end on the dev VM against a real deployment (main branch build): with `view_detail` only, `GET /resources/:id/data/:doc_id` returns 403 naming `query_data`; after granting `query_data` the request passes the gate and fails downstream on data, not permission.

## Pre-merge checklist

- [x] Unit tests pass
- [x] Cherry-pick applied cleanly
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
