### PR TITLE
fix(deploy): reconcile trace timestamp pipeline profile

### DIFF
--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -985,11 +985,13 @@ except (json.JSONDecodeError, TypeError):
     sys.exit(2)
 core = values.get("core", {})
 evidence = values.get("evidence", {})
+opensearch = values.get("opensearch", {})
 durable = (
     core.get("store") == "mariadb"
     and core.get("projection", {}).get("enabled") is True
     and evidence.get("store") == "opensearch"
     and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
+    and opensearch.get("traceTimestampPipeline") == "bkn-trace-span-timestamp-v1"
 )
 sys.exit(0 if durable else 1)
 ' <<<"${values}"
@@ -1019,6 +1021,12 @@ sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
 _openbkn_collector_pipeline_is_explicitly_overridden() {
     local value
     value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
+    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
+}
+
+_openbkn_agent_observability_pipeline_is_explicitly_overridden() {
+    local value
+    value="$(_openbkn_last_set_value "opensearch.traceTimestampPipeline" "${CORE_SET_VALUES[@]-}")" || return 1
     [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
 }
 
@@ -1070,7 +1078,8 @@ _openbkn_should_skip_upgrade() {
         case "$?" in
             0) ;;
             1)
-                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
+                if _openbkn_agent_observability_profile_is_explicitly_volatile ||
+                   _openbkn_agent_observability_pipeline_is_explicitly_overridden; then
                     return 0
                 fi
                 log_info "Reconcile agent-observability: installed runtime profile is not durable."

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -991,7 +991,7 @@ durable = (
     and core.get("projection", {}).get("enabled") is True
     and evidence.get("store") == "opensearch"
     and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
-    and opensearch.get("traceTimestampPipeline") == "bkn-trace-span-timestamp-v1"
+    and bool(opensearch.get("traceTimestampPipeline"))
 )
 sys.exit(0 if durable else 1)
 ' <<<"${values}"
@@ -1021,12 +1021,6 @@ sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
 _openbkn_collector_pipeline_is_explicitly_overridden() {
     local value
     value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
-    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
-}
-
-_openbkn_agent_observability_pipeline_is_explicitly_overridden() {
-    local value
-    value="$(_openbkn_last_set_value "opensearch.traceTimestampPipeline" "${CORE_SET_VALUES[@]-}")" || return 1
     [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
 }
 
@@ -1078,8 +1072,7 @@ _openbkn_should_skip_upgrade() {
         case "$?" in
             0) ;;
             1)
-                if _openbkn_agent_observability_profile_is_explicitly_volatile ||
-                   _openbkn_agent_observability_pipeline_is_explicitly_overridden; then
+                if _openbkn_agent_observability_profile_is_explicitly_volatile; then
                     return 0
                 fi
                 log_info "Reconcile agent-observability: installed runtime profile is not durable."

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -95,9 +95,16 @@ fi
 
 HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
 if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a durable profile that lacks the timestamp pipeline"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
     ok
 else
-    fail "installer should retain the version-skip optimization for a durable runtime profile"
+    fail "installer should retain the version-skip optimization for a fully reconciled runtime profile"
 fi
 
 CORE_SET_VALUES=("core.store=memory")
@@ -180,7 +187,7 @@ else
     fail "repository installer must upgrade a volatile runtime profile"
 fi
 
-HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}}}'
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
 _install_openbkn_release_local agent-observability /tmp openbkn
 _install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
 if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -114,6 +114,13 @@ if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 
 else
     fail "an explicit volatile override must retain the normal version-skip decision"
 fi
+CORE_SET_VALUES=("opensearch.traceTimestampPipeline=custom-trace-pipeline")
+HELM_VALUES='{"core":{"store":"memory","projection":{"enabled":false}},"evidence":{"store":"memory"},"opensearch":{"traceTimestampPipeline":"custom-trace-pipeline"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "a custom timestamp pipeline must not bypass durable Core profile reconciliation"
+else
+    ok
+fi
 CORE_SET_VALUES=("")
 
 HELM_VALUES='{not-json}'


### PR DESCRIPTION
## What Changed

- [x] Include the Trace timestamp pipeline in the agent-observability same-version durability check.
- [x] Add regression coverage for an otherwise durable existing profile that lacks the pipeline.

---

## Why

- Follow-up to #1129. The prior same-version checks could skip agent-observability while upgrading Collector, leaving Collector configured to reference a pipeline that had never been created.

---

## How

- A profile is now durable only when its OpenSearch timestamp pipeline is also present.
- Explicit user pipeline overrides remain respected.

---

## Testing

- [x] `bash deploy/scripts/services/openbkn_trace_profile_test.sh` (88 checks)
- [x] `bash -n deploy/scripts/services/openbkn.sh`

---

## Risk & Rollback

- Risk: an existing AO deployment without the pipeline is rolled once to reconcile its Helm values.
- Rollback: revert this focused commit; no data is changed.