### PR TITLE
fix(bkn-safe): backport resource_manage implies view_detail to 0.1.4

### DIFF
--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -103,25 +103,14 @@ type Services interface {
 	UpdateRole(ctx context.Context, id string, patch RolePatch) error
 	// DeleteRole deletes a custom role and purges its bindings and grants.
 	DeleteRole(ctx context.Context, id string) error
-	// RevokeRolePermissions revokes a set of operations from a custom role over
-	// one resource pattern, judged against the state the role will be left in.
-	//
-	// The set matters. An operation another operation implies cannot be dropped
-	// while that implying operation is kept (#1121), and deciding that one
-	// operation at a time makes the answer depend on the order the caller listed
-	// them: revoking [view_detail, resource_manage] would keep view_detail,
-	// while [resource_manage, view_detail] would drop both. Judged against the
-	// remainder, both orders drop both.
-	RevokeRolePermissions(ctx context.Context, roleID, resourceType, resourceID string, ops []string) error
-
 	// GrantRolePermission grants a custom role an op over a resource pattern.
 	// Refuses wildcard types/ops and the admin-console capability (ErrInvalid).
 	GrantRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
-	// RevokeRolePermission revokes one operation.
+	// RevokeRolePermission revokes one operation from a custom role.
 	//
-	// Deprecated: use RevokeRolePermissions. Revoking one operation at a time
-	// cannot see the rest of the caller's set, so a multi-operation revoke
-	// issued through this entry point still depends on the order.
+	// An implementation that also satisfies RoleSetRevoker gets the whole set
+	// instead, which is what an accurate multi-operation revoke needs — see that
+	// interface.
 	RevokeRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
 }
 
@@ -157,6 +146,28 @@ func requireAnyPermission(svc Services, points ...PermissionPoint) gin.HandlerFu
 		return r.RequireAnyPermission(points...)
 	}
 	return svc.RequirePermission(points[0].ResourceType, points[0].Op)
+}
+
+// RoleSetRevoker is an OPTIONAL extension of Services: revoke a SET of
+// operations from a role over one resource pattern, in a single call.
+//
+// The set is what makes the answer correct. An operation another operation
+// implies cannot be dropped while that implying operation is kept (#1121), and
+// deciding that one operation at a time — against the live state, where an
+// operation earlier in the caller's list is still held — makes the outcome
+// depend on the order: revoking ["view_detail", "resource_manage"] keeps
+// view_detail, while ["resource_manage", "view_detail"] drops both. Judged
+// against the remainder, computed once before anything is removed, both orders
+// drop both.
+//
+// Like AnyPermissionRequirer, this is a separate interface rather than a
+// Services method so that adding it does not break existing Services
+// implementations (notably ee's test doubles). revokeRolePermissions falls back
+// to the per-operation method when the implementation does not provide it,
+// which restores the order dependence for that implementation only — core's
+// does provide it.
+type RoleSetRevoker interface {
+	RevokeRolePermissions(ctx context.Context, roleID, resourceType, resourceID string, ops []string) error
 }
 
 // Mounter registers the rbac_basic write routes onto g using svc. The ee build

--- a/bkn-safe/server/extension/adminwrite/adminwrite.go
+++ b/bkn-safe/server/extension/adminwrite/adminwrite.go
@@ -103,10 +103,25 @@ type Services interface {
 	UpdateRole(ctx context.Context, id string, patch RolePatch) error
 	// DeleteRole deletes a custom role and purges its bindings and grants.
 	DeleteRole(ctx context.Context, id string) error
+	// RevokeRolePermissions revokes a set of operations from a custom role over
+	// one resource pattern, judged against the state the role will be left in.
+	//
+	// The set matters. An operation another operation implies cannot be dropped
+	// while that implying operation is kept (#1121), and deciding that one
+	// operation at a time makes the answer depend on the order the caller listed
+	// them: revoking [view_detail, resource_manage] would keep view_detail,
+	// while [resource_manage, view_detail] would drop both. Judged against the
+	// remainder, both orders drop both.
+	RevokeRolePermissions(ctx context.Context, roleID, resourceType, resourceID string, ops []string) error
+
 	// GrantRolePermission grants a custom role an op over a resource pattern.
 	// Refuses wildcard types/ops and the admin-console capability (ErrInvalid).
 	GrantRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
-	// RevokeRolePermission revokes a custom role's op over a resource pattern.
+	// RevokeRolePermission revokes one operation.
+	//
+	// Deprecated: use RevokeRolePermissions. Revoking one operation at a time
+	// cannot see the rest of the caller's set, so a multi-operation revoke
+	// issued through this entry point still depends on the order.
 	RevokeRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error
 }
 

--- a/bkn-safe/server/extension/adminwrite/rolesetrevoker_test.go
+++ b/bkn-safe/server/extension/adminwrite/rolesetrevoker_test.go
@@ -1,0 +1,74 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package adminwrite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// legacyServices implements exactly the Services method set and nothing more —
+// the shape an existing implementation outside this repository has, including
+// ee's test doubles. It must keep satisfying Services after RoleSetRevoker is
+// introduced, which is the whole reason that is a separate interface.
+type legacyServices struct {
+	revoked []string
+}
+
+func (s *legacyServices) RequirePermission(string, string) gin.HandlerFunc { return nil }
+func (s *legacyServices) CreateRole(context.Context, RoleSpec) (string, error) {
+	return "", nil
+}
+func (s *legacyServices) UpdateRole(context.Context, string, RolePatch) error { return nil }
+func (s *legacyServices) DeleteRole(context.Context, string) error            { return nil }
+func (s *legacyServices) GrantRolePermission(context.Context, string, string, string, string) error {
+	return nil
+}
+func (s *legacyServices) RevokeRolePermission(_ context.Context, _, _, _, op string) error {
+	s.revoked = append(s.revoked, op)
+	return nil
+}
+
+// setServices adds the optional set form on top.
+type setServices struct {
+	legacyServices
+	sets [][]string
+}
+
+func (s *setServices) RevokeRolePermissions(_ context.Context, _, _, _ string, ops []string) error {
+	s.sets = append(s.sets, ops)
+	return nil
+}
+
+func TestRevokeRolePermissionsFallsBackForALegacyImplementation(t *testing.T) {
+	var svc Services = &legacyServices{}
+	if _, ok := svc.(RoleSetRevoker); ok {
+		t.Fatal("the legacy shape must not satisfy RoleSetRevoker")
+	}
+	if err := revokeRolePermissions(t.Context(), svc, "r-1", "catalog", "c1",
+		[]string{"view_detail", "resource_manage"}); err != nil {
+		t.Fatal(err)
+	}
+	got := svc.(*legacyServices).revoked
+	if len(got) != 2 || got[0] != "view_detail" || got[1] != "resource_manage" {
+		t.Fatalf("fallback did not revoke one at a time in order: %v", got)
+	}
+}
+
+func TestRevokeRolePermissionsPrefersTheSetForm(t *testing.T) {
+	svc := &setServices{}
+	if err := revokeRolePermissions(t.Context(), svc, "r-1", "catalog", "c1",
+		[]string{"view_detail", "resource_manage"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(svc.sets) != 1 || len(svc.sets[0]) != 2 {
+		t.Fatalf("set form not used: %v", svc.sets)
+	}
+	if len(svc.revoked) != 0 {
+		t.Fatalf("per-operation path also ran: %v", svc.revoked)
+	}
+}

--- a/bkn-safe/server/extension/adminwrite/routes.go
+++ b/bkn-safe/server/extension/adminwrite/routes.go
@@ -117,11 +117,13 @@ func Routes(g *gin.RouterGroup, svc Services) {
 		if !ok {
 			return
 		}
-		for _, op := range req.Operations {
-			if err := svc.RevokeRolePermission(c.Request.Context(), c.Param("id"), req.Resource.Type, req.Resource.ID, op); err != nil {
-				writeErr(c, err)
-				return
-			}
+		// One call with the whole set: whether an operation may be dropped depends
+		// on what the role is left with, which a per-operation loop cannot see
+		// (#1121).
+		if err := svc.RevokeRolePermissions(c.Request.Context(), c.Param("id"),
+			req.Resource.Type, req.Resource.ID, req.Operations); err != nil {
+			writeErr(c, err)
+			return
 		}
 		c.Status(http.StatusNoContent)
 	})

--- a/bkn-safe/server/extension/adminwrite/routes.go
+++ b/bkn-safe/server/extension/adminwrite/routes.go
@@ -5,6 +5,7 @@
 package adminwrite
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -117,10 +118,10 @@ func Routes(g *gin.RouterGroup, svc Services) {
 		if !ok {
 			return
 		}
-		// One call with the whole set: whether an operation may be dropped depends
-		// on what the role is left with, which a per-operation loop cannot see
-		// (#1121).
-		if err := svc.RevokeRolePermissions(c.Request.Context(), c.Param("id"),
+		// One call with the whole set where the implementation supports it:
+		// whether an operation may be dropped depends on what the role is left
+		// with, which a per-operation loop cannot see (#1121).
+		if err := revokeRolePermissions(c.Request.Context(), svc, c.Param("id"),
 			req.Resource.Type, req.Resource.ID, req.Operations); err != nil {
 			writeErr(c, err)
 			return
@@ -183,4 +184,23 @@ func writeErr(c *gin.Context, err error) {
 		code = httperrors.AdminWriteInvalid
 	}
 	httperrors.WriteCode(c, status, code, nil)
+}
+
+// revokeRolePermissions hands the whole set to svc when it satisfies
+// RoleSetRevoker, and otherwise falls back to revoking one operation at a time.
+// The fallback keeps an older Services implementation compiling and working; it
+// carries the order dependence RoleSetRevoker exists to remove, which is why
+// core implements the set form.
+func revokeRolePermissions(ctx context.Context, svc Services,
+	roleID, resourceType, resourceID string, ops []string) error {
+
+	if r, ok := svc.(RoleSetRevoker); ok {
+		return r.RevokeRolePermissions(ctx, roleID, resourceType, resourceID, ops)
+	}
+	for _, op := range ops {
+		if err := svc.RevokeRolePermission(ctx, roleID, resourceType, resourceID, op); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -431,6 +431,51 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 	return moved, nil
 }
 
+// BackfillImpliedOperation adds impliedOp to every policy row on a resource type
+// that already grants holderOp and does not yet grant the implied one. Returns
+// how many rows gained the operation, so an upgrade that did something is
+// visible in the log.
+//
+// The rule it repairs is enforced when a grant is WRITTEN (see the grant paths
+// in httpapi), which leaves grants written before the rule existed unrepaired —
+// and for catalog.resource_manage that is not a cosmetic gap: a grant carrying
+// only the management verb reaches nothing, because every management route
+// loads its target first and that load is a view_detail judgement. Without this
+// backfill the fix would apply to new grants only, and an administrator would
+// have to re-save each old one without ever being told to.
+//
+// Idempotent: once every holder row carries the implied operation it adds
+// nothing, at the cost of one filtered read per declared implication per start.
+func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp string) (int, error) {
+	rows, err := en.e.GetFilteredPolicy(2, holderOp)
+	if err != nil {
+		return 0, err
+	}
+	prefix := resourceType + ":"
+	added := 0
+	for _, row := range rows {
+		if len(row) < 3 {
+			continue
+		}
+		object := row[1]
+		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
+			continue
+		}
+		has, err := en.e.HasPolicy(row[0], object, impliedOp)
+		if err != nil {
+			return added, err
+		}
+		if has {
+			continue
+		}
+		if _, err := en.e.AddPolicy(row[0], object, impliedOp); err != nil {
+			return added, err
+		}
+		added++
+	}
+	return added, nil
+}
+
 // RemoveRolePermissions purges only the p-lines owned by a role, preserving its
 // member bindings. Seed uses this before re-applying the built-in permission
 // matrix so removed grants do not linger across upgrades.

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -431,10 +431,17 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 	return moved, nil
 }
 
+// BackfilledGrant names one policy row that gained an implied operation, so the
+// caller can record each repair in the audit trail rather than only counting it.
+type BackfilledGrant struct {
+	AccessorID string
+	ResourceID string
+}
+
 // BackfillImpliedOperation adds impliedOp to every policy row on a resource type
 // that already grants holderOp and does not yet grant the implied one. Returns
-// how many rows gained the operation, so an upgrade that did something is
-// visible in the log.
+// the rows that gained the operation, so an upgrade that did something is both
+// visible in the log and recordable per grant.
 //
 // The rule it repairs is enforced when a grant is WRITTEN (see the grant paths
 // in httpapi), which leaves grants written before the rule existed unrepaired —
@@ -446,13 +453,13 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 //
 // Idempotent: once every holder row carries the implied operation it adds
 // nothing, at the cost of one filtered read per declared implication per start.
-func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp string) (int, error) {
+func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp string) ([]BackfilledGrant, error) {
 	rows, err := en.e.GetFilteredPolicy(2, holderOp)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	prefix := resourceType + ":"
-	added := 0
+	var added []BackfilledGrant
 	for _, row := range rows {
 		if len(row) < 3 {
 			continue
@@ -471,7 +478,7 @@ func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp s
 		if _, err := en.e.AddPolicy(row[0], object, impliedOp); err != nil {
 			return added, err
 		}
-		added++
+		added = append(added, BackfilledGrant{AccessorID: row[0], ResourceID: object[len(prefix):]})
 	}
 	return added, nil
 }

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -142,28 +143,62 @@ func (s *adminWriteServices) RevokeRolePermission(ctx context.Context, roleID, r
 	if err != nil {
 		return err
 	}
-	// Revoking view_detail takes resource_manage with it (#1121). Leaving the
-	// implying verb behind would rebuild the grant that cannot be used, and the
-	// role would keep a permission whose every route answers 403.
+	// An operation stays if another operation the role still holds implies it
+	// (#1121): revoking view_detail while resource_manage remains would leave a
+	// verb whose every route answers 403, the grant this rule exists to prevent.
 	//
-	// The reverse is deliberately NOT symmetric: revoking resource_manage leaves
-	// view_detail standing. view_detail is a permission in its own right, held by
-	// plenty of roles that never manage anything, and this route cannot tell one
-	// the expansion added from one granted on purpose. Taking it away would
-	// silently narrow access nobody asked to narrow, whereas keeping it lands on
-	// "may open the catalog, may no longer manage its tables" — which is what an
-	// operator issuing exactly this revoke means, and what the object-grant
-	// surface produces for the same edit.
-	ops, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
+	// Retaining is what the whole-set object-grant surface already does for the
+	// same edit — a console that clears view_detail while leaving resource_manage
+	// ticked gets view_detail back — and it is the only shape that does not
+	// depend on the order a caller sends its pair of requests in. Revoking the
+	// implying verb as well would mean a console saving "add resource_manage,
+	// drop view_detail" as two calls ends up with NEITHER, silently discarding
+	// the grant it had just made.
+	//
+	// So this route only ever removes the operation it was given, and only when
+	// nothing the role retains implies it. To drop view_detail, revoke
+	// resource_manage first; that revoke is honoured immediately, because
+	// view_detail implies nothing.
+	implying, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
 	if err != nil {
 		return err
 	}
-	for _, revoked := range ops {
-		if err := s.e.RevokeRolePermission(role.ID, resourceType, resourceID, revoked); err != nil {
+	if len(implying) > 1 {
+		held, err := s.roleOperationsOn(role.ID, resourceType, resourceID)
+		if err != nil {
 			return err
 		}
+		for _, other := range implying {
+			if other == op || !held[other] {
+				continue
+			}
+			slog.Info("kept an operation the role still implies",
+				"role_id", role.ID, "resource_type", resourceType, "resource_id", resourceID,
+				"operation", op, "implied_by", other)
+			return nil
+		}
 	}
-	return nil
+	return s.e.RevokeRolePermission(role.ID, resourceType, resourceID, op)
+}
+
+// roleOperationsOn returns the operations the role holds on exactly one
+// resource pattern, as a set.
+func (s *adminWriteServices) roleOperationsOn(roleID, resourceType, resourceID string) (map[string]bool, error) {
+	grants, err := s.e.RolePermissions(roleID)
+	if err != nil {
+		return nil, err
+	}
+	want := resourceType + ":" + resourceID
+	out := map[string]bool{}
+	for _, g := range grants {
+		if g.Object != want {
+			continue
+		}
+		for _, op := range g.Operations {
+			out[op] = true
+		}
+	}
+	return out, nil
 }
 
 // loadCustomRole fetches a role and rejects built-ins. It maps to the

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -121,7 +121,19 @@ func (s *adminWriteServices) GrantRolePermission(ctx context.Context, roleID, re
 	if resourceType == adminConsoleResourceType {
 		return adminwrite.ErrAdminConsolePermission
 	}
-	return s.e.GrantRolePermission(role.ID, resourceType, resourceID, op)
+	// A role granted resource_manage gets view_detail with it (#1121): the
+	// management routes load their target first, so without it the role holds a
+	// verb it can never reach.
+	ops, err := impliedOps(s.db.WithContext(ctx), resourceType, []string{op})
+	if err != nil {
+		return err
+	}
+	for _, granted := range ops {
+		if err := s.e.GrantRolePermission(role.ID, resourceType, resourceID, granted); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RevokeRolePermission revokes a custom role's op over a resource pattern.
@@ -130,7 +142,19 @@ func (s *adminWriteServices) RevokeRolePermission(ctx context.Context, roleID, r
 	if err != nil {
 		return err
 	}
-	return s.e.RevokeRolePermission(role.ID, resourceType, resourceID, op)
+	// Revoking view_detail takes resource_manage with it (#1121). Leaving the
+	// implying verb behind would rebuild the grant that cannot be used, and the
+	// role would keep a permission whose every route answers 403.
+	ops, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
+	if err != nil {
+		return err
+	}
+	for _, revoked := range ops {
+		if err := s.e.RevokeRolePermission(role.ID, resourceType, resourceID, revoked); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // loadCustomRole fetches a role and rejects built-ins. It maps to the

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -145,6 +145,15 @@ func (s *adminWriteServices) RevokeRolePermission(ctx context.Context, roleID, r
 	// Revoking view_detail takes resource_manage with it (#1121). Leaving the
 	// implying verb behind would rebuild the grant that cannot be used, and the
 	// role would keep a permission whose every route answers 403.
+	//
+	// The reverse is deliberately NOT symmetric: revoking resource_manage leaves
+	// view_detail standing. view_detail is a permission in its own right, held by
+	// plenty of roles that never manage anything, and this route cannot tell one
+	// the expansion added from one granted on purpose. Taking it away would
+	// silently narrow access nobody asked to narrow, whereas keeping it lands on
+	// "may open the catalog, may no longer manage its tables" — which is what an
+	// operator issuing exactly this revoke means, and what the object-grant
+	// surface produces for the same edit.
 	ops, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
 	if err != nil {
 		return err

--- a/bkn-safe/server/internal/httpapi/adminwrite_svc.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_svc.go
@@ -137,48 +137,83 @@ func (s *adminWriteServices) GrantRolePermission(ctx context.Context, roleID, re
 	return nil
 }
 
-// RevokeRolePermission revokes a custom role's op over a resource pattern.
+// RevokeRolePermission revokes one operation.
+//
+// Deprecated: use RevokeRolePermissions. One operation at a time cannot see the
+// rest of the caller's set, so the outcome of a multi-operation revoke depends
+// on the order — see RevokeRolePermissions.
 func (s *adminWriteServices) RevokeRolePermission(ctx context.Context, roleID, resourceType, resourceID, op string) error {
+	return s.RevokeRolePermissions(ctx, roleID, resourceType, resourceID, []string{op})
+}
+
+// RevokeRolePermissions revokes a set of operations from a custom role over one
+// resource pattern.
+//
+// An operation stays if something the role is LEFT WITH implies it (#1121):
+// dropping view_detail while resource_manage remains would leave a verb whose
+// every route answers 403, the grant this rule exists to prevent. Retaining is
+// also what the whole-set object-grant surface does for the same edit, so the
+// two surfaces agree.
+//
+// "Left with" is the whole point, and it is why this takes a set. Judging one
+// operation at a time against the live state makes the answer depend on the
+// order the caller listed them — revoking [view_detail, resource_manage] would
+// keep view_detail because resource_manage was still there when view_detail was
+// considered, while the reverse order would drop both. The remainder is
+// computed once, before anything is removed, so both orders drop both.
+//
+// Dropping view_detail alone stays reachable: revoke resource_manage first, and
+// the next revoke is honoured because nothing left implies view_detail.
+func (s *adminWriteServices) RevokeRolePermissions(ctx context.Context,
+	roleID, resourceType, resourceID string, ops []string) error {
+
 	role, err := s.loadCustomRole(ctx, roleID)
 	if err != nil {
 		return err
 	}
-	// An operation stays if another operation the role still holds implies it
-	// (#1121): revoking view_detail while resource_manage remains would leave a
-	// verb whose every route answers 403, the grant this rule exists to prevent.
-	//
-	// Retaining is what the whole-set object-grant surface already does for the
-	// same edit — a console that clears view_detail while leaving resource_manage
-	// ticked gets view_detail back — and it is the only shape that does not
-	// depend on the order a caller sends its pair of requests in. Revoking the
-	// implying verb as well would mean a console saving "add resource_manage,
-	// drop view_detail" as two calls ends up with NEITHER, silently discarding
-	// the grant it had just made.
-	//
-	// So this route only ever removes the operation it was given, and only when
-	// nothing the role retains implies it. To drop view_detail, revoke
-	// resource_manage first; that revoke is honoured immediately, because
-	// view_detail implies nothing.
-	implying, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
+	if len(ops) == 0 {
+		return nil
+	}
+	held, err := s.roleOperationsOn(role.ID, resourceType, resourceID)
 	if err != nil {
 		return err
 	}
-	if len(implying) > 1 {
-		held, err := s.roleOperationsOn(role.ID, resourceType, resourceID)
+	// What the role keeps once this request is applied — computed before the
+	// first removal so no operation's verdict can depend on another's.
+	remaining := map[string]bool{}
+	requested := make(map[string]bool, len(ops))
+	for _, op := range ops {
+		requested[op] = true
+	}
+	for op := range held {
+		if !requested[op] {
+			remaining[op] = true
+		}
+	}
+
+	for _, op := range ops {
+		implying, err := impliedBy(s.db.WithContext(ctx), resourceType, []string{op})
 		if err != nil {
 			return err
 		}
+		retainedBy := ""
 		for _, other := range implying {
-			if other == op || !held[other] {
-				continue
+			if other != op && remaining[other] {
+				retainedBy = other
+				break
 			}
+		}
+		if retainedBy != "" {
 			slog.Info("kept an operation the role still implies",
 				"role_id", role.ID, "resource_type", resourceType, "resource_id", resourceID,
-				"operation", op, "implied_by", other)
-			return nil
+				"operation", op, "implied_by", retainedBy)
+			continue
+		}
+		if err := s.e.RevokeRolePermission(role.ID, resourceType, resourceID, op); err != nil {
+			return err
 		}
 	}
-	return s.e.RevokeRolePermission(role.ID, resourceType, resourceID, op)
+	return nil
 }
 
 // roleOperationsOn returns the operations the role holds on exactly one

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -191,7 +191,16 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		auditPolicyWriteShape(c, db, "POST", req.AccessorID, req.Resource, req.Operations)
-		for _, op := range req.Operations {
+		// Expand implications here too (#1121). This route is the one a service
+		// calls directly, so leaving it out would keep the very bypass the rule
+		// exists to close: a caller could still write catalog.resource_manage
+		// alone and produce a grant that reaches nothing.
+		ops, err := impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		for _, op := range ops {
 			if err := e.GrantObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
 				serverError(c, err)
 				return

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -277,7 +277,17 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 				return
 			}
 		}
-		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, req.Operations); err != nil {
+		// Add the operations the requested ones imply (#1121). Expanded after
+		// validation so a typo is still a 400 rather than something the expansion
+		// quietly absorbs. Upsert semantics make this self-healing: a console that
+		// clears view_detail while leaving resource_manage ticked sends a set this
+		// puts back, instead of storing a grant nothing can use.
+		ops, err := impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, ops); err != nil {
 			serverError(c, err)
 			return
 		}

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -287,6 +287,15 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			serverError(c, err)
 			return
 		}
+		// The audit Detail snapshots the request body, so without this the trail
+		// would say only what was asked for and an implied operation would appear
+		// on the accessor with nothing recording where it came from — the one
+		// question ("why can this account see this catalog?") the trail exists to
+		// answer. The seed's back-fill records its own repairs for the same
+		// reason; this keeps the two paths saying the same thing.
+		if implied := addedOps(req.Operations, ops); len(implied) > 0 {
+			setAuditOutcome(c, map[string]any{"implied_operations": implied})
+		}
 		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, ops); err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/opimplications.go
+++ b/bkn-safe/server/internal/httpapi/opimplications.go
@@ -1,0 +1,98 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"strings"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// Operation implications (#1121) close a gap that no enforcement change could:
+// resource_manage on a catalog is worthless without view_detail on the same
+// catalog, because every management route loads its target first and that load
+// is a view_detail judgement. A grant carrying only resource_manage produces a
+// 403 that names view_detail — an operator reads it as a bug in the check
+// rather than as a hole in the grant they just made.
+//
+// The rule is applied where grants are WRITTEN, not where they are read. A
+// grant is therefore stored complete: the policy table says what the accessor
+// holds, and no reader has to replay an implication to know it. It also means
+// existing grants are untouched by a deployment picking this version up —
+// re-saving one is what repairs it.
+
+// impliedOps expands ops with everything they imply on the same resource type,
+// transitively. Order is preserved and the original ops come first, so an
+// audit record still reads as "what was asked for, plus what came with it".
+//
+// A type with no implications (every type but catalog today) returns the input
+// unchanged after one query.
+func impliedOps(db *gorm.DB, resourceType string, ops []string) ([]string, error) {
+	forward, _, err := implicationMaps(db, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	return closure(ops, forward), nil
+}
+
+// impliedBy expands ops with everything that IMPLIES them, transitively — the
+// reverse direction, used when revoking. Dropping view_detail while leaving
+// resource_manage behind would rebuild exactly the unusable grant this rule
+// exists to prevent, so a revoke takes the implying operation with it.
+func impliedBy(db *gorm.DB, resourceType string, ops []string) ([]string, error) {
+	_, reverse, err := implicationMaps(db, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	return closure(ops, reverse), nil
+}
+
+// implicationMaps reads the type's operation rows once and returns the
+// implication graph in both directions.
+func implicationMaps(db *gorm.DB, resourceType string) (forward, reverse map[string][]string, err error) {
+	var rows []model.Operation
+	if err := db.Where("resource_type_id = ? AND implied_operation_ids <> ''", resourceType).
+		Find(&rows).Error; err != nil {
+		return nil, nil, err
+	}
+	forward = make(map[string][]string, len(rows))
+	reverse = make(map[string][]string, len(rows))
+	for _, row := range rows {
+		for _, implied := range strings.Split(row.ImpliedOperationIDs, ",") {
+			implied = strings.TrimSpace(implied)
+			if implied == "" {
+				continue
+			}
+			forward[row.ID] = append(forward[row.ID], implied)
+			reverse[implied] = append(reverse[implied], row.ID)
+		}
+	}
+	return forward, reverse, nil
+}
+
+// closure walks the graph breadth-first from ops. The seed refuses to boot on a
+// cyclic implication graph, but the visited set makes this terminate anyway:
+// a cycle reaching production must not hang a grant request.
+func closure(ops []string, graph map[string][]string) []string {
+	if len(graph) == 0 {
+		return ops
+	}
+	out := make([]string, 0, len(ops)+len(graph))
+	seen := make(map[string]bool, len(ops)+len(graph))
+	queue := append([]string(nil), ops...)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if seen[cur] {
+			continue
+		}
+		seen[cur] = true
+		out = append(out, cur)
+		queue = append(queue, graph[cur]...)
+	}
+	return out
+}

--- a/bkn-safe/server/internal/httpapi/opimplications.go
+++ b/bkn-safe/server/internal/httpapi/opimplications.go
@@ -96,3 +96,19 @@ func closure(ops []string, graph map[string][]string) []string {
 	}
 	return out
 }
+
+// addedOps returns the members of expanded that were not in requested, in
+// expanded's order — what the implication added on top of what was asked for.
+func addedOps(requested, expanded []string) []string {
+	asked := make(map[string]bool, len(requested))
+	for _, op := range requested {
+		asked[op] = true
+	}
+	var out []string
+	for _, op := range expanded {
+		if !asked[op] {
+			out = append(out, op)
+		}
+	}
+	return out
+}

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -11,6 +11,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -318,11 +319,12 @@ func TestRevokeSetIsOrderIndependent(t *testing.T) {
 				t.Fatal(err)
 			}
 			svc := newAdminWriteServices(e, db)
+			revoker := svc.(adminwrite.RoleSetRevoker)
 			ctx := t.Context()
 			if err := svc.GrantRolePermission(ctx, "r-3", "catalog", "c1", "resource_manage"); err != nil {
 				t.Fatal(err)
 			}
-			if err := svc.RevokeRolePermissions(ctx, "r-3", "catalog", "c1", ops); err != nil {
+			if err := revoker.RevokeRolePermissions(ctx, "r-3", "catalog", "c1", ops); err != nil {
 				t.Fatalf("revoke %v: %v", ops, err)
 			}
 			for _, op := range []string{"view_detail", "resource_manage"} {
@@ -345,11 +347,12 @@ func TestRevokeSetKeepsAnOperationTheRemainderImplies(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc := newAdminWriteServices(e, db)
+	revoker := svc.(adminwrite.RoleSetRevoker)
 	ctx := t.Context()
 	if err := svc.GrantRolePermission(ctx, "r-4", "catalog", "c1", "resource_manage"); err != nil {
 		t.Fatal(err)
 	}
-	if err := svc.RevokeRolePermissions(ctx, "r-4", "catalog", "c1", []string{"view_detail"}); err != nil {
+	if err := revoker.RevokeRolePermissions(ctx, "r-4", "catalog", "c1", []string{"view_detail"}); err != nil {
 		t.Fatal(err)
 	}
 	for _, op := range []string{"view_detail", "resource_manage"} {

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -174,3 +174,27 @@ func TestImpliedOpsAndImpliedBy(t *testing.T) {
 		t.Fatalf("no-implication type: %+v", got)
 	}
 }
+
+// TestInternalPolicyGrantExpandsImplications covers the third write face. It is
+// the one a service calls directly, and it was missed on the first pass: found
+// by driving a real deployment, where a grant written through it came back
+// carrying resource_manage alone.
+func TestInternalPolicyGrantExpandsImplications(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+
+	w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", map[string]any{
+		"accessor_id": "svc-created",
+		"resource":    map[string]any{"type": "catalog", "id": "c9"},
+		"operations":  []string{"resource_manage"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	for _, op := range []string{"resource_manage", "view_detail"} {
+		if ok, _ := e.Check("svc-created", "catalog", "c9", op); !ok {
+			t.Fatalf("%s not granted", op)
+		}
+	}
+}

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -6,10 +6,12 @@ package httpapi
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -126,9 +128,11 @@ func TestRolePermissionImplicationDirections(t *testing.T) {
 		t.Fatal("revoking resource_manage took view_detail with it")
 	}
 
-	// The other direction is not symmetric, deliberately: revoking view_detail
-	// takes resource_manage with it, because the alternative is to leave a verb
-	// whose every route answers 403 — the exact grant #1121 exists to prevent.
+	// Revoking view_detail while resource_manage is held does NOT remove it: the
+	// operation is still implied, and dropping it would leave a verb whose every
+	// route answers 403. This is what the whole-set object-grant surface already
+	// does for the same edit, and it makes the outcome independent of the order
+	// a console sends its pair of requests in — see the sequence below.
 	if err := svc.GrantRolePermission(ctx, "r-1", "catalog", "c1", "resource_manage"); err != nil {
 		t.Fatalf("re-grant: %v", err)
 	}
@@ -136,9 +140,105 @@ func TestRolePermissionImplicationDirections(t *testing.T) {
 		t.Fatalf("revoke view_detail: %v", err)
 	}
 	for _, op := range []string{"view_detail", "resource_manage"} {
-		if ok, _ := e.Check("r-1", "catalog", "c1", op); ok {
-			t.Fatalf("%s survived the view_detail revoke", op)
+		if ok, _ := e.Check("r-1", "catalog", "c1", op); !ok {
+			t.Fatalf("%s was dropped by a revoke that had to be refused", op)
 		}
+	}
+
+	// Revoking the implying verb first is honoured immediately, and view_detail
+	// can then be revoked too, because nothing implies it any more.
+	if err := svc.RevokeRolePermission(ctx, "r-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatalf("revoke resource_manage: %v", err)
+	}
+	if err := svc.RevokeRolePermission(ctx, "r-1", "catalog", "c1", "view_detail"); err != nil {
+		t.Fatalf("revoke view_detail after: %v", err)
+	}
+	for _, op := range []string{"view_detail", "resource_manage"} {
+		if ok, _ := e.Check("r-1", "catalog", "c1", op); ok {
+			t.Fatalf("%s survived an unblocked revoke", op)
+		}
+	}
+}
+
+// TestRolePermissionSaveOrderDoesNotChangeTheResult is the case review raised:
+// a console saving a permission diff as "grant resource_manage" plus "revoke
+// view_detail" must not end up with neither, silently discarding the grant it
+// just made. Both orders must land on the same held set.
+func TestRolePermissionSaveOrderDoesNotChangeTheResult(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		revokeFirst bool
+	}{
+		{"grant then revoke", false},
+		{"revoke then grant", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, e, db, _ := newAdminServer(t)
+			seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+			seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+			if err := db.Create(&model.Role{ID: "r-2", Name: "custom", Source: model.RoleSourceCustom}).Error; err != nil {
+				t.Fatal(err)
+			}
+			svc := newAdminWriteServices(e, db)
+			ctx := t.Context()
+
+			grant := func() error {
+				return svc.GrantRolePermission(ctx, "r-2", "catalog", "c1", "resource_manage")
+			}
+			revoke := func() error {
+				return svc.RevokeRolePermission(ctx, "r-2", "catalog", "c1", "view_detail")
+			}
+			steps := []func() error{grant, revoke}
+			if tc.revokeFirst {
+				steps = []func() error{revoke, grant}
+			}
+			for i, step := range steps {
+				if err := step(); err != nil {
+					t.Fatalf("step %d: %v", i, err)
+				}
+			}
+			for _, op := range []string{"resource_manage", "view_detail"} {
+				if ok, _ := e.Check("r-2", "catalog", "c1", op); !ok {
+					t.Fatalf("%s missing after %s", op, tc.name)
+				}
+			}
+		})
+	}
+}
+
+// TestObjectGrantAuditNamesTheImpliedOperation: the audit Detail snapshots the
+// request body, so an implied operation would otherwise land on the accessor
+// with nothing in the trail saying where it came from.
+func TestObjectGrantAuditNamesTheImpliedOperation(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(),
+		&model.User{ID: "u-9", Account: "carol", Name: "Carol", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-9",
+		"resource":    map[string]any{"type": "catalog", "id": "c7"},
+		"operations":  []string{"resource_manage"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	entries, total, err := audit.New(db).List(t.Context(), audit.Filter{
+		Resource: "object-grants", Action: "grant", TargetID: "c7",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("audit rows = %d, want 1", total)
+	}
+	if !strings.Contains(entries[0].Detail, "implied_operations") ||
+		!strings.Contains(entries[0].Detail, "view_detail") {
+		t.Fatalf("audit detail does not name the implied operation: %s", entries[0].Detail)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -1,0 +1,122 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// seedCatalogOpImplies registers one operation that carries same-type
+// implications, the shape catalog.json gives resource_manage.
+func seedCatalogOpImplies(t *testing.T, db *gorm.DB, resourceType, op string, implies string) {
+	t.Helper()
+	row := model.Operation{
+		ResourceTypeID: resourceType, ID: op, Name: op,
+		ImpliedOperationIDs: implies,
+	}
+	if err := db.Create(&row).Error; err != nil {
+		t.Fatalf("seed op %s/%s: %v", resourceType, op, err)
+	}
+}
+
+func TestObjectGrantResourceManageImpliesViewDetail(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(),
+		&model.User{ID: "u-1", Account: "alice", Name: "Alice", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+
+	// Granting only resource_manage must still leave the grantee able to open the
+	// catalog: every management route loads its target first, and that load is a
+	// view_detail judgement, so resource_manage on its own reaches nothing.
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"resource_manage"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	for _, op := range []string{"resource_manage", "view_detail"} {
+		if ok, _ := e.Check("u-1", "catalog", "c1", op); !ok {
+			t.Fatalf("%s not granted", op)
+		}
+	}
+
+	// The expansion is reported back, so an operator reading the grant sees what
+	// the accessor actually holds rather than what was typed.
+	entries := listObjectGrants(t, r, "?accessor_id=u-1")
+	if len(entries) != 1 || len(entries[0].Operations) != 2 {
+		t.Fatalf("unexpected list: %+v", entries)
+	}
+
+	// Replace semantics make it self-healing: a console that clears view_detail
+	// while leaving resource_manage ticked sends a set the expansion puts back.
+	w = adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"resource_manage"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("re-grant: want 204, got %d", w.Code)
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "view_detail"); !ok {
+		t.Fatal("re-grant dropped the implied op")
+	}
+
+	// The implication runs one way only: view_detail must not drag the
+	// management verb in behind it.
+	w = adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-1",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"view_detail"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("narrow: want 204, got %d", w.Code)
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "resource_manage"); ok {
+		t.Fatal("view_detail granted the implying op")
+	}
+}
+
+func TestImpliedOpsAndImpliedBy(t *testing.T) {
+	_, _, db, _ := newAdminServer(t)
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+	seedCatalogOps(t, db, "connector_type", "view_detail", "modify")
+
+	got, err := impliedOps(db, "catalog", []string{"resource_manage"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "resource_manage" || got[1] != "view_detail" {
+		t.Fatalf("forward closure: %+v", got)
+	}
+
+	got, err = impliedBy(db, "catalog", []string{"view_detail"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0] != "view_detail" || got[1] != "resource_manage" {
+		t.Fatalf("reverse closure: %+v", got)
+	}
+
+	// A type that declares no implications is returned untouched, which is every
+	// type but catalog today.
+	got, err = impliedOps(db, "connector_type", []string{"modify"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0] != "modify" {
+		t.Fatalf("no-implication type: %+v", got)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -298,3 +298,63 @@ func TestInternalPolicyGrantExpandsImplications(t *testing.T) {
 		}
 	}
 }
+
+// TestRevokeSetIsOrderIndependent is the case the second review round raised:
+// judging one operation at a time against the LIVE state makes a
+// multi-operation revoke depend on the order the caller listed them, so
+// ["view_detail", "resource_manage"] left view_detail behind while the reverse
+// order dropped both. The verdict is computed against what the role is left
+// with, so both orders now drop both.
+func TestRevokeSetIsOrderIndependent(t *testing.T) {
+	for _, ops := range [][]string{
+		{"view_detail", "resource_manage"},
+		{"resource_manage", "view_detail"},
+	} {
+		t.Run(strings.Join(ops, ","), func(t *testing.T) {
+			_, e, db, _ := newAdminServer(t)
+			seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+			seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+			if err := db.Create(&model.Role{ID: "r-3", Name: "custom", Source: model.RoleSourceCustom}).Error; err != nil {
+				t.Fatal(err)
+			}
+			svc := newAdminWriteServices(e, db)
+			ctx := t.Context()
+			if err := svc.GrantRolePermission(ctx, "r-3", "catalog", "c1", "resource_manage"); err != nil {
+				t.Fatal(err)
+			}
+			if err := svc.RevokeRolePermissions(ctx, "r-3", "catalog", "c1", ops); err != nil {
+				t.Fatalf("revoke %v: %v", ops, err)
+			}
+			for _, op := range []string{"view_detail", "resource_manage"} {
+				if ok, _ := e.Check("r-3", "catalog", "c1", op); ok {
+					t.Fatalf("%s survived revoke of %v", op, ops)
+				}
+			}
+		})
+	}
+}
+
+// TestRevokeSetKeepsAnOperationTheRemainderImplies is the other half: dropping
+// only view_detail while resource_manage is kept must leave view_detail in
+// place, or the role is left holding a verb that answers 403 everywhere.
+func TestRevokeSetKeepsAnOperationTheRemainderImplies(t *testing.T) {
+	_, e, db, _ := newAdminServer(t)
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+	if err := db.Create(&model.Role{ID: "r-4", Name: "custom", Source: model.RoleSourceCustom}).Error; err != nil {
+		t.Fatal(err)
+	}
+	svc := newAdminWriteServices(e, db)
+	ctx := t.Context()
+	if err := svc.GrantRolePermission(ctx, "r-4", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.RevokeRolePermissions(ctx, "r-4", "catalog", "c1", []string{"view_detail"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, op := range []string{"view_detail", "resource_manage"} {
+		if ok, _ := e.Check("r-4", "catalog", "c1", op); !ok {
+			t.Fatalf("%s dropped by a revoke the invariant had to refuse", op)
+		}
+	}
+}

--- a/bkn-safe/server/internal/httpapi/opimplications_test.go
+++ b/bkn-safe/server/internal/httpapi/opimplications_test.go
@@ -88,6 +88,60 @@ func TestObjectGrantResourceManageImpliesViewDetail(t *testing.T) {
 	}
 }
 
+// TestRolePermissionImplicationDirections pins the role write path, which the
+// object-grant surface cannot stand in for: role grants and revokes arrive one
+// operation at a time, so each direction has to be decided on its own rather
+// than falling out of a whole-set replace.
+func TestRolePermissionImplicationDirections(t *testing.T) {
+	_, e, db, _ := newAdminServer(t)
+	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")
+	seedCatalogOpImplies(t, db, "catalog", "resource_manage", "view_detail")
+	if err := db.Create(&model.Role{ID: "r-1", Name: "custom", Source: model.RoleSourceCustom}).Error; err != nil {
+		t.Fatal(err)
+	}
+	svc := newAdminWriteServices(e, db)
+	ctx := t.Context()
+
+	if err := svc.GrantRolePermission(ctx, "r-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	for _, op := range []string{"resource_manage", "view_detail"} {
+		if ok, _ := e.Check("r-1", "catalog", "c1", op); !ok {
+			t.Fatalf("%s not granted to the role", op)
+		}
+	}
+
+	// Revoking the management verb leaves view_detail standing. It is a
+	// permission in its own right — "may open this catalog but no longer manage
+	// the tables in it" is the end state an operator asking for exactly this
+	// revoke wants, and it is also what the object-grant surface produces when a
+	// console re-saves the same set without resource_manage.
+	if err := svc.RevokeRolePermission(ctx, "r-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatalf("revoke resource_manage: %v", err)
+	}
+	if ok, _ := e.Check("r-1", "catalog", "c1", "resource_manage"); ok {
+		t.Fatal("resource_manage survived its own revoke")
+	}
+	if ok, _ := e.Check("r-1", "catalog", "c1", "view_detail"); !ok {
+		t.Fatal("revoking resource_manage took view_detail with it")
+	}
+
+	// The other direction is not symmetric, deliberately: revoking view_detail
+	// takes resource_manage with it, because the alternative is to leave a verb
+	// whose every route answers 403 — the exact grant #1121 exists to prevent.
+	if err := svc.GrantRolePermission(ctx, "r-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatalf("re-grant: %v", err)
+	}
+	if err := svc.RevokeRolePermission(ctx, "r-1", "catalog", "c1", "view_detail"); err != nil {
+		t.Fatalf("revoke view_detail: %v", err)
+	}
+	for _, op := range []string{"view_detail", "resource_manage"} {
+		if ok, _ := e.Check("r-1", "catalog", "c1", op); ok {
+			t.Fatalf("%s survived the view_detail revoke", op)
+		}
+	}
+}
+
 func TestImpliedOpsAndImpliedBy(t *testing.T) {
 	_, _, db, _ := newAdminServer(t)
 	seedCatalogOps(t, db, "catalog", "view_detail", "query_data")

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -140,6 +140,16 @@ type Operation struct {
 	// name would turn the right to rename a catalog into the right to rewrite
 	// every table in it. Empty = the operation does not inherit at all (#800).
 	ParentOperationID string `gorm:"size:64"`
+	// ImpliedOperationIDs are operations on the SAME type that come with this one
+	// and cannot sensibly be held without it: resource_manage on a catalog also
+	// grants view_detail, because managing the tables inside a catalog is
+	// unreachable without the right to open it — every management route loads the
+	// target first, and that load is a view_detail judgement (#1121).
+	//
+	// Comma-separated operation ids, resolved when the grant is written rather
+	// than when it is enforced, so the policy table stores what the accessor
+	// actually holds and a reader need not replay a rule to know it.
+	ImpliedOperationIDs string `gorm:"size:512"`
 }
 
 // ResourceParent records that ONE concrete resource instance sits under one

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -44,7 +44,7 @@
       "id": "catalog",
       "name": "数据目录",
       "_source": "vega",
-      "_note": "create/modify/delete 只针对目录本身;管理目录下的数据表用 resource_manage;query_data 是「目录下的表默认可取数」,它能一次性放开整个目录的数据,界面上不要与 view_detail 捆绑勾选(#800 / #801)",
+      "_note": "create/modify/delete 只针对目录本身;管理目录下的数据表用 resource_manage;query_data 是「目录下的表默认可取数」,它能一次性放开整个目录的数据,界面上不要与 view_detail 捆绑勾选(#800 / #801)。resource_manage 是例外:它 implies view_detail,授出时自动带上,因为每条管理路由都先加载目标,而那一次加载判的就是 view_detail,只给 resource_manage 的授权谁也用不了(#1121)",
       "operations": [
         {"id": "view_detail", "name": "查看详情"},
         {"id": "create", "name": "创建目录"},
@@ -52,7 +52,7 @@
         {"id": "delete", "name": "删除目录"},
         {"id": "authorize", "name": "授权"},
         {"id": "task_manage", "name": "任务管理"},
-        {"id": "resource_manage", "name": "管理目录下的数据表"},
+        {"id": "resource_manage", "name": "管理目录下的数据表", "implies": ["view_detail"]},
         {"id": "query_data", "name": "查询目录下的表数据"}
       ]
     },

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -185,3 +185,64 @@ func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
 		t.Fatalf("audit detail does not name the operations: %s", got.Detail)
 	}
 }
+
+// TestBackfillAuditLabelsMatchTheSurfaceThatShowsTheGrant pins the vocabulary
+// per subject kind. An audit row naming a surface where the grant is absent is
+// worse than no row: it sends the auditor looking in a list that by
+// construction will never contain it. GET /object-grants excludes role
+// subjects, the public accessor and type-wide "type:*" rows alike.
+func TestBackfillAuditLabelsMatchTheSurfaceThatShowsTheGrant(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := db.Create(&model.Role{ID: "role-x", Name: "自定义角色", Source: model.RoleSourceCustom}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// One row of each shape, all holding the management verb without the
+	// visibility it implies.
+	if err := e.GrantObjectPermission("u-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission("role-x", "catalog", "*", "resource_manage"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission(authz.PublicAccessorID, "catalog", "c2", "resource_manage"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+
+	trail := audit.New(db)
+	for _, tc := range []struct {
+		name             string
+		resource, action string
+		targetID         string
+	}{
+		{"user object grant", "object-grants", "grant", "c1"},
+		{"role permission", "roles", "grant_permission", "role-x"},
+		{"public accessor is not an object grant", "policies", "grant", "c2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entries, total, err := trail.List(t.Context(), audit.Filter{
+				Resource: tc.resource, Action: tc.action, TargetID: tc.targetID,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if total != 1 {
+				t.Fatalf("rows = %d, want 1", total)
+			}
+			if entries[0].ActorID != "system:seed" {
+				t.Fatalf("actor = %q", entries[0].ActorID)
+			}
+		})
+	}
+}

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -112,3 +112,54 @@ func TestSeedPersistsImplications(t *testing.T) {
 		t.Fatalf("implied_operation_ids = %q, want %q", row.ImpliedOperationIDs, "view_detail")
 	}
 }
+
+// TestBackfillRepairsGrantsWrittenBeforeTheRule is the reason the write-time
+// rule alone is not a fix: a grant made before it existed carries only
+// resource_manage, reaches nothing, and nobody tells the administrator to
+// re-save it.
+func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// The shape an operator could produce before #1121: management without the
+	// visibility every management route needs.
+	if err := e.GrantObjectPermission("u-1", "catalog", "c1", "resource_manage"); err != nil {
+		t.Fatal(err)
+	}
+	// An unrelated grant on the same type must come through untouched.
+	if err := e.GrantObjectPermission("u-2", "catalog", "c2", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+
+	if ok, _ := e.Check("u-1", "catalog", "c1", "view_detail"); !ok {
+		t.Fatal("backfill did not repair the pre-existing grant")
+	}
+	if ok, _ := e.Check("u-1", "catalog", "c1", "resource_manage"); !ok {
+		t.Fatal("backfill dropped the operation it was repairing")
+	}
+	if ok, _ := e.Check("u-2", "catalog", "c2", "view_detail"); ok {
+		t.Fatal("backfill widened a grant that implies nothing")
+	}
+
+	// Idempotent: a start with nothing left to repair changes nothing.
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("third apply: %v", err)
+	}
+	grants, err := e.ListObjectGrants("u-1", "catalog", "c1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 1 || len(grants[0].Operations) != 2 {
+		t.Fatalf("grant after repeated apply: %+v", grants)
+	}
+}

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -1,0 +1,114 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package seed
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestValidateImplicationsRejectsAuthoringMistakes(t *testing.T) {
+	cases := []struct {
+		name    string
+		catalog catalog
+		wantErr string
+	}{
+		{
+			name: "implies an operation the type does not declare",
+			catalog: catalog{ResourceTypes: []catalogResourceType{
+				{ID: "catalog", Operations: []catalogOperation{
+					{ID: "resource_manage", Implies: []string{"view_detail"}},
+				}},
+			}},
+			wantErr: "does not declare",
+		},
+		{
+			name: "self implication",
+			catalog: catalog{ResourceTypes: []catalogResourceType{
+				{ID: "catalog", Operations: []catalogOperation{
+					{ID: "resource_manage", Implies: []string{"resource_manage"}},
+				}},
+			}},
+			wantErr: "implies itself",
+		},
+		{
+			name: "cycle",
+			catalog: catalog{ResourceTypes: []catalogResourceType{
+				{ID: "catalog", Operations: []catalogOperation{
+					{ID: "a", Implies: []string{"b"}},
+					{ID: "b", Implies: []string{"a"}},
+				}},
+			}},
+			wantErr: "cycle",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateImplications(tc.catalog)
+			if err == nil {
+				t.Fatalf("validateImplications accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestShippedCatalogBindsResourceManageToViewDetail is the regression guard on
+// the product rule (#1121): managing the tables in a catalog is unreachable
+// without the right to open the catalog, because every management route loads
+// its target first and that load is a view_detail judgement. Dropping the
+// implication would let the console hand out a grant whose every route answers
+// 403 while naming a permission the operator never meant to withhold.
+func TestShippedCatalogBindsResourceManageToViewDetail(t *testing.T) {
+	var c catalog
+	if err := json.Unmarshal(catalogJSON, &c); err != nil {
+		t.Fatalf("parse catalog.json: %v", err)
+	}
+	if err := validateImplications(c); err != nil {
+		t.Fatalf("shipped catalog.json declares an invalid implication: %v", err)
+	}
+	for _, rt := range c.ResourceTypes {
+		if rt.ID != "catalog" {
+			continue
+		}
+		for _, op := range rt.Operations {
+			if op.ID != "resource_manage" {
+				continue
+			}
+			if len(op.Implies) != 1 || op.Implies[0] != "view_detail" {
+				t.Fatalf("catalog.resource_manage implies %v, want [view_detail]", op.Implies)
+			}
+			return
+		}
+		t.Fatal("catalog type no longer declares resource_manage")
+	}
+	t.Fatal("catalog type missing from catalog.json")
+}
+
+// TestSeedPersistsImplications proves the declaration survives the seed, since
+// the grant paths read it from the operations table rather than from the file.
+func TestSeedPersistsImplications(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var row model.Operation
+	if err := db.First(&row, "resource_type_id = ? AND id = ?", "catalog", "resource_manage").Error; err != nil {
+		t.Fatalf("load operation: %v", err)
+	}
+	if row.ImpliedOperationIDs != "view_detail" {
+		t.Fatalf("implied_operation_ids = %q, want %q", row.ImpliedOperationIDs, "view_detail")
+	}
+}

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -161,5 +162,26 @@ func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
 	}
 	if len(grants) != 1 || len(grants[0].Operations) != 2 {
 		t.Fatalf("grant after repeated apply: %+v", grants)
+	}
+
+	// The repair is a permission change nobody asked for at the console, so it
+	// has to be findable there — one row per repaired grant, under the same
+	// resource/action an operator-issued object grant carries, and not repeated
+	// on the idempotent starts that followed.
+	entries, total, err := audit.New(db).List(t.Context(), audit.Filter{
+		Resource: "object-grants", Action: "grant",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 {
+		t.Fatalf("audit rows for the backfill = %d, want 1", total)
+	}
+	got := entries[0]
+	if got.ActorID != "system:seed" || got.TargetID != "c1" {
+		t.Fatalf("audit row = %+v", got)
+	}
+	if !strings.Contains(got.Detail, "view_detail") || !strings.Contains(got.Detail, "resource_manage") {
+		t.Fatalf("audit detail does not name the operations: %s", got.Detail)
 	}
 }

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
@@ -86,6 +87,10 @@ type catalogOperation struct {
 	// ParentOperation is the operation checked on the parent instance when this
 	// one is not granted on the instance itself. Empty = no inheritance.
 	ParentOperation string `json:"parent_operation"`
+	// Implies lists operations on the SAME type that are granted along with this
+	// one and cannot be taken away while it is held (#1121). Empty for almost
+	// every operation; see model.Operation.ImpliedOperationIDs.
+	Implies []string `json:"implies"`
 }
 
 type grantsFile struct {
@@ -222,6 +227,9 @@ func seedCatalog(db *gorm.DB) error {
 	// or a parent_operation the parent does not define would otherwise be stored
 	// and then silently deny at enforce time, which reads as "the grant does not
 	// work" rather than "the catalog is wrong".
+	if err := validateImplications(c); err != nil {
+		return err
+	}
 	if err := validateHierarchy(c); err != nil {
 		return err
 	}
@@ -238,11 +246,12 @@ func seedCatalog(db *gorm.DB) error {
 			declared = append(declared, op.ID)
 			opRow := model.Operation{
 				ResourceTypeID: rt.ID, ID: op.ID, Name: op.Name,
-				ParentOperationID: op.ParentOperation,
+				ParentOperationID:   op.ParentOperation,
+				ImpliedOperationIDs: strings.Join(op.Implies, ","),
 			}
 			if err := db.Clauses(clause.OnConflict{
 				Columns:   []clause.Column{{Name: "resource_type_id"}, {Name: "id"}},
-				DoUpdates: clause.AssignmentColumns([]string{"name", "parent_operation_id"}),
+				DoUpdates: clause.AssignmentColumns([]string{"name", "parent_operation_id", "implied_operation_ids"}),
 			}).Create(&opRow).Error; err != nil {
 				return err
 			}
@@ -323,6 +332,61 @@ func validateHierarchy(c catalog) error {
 				return fmt.Errorf("resource type parent chain has a cycle at %q", cur)
 			}
 			seen[cur] = true
+		}
+	}
+	return nil
+}
+
+// validateImplications checks the same-type implications declared in
+// catalog.json: every implied operation is declared on the same type, no
+// operation implies itself, and the implication graph is acyclic.
+//
+// The failure this guards against is silent. An implication naming an operation
+// the type does not declare would expand a grant into an op no check ever asks
+// about, and a cycle would make the expansion at grant time loop; both are
+// authoring mistakes in an embedded file, so refusing to boot is the honest
+// response.
+func validateImplications(c catalog) error {
+	for _, rt := range c.ResourceTypes {
+		declared := make(map[string]bool, len(rt.Operations))
+		implies := make(map[string][]string, len(rt.Operations))
+		for _, op := range rt.Operations {
+			declared[op.ID] = true
+			implies[op.ID] = op.Implies
+		}
+		for _, op := range rt.Operations {
+			for _, implied := range op.Implies {
+				if implied == op.ID {
+					return fmt.Errorf("operation %s/%s implies itself", rt.ID, op.ID)
+				}
+				if !declared[implied] {
+					return fmt.Errorf("operation %s/%s implies %q, which %s does not declare",
+						rt.ID, op.ID, implied, rt.ID)
+				}
+			}
+		}
+		// Walk every chain with a step budget of the operation count, the same
+		// shape the parent-chain check uses.
+		for start := range implies {
+			seen := map[string]bool{}
+			queue := []string{start}
+			for steps := 0; len(queue) > 0; steps++ {
+				if steps > len(implies) {
+					return fmt.Errorf("operation implication chain has a cycle in %q", rt.ID)
+				}
+				cur := queue[0]
+				queue = queue[1:]
+				for _, next := range implies[cur] {
+					if next == start {
+						return fmt.Errorf("operation implication chain has a cycle at %s/%s", rt.ID, start)
+					}
+					if seen[next] {
+						continue
+					}
+					seen[next] = true
+					queue = append(queue, next)
+				}
+			}
 		}
 	}
 	return nil

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -12,16 +12,19 @@
 package seed
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
@@ -127,7 +130,7 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedGrants(enforcer); err != nil {
 		return fmt.Errorf("seed grants: %w", err)
 	}
-	if err := backfillImpliedOperations(enforcer); err != nil {
+	if err := backfillImpliedOperations(db, enforcer); err != nil {
 		return fmt.Errorf("backfill implied operations: %w", err)
 	}
 	if err := seedRoleBindings(enforcer); err != nil {
@@ -410,11 +413,12 @@ func validateImplications(c catalog) error {
 // Deliberately NOT symmetric with revocation: this only ever adds. A row that
 // an administrator has since narrowed on purpose is repaired back to a usable
 // shape rather than left as a permission that answers 403 everywhere.
-func backfillImpliedOperations(enforcer *authz.Enforcer) error {
+func backfillImpliedOperations(db *gorm.DB, enforcer *authz.Enforcer) error {
 	var c catalog
 	if err := json.Unmarshal(catalogJSON, &c); err != nil {
 		return err
 	}
+	trail := audit.New(db)
 	for _, rt := range c.ResourceTypes {
 		implies := make(map[string][]string, len(rt.Operations))
 		for _, op := range rt.Operations {
@@ -441,14 +445,53 @@ func backfillImpliedOperations(enforcer *authz.Enforcer) error {
 				if err != nil {
 					return err
 				}
-				if added > 0 {
-					slog.Info("backfilled the operation an existing grant implies",
-						"resource_type", rt.ID, "holder", holder, "implied", implied, "rows", added)
+				if len(added) == 0 {
+					continue
 				}
+				slog.Info("backfilled the operation an existing grant implies",
+					"resource_type", rt.ID, "holder", holder, "implied", implied, "rows", len(added))
+				recordBackfillAudit(trail, rt.ID, holder, implied, added)
 			}
 		}
 	}
 	return nil
+}
+
+// recordBackfillAudit writes one audit row per repaired grant, under the same
+// resource/action the console shows for an operator-issued object grant. A
+// permission that appears without anyone having clicked anything is exactly the
+// change an auditor asking "why does this account see this catalog" needs to
+// find, and a line in the pod log is not somewhere they can look.
+//
+// Failures are logged and swallowed: auditing must never be the reason a
+// deployment fails to start.
+func recordBackfillAudit(trail *audit.Store, resourceType, holder, implied string,
+	grants []authz.BackfilledGrant) {
+
+	for _, g := range grants {
+		detail, err := json.Marshal(map[string]any{
+			"accessor_id": g.AccessorID,
+			"resource":    map[string]string{"type": resourceType, "id": g.ResourceID},
+			"operations":  []string{implied},
+			"_reason":     "implied by " + holder,
+		})
+		if err != nil {
+			slog.Error("seed: could not encode backfill audit detail", "err", err)
+			continue
+		}
+		if err := trail.Record(context.Background(), audit.Entry{
+			ActorID:  "system:seed",
+			Method:   "SYSTEM",
+			Resource: "object-grants",
+			Action:   "grant",
+			TargetID: g.ResourceID,
+			Detail:   string(detail),
+			Status:   http.StatusOK,
+		}); err != nil {
+			slog.Error("seed: backfill audit record failed",
+				"resource_type", resourceType, "resource_id", g.ResourceID, "err", err)
+		}
+	}
 }
 
 func seedGrants(enforcer *authz.Enforcer) error {

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -419,6 +419,13 @@ func backfillImpliedOperations(db *gorm.DB, enforcer *authz.Enforcer) error {
 		return err
 	}
 	trail := audit.New(db)
+	// Role ids up front: the audit vocabulary for a role's permission differs
+	// from an object grant's, and telling them apart per repaired row would be a
+	// query each.
+	roleNames, err := roleNameByID(db)
+	if err != nil {
+		return err
+	}
 	for _, rt := range c.ResourceTypes {
 		implies := make(map[string][]string, len(rt.Operations))
 		for _, op := range rt.Operations {
@@ -450,7 +457,7 @@ func backfillImpliedOperations(db *gorm.DB, enforcer *authz.Enforcer) error {
 				}
 				slog.Info("backfilled the operation an existing grant implies",
 					"resource_type", rt.ID, "holder", holder, "implied", implied, "rows", len(added))
-				recordBackfillAudit(trail, rt.ID, holder, implied, added)
+				recordBackfillAudit(trail, roleNames, rt.ID, holder, implied, added)
 			}
 		}
 	}
@@ -465,8 +472,8 @@ func backfillImpliedOperations(db *gorm.DB, enforcer *authz.Enforcer) error {
 //
 // Failures are logged and swallowed: auditing must never be the reason a
 // deployment fails to start.
-func recordBackfillAudit(trail *audit.Store, resourceType, holder, implied string,
-	grants []authz.BackfilledGrant) {
+func recordBackfillAudit(trail *audit.Store, roleNames map[string]string,
+	resourceType, holder, implied string, grants []authz.BackfilledGrant) {
 
 	for _, g := range grants {
 		detail, err := json.Marshal(map[string]any{
@@ -479,19 +486,61 @@ func recordBackfillAudit(trail *audit.Store, resourceType, holder, implied strin
 			slog.Error("seed: could not encode backfill audit detail", "err", err)
 			continue
 		}
-		if err := trail.Record(context.Background(), audit.Entry{
-			ActorID:  "system:seed",
-			Method:   "SYSTEM",
-			Resource: "object-grants",
-			Action:   "grant",
-			TargetID: g.ResourceID,
-			Detail:   string(detail),
-			Status:   http.StatusOK,
-		}); err != nil {
+		entry := audit.Entry{
+			ActorID: "system:seed",
+			Method:  "SYSTEM",
+			Detail:  string(detail),
+			Status:  http.StatusOK,
+		}
+		applyBackfillAuditTarget(&entry, roleNames, g)
+		if err := trail.Record(context.Background(), entry); err != nil {
 			slog.Error("seed: backfill audit record failed",
 				"resource_type", resourceType, "resource_id", g.ResourceID, "err", err)
 		}
 	}
+}
+
+// applyBackfillAuditTarget labels one repaired row with the vocabulary of the
+// surface that can actually show it. Getting this wrong is not cosmetic: an
+// audit row naming a surface where the grant is absent sends the auditor
+// looking in a list that will never contain it.
+//
+//   - a role subject is a role permission, which the console records as
+//     roles/grant_permission against the ROLE, not the resource;
+//   - a concrete grant to a real account is an object grant, and lands next to
+//     the operator-issued grant of the same object;
+//   - everything else — the public accessor, and type-wide "type:*" rows — is
+//     excluded from the object-grant list by construction, so it is labelled as
+//     what it is: a raw policy row, visible through GET /admin/policies.
+func applyBackfillAuditTarget(entry *audit.Entry, roleNames map[string]string, g authz.BackfilledGrant) {
+	if name, isRole := roleNames[g.AccessorID]; isRole {
+		entry.Resource = "roles"
+		entry.Action = "grant_permission"
+		entry.TargetID = g.AccessorID
+		entry.TargetName = name
+		return
+	}
+	entry.TargetID = g.ResourceID
+	entry.Action = "grant"
+	if g.ResourceID == "*" || g.AccessorID == authz.PublicAccessorID {
+		entry.Resource = "policies"
+		return
+	}
+	entry.Resource = "object-grants"
+}
+
+// roleNameByID loads the role id -> name map used to tell a role subject from
+// an accessor. Roles are few and this runs once per start.
+func roleNameByID(db *gorm.DB) (map[string]string, error) {
+	var roles []model.Role
+	if err := db.Find(&roles).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]string, len(roles))
+	for _, r := range roles {
+		out[r.ID] = r.Name
+	}
+	return out, nil
 }
 
 func seedGrants(enforcer *authz.Enforcer) error {

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -127,6 +127,9 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedGrants(enforcer); err != nil {
 		return fmt.Errorf("seed grants: %w", err)
 	}
+	if err := backfillImpliedOperations(enforcer); err != nil {
+		return fmt.Errorf("backfill implied operations: %w", err)
+	}
 	if err := seedRoleBindings(enforcer); err != nil {
 		return fmt.Errorf("seed role bindings: %w", err)
 	}
@@ -385,6 +388,62 @@ func validateImplications(c catalog) error {
 					}
 					seen[next] = true
 					queue = append(queue, next)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// backfillImpliedOperations repairs grants written before an implication was
+// declared: every policy row holding an operation now marked as implying others
+// gains the implied ones.
+//
+// The implication is applied when a grant is written, so without this the fix
+// would reach new grants only. For catalog.resource_manage that would leave the
+// reported defect standing for everyone who had already been granted it — the
+// grant reaches nothing on its own, and nothing tells the administrator to
+// re-save it. Runs after seedGrants so the rebuilt role matrix is in place, and
+// it is idempotent, so a start with nothing to repair costs one filtered read
+// per declared implication.
+//
+// Deliberately NOT symmetric with revocation: this only ever adds. A row that
+// an administrator has since narrowed on purpose is repaired back to a usable
+// shape rather than left as a permission that answers 403 everywhere.
+func backfillImpliedOperations(enforcer *authz.Enforcer) error {
+	var c catalog
+	if err := json.Unmarshal(catalogJSON, &c); err != nil {
+		return err
+	}
+	for _, rt := range c.ResourceTypes {
+		implies := make(map[string][]string, len(rt.Operations))
+		for _, op := range rt.Operations {
+			if len(op.Implies) > 0 {
+				implies[op.ID] = op.Implies
+			}
+		}
+		for holder := range implies {
+			// Transitive: an operation implying one that implies another must
+			// backfill both. validateImplications has already refused a cycle, and
+			// the visited set keeps this terminating regardless.
+			seen := map[string]bool{holder: true}
+			queue := append([]string(nil), implies[holder]...)
+			for len(queue) > 0 {
+				implied := queue[0]
+				queue = queue[1:]
+				if seen[implied] {
+					continue
+				}
+				seen[implied] = true
+				queue = append(queue, implies[implied]...)
+
+				added, err := enforcer.BackfillImpliedOperation(rt.ID, holder, implied)
+				if err != nil {
+					return err
+				}
+				if added > 0 {
+					slog.Info("backfilled the operation an existing grant implies",
+						"resource_type", rt.ID, "holder", holder, "implied", implied, "rows", added)
 				}
 			}
 		}


### PR DESCRIPTION
Backport of #1123 to `release/0.1.4`. Refs #1121.

`release/0.1.4` carries #977, which converged the table's management verbs onto the catalog — so on this branch too, `catalog.resource_manage` is the normal way to hand out table management, and a grant of it alone reaches nothing: every management route loads its target first, and that load is a `view_detail` judgement.

Cherry-pick of the six commits on `fix/1121-resource-manage-implies-view-detail`, clean — no conflicts, no adaptation.

## What it does

- Declares the rule as data: `catalog.resource_manage` `implies` `view_detail`; the seed refuses to boot on an implication that names an undeclared operation, implies itself, or forms a cycle.
- Expands at grant time on all three write faces: admin object-grants, role grants, and the internal `POST /authz/policies`. Role revoke expands in reverse so dropping `view_detail` cannot leave the unusable verb behind.
- Repairs grants written before the rule existed, at seed time, add-only and idempotent.
- Records each repair in the audit trail, labelled by the surface that can actually show the grant (`object-grants` / `roles` / `policies`).

## Compatibility

Additive in code: new column via AutoMigrate, no change to the enforcement engine, socket signatures `ee` consumes unchanged.

**Sign-off needed at merge**, same as on the main PR: the back-fill is the one part that is not inert on upgrade. Accounts already granted `catalog.resource_manage` gain `view_detail` visibility the first time the new build boots. That is the product decision taking effect, as a one-off auditable data change.

## Testing

- `go build ./... && go test ./... -count=1` in `bkn-safe/server` on this branch — all green.
- Verified end to end on the dev VM against real MariaDB data (main branch build):
  - a grant carrying `catalog.resource_manage` alone reproduced the reported 403 naming `view_detail`;
  - after the upgrade the seed logged `rows=1` and repaired exactly that row — `view_detail` count went 17 to 18, nothing else moved;
  - the audit row landed as `object-grants` / `grant` with `_reason: implied by resource_manage`;
  - the same request then passed both permission gates;
  - a fresh grant of `resource_manage` alone through the internal policy route came back carrying `view_detail`.

## Pre-merge checklist

- [x] Unit tests pass
- [x] Verified against a real deployment
- [x] Cherry-pick applied cleanly
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
