### PR TITLE
fix(bkn-safe): 对象级授权在启动权限里丢失，且 owner 无法转授自己创建的对象

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -17,6 +17,7 @@ package authz
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
@@ -213,9 +214,17 @@ func (en *Enforcer) RoleMembers(roleID string) ([]string, error) {
 
 // RoleGrant is one resource-object grant held by a role: the object pattern
 // ("type:id", id may be "*") and the operations allowed on it.
+//
+// InstanceOperations is set only by EffectivePermissions under TypeWideOnly, on
+// a type row ("type:*"): it carries the operations the accessor holds on at
+// least one INSTANCE of the type but not type-wide. It answers "is this type
+// reachable at all", which is what menu/navigation callers ask; it deliberately
+// does not say which instance, so it must never gate a concrete (type,id) — use
+// an unscoped or resource_id-scoped read for that.
 type RoleGrant struct {
-	Object     string
-	Operations []string
+	Object             string
+	Operations         []string
+	InstanceOperations []string
 }
 
 // RolePermissions lists the policy grants whose subject is the role, grouped by
@@ -260,10 +269,11 @@ func groupGrantsByObject(rows [][]string) []RoleGrant {
 // PermQuery narrows an EffectivePermissions read. The zero value returns the
 // full effective set; ResourceType scopes to one type and ResourceIDs further
 // narrows the instance exception rows (ResourceIDs is only meaningful with a
-// ResourceType set). TypeWideOnly drops instance exception rows entirely —
-// for callers that only render type-level UI (menus/navigation) and would
-// discard per-instance rows anyway; with per-object grants those rows dominate
-// the payload (#353).
+// ResourceType set). TypeWideOnly emits no instance exception rows — for
+// callers that only render type-level UI (menus/navigation) and would discard
+// per-instance rows anyway; with per-object grants those rows dominate the
+// payload (#353). Their operations are not lost: they fold into the type row's
+// InstanceOperations, so "granted only on objects" still reports the type.
 type PermQuery struct {
 	ResourceType string   // "" = all types
 	ResourceIDs  []string // empty = all instances of the type
@@ -292,6 +302,13 @@ type PermQuery struct {
 //     type-wide grant are dropped. Callers/frontends judge "may do op on
 //     (type,id)" as op ∈ typeWide(type) OR op ∈ instance(type,id) — i.e. they
 //     union the id:"*" row with the instance row.
+//
+//   - Under TypeWideOnly the instance rows collapse instead of appearing: their
+//     surplus ops move to the type row's InstanceOperations, and a type reached
+//     only through instances gets a row with empty Operations. A caller asking
+//     "may this accessor touch this type at all" unions Operations with
+//     InstanceOperations; a caller asking about a concrete instance must not use
+//     this shape at all, since it no longer says which instance.
 //
 // Object/op order follows GetImplicitPermissionsForUser; callers treat the
 // result as sets.
@@ -333,6 +350,13 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 	}
 
 	out := make([]RoleGrant, 0, len(grouped))
+	// TypeWideOnly still emits no instance ROWS, but their operations are folded
+	// into the type row's InstanceOperations rather than discarded: an accessor
+	// whose only grants are per-object would otherwise come back with nothing at
+	// all, and a caller rendering navigation from this read would hide the entry
+	// to a resource the accessor was explicitly granted (bkn-studio#478).
+	instanceExtra := map[string]map[string]bool{}
+	typeRowIndex := map[string]int{}
 	for _, g := range grouped {
 		rtype, rid := splitObjectKey(g.Object)
 		if q.ResourceType != "" && rtype != q.ResourceType {
@@ -340,10 +364,8 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		}
 		if rid == "*" {
 			// Type-wide row: always kept within scope; the frontend unions on it.
+			typeRowIndex[rtype] = len(out)
 			out = append(out, RoleGrant{Object: g.Object, Operations: g.Operations})
-			continue
-		}
-		if q.TypeWideOnly {
 			continue
 		}
 		// Instance row: keep only ops beyond the type-wide set; drop if fully
@@ -366,10 +388,44 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		if len(extra) == 0 {
 			continue
 		}
+		if q.TypeWideOnly {
+			if instanceExtra[rtype] == nil {
+				instanceExtra[rtype] = map[string]bool{}
+			}
+			for _, op := range extra {
+				instanceExtra[rtype][op] = true
+			}
+			continue
+		}
 		if len(idFilter) > 0 && !idFilter[rid] {
 			continue
 		}
 		out = append(out, RoleGrant{Object: g.Object, Operations: extra})
+	}
+
+	// Attach the folded instance operations. Sorted throughout so a payload the
+	// frontend caches after login does not churn between two identical reads.
+	foldedTypes := make([]string, 0, len(instanceExtra))
+	for rtype := range instanceExtra {
+		foldedTypes = append(foldedTypes, rtype)
+	}
+	sort.Strings(foldedTypes)
+	for _, rtype := range foldedTypes {
+		ops := make([]string, 0, len(instanceExtra[rtype]))
+		for op := range instanceExtra[rtype] {
+			ops = append(ops, op)
+		}
+		sort.Strings(ops)
+		if i, ok := typeRowIndex[rtype]; ok {
+			out[i].InstanceOperations = ops
+			continue
+		}
+		// The accessor holds nothing type-wide on this type, only instances, so
+		// there is no row to attach to. Emit one whose Operations is empty: the
+		// id keeps the "*" shape every caller unions on, and an empty type-wide
+		// set plus a non-empty instance set reads exactly as what it is — "you
+		// may reach this type, but only through specific objects".
+		out = append(out, RoleGrant{Object: rtype + ":*", Operations: []string{}, InstanceOperations: ops})
 	}
 	return false, out, nil
 }

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -20,6 +20,16 @@ func byObject(grants []RoleGrant) map[string][]string {
 	return out
 }
 
+// instanceOpsOf returns the folded instance operations on one collapsed row.
+func instanceOpsOf(grants []RoleGrant, object string) []string {
+	for _, g := range grants {
+		if g.Object == object {
+			return g.InstanceOperations
+		}
+	}
+	return nil
+}
+
 func eqOps(got []string, want ...string) bool {
 	if len(got) != len(want) {
 		return false
@@ -233,15 +243,15 @@ func TestEffectivePermissionsScope(t *testing.T) {
 	}
 }
 
-// TypeWideOnly drops every instance exception row — including instance-only
-// grants with no type-wide row — and composes with ResourceType.
+// TypeWideOnly emits no instance exception row — the surplus ops fold into the
+// type row's InstanceOperations instead — and composes with ResourceType.
 func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 	e := newTestEnforcer(t)
 	const user = "u-tw"
 	mustNoErr(t, e.GrantRolePermission("role-tw", "large_model", "*", "view"))
 	mustNoErr(t, e.AssignRole(user, "role-tw"))
 	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m1", "modify")) // surplus over type-wide
-	mustNoErr(t, e.GrantObjectPermission(user, "agent", "a1", "use"))          // instance-only, no type-wide row
+	mustNoErr(t, e.GrantObjectPermission(user, "large_model", "m2", "view"))   // covered, contributes nothing
 
 	has, grants, err := e.EffectivePermissions(user, PermQuery{TypeWideOnly: true})
 	mustNoErr(t, err)
@@ -253,10 +263,11 @@ func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 		t.Errorf("large_model:* = %v, want [view]", idx["large_model:*"])
 	}
 	if _, ok := idx["large_model:m1"]; ok {
-		t.Errorf("surplus instance row must be dropped: %+v", grants)
+		t.Errorf("surplus instance row must not appear as a row: %+v", grants)
 	}
-	if _, ok := idx["agent:a1"]; ok {
-		t.Errorf("instance-only grant must be dropped: %+v", grants)
+	if !eqOps(instanceOpsOf(grants, "large_model:*"), "modify") {
+		t.Errorf("large_model:* instance_operations = %v, want [modify]",
+			instanceOpsOf(grants, "large_model:*"))
 	}
 
 	// Composes with ResourceType: single type-wide row of the queried type.
@@ -265,5 +276,57 @@ func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 	idx = byObject(grants)
 	if len(idx) != 1 || !eqOps(idx["large_model:*"], "view") {
 		t.Errorf("scoped type-wide = %+v, want only large_model:* [view]", grants)
+	}
+}
+
+// The regression this fold exists for: an accessor holding NOTHING type-wide on
+// a type, only a grant on one object. Before, scope=type returned no row for the
+// type and the console hid the entry to a resource the accessor was explicitly
+// granted (bkn-studio#478). Now the type reports with empty Operations and the
+// instance ops on the side.
+func TestEffectivePermissionsTypeWideOnlyInstanceOnlyType(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "u-obj"
+	// Mirrors the shipped normal_user role: capability types type-wide, no data
+	// grants at all — data types are reachable only through object grants.
+	mustNoErr(t, e.GrantRolePermission("role-normal", "tool_box", "*", "view"))
+	mustNoErr(t, e.AssignRole(user, "role-normal"))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail"))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-2", "query_data"))
+
+	_, grants, err := e.EffectivePermissions(user, PermQuery{TypeWideOnly: true})
+	mustNoErr(t, err)
+
+	idx := byObject(grants)
+	row, ok := idx["knowledge_network:*"]
+	if !ok {
+		t.Fatalf("knowledge_network must report despite having no type-wide grant: %+v", grants)
+	}
+	if len(row) != 0 {
+		t.Errorf("knowledge_network:* operations = %v, want empty — nothing is granted type-wide", row)
+	}
+	// Union across both objects: the caller learns the type is reachable, not
+	// which network carries which op.
+	if !eqOps(instanceOpsOf(grants, "knowledge_network:*"), "query_data", "view_detail") {
+		t.Errorf("knowledge_network:* instance_operations = %v, want [query_data view_detail]",
+			instanceOpsOf(grants, "knowledge_network:*"))
+	}
+	// The role-held type-wide grant is untouched and carries no instance ops.
+	if !eqOps(idx["tool_box:*"], "view") {
+		t.Errorf("tool_box:* = %v, want [view]", idx["tool_box:*"])
+	}
+	if got := instanceOpsOf(grants, "tool_box:*"); len(got) != 0 {
+		t.Errorf("tool_box:* instance_operations = %v, want empty", got)
+	}
+
+	// Unscoped reads are unchanged: real instance rows, no fold.
+	_, grants, err = e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	idx = byObject(grants)
+	if !eqOps(idx["knowledge_network:kn-1"], "view_detail") {
+		t.Errorf("kn-1 = %v, want [view_detail]", idx["knowledge_network:kn-1"])
+	}
+	if _, ok := idx["knowledge_network:*"]; ok {
+		t.Errorf("no synthetic type row without TypeWideOnly: %+v", grants)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -670,10 +670,16 @@ func grantsJSON(grants []authz.RoleGrant) []gin.H {
 	out := make([]gin.H, 0, len(grants))
 	for _, gr := range grants {
 		rtype, rid := splitObject(gr.Object)
-		out = append(out, gin.H{
+		row := gin.H{
 			"resource":   gin.H{"type": rtype, "id": rid},
 			"operations": gr.Operations,
-		})
+		}
+		// Only the scope=type read ever sets this, so the key stays absent from
+		// every other response rather than showing up empty everywhere.
+		if len(gr.InstanceOperations) > 0 {
+			row["instance_operations"] = gr.InstanceOperations
+		}
+		out = append(out, row)
 	}
 	return out
 }

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -91,7 +91,8 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 		})
 	})
 
-	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...] } ] }
+	// GET /permissions -> { is_admin, permissions:[ { resource{type,id}, operations:[...],
+	//   instance_operations?:[...] } ] }
 	// Returns the EFFECTIVE (collapsed) authorization, not one row per instance:
 	// a resource-wildcard holder gets a single {type:"*",id:"*",ops:["*"]} row;
 	// everyone else gets one type-wide row per type plus an instance row only
@@ -103,11 +104,20 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 	// Optional scope filters: ?resource_type=<T> narrows to one type;
 	// &resource_id=<id1,id2,...> (comma-separated) narrows the instance rows,
 	// keeping the type-wide id:"*" row. resource_id requires resource_type.
-	// ?scope=type drops instance exception rows entirely (only id:"*" rows and
-	// the wildcard row) — for the login/boot call that renders menus from
-	// type-level grants and discards instance rows anyway; with per-object
-	// grants those rows dominate the payload (#353). Conflicts with
-	// resource_id (asking for instance rows while dropping them) -> 400.
+	// ?scope=type returns no instance exception rows (only id:"*" rows and the
+	// wildcard row) — for the login/boot call that renders menus from type-level
+	// grants and discards instance rows anyway; with per-object grants those
+	// rows dominate the payload (#353). Conflicts with resource_id (asking for
+	// instance rows while dropping them) -> 400.
+	//
+	// The ops on those rows are folded, not dropped: a type row carries
+	// "instance_operations" for what the caller holds on at least one instance
+	// but not type-wide, and a type reached only through instances still gets a
+	// row, with "operations" empty. Without that, an accessor granted a single
+	// knowledge network came back with no permissions at all and the console hid
+	// the entry to a network it had explicitly been given (bkn-studio#478). The
+	// field says nothing about WHICH instance, so it drives entry visibility
+	// only; per-object decisions use an unscoped or resource_id-scoped read.
 	g.GET("/permissions", func(c *gin.Context) {
 		accessorID := c.GetString(ctxAccessorID)
 		isAdmin, err := e.CanAdmin(accessorID)

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -297,6 +297,31 @@ func TestMeKnowledgeNetworkGrantsReturnsDirectInstancesWithoutRoleWildcard(t *te
 	}
 }
 
+// decodeInstanceOps indexes the folded instance_operations by "type/id",
+// omitting rows where the key is absent so a test can assert absence.
+func decodeInstanceOps(t *testing.T, w *httptest.ResponseRecorder) map[string][]string {
+	t.Helper()
+	var resp struct {
+		Permissions []struct {
+			Resource struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resource"`
+			InstanceOperations []string `json:"instance_operations"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	out := map[string][]string{}
+	for _, p := range resp.Permissions {
+		if len(p.InstanceOperations) > 0 {
+			out[p.Resource.Type+"/"+p.Resource.ID] = p.InstanceOperations
+		}
+	}
+	return out
+}
+
 // TestMePermissionsScope covers the scope filters and their validation.
 func TestMePermissionsScope(t *testing.T) {
 	r, e, _, _ := newAdminServer(t)
@@ -376,16 +401,33 @@ func TestMePermissionsScope(t *testing.T) {
 		t.Errorf("resource_id without resource_type: want 400, got %d", w.Code)
 	}
 
-	// scope=type: only type-wide rows; every instance row (surplus or
-	// instance-only) is dropped.
-	got = decode(tokReq(t, r, http.MethodGet, path+"?scope=type", nil, "u1"))
+	// scope=type: no instance rows; their surplus ops fold into the type row's
+	// instance_operations, and agent — held only through one object — still
+	// reports as a type with empty operations.
+	scoped := tokReq(t, r, http.MethodGet, path+"?scope=type", nil, "u1")
+	got = decode(scoped)
 	if got["large_model/*"] == nil {
 		t.Errorf("type-wide large_model/* row missing under scope=type: %v", got)
 	}
 	for _, k := range []string{"large_model/m1", "large_model/m2", "agent/a1"} {
 		if _, ok := got[k]; ok {
-			t.Errorf("%s must be dropped under scope=type: %v", k, got)
+			t.Errorf("%s must not appear as a row under scope=type: %v", k, got)
 		}
+	}
+	inst := decodeInstanceOps(t, scoped)
+	if len(inst["large_model/*"]) != 1 || inst["large_model/*"][0] != "modify" {
+		t.Errorf("large_model/* instance_operations = %v, want [modify]", inst["large_model/*"])
+	}
+	if len(got["agent/*"]) != 0 {
+		t.Errorf("agent/* operations = %v, want empty — nothing granted type-wide", got["agent/*"])
+	}
+	if len(inst["agent/*"]) != 1 || inst["agent/*"][0] != "use" {
+		t.Errorf("agent/* instance_operations = %v, want [use]", inst["agent/*"])
+	}
+
+	// The key is absent, not empty, on reads that never fold.
+	if inst := decodeInstanceOps(t, tokReq(t, r, http.MethodGet, path, nil, "u1")); len(inst) != 0 {
+		t.Errorf("instance_operations must not appear on an unscoped read: %v", inst)
 	}
 
 	// scope=type composes with resource_type.

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -134,6 +134,36 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 //
 // Administrators skip both: admin-authz:grant is the platform-level authority
 // these two rules exist to protect.
+// restrictDelegatedRevoke stops a delegate from stripping another delegate — or
+// the creator — of `authorize` on the object.
+//
+// Revoking removes every p-line the accessor holds on the object, `authorize`
+// included, and restrictDelegatedOps forbids a delegate from granting it back.
+// Without this, anyone the platform trusts to share ONE object could silently
+// take the object away from the person who made it, and only a platform
+// administrator could undo it. That is the same reason `authorize` cannot be
+// handed out by a delegate, applied to the other direction: it is conferred by
+// an administrator, so only an administrator takes it away.
+//
+// Grants without `authorize` stay revocable — sharing you can undo is the whole
+// point of the owner surface.
+func restrictDelegatedRevoke(c *gin.Context, e *authz.Enforcer, ref resourceRef, accessorID string) bool {
+	held, err := e.ListObjectGrants(accessorID, ref.Type, ref.ID)
+	if err != nil {
+		serverError(c, err)
+		return false
+	}
+	for _, grant := range held {
+		for _, op := range grant.Operations {
+			if op == opAuthorize {
+				replyPublicError(c, http.StatusForbidden)
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func restrictDelegatedOps(c *gin.Context, e *authz.Enforcer, ref resourceRef, ops []string) bool {
 	for _, op := range ops {
 		if op == opAuthorize {
@@ -568,12 +598,21 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
+		// Search is mandatory. Holding `authorize` on one object says nothing about
+		// being allowed to page through the platform's accounts, and an empty
+		// search turned this into exactly that — the per-object gate below is not
+		// a bound on WHO is listed, only on who may ask.
+		search := strings.TrimSpace(c.Query("search"))
+		if search == "" {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
 		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
 			return
 		}
 		enabled := true
 		users, _, err := dir.ListUsers(c.Request.Context(), directory.UserListFilter{
-			Search: strings.TrimSpace(c.Query("search")),
+			Search: search,
 			// A disabled account cannot log in, so granting it access is a grant
 			// that does nothing; keep it out of the picker.
 			Enabled: &enabled,
@@ -731,6 +770,9 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		// taking access away can only narrow, never widen.
 		authority, ok := resolveGrantAuthority(c, e, "revoke", req.Resource)
 		if !ok {
+			return
+		}
+		if authority != authorityAdminAuthz && !restrictDelegatedRevoke(c, e, req.Resource, req.AccessorID) {
 			return
 		}
 		valid, err := catalogOpSet(db, req.Resource.Type)

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -12,6 +12,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -31,6 +32,129 @@ import (
 // holds no user→department membership rules, so a department grant would be a
 // dead policy that never matches at enforce time (see RolePermissions path for
 // the role-based alternative).
+// opAuthorize is the resource-level operation that lets someone who is NOT a
+// platform administrator hand out access to one concrete object. The domain
+// services write it to the creator at create time (bkn-backend and vega call
+// CreateResources with COMMON_OPERATIONS, which includes it), so "whoever made
+// this" is exactly who holds it. Until these handlers consulted it the operation
+// was inert: every write was gated on admin-authz alone, and the person who
+// built a knowledge network could not share it (bkn-studio#478).
+const opAuthorize = "authorize"
+
+// grantAuthority is how a caller earned the right to write grants on one object.
+// It is recorded in the audit trail because "the security administrator opened
+// this up" and "the owner shared their own object" are different acts that would
+// otherwise be indistinguishable — both arrive as the same endpoint call.
+type grantAuthority string
+
+const (
+	// Platform-wide admin-authz:grant / :revoke. Unrestricted: may write any op
+	// on any object, including opAuthorize itself.
+	authorityAdminAuthz grantAuthority = "admin-authz"
+	// A direct object grant carrying opAuthorize on this exact instance — the row
+	// the creator receives. Restricted (see restrictDelegatedOps).
+	authorityOwner grantAuthority = "owner"
+	// A type-wide role grant carrying opAuthorize (network_builder holds it on
+	// knowledge_network, catalog, resource, connector_type). The seeded role
+	// already says this role may delegate this type; honoring it here does not
+	// widen the policy, it stops ignoring it. Restricted the same way as owner.
+	authorityTypeAuthorize grantAuthority = "type-authorize"
+)
+
+// resolveGrantAuthority decides whether the caller may write object grants on
+// ref, and on what footing. adminOp is the admin-authz operation this endpoint
+// corresponds to ("grant" or "revoke"). It replies to the client and returns
+// false when the answer is no, so callers just return.
+//
+// Order matters: administrators are answered without reading any policy for the
+// object, so the admin path costs what it did before this existed.
+func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, ref resourceRef) (grantAuthority, bool) {
+	sub := c.GetString(ctxAccessorID)
+	if sub == "" {
+		replyPublicError(c, http.StatusUnauthorized)
+		return "", false
+	}
+	admin, err := e.Check(sub, "admin-authz", "*", adminOp)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	if admin {
+		return authorityAdminAuthz, true
+	}
+	// A concrete instance is required from here on. An empty or wildcard id would
+	// make the ownership lookup below match ANY instance the caller happens to
+	// own, and casbin keyMatch would let a "type:*" role grant match it too —
+	// either turns "I own one network" into "I may act on the whole type".
+	if ref.ID == "" || ref.ID == "*" {
+		replyPublicError(c, http.StatusForbidden)
+		return "", false
+	}
+	// Ownership first, and read as a DIRECT grant rather than through Check:
+	// Check cannot tell "granted on this object" from "granted on the whole
+	// type", and the audit trail needs them apart.
+	direct, err := e.ListObjectGrants(sub, ref.Type, ref.ID)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	for _, grant := range direct {
+		for _, op := range grant.Operations {
+			if op == opAuthorize {
+				return authorityOwner, true
+			}
+		}
+	}
+	ok, err := e.Check(sub, ref.Type, ref.ID, opAuthorize)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	if ok {
+		return authorityTypeAuthorize, true
+	}
+	replyPublicError(c, http.StatusForbidden)
+	return "", false
+}
+
+// restrictDelegatedOps enforces the two limits on a non-administrator writing a
+// grant. It replies and returns false when the request breaks either.
+//
+//  1. The delegation chain is one deep: opAuthorize is administrator-conferred
+//     only. A delegate handing out opAuthorize would mint another delegate, and
+//     the set of people who can open an object up would grow without any
+//     administrator ever acting.
+//  2. A delegate cannot pass on more than it holds itself. Without this, someone
+//     holding only view_detail plus opAuthorize could grant modify — writing a
+//     permission that was never given to them.
+//
+// Administrators skip both: admin-authz:grant is the platform-level authority
+// these two rules exist to protect.
+func restrictDelegatedOps(c *gin.Context, e *authz.Enforcer, ref resourceRef, ops []string) bool {
+	for _, op := range ops {
+		if op == opAuthorize {
+			replyPublicError(c, http.StatusForbidden)
+			return false
+		}
+	}
+	held, err := e.AllowedOps(c.GetString(ctxAccessorID), ref.Type, ref.ID, ops)
+	if err != nil {
+		serverError(c, err)
+		return false
+	}
+	heldSet := make(map[string]bool, len(held))
+	for _, op := range held {
+		heldSet[op] = true
+	}
+	for _, op := range ops {
+		if !heldSet[op] {
+			replyPublicError(c, http.StatusForbidden)
+			return false
+		}
+	}
+	return true
+}
+
 func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 	// GET /policies?resource_type=&resource_id= — the p-lines written directly
 	// against this exact object key, grouped by subject. -> { entries:[
@@ -224,84 +348,7 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 	// Upsert semantics: the grant's ops become exactly `operations`. An empty
 	// list is rejected (use DELETE to revoke) so an accidental empty body can't
 	// silently wipe a grant.
-	g.POST("/object-grants", RequirePermission(e, "admin-authz", "grant"), func(c *gin.Context) {
-		var req struct {
-			AccessorID string      `json:"accessor_id" binding:"required"`
-			Resource   resourceRef `json:"resource" binding:"required"`
-			Operations []string    `json:"operations" binding:"required"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		if req.Resource.ID == "" || req.Resource.ID == "*" {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		if len(req.Operations) == 0 {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		// safe_admin:console:manage is exactly what CanAdmin tests, so granting it
-		// here would promote any grantee to platform administrator through the
-		// object-grant route — bypassing role binding and its escalation guards.
-		// Administrative capability is role-conferred only.
-		if req.Resource.Type == adminConsoleResourceType {
-			replyPublicError(c, http.StatusForbidden)
-			return
-		}
-		// Grantee must be a user (apps are user rows too). Departments/groups are
-		// rejected: their grants never match at enforce time.
-		ok, err := isUserAccessor(c, db, req.AccessorID)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		if !ok {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		// Ops must be registered for the resource type — blocks typos that would
-		// create policies no /check can ever satisfy.
-		valid, err := catalogOpSet(db, req.Resource.Type)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		if len(valid) == 0 {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		for _, op := range req.Operations {
-			if !valid[op] {
-				replyPublicError(c, http.StatusBadRequest)
-				return
-			}
-		}
-		// Add the operations the requested ones imply (#1121). Expanded after
-		// validation so a typo is still a 400 rather than something the expansion
-		// quietly absorbs. Upsert semantics make this self-healing: a console that
-		// clears view_detail while leaving resource_manage ticked sends a set this
-		// puts back, instead of storing a grant nothing can use.
-		ops, err := impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		// The audit Detail snapshots the request body, so without this the trail
-		// would say only what was asked for and an implied operation would appear
-		// on the accessor with nothing recording where it came from — the one
-		// question ("why can this account see this catalog?") the trail exists to
-		// answer. The seed's back-fill records its own repairs for the same
-		// reason; this keeps the two paths saying the same thing.
-		if implied := addedOps(req.Operations, ops); len(implied) > 0 {
-			setAuditOutcome(c, map[string]any{"implied_operations": implied})
-		}
-		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, ops); err != nil {
-			serverError(c, err)
-			return
-		}
-		c.Status(http.StatusNoContent)
-	})
+	g.POST("/object-grants", setObjectGrantHandler(e, db))
 
 	// DELETE /object-grants — revoke one user's grant on one concrete resource
 	// instance, leaving other grantees on the same resource untouched.
@@ -317,35 +364,7 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 	// unregistered type would harmlessly match nothing: a typo'd type is a silent
 	// no-op the operator would read as a successful revoke, which is the worst
 	// possible outcome for a security operation.
-	g.DELETE("/object-grants", RequirePermission(e, "admin-authz", "revoke"), func(c *gin.Context) {
-		var req struct {
-			AccessorID string      `json:"accessor_id" binding:"required"`
-			Resource   resourceRef `json:"resource" binding:"required"`
-		}
-		if !bind(c, &req) {
-			return
-		}
-		if req.Resource.ID == "" || req.Resource.ID == "*" {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		valid, err := catalogOpSet(db, req.Resource.Type)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		if len(valid) == 0 {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		removed, err := e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		setAuditOutcome(c, map[string]any{"removed": removed})
-		c.Status(http.StatusNoContent)
-	})
+	g.DELETE("/object-grants", revokeObjectGrantHandler(e, db))
 }
 
 // listGroupedObjectGrants serves the grouped, paginated object-grant views the
@@ -456,4 +475,277 @@ func catalogOpSet(db *gorm.DB, resourceType string) (map[string]bool, error) {
 		set[op] = true
 	}
 	return set, nil
+}
+
+// registerMeObjectGrants mounts the self-service mirror of the object-grant
+// writes under /api/safe/v1/me. Same handlers as the administrator surface — the
+// authority test inside them (resolveGrantAuthority) is what differs, and it
+// already accepts both an administrator and the object's owner.
+//
+// Why /me and not a group of its own: the gateway routes exactly three bkn-safe
+// prefixes (/api/safe/v1/admin, /me, /capabilities). A fourth would need an
+// ingress change on every cluster before the feature worked anywhere, for a
+// surface that is genuinely self-service — "the objects I own", the same footing
+// as /me/api-keys being "the keys I own".
+//
+// The platform-wide listing is deliberately NOT mirrored here. An owner may read
+// and write the grants on an object they own, one object at a time; "show me
+// every grant on the platform" stays with the administrator.
+func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *directory.Service) {
+	// GET /object-grants?resource_type=&resource_id= — who currently holds what
+	// on ONE object. The share UI opens with this: an owner about to hand their
+	// network to a colleague has to see who already has it, and submitting
+	// without that read would silently replace someone else's operation set
+	// (POST is replace, not merge).
+	g.GET("/object-grants", func(c *gin.Context) {
+		ref := resourceRef{
+			Type: objectGrantQueryParam(c, "resource_type", "obj_type"),
+			ID:   objectGrantQueryParam(c, "resource_id", "obj_id"),
+		}
+		if ref.Type == "" || ref.ID == "" {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		// Reading who has access is itself a privilege on the object: the same
+		// authority that lets a caller change the grants lets it see them.
+		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
+			return
+		}
+		policies, err := e.ResourcePolicies(ref.Type, ref.ID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		ids := make([]string, 0, len(policies))
+		for _, policy := range policies {
+			ids = append(ids, policy.AccessorID)
+		}
+		// Names are resolved here rather than left to the caller: the owner-facing
+		// surface has no user directory of its own (that is admin-only), so a
+		// client would have nothing to turn an accessor id into a person with.
+		named, err := grantAccessorNames(c, db, ids)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		entries := make([]gin.H, 0, len(policies))
+		for _, policy := range policies {
+			entry := gin.H{
+				"accessor_id": policy.AccessorID,
+				"resource":    gin.H{"type": ref.Type, "id": ref.ID},
+				"operations":  policy.Operations,
+			}
+			// A row whose subject is a role, or a user since deleted, resolves to
+			// nothing. It is still shown — hiding a grant that exists would be
+			// worse than showing a bare id.
+			if who, ok := named[policy.AccessorID]; ok {
+				entry["accessor_account"] = who.Account
+				entry["accessor_name"] = who.Name
+			}
+			entries = append(entries, entry)
+		}
+		c.JSON(http.StatusOK, gin.H{"entries": entries})
+	})
+
+	// GET /grantable-users?resource_type=&resource_id=&search=&limit= — the people
+	// an owner may pick when sharing ONE object.
+	//
+	// The platform user directory is admin-only, which left the owner surface
+	// unusable: you cannot grant to someone you cannot name. Rather than opening
+	// the directory to every logged-in account, this read is gated on the very
+	// same authority as writing grants on the object named in the query — you can
+	// look up candidates exactly when you have something to give them.
+	g.GET("/grantable-users", func(c *gin.Context) {
+		ref := resourceRef{
+			Type: objectGrantQueryParam(c, "resource_type", "obj_type"),
+			ID:   objectGrantQueryParam(c, "resource_id", "obj_id"),
+		}
+		if ref.Type == "" || ref.ID == "" {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
+			return
+		}
+		limit := atoiDefault(c.Query("limit"), 0)
+		if limit <= 0 {
+			limit = 20
+		}
+		if limit > 100 {
+			limit = 100
+		}
+		enabled := true
+		users, _, err := dir.ListUsers(c.Request.Context(), directory.UserListFilter{
+			Search: strings.TrimSpace(c.Query("search")),
+			// A disabled account cannot log in, so granting it access is a grant
+			// that does nothing; keep it out of the picker.
+			Enabled: &enabled,
+			Limit:   limit,
+		})
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		out := make([]gin.H, 0, len(users))
+		for _, user := range users {
+			out = append(out, gin.H{"id": user.ID, "account": user.Account, "name": user.Name})
+		}
+		c.JSON(http.StatusOK, gin.H{"users": out})
+	})
+	g.POST("/object-grants", setObjectGrantHandler(e, db))
+	g.DELETE("/object-grants", revokeObjectGrantHandler(e, db))
+}
+
+// grantAccessorNames resolves grant subjects to accounts, skipping ids that are
+// not users (casbin stores role subjects in the same column).
+func grantAccessorNames(c *gin.Context, db *gorm.DB, ids []string) (map[string]model.User, error) {
+	out := map[string]model.User{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	var rows []model.User
+	if err := db.WithContext(c.Request.Context()).Model(&model.User{}).
+		Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		out[row.ID] = row
+	}
+	return out, nil
+}
+
+func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+			Operations []string    `json:"operations" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		if req.Resource.ID == "" || req.Resource.ID == "*" {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if len(req.Operations) == 0 {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		// safe_admin:console:manage is exactly what CanAdmin tests, so granting it
+		// here would promote any grantee to platform administrator through the
+		// object-grant route — bypassing role binding and its escalation guards.
+		// Administrative capability is role-conferred only.
+		if req.Resource.Type == adminConsoleResourceType {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
+		// Administrator, or the object's own owner delegating it. Resolved here
+		// rather than in middleware because the owner branch is a question about
+		// the object named in the BODY, which middleware cannot see.
+		authority, ok := resolveGrantAuthority(c, e, "grant", req.Resource)
+		if !ok {
+			return
+		}
+		// Grantee must be a user (apps are user rows too). Departments/groups are
+		// rejected: their grants never match at enforce time.
+		ok, err := isUserAccessor(c, db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if !ok {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		// Ops must be registered for the resource type — blocks typos that would
+		// create policies no /check can ever satisfy.
+		valid, err := catalogOpSet(db, req.Resource.Type)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if len(valid) == 0 {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		for _, op := range req.Operations {
+			if !valid[op] {
+				replyPublicError(c, http.StatusBadRequest)
+				return
+			}
+		}
+		// Add the operations the requested ones imply (#1121). Expanded after
+		// validation so a typo is still a 400 rather than something the expansion
+		// quietly absorbs. Upsert semantics make this self-healing: a console that
+		// clears view_detail while leaving resource_manage ticked sends a set this
+		// puts back, instead of storing a grant nothing can use.
+		ops, err := impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		// Checked against the EXPANDED set, not what was asked for: the implication
+		// pass can add operations, and a delegate must not acquire one that way
+		// that it could not have named directly.
+		if authority != authorityAdminAuthz && !restrictDelegatedOps(c, e, req.Resource, ops) {
+			return
+		}
+		// The audit Detail snapshots the request body, so without this the trail
+		// would say only what was asked for and an implied operation would appear
+		// on the accessor with nothing recording where it came from — the one
+		// question ("why can this account see this catalog?") the trail exists to
+		// answer. The seed's back-fill records its own repairs for the same
+		// reason; this keeps the two paths saying the same thing.
+		outcome := map[string]any{"via": string(authority)}
+		if implied := addedOps(req.Operations, ops); len(implied) > 0 {
+			outcome["implied_operations"] = implied
+		}
+		setAuditOutcome(c, outcome)
+		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, ops); err != nil {
+			serverError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		if req.Resource.ID == "" || req.Resource.ID == "*" {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		// Revoking on an object is the mirror of granting on it: whoever can open
+		// their own object up can close it again. No op restriction applies —
+		// taking access away can only narrow, never widen.
+		authority, ok := resolveGrantAuthority(c, e, "revoke", req.Resource)
+		if !ok {
+			return
+		}
+		valid, err := catalogOpSet(db, req.Resource.Type)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if len(valid) == 0 {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		removed, err := e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		setAuditOutcome(c, map[string]any{"removed": removed, "via": string(authority)})
+		c.Status(http.StatusNoContent)
+	}
 }

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -134,20 +134,24 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 //
 // Administrators skip both: admin-authz:grant is the platform-level authority
 // these two rules exist to protect.
-// restrictDelegatedRevoke stops a delegate from stripping another delegate — or
-// the creator — of `authorize` on the object.
+// protectAuthorizeHolder stops a delegate from touching the grant of another
+// `authorize` holder — the object's creator included.
 //
-// Revoking removes every p-line the accessor holds on the object, `authorize`
-// included, and restrictDelegatedOps forbids a delegate from granting it back.
-// Without this, anyone the platform trusts to share ONE object could silently
-// take the object away from the person who made it, and only a platform
-// administrator could undo it. That is the same reason `authorize` cannot be
-// handed out by a delegate, applied to the other direction: it is conferred by
-// an administrator, so only an administrator takes it away.
+// It guards BOTH writes, because both erase. DELETE removes every p-line the
+// accessor holds on the object; POST is replace-semantics, so writing
+// operations:["view_detail"] onto a holder drops everything else in the same
+// motion. And restrictDelegatedOps forbids a delegate from putting `authorize`
+// back. Without this, anyone the platform trusts to share ONE object could
+// silently take that object away from the person who made it, and only a
+// platform administrator could undo it — network_builder holds `authorize`
+// type-wide on knowledge_network, so that is every member of the role against
+// every network.
 //
-// Grants without `authorize` stay revocable — sharing you can undo is the whole
-// point of the owner surface.
-func restrictDelegatedRevoke(c *gin.Context, e *authz.Enforcer, ref resourceRef, accessorID string) bool {
+// Same rule as the grant side, in the other direction: `authorize` is
+// administrator-conferred, so only an administrator takes it away. Grants
+// without `authorize` stay fully editable and revocable, which is what the owner
+// surface exists for.
+func protectAuthorizeHolder(c *gin.Context, e *authz.Enforcer, ref resourceRef, accessorID string) bool {
 	held, err := e.ListObjectGrants(accessorID, ref.Type, ref.ID)
 	if err != nil {
 		serverError(c, err)
@@ -688,6 +692,9 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if !ok {
 			return
 		}
+		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
+			return
+		}
 		// Grantee must be a user (apps are user rows too). Departments/groups are
 		// rejected: their grants never match at enforce time.
 		ok, err := isUserAccessor(c, db, req.AccessorID)
@@ -772,7 +779,7 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if !ok {
 			return
 		}
-		if authority != authorityAdminAuthz && !restrictDelegatedRevoke(c, e, req.Resource, req.AccessorID) {
+		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
 			return
 		}
 		valid, err := catalogOpSet(db, req.Resource.Type)

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -41,6 +41,10 @@ import (
 // built a knowledge network could not share it (bkn-studio#478).
 const opAuthorize = "authorize"
 
+// grantableUserPageSize caps the owner-facing account picker. Deliberately not
+// caller-tunable: see the Limit comment in the handler.
+const grantableUserPageSize = 20
+
 // grantAuthority is how a caller earned the right to write grants on one object.
 // It is recorded in the audit trail because "the security administrator opened
 // this up" and "the owner shared their own object" are different acts that would
@@ -567,20 +571,18 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
 			return
 		}
-		limit := atoiDefault(c.Query("limit"), 0)
-		if limit <= 0 {
-			limit = 20
-		}
-		if limit > 100 {
-			limit = 100
-		}
 		enabled := true
 		users, _, err := dir.ListUsers(c.Request.Context(), directory.UserListFilter{
 			Search: strings.TrimSpace(c.Query("search")),
 			// A disabled account cannot log in, so granting it access is a grant
 			// that does nothing; keep it out of the picker.
 			Enabled: &enabled,
-			Limit:   limit,
+			// Fixed page size, not a caller-supplied one. A picker has no use for
+			// a tunable limit, and letting the query string reach the slice
+			// pre-allocation inside ListUsers is a memory-exhaustion path for the
+			// sake of nothing (CodeQL go/uncontrolled-allocation-size). Narrow the
+			// search instead of asking for more rows.
+			Limit: grantableUserPageSize,
 		})
 		if err != nil {
 			serverError(c, err)

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -32,6 +32,20 @@ import (
 // holds no user→department membership rules, so a department grant would be a
 // dead policy that never matches at enforce time (see RolePermissions path for
 // the role-based alternative).
+// isConcreteResourceID reports whether an id names ONE instance.
+//
+// Rejecting only the literal "*" is not enough: the casbin matcher is keyMatch,
+// which treats a "*" ANYWHERE in the object as a wildcard. An id of "tb-*" is
+// stored verbatim by SetObjectPermissions and then matches every tool_box whose
+// id starts with "tb-", including ones created later — a grant the console can
+// neither show nor revoke, because every screen there works from a concrete id.
+//
+// Concrete ids never contain "*" (they are ULIDs, UUIDs or slugs), so refusing
+// the character outright costs nothing and closes the shape entirely.
+func isConcreteResourceID(id string) bool {
+	return id != "" && !strings.Contains(id, "*")
+}
+
 // opAuthorize is the resource-level operation that lets someone who is NOT a
 // platform administrator hand out access to one concrete object. The domain
 // services write it to the creator at create time (bkn-backend and vega call
@@ -86,11 +100,11 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 	if admin {
 		return authorityAdminAuthz, true
 	}
-	// A concrete instance is required from here on. An empty or wildcard id would
+	// A concrete instance is required from here on. An empty or wildcard-bearing id would
 	// make the ownership lookup below match ANY instance the caller happens to
 	// own, and casbin keyMatch would let a "type:*" role grant match it too —
 	// either turns "I own one network" into "I may act on the whole type".
-	if ref.ID == "" || ref.ID == "*" {
+	if !isConcreteResourceID(ref.ID) {
 		replyPublicError(c, http.StatusForbidden)
 		return "", false
 	}
@@ -135,7 +149,7 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 // Administrators skip both: admin-authz:grant is the platform-level authority
 // these two rules exist to protect.
 // protectAuthorizeHolder stops a delegate from touching the grant of another
-// `authorize` holder — the object's creator included.
+// `authorize` holder — the object's creator included — or the public-access row.
 //
 // It guards BOTH writes, because both erase. DELETE removes every p-line the
 // accessor holds on the object; POST is replace-semantics, so writing
@@ -152,6 +166,15 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 // without `authorize` stay fully editable and revocable, which is what the owner
 // surface exists for.
 func protectAuthorizeHolder(c *gin.Context, e *authz.Enforcer, ref resourceRef, accessorID string) bool {
+	// The public accessor is not a person whose access a delegate may adjust: it
+	// is how the execution factory publishes a built-in toolbox to everyone. Its
+	// row carries no `authorize`, so the holder check below would wave it through,
+	// and removing it would un-publish the toolbox platform-wide — previously an
+	// admin-authz:revoke action.
+	if accessorID == authz.PublicAccessorID {
+		replyPublicError(c, http.StatusForbidden)
+		return false
+	}
 	held, err := e.ListObjectGrants(accessorID, ref.Type, ref.ID)
 	if err != nil {
 		serverError(c, err)
@@ -669,7 +692,7 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if !bind(c, &req) {
 			return
 		}
-		if req.Resource.ID == "" || req.Resource.ID == "*" {
+		if !isConcreteResourceID(req.Resource.ID) {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
@@ -768,7 +791,7 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if !bind(c, &req) {
 			return
 		}
-		if req.Resource.ID == "" || req.Resource.ID == "*" {
+		if !isConcreteResourceID(req.Resource.ID) {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -329,5 +330,240 @@ func TestObjectGrantsGroupedViews(t *testing.T) {
 	page := decode("?group_by=object&limit=1&offset=0")
 	if page.Total != 2 || len(page.Groups) != 1 {
 		t.Fatalf("grouped pagination: total=%d groups=%d", page.Total, len(page.Groups))
+	}
+}
+
+// ownerGrantFixture builds the situation the owner path exists for: a builder
+// who created a knowledge network (and therefore holds the creator's object
+// grant, opAuthorize included) but holds no admin-authz permission at all.
+func ownerGrantFixture(t *testing.T) (*gin.Engine, *authz.Enforcer) {
+	t.Helper()
+	r, e, db, users := newAdminServer(t)
+	ctx := t.Context()
+	for _, u := range []struct{ id, account string }{
+		{"u-owner", "builder"},
+		{"u-mate", "teammate"},
+		{"u-stranger", "stranger"},
+	} {
+		if err := users.CreateLocalUser(ctx, &model.User{ID: u.id, Account: u.account, Name: u.account, Enabled: true}, "pw-init0"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// task_manage is registered for the type but deliberately NOT granted below,
+	// so a test can ask for an operation that is valid yet unheld.
+	seedCatalogOps(t, db, "knowledge_network",
+		"view_detail", "modify", "delete", "query_data", "authorize", "task_manage")
+	// Exactly what bkn-backend writes on create (COMMON_OPERATIONS).
+	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize"} {
+		if err := e.GrantObjectPermission("u-owner", "knowledge_network", "kn-mine", op); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return r, e
+}
+
+// The regression: the creator of a knowledge network can share it, without any
+// admin-authz permission. Before, opAuthorize was written on create and then
+// never consulted, so this was a flat 403 (bkn-studio#478).
+func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+
+	w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail", "query_data"},
+	}, "u-owner")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("owner share: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); !ok {
+		t.Error("shared grant did not take effect at enforce time")
+	}
+
+	// And can take it back.
+	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-owner")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
+		t.Error("owner revoke did not remove the grant")
+	}
+}
+
+// The two limits on a delegate, and the boundary of what it owns.
+func TestObjectGrantsOwnerLimits(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+	// A second network the owner did NOT create.
+	if err := e.GrantObjectPermission("u-stranger", "knowledge_network", "kn-theirs", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			// The chain stops at one: a delegate cannot mint another delegate.
+			"cannot pass authorize on",
+			map[string]any{
+				"accessor_id": "u-mate",
+				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+				"operations":  []string{"view_detail", "authorize"},
+			},
+		},
+		{
+			// task_manage is registered for the type but the owner does not hold
+			// it, so it cannot be handed out.
+			"cannot grant an op it does not hold",
+			map[string]any{
+				"accessor_id": "u-mate",
+				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+				"operations":  []string{"view_detail", "task_manage"},
+			},
+		},
+		{
+			// Ownership is per object, not per type.
+			"cannot reach another owner's object",
+			map[string]any{
+				"accessor_id": "u-mate",
+				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-theirs"},
+				"operations":  []string{"view_detail"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", tc.body, "u-owner"); w.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d (%s)", w.Code, w.Body.String())
+			}
+		})
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
+		t.Error("a rejected request must not write a partial grant")
+	}
+
+	// Someone with no stake in the object gets nothing.
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-stranger"); w.Code != http.StatusForbidden {
+		t.Fatalf("non-owner: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// A role holding type-wide authorize (network_builder does, on
+// knowledge_network) may delegate any instance of that type — the seeded policy
+// already says so. It is still a delegate: the same two limits apply.
+func TestObjectGrantsTypeWideAuthorize(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+	if err := e.GrantRolePermission("role-builder", "knowledge_network", "*", "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission("role-builder", "knowledge_network", "*", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u-stranger", "role-builder"); err != nil {
+		t.Fatal(err)
+	}
+
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-stranger"); w.Code != http.StatusNoContent {
+		t.Fatalf("type-wide authorize holder: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	// modify is not in the role grant, so it cannot be passed on.
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"modify"},
+	}, "u-stranger"); w.Code != http.StatusForbidden {
+		t.Fatalf("op it does not hold: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// The self-service read follows the write authority: an owner sees who already
+// holds their own network, and nothing else. It is per object by construction —
+// there is no way to widen it into a platform view.
+func TestObjectGrantsOwnerPolicyRead(t *testing.T) {
+	r, _ := ownerGrantFixture(t)
+	const base = "/api/safe/v1/me/object-grants?resource_type=knowledge_network"
+
+	if w := tokReq(t, r, http.MethodGet, base+"&resource_id=kn-mine", nil, "u-owner"); w.Code != http.StatusOK {
+		t.Fatalf("owner reading its own object: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := tokReq(t, r, http.MethodGet, base+"&resource_id=kn-theirs", nil, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("owner reading another object: want 403, got %d", w.Code)
+	}
+	// No id at all is rejected as a malformed request rather than answered as a
+	// type-wide read — the endpoint has no type-wide mode to fall into.
+	if w := tokReq(t, r, http.MethodGet, base, nil, "u-owner"); w.Code != http.StatusBadRequest {
+		t.Fatalf("owner reading the whole type: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	// The platform-wide listing stays where it was, administrator-only.
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/object-grants", nil, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("owner listing every grant: want 403, got %d", w.Code)
+	}
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/policies?resource_type=knowledge_network", nil); w.Code != http.StatusOK {
+		t.Fatalf("administrator reading the whole type: want 200, got %d", w.Code)
+	}
+}
+
+// The owner-facing lookups: names on the grant rows, and a candidate picker.
+// Both exist because the platform user directory is administrator-only, and both
+// are gated on the same authority as writing grants on the object.
+func TestObjectGrantsOwnerDirectoryLookups(t *testing.T) {
+	r, _ := ownerGrantFixture(t)
+	const base = "/api/safe/v1/me"
+
+	w := tokReq(t, r, http.MethodGet, base+"/object-grants?resource_type=knowledge_network&resource_id=kn-mine", nil, "u-owner")
+	if w.Code != http.StatusOK {
+		t.Fatalf("read grants: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var grants struct {
+		Entries []struct {
+			AccessorID      string `json:"accessor_id"`
+			AccessorAccount string `json:"accessor_account"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &grants); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(grants.Entries) != 1 || grants.Entries[0].AccessorID != "u-owner" {
+		t.Fatalf("want the owner's own row, got %+v", grants.Entries)
+	}
+	if grants.Entries[0].AccessorAccount != "builder" {
+		t.Errorf("accessor_account = %q, want \"builder\" — an id alone names nobody", grants.Entries[0].AccessorAccount)
+	}
+
+	// The picker is scoped to an object the caller may authorize...
+	w = tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network&resource_id=kn-mine&search=team", nil, "u-owner")
+	if w.Code != http.StatusOK {
+		t.Fatalf("picker: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var picker struct {
+		Users []struct {
+			ID      string `json:"id"`
+			Account string `json:"account"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &picker); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(picker.Users) != 1 || picker.Users[0].Account != "teammate" {
+		t.Fatalf("search=team should match only teammate, got %+v", picker.Users)
+	}
+
+	// ...and is not a back door into the directory for anyone else.
+	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network&resource_id=kn-mine&search=team", nil, "u-stranger"); w.Code != http.StatusForbidden {
+		t.Fatalf("non-owner picker: want 403, got %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network", nil, "u-owner"); w.Code != http.StatusBadRequest {
+		t.Fatalf("picker without an object: want 400, got %d", w.Code)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -639,3 +639,59 @@ func mustGrantRole(t *testing.T, e *authz.Enforcer, roleID, resourceType, op str
 		t.Fatal(err)
 	}
 }
+
+// A delegate must not be able to write a wildcard grant, or to un-publish a
+// built-in by deleting the public-access row. Both are shapes that look like an
+// ordinary per-object write but reach far past one object.
+func TestObjectGrantsDelegateCannotWriteWildcardOrTouchPublic(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+
+	// keyMatch treats "*" anywhere as a wildcard, so an id like "kn-*" would be
+	// stored verbatim and then match every network with that prefix — a grant no
+	// console screen could show or revoke.
+	for _, id := range []string{"kn-*", "*-mine", "*"} {
+		if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+			"accessor_id": "u-mate",
+			"resource":    map[string]any{"type": "knowledge_network", "id": id},
+			"operations":  []string{"view_detail"},
+		}, "u-owner"); w.Code != http.StatusBadRequest {
+			t.Errorf("granting on id %q: want 400, got %d (%s)", id, w.Code, w.Body.String())
+		}
+		if w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+			"accessor_id": "u-mate",
+			"resource":    map[string]any{"type": "knowledge_network", "id": id},
+		}, "u-owner"); w.Code != http.StatusBadRequest {
+			t.Errorf("revoking on id %q: want 400, got %d (%s)", id, w.Code, w.Body.String())
+		}
+	}
+	// An administrator gets the same answer: these endpoints write one instance.
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-*"},
+		"operations":  []string{"view_detail"},
+	}); w.Code != http.StatusBadRequest {
+		t.Errorf("administrator granting on a wildcard id: want 400, got %d", w.Code)
+	}
+
+	// The public-access row publishes a built-in to everyone. It carries no
+	// `authorize`, so the holder check alone would let a delegate delete it.
+	if err := e.GrantObjectPermission(authz.PublicAccessorID, "knowledge_network", "kn-mine", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": authz.PublicAccessorID,
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("delegate deleting the public row: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check(authz.PublicAccessorID, "knowledge_network", "kn-mine", "view_detail"); !ok {
+		t.Error("the public-access row was removed by a delegate")
+	}
+	// An administrator may still remove it.
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": authz.PublicAccessorID,
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}); w.Code != http.StatusNoContent {
+		t.Errorf("administrator removing the public row: want 204, got %d", w.Code)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -563,7 +563,66 @@ func TestObjectGrantsOwnerDirectoryLookups(t *testing.T) {
 	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network&resource_id=kn-mine&search=team", nil, "u-stranger"); w.Code != http.StatusForbidden {
 		t.Fatalf("non-owner picker: want 403, got %d", w.Code)
 	}
-	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network", nil, "u-owner"); w.Code != http.StatusBadRequest {
+	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network&search=team", nil, "u-owner"); w.Code != http.StatusBadRequest {
 		t.Fatalf("picker without an object: want 400, got %d", w.Code)
+	}
+	// Holding authorize on one object is not a licence to page through the
+	// directory, so an empty search is refused rather than answered with a page.
+	if w := tokReq(t, r, http.MethodGet, base+"/grantable-users?resource_type=knowledge_network&resource_id=kn-mine", nil, "u-owner"); w.Code != http.StatusBadRequest {
+		t.Fatalf("picker without a search term: want 400, got %d", w.Code)
+	}
+}
+
+// A delegate may take back what it shared, but must not strip another holder of
+// `authorize` — the creator included. Revoking removes every op the accessor has
+// on the object, and a delegate cannot grant `authorize` back, so without this
+// rule anyone trusted with one object could take it from the person who made it.
+func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+	// u-stranger is a network_builder: type-wide authorize on the whole type, no
+	// stake in this particular network.
+	mustGrantRole(t, e, "role-builder", "knowledge_network", "authorize")
+	mustGrantRole(t, e, "role-builder", "knowledge_network", "view_detail")
+	if err := e.AssignRole("u-stranger", "role-builder"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The creator holds authorize on kn-mine and must survive.
+	w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-owner",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-stranger")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("stripping the creator: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-owner", "knowledge_network", "kn-mine", "authorize"); !ok {
+		t.Fatal("the creator lost authorize on its own object")
+	}
+
+	// A plain grantee stays revocable — undoing a share is the point.
+	if err := e.GrantObjectPermission("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-stranger")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("revoking a plain grantee: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	// An administrator is still able to do both.
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-owner",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}); w.Code != http.StatusNoContent {
+		t.Fatalf("administrator revoking an authorize holder: want 204, got %d", w.Code)
+	}
+}
+
+func mustGrantRole(t *testing.T, e *authz.Enforcer, roleID, resourceType, op string) {
+	t.Helper()
+	if err := e.GrantRolePermission(roleID, resourceType, "*", op); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -611,6 +611,19 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 		t.Fatalf("revoking a plain grantee: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
 
+	// The grant side erases just as thoroughly: POST replaces the whole op set, so
+	// writing view_detail onto the creator would drop its authorize in one move.
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-owner",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-stranger"); w.Code != http.StatusForbidden {
+		t.Fatalf("overwriting the creator's grant: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-owner", "knowledge_network", "kn-mine", "authorize"); !ok {
+		t.Fatal("the creator lost authorize through the grant path")
+	}
+
 	// An administrator is still able to do both.
 	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
 		"accessor_id": "u-owner",

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -213,6 +213,10 @@ func New(deps Deps) *gin.Engine {
 			meWrites.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}
 		registerMeProfile(meWrites, deps.Users)
+		// Object-grant delegation: sharing an object you own is a write, so it
+		// belongs on the raw-verifier group with the rest of the mutating /me
+		// surface — and it must be audited like any other authorization change.
+		registerMeObjectGrants(meWrites, deps.Enforcer, deps.DB, deps.Directory)
 		if deps.AccessLog != nil && deps.Directory != nil {
 			registerLogout(meWrites, deps.AccessLog, deps.Directory)
 		}

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -151,7 +151,8 @@
       "role_name": "network_builder",
       "resource_type": "knowledge_network",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage"]
+      "_note": "无 authorize:构建者管得了每一张网,但「把某张网授权给谁」只有它的创建者(建网时写给创建者的对象授权里带 authorize)和平台管理员能做。类型级放开会让角色的每个成员都能把任意网络授出去,而 authorize 又只能由管理员收回。",
+      "operations": ["view_detail", "create", "modify", "delete", "query_data", "task_manage"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -517,3 +517,57 @@ func TestSeedRevokesNormalUserDataGrants(t *testing.T) {
 		t.Error("network_builder lost catalog resource_manage — creating a data table would 403 after upgrade")
 	}
 }
+
+// network_builder manages every knowledge network but may not hand one out.
+//
+// Sharing a network is the creator's call: bkn-backend writes `authorize` to
+// whoever created it, and that object grant is what the owner surface reads. A
+// type-wide `authorize` would instead let every member of the role give any
+// network to anyone — and since `authorize` can only be taken back by a platform
+// administrator, that power could not be walked back from inside the role.
+//
+// The rest of the row stays: the role is still the business-plane administrator.
+func TestNetworkBuilderCannotShareNetworksItDidNotCreate(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		builder = "u-builder"
+		network = "kn-someone-elses"
+	)
+	if err := e.AssignRole(builder, "1572fb82-526f-11f0-bde6-e674ec8dde71"); err != nil {
+		t.Fatal(err)
+	}
+
+	if ok, err := e.Check(builder, "knowledge_network", network, "authorize"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Error("network_builder must not hold type-wide authorize on knowledge networks")
+	}
+
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "query_data", "task_manage"} {
+		ok, err := e.Check(builder, "knowledge_network", network, op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Errorf("network_builder lost %q — it is still the business-plane administrator", op)
+		}
+	}
+
+	// The creator's own grant is untouched: that is where sharing comes from.
+	const creator = "u-creator"
+	if err := e.GrantObjectPermission(creator, "knowledge_network", network, "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := e.Check(creator, "knowledge_network", network, "authorize"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Error("the creator's object-level authorize must still decide sharing")
+	}
+}


### PR DESCRIPTION
与 #1135 同源，面向 `main`。0.1.4 那条是先发版本；本分支基于 `main`，因此不含 0.1.4 独有的 `impliedOps`（#1121）扩展。

两个独立缺陷，都让「被授权了却用不了」。

## 1. `scope=type` 丢掉全部对象级授权

前端启动拉 `GET /me/permissions?scope=type`，而 `EffectivePermissions` 在 `TypeWideOnly` 下把实例行整行丢弃。`normal_user` 角色按设计**不含任何数据权限**（allow-only 引擎里类型级放行无法被对象授权收窄），所以「管理员把某个知识网络授权给某人」正是唯一路径 —— 这些人拿到的是空权限集，Studio 直接把入口藏掉，直连 URL 也被路由守卫拦成 403。

改为折叠而非丢弃：类型行带 `instance_operations`（只在某些实例上持有、类型级没有的操作），某个类型只通过实例可达时也照样出一行，`operations` 为空。这正是 bkn-studio `flattenSafeGrants` 早已在等的形状，之前只落了客户端那一半。

该字段只回答「这个类型能不能进」，**不说是哪个实例**，因此仅用于入口可见性；针对具体对象的判定仍需不带 scope 或带 `resource_id` 的读取。

## 2. `authorize` 操作从未被消费

`bkn-backend` / `vega` 在每次创建时就把 `authorize` 写给创建者（`CreateResources` + `COMMON_OPERATIONS`），但没有任何代码读它：对象授权的写入口只认 `admin-authz`。结果是建了知识网络的人无法把它分享给同事。

现在写入接受两种身份：管理员，或**在请求所指对象上**持有 `authorize` 的人。后者受两条限制：

- 委托链只有一层 —— `authorize` 仅由管理员授予，delegate 造不出下一个 delegate；
- delegate 只能授出自己持有的操作。

审计记录 `_outcome.via`（`admin-authz` / `owner` / `type-authorize`），把「安全管理员放开的」和「属主自己分享的」分开。

自助入口挂在 `/api/safe/v1/me` 而非新开一组：网关只路由三个 bkn-safe 前缀，新增第四个要先改每套集群的 ingress。它另带两个只读接口 —— 授权行解析出账号、候选人选择器 —— 都按对象授权身份收口，没有把管理员专属的用户目录开放给所有登录账号。

管理员面不变：平台级列表和类型级 policy 读取原样保留。

## 验证

`go vet ./internal/...` 干净，`go test ./internal/...` 全过（新增 5 个用例覆盖折叠、属主授权、两条限制、跨对象越权、目录查询收口）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)