### PR TITLE
fix(bkn-trace): bind timestamp repair at index level

### DIFF
--- a/.github/workflows/release-bkn-trace-otelcol.yml
+++ b/.github/workflows/release-bkn-trace-otelcol.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Verify Collector chart regressions
         working-directory: bkn-trace/otelcol-contribute-chart
+        env:
+          OTELCOL_RUNTIME_IMAGE: swr.cn-east-3.myhuaweicloud.com/openbkn-ai/otel/opentelemetry-collector-contrib:0.148.0
         run: |
           ./scripts/test_4c8g_baseline.sh
           ./scripts/test_config_rollout.sh

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -154,7 +154,7 @@ opensearch:
   traceIndex: ss4o_traces-default-namespace
   logIndex: ss4o_logs-default-namespace
   # Empty for standalone use. The product installer supplies the compatibility
-  # pipeline before it configures the Collector to require it.
+  # pipeline and binds it as the Trace index default ingest pipeline.
   traceTimestampPipeline: ""
   auth:
     enabled: false

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -105,6 +105,7 @@ func NewApp() (*App, error) {
 	)
 	if err := openSearchClient.EnsureTraceTimestampPipeline(
 		context.Background(), openSearchConfig.TraceTimestampPipeline,
+		openSearchConfig.TraceIndex,
 	); err != nil {
 		return nil, fmt.Errorf("initialize trace timestamp pipeline: %w", err)
 	}

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -97,10 +97,14 @@ func NewWithHTTPClient(baseURL string, auth AuthConfig, httpClient *http.Client)
 // repair for the Collector's SS4O trace encoder. The affected upstream encoder
 // serializes @timestamp as Go's zero time while retaining span startTime. The
 // condition deliberately requires a traceId, so logs never enter this path.
-func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string) error {
+func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, traceIndex string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return nil
+	}
+	traceIndex = strings.Trim(strings.TrimSpace(traceIndex), "/")
+	if traceIndex == "" {
+		return errors.New("trace index is required when trace timestamp pipeline is enabled")
 	}
 	body, err := json.Marshal(map[string]any{
 		"description": "Repair zero @timestamp on OpenTelemetry SS4O trace spans from startTime.",
@@ -135,6 +139,70 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string) 
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("opensearch trace timestamp pipeline failed with status %d: %s", resp.StatusCode, string(responseBody))
+	}
+
+	indexSettings := map[string]string{"index.default_pipeline": name}
+	indexTemplate, err := json.Marshal(map[string]any{
+		"index_patterns": []string{traceIndex},
+		"template": map[string]any{
+			"settings": indexSettings,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("encode trace index default pipeline template: %w", err)
+	}
+	templateURL := fmt.Sprintf("%s/_index_template/bkn-trace-timestamp-default", c.baseURL)
+	templateRequest, err := http.NewRequestWithContext(ctx, http.MethodPut, templateURL, bytes.NewReader(indexTemplate))
+	if err != nil {
+		return fmt.Errorf("create trace index default pipeline template request: %w", err)
+	}
+	templateRequest.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		templateRequest.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	templateResponse, err := c.httpClient.Do(templateRequest)
+	if err != nil {
+		return fmt.Errorf("execute trace index default pipeline template request: %w", err)
+	}
+	defer func() { _ = templateResponse.Body.Close() }()
+	templateBody, err := io.ReadAll(templateResponse.Body)
+	if err != nil {
+		return fmt.Errorf("read trace index default pipeline template response: %w", err)
+	}
+	if templateResponse.StatusCode < http.StatusOK || templateResponse.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch trace index default pipeline template failed with status %d: %s", templateResponse.StatusCode, string(templateBody))
+	}
+
+	indexSettingsBody, err := json.Marshal(indexSettings)
+	if err != nil {
+		return fmt.Errorf("encode trace index default pipeline setting: %w", err)
+	}
+	settingsURL := fmt.Sprintf("%s/%s/_settings", c.baseURL, url.PathEscape(traceIndex))
+	settingsRequest, err := http.NewRequestWithContext(ctx, http.MethodPut, settingsURL, bytes.NewReader(indexSettingsBody))
+	if err != nil {
+		return fmt.Errorf("create trace index default pipeline setting request: %w", err)
+	}
+	settingsRequest.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		settingsRequest.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	settingsResponse, err := c.httpClient.Do(settingsRequest)
+	if err != nil {
+		return fmt.Errorf("execute trace index default pipeline setting request: %w", err)
+	}
+	defer func() { _ = settingsResponse.Body.Close() }()
+	settingsBody, err := io.ReadAll(settingsResponse.Body)
+	if err != nil {
+		return fmt.Errorf("read trace index default pipeline setting response: %w", err)
+	}
+	// On a fresh installation the Collector creates the trace index later. The
+	// template above binds the pipeline then; only an existing index needs this
+	// immediate update.
+	if settingsResponse.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if settingsResponse.StatusCode < http.StatusOK || settingsResponse.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch trace index default pipeline setting failed with status %d: %s", settingsResponse.StatusCode, string(settingsBody))
 	}
 	return nil
 }

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -144,6 +144,10 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 	indexSettings := map[string]string{"index.default_pipeline": name}
 	indexTemplate, err := json.Marshal(map[string]any{
 		"index_patterns": []string{traceIndex},
+		// Generic SS4O templates may also match the Trace index. Keep this
+		// narrowly scoped template above their default priority so the repair
+		// pipeline cannot be displaced by an unrelated template.
+		"priority": 500,
 		"template": map[string]any{
 			"settings": indexSettings,
 		},

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -15,27 +15,75 @@ import (
 )
 
 func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T) {
+	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut || r.URL.Path != "/_ingest/pipeline/bkn-trace-span-timestamp-v1" {
+		requests++
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/_ingest/pipeline/bkn-trace-span-timestamp-v1":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content := string(body)
+			if !strings.Contains(content, "startTime") || !strings.Contains(content, "0001-01-01T00:00:00Z") {
+				t.Fatalf("pipeline must repair only zero trace timestamps: %s", content)
+			}
+			if !strings.Contains(content, "ctx.containsKey('traceId')") {
+				t.Fatalf("pipeline must not alter log records: %s", content)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == "/_index_template/bkn-trace-timestamp-default":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			content := string(body)
+			if !strings.Contains(content, `"index_patterns":["ss4o_traces-default-namespace"]`) {
+				t.Fatalf("template must target the trace index: %s", content)
+			}
+			if !strings.Contains(content, `"index.default_pipeline":"bkn-trace-span-timestamp-v1"`) {
+				t.Fatalf("template must configure the timestamp repair pipeline: %s", content)
+			}
+		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace/_settings":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
-		content := string(body)
-		if !strings.Contains(content, "startTime") || !strings.Contains(content, "0001-01-01T00:00:00Z") {
-			t.Fatalf("pipeline must repair only zero trace timestamps: %s", content)
-		}
-		if !strings.Contains(content, "ctx.containsKey('traceId')") {
-			t.Fatalf("pipeline must not alter log records: %s", content)
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	client := New(server.URL, AuthConfig{}, time.Second)
-	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1"); err != nil {
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
+		t.Fatalf("ensure timestamp pipeline: %v", err)
+	}
+	if requests != 3 {
+		t.Fatalf("expected pipeline, template and index settings requests, got %d", requests)
+	}
+}
+
+func TestEnsureTraceTimestampPipelineUpdatesExistingTraceIndex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1", "/_index_template/bkn-trace-timestamp-default":
+			w.WriteHeader(http.StatusOK)
+		case "/ss4o_traces-default-namespace/_settings":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(body), `"index.default_pipeline":"bkn-trace-span-timestamp-v1"`) {
+				t.Fatalf("existing trace index must use the timestamp repair pipeline: %s", body)
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.URL, AuthConfig{}, time.Second)
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
 		t.Fatalf("ensure timestamp pipeline: %v", err)
 	}
 }

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -43,6 +43,9 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 			if !strings.Contains(content, `"index.default_pipeline":"bkn-trace-span-timestamp-v1"`) {
 				t.Fatalf("template must configure the timestamp repair pipeline: %s", content)
 			}
+			if !strings.Contains(content, `"priority":500`) {
+				t.Fatalf("template must take precedence over generic SS4O templates: %s", content)
+			}
 		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace/_settings":
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -103,6 +103,8 @@ exporters:
 
 注意：官方 `opensearchexporter` 当前支持 `traces` 和 `logs`，默认不为 `metrics` 创建 OpenSearch 导出 pipeline。
 
+Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，再绑定到 Trace 索引及其模板。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。
+
 ### 4C8G 最小部署基线
 
 默认单副本 Collector 限制为 `500m CPU / 768MiB`，适配 OpenBKN `4C8G` 最小环境：

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -105,6 +105,8 @@ exporters:
 
 Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，再绑定到 Trace 索引及其模板。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。
 
+`scripts/test_config_rollout.sh` 默认使用交付中的 SWR Collector 镜像执行 `validate`；可通过 `OTELCOL_RUNTIME_IMAGE` 覆盖镜像。该校验不会因未设置环境变量而跳过。
+
 ### 4C8G 最小部署基线
 
 默认单副本 Collector 限制为 `500m CPU / 768MiB`，适配 OpenBKN `4C8G` 最小环境：

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/templates/configmap.yaml
@@ -46,9 +46,6 @@ metadata:
 {{- if .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- $_ := set $opensearch "traces_index_time_format" .Values.opensearchExporter.tracesIndexTimeFormat }}
 {{- end }}
-{{- if .Values.opensearchExporter.pipeline }}
-{{- $_ := set $opensearch "pipeline" .Values.opensearchExporter.pipeline }}
-{{- end }}
 {{- $mapping := dict "mode" .Values.opensearchExporter.mapping.mode }}
 {{- if .Values.opensearchExporter.mapping.timestampField }}
 {{- $_ := set $mapping "timestamp_field" .Values.opensearchExporter.mapping.timestampField }}

--- a/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
+++ b/bkn-trace/otelcol-contribute-chart/charts/otelcol-contrib/values.yaml
@@ -97,9 +97,6 @@ opensearchExporter:
   tracesIndex: ""
   tracesIndexFallback: unknown
   tracesIndexTimeFormat: ""
-  # Optional OpenSearch ingest pipeline applied by the exporter. The full
-  # OpenBKN installer sets its trace timestamp repair pipeline explicitly.
-  pipeline: ""
   mapping:
     mode: ss4o
     timestampField: ""

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+runtime_image="${OTELCOL_RUNTIME_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openbkn-ai/otel/opentelemetry-collector-contrib:0.148.0}"
+
 chart_dir="${1:-charts/otelcol-contrib}"
 
 checksum() {
@@ -38,19 +40,17 @@ if grep -Fq "pipeline: bkn-trace-span-timestamp-v1" <<<"${timestamp_pipeline_ren
   exit 1
 fi
 
-if [[ -n "${OTELCOL_RUNTIME_IMAGE:-}" ]]; then
-  rendered_config="$(mktemp)"
-  trap 'rm -f "${rendered_config}"' EXIT
-  helm template otelcol-contrib "${chart_dir}" >"${rendered_config}.manifest"
-  awk '
-    $0 == "  collector-config.yaml: |" { in_config=1; next }
-    in_config && $0 == "---" { exit }
-    in_config { sub(/^    /, ""); print }
-  ' "${rendered_config}.manifest" >"${rendered_config}"
-  rm -f "${rendered_config}.manifest"
-  docker run --rm \
-    -v "${rendered_config}:/tmp/collector-config.yaml:ro" \
-    "${OTELCOL_RUNTIME_IMAGE}" validate --config=/tmp/collector-config.yaml
-fi
+rendered_config="$(mktemp)"
+trap 'rm -f "${rendered_config}" "${rendered_config}.manifest"' EXIT
+helm template otelcol-contrib "${chart_dir}" >"${rendered_config}.manifest"
+awk '
+  $0 == "  collector-config.yaml: |" { in_config=1; next }
+  in_config && $0 == "---" { exit }
+  in_config { sub(/^    /, ""); print }
+' "${rendered_config}.manifest" >"${rendered_config}"
+chmod a+r "${rendered_config}"
+docker run --rm \
+  -v "${rendered_config}:/tmp/collector-config.yaml:ro" \
+  "${runtime_image}" validate --config=/tmp/collector-config.yaml
 
 echo "collector config rollout checksum verified"

--- a/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
+++ b/bkn-trace/otelcol-contribute-chart/scripts/test_config_rollout.sh
@@ -33,9 +33,24 @@ if [[ "${baseline}" != "${unchanged}" ]]; then
   exit 1
 fi
 
-if ! grep -Fq "pipeline: bkn-trace-span-timestamp-v1" <<<"${timestamp_pipeline_rendered}"; then
-  echo "collector must pass the configured OpenSearch ingest pipeline to its exporter" >&2
+if grep -Fq "pipeline: bkn-trace-span-timestamp-v1" <<<"${timestamp_pipeline_rendered}"; then
+  echo "collector OpenSearch exporter must not render unsupported pipeline configuration" >&2
   exit 1
+fi
+
+if [[ -n "${OTELCOL_RUNTIME_IMAGE:-}" ]]; then
+  rendered_config="$(mktemp)"
+  trap 'rm -f "${rendered_config}"' EXIT
+  helm template otelcol-contrib "${chart_dir}" >"${rendered_config}.manifest"
+  awk '
+    $0 == "  collector-config.yaml: |" { in_config=1; next }
+    in_config && $0 == "---" { exit }
+    in_config { sub(/^    /, ""); print }
+  ' "${rendered_config}.manifest" >"${rendered_config}"
+  rm -f "${rendered_config}.manifest"
+  docker run --rm \
+    -v "${rendered_config}:/tmp/collector-config.yaml:ro" \
+    "${OTELCOL_RUNTIME_IMAGE}" validate --config=/tmp/collector-config.yaml
 fi
 
 echo "collector config rollout checksum verified"

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -487,9 +487,6 @@ _openbkn_trace_profile_sets() {
             fi
             ;;
         otelcol-contrib)
-            CORE_RELEASE_EXTRA_SETS+=(
-                "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
-            )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
                     "opensearchExporter.http.endpoint=$(_openbkn_trace_opensearch_endpoint)"
@@ -997,33 +994,6 @@ sys.exit(0 if durable else 1)
 ' <<<"${values}"
 }
 
-# The Collector chart has an independent same-version skip. Reconcile its
-# rendered values as well: otherwise an already-installed Collector never
-# receives the trace timestamp pipeline even though agent-observability has
-# created it successfully.
-_openbkn_collector_has_trace_timestamp_pipeline() {
-    local namespace="$1"
-    local values
-    if ! values="$(helm get values otelcol-contrib -n "${namespace}" --all -o json 2>/dev/null)"; then
-        return 2
-    fi
-    python3 -c '
-import json, sys
-try:
-    values = json.load(sys.stdin)
-except (json.JSONDecodeError, TypeError):
-    sys.exit(2)
-pipeline = values.get("opensearchExporter", {}).get("pipeline")
-sys.exit(0 if pipeline == "bkn-trace-span-timestamp-v1" else 1)
-' <<<"${values}"
-}
-
-_openbkn_collector_pipeline_is_explicitly_overridden() {
-    local value
-    value="$(_openbkn_last_set_value "opensearchExporter.pipeline" "${CORE_SET_VALUES[@]-}")" || return 1
-    [[ "${value}" != "bkn-trace-span-timestamp-v1" ]]
-}
-
 _openbkn_agent_observability_profile_is_explicitly_volatile() {
     local key value
     local -a set_values=("${CORE_SET_VALUES[@]-}")
@@ -1080,22 +1050,6 @@ _openbkn_should_skip_upgrade() {
                 ;;
             *)
                 log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
-                return 0
-                ;;
-        esac
-    elif [[ "${release_name}" == "otelcol-contrib" ]]; then
-        _openbkn_collector_has_trace_timestamp_pipeline "${namespace}"
-        case "$?" in
-            0) ;;
-            1)
-                if _openbkn_collector_pipeline_is_explicitly_overridden; then
-                    return 0
-                fi
-                log_info "Reconcile otelcol-contrib: installed Collector has no trace timestamp pipeline."
-                return 1
-                ;;
-            *)
-                log_warn "Cannot read otelcol-contrib Helm values; preserving the version-skip decision to avoid an unverified rollout."
                 return 0
                 ;;
         esac

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -1011,6 +1011,28 @@ _openbkn_agent_observability_profile_is_explicitly_volatile() {
     return 1
 }
 
+# Collector builds prior to the index-level timestamp repair passed a pipeline
+# option that the currently delivered Collector binary rejects at startup. Helm
+# still considers that release deployed, so chart-version equality alone would
+# leave it CrashLooping forever. Inspect the recorded values and reconcile it
+# once; empty/missing is the supported current state.
+_openbkn_otelcol_has_unsupported_pipeline() {
+    local namespace="$1"
+    local values
+    if ! values="$(helm get values otelcol-contrib -n "${namespace}" --all -o json 2>/dev/null)"; then
+        return 2
+    fi
+    python3 -c '
+import json, sys
+try:
+    values = json.load(sys.stdin)
+except (json.JSONDecodeError, TypeError):
+    sys.exit(2)
+pipeline = values.get("opensearchExporter", {}).get("pipeline")
+sys.exit(0 if isinstance(pipeline, str) and pipeline.strip() else 1)
+' <<<"${values}"
+}
+
 _openbkn_last_set_value() {
     local key="$1"
     shift
@@ -1050,6 +1072,20 @@ _openbkn_should_skip_upgrade() {
                 ;;
             *)
                 log_warn "Cannot read agent-observability Helm values; preserving the version-skip decision to avoid an unverified rollout."
+                return 0
+                ;;
+        esac
+    fi
+    if [[ "${release_name}" == "otelcol-contrib" ]]; then
+        _openbkn_otelcol_has_unsupported_pipeline "${namespace}"
+        case "$?" in
+            0)
+                log_info "Reconcile otelcol-contrib: installed values contain unsupported OpenSearch pipeline configuration."
+                return 1
+                ;;
+            1) ;;
+            *)
+                log_warn "Cannot read otelcol-contrib Helm values; preserving the version-skip decision to avoid an unverified rollout."
                 return 0
                 ;;
         esac

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -140,16 +140,9 @@ HELM_GET_VALUES_EXIT=0
 CORE_SET_VALUES=()
 HELM_VALUES='{"opensearchExporter":{"pipeline":""}}'
 if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
-    fail "installer must reconcile a Collector without the timestamp repair pipeline"
-else
-    ok
-fi
-
-HELM_VALUES='{"opensearchExporter":{"pipeline":"bkn-trace-span-timestamp-v1"}}'
-if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
     ok
 else
-    fail "installer should retain the version-skip optimization for a reconciled Collector"
+    fail "collector does not own the timestamp repair pipeline and should retain version-skip optimization"
 fi
 
 HELM_VALUES='{not-json}'
@@ -231,7 +224,7 @@ not_contains "secure AO never forwards an OpenSearch password to Helm" "${secure
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_trace_profile_sets otelcol-contrib
 secure_collector_sets="${CORE_RELEASE_EXTRA_SETS[*]:-}"
-contains "Collector routes spans through the timestamp repair pipeline" "${secure_collector_sets}" "opensearchExporter.pipeline=bkn-trace-span-timestamp-v1"
+not_contains "Collector does not receive unsupported timestamp pipeline configuration" "${secure_collector_sets}" "opensearchExporter.pipeline="
 contains "secure Collector uses the OpenSearch endpoint from config" "${secure_collector_sets}" "opensearchExporter.http.endpoint=https://opensearch-secure.resource.svc.cluster.local:9200"
 contains "secure Collector verifies the OpenSearch TLS peer" "${secure_collector_sets}" "opensearchExporter.http.tls.insecure=false"
 contains "secure Collector enables OpenSearch auth" "${secure_collector_sets}" "opensearchExporter.auth.enabled=true"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -138,11 +138,18 @@ fi
 HELM_GET_VALUES_EXIT=0
 
 CORE_SET_VALUES=()
+HELM_VALUES='{"opensearchExporter":{"pipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
+    fail "installer must reconcile a Collector release with the unsupported pipeline value"
+else
+    ok
+fi
+
 HELM_VALUES='{"opensearchExporter":{"pipeline":""}}'
 if _openbkn_should_skip_upgrade otelcol-contrib openbkn otelcol-contrib 0.1.4; then
     ok
 else
-    fail "collector does not own the timestamp repair pipeline and should retain version-skip optimization"
+    fail "collector without the unsupported pipeline value should retain version-skip optimization"
 fi
 
 HELM_VALUES='{not-json}'


### PR DESCRIPTION
## What Changed
- [x] Removed the unsupported OpenTelemetry Collector `exporters.opensearch.pipeline` setting.
- [x] Applied the timestamp-repair ingest pipeline as the default pipeline for the Trace index through an OpenSearch index template and existing-index settings update.
- [x] Added a runtime configuration validation that runs the exact deployed Collector image.
- [x] Documented the runtime compatibility contract in the Collector chart README.

## Why
- Related Issue: N/A — discovered during localhost mainline rollout.
- Related Feature: BKN Trace timestamp repair.
- Background: the rendered chart was valid YAML but the current Collector image rejects the exporter `pipeline` field, causing the Collector to CrashLoop after upgrade.

## How
- Timestamp repair remains scoped to the Trace index; logs are unaffected.
- Fresh installs inherit the setting from the index template; existing Trace indexes are updated explicitly.
- Breaking changes: no public API or schema changes.

## Testing
- [x] `go test ./...` in `bkn-trace/agent-observability`
- [x] `bash ./scripts/test_config_rollout.sh`
- [x] Runtime validation with `swr.cn-east-3.myhuaweicloud.com/openbkn-ai/otel/opentelemetry-collector-contrib:0.148.0`
- [x] `bash ./scripts/services/openbkn_trace_profile_test.sh`
- [x] `helm lint charts/otelcol-contrib`

## Risk & Rollback
- Risk: an unavailable OpenSearch during bootstrap will defer the default-pipeline setup until the service is retried.
- Rollback: revert this PR; for a running deployment, retain the Collector configuration without the unsupported exporter field and remove the Trace index default-pipeline setting if necessary.

## Additional Notes
- The design uses OpenSearch index-level default pipelines: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index-settings/