### PR TITLE
fix(bkn-trace): reconcile index-level timestamp repair

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -22,10 +22,11 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        openbkn.ai/trace-timestamp-pipeline-revision: {{ .Values.opensearch.traceTimestampPipelineRevision | quote }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "agent-observability.serviceAccountName" . }}
       {{- with .Values.imagePullSecrets }}

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -156,6 +156,10 @@ opensearch:
   # Empty for standalone use. The product installer supplies the compatibility
   # pipeline and binds it as the Trace index default ingest pipeline.
   traceTimestampPipeline: ""
+  # Records the installer-managed timestamp repair contract. It is not an
+  # OpenSearch setting; it lets same-version release installs reconcile once
+  # when the repair implementation changes.
+  traceTimestampPipelineRevision: ""
   auth:
     enabled: false
     existingSecret: ""

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -106,6 +106,9 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 	if traceIndex == "" {
 		return errors.New("trace index is required when trace timestamp pipeline is enabled")
 	}
+	if err := c.deleteLegacyTraceTimestampTemplate(ctx); err != nil {
+		return err
+	}
 	body, err := json.Marshal(map[string]any{
 		"description": "Repair zero @timestamp on OpenTelemetry SS4O trace spans from startTime.",
 		"processors": []map[string]any{{
@@ -181,6 +184,33 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 		return fmt.Errorf("opensearch trace index default pipeline setting failed with status %d: %s", settingsResponse.StatusCode, string(settingsBody))
 	}
 	return nil
+}
+
+// deleteLegacyTraceTimestampTemplate removes the settings-only template used
+// by the first index-level repair implementation. It could suppress matching
+// SS4O mappings because OpenSearch applies only the highest-priority template.
+func (c *Client) deleteLegacyTraceTimestampTemplate(ctx context.Context) error {
+	requestURL := fmt.Sprintf("%s/_index_template/bkn-trace-timestamp-default", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return fmt.Errorf("create legacy trace timestamp template delete request: %w", err)
+	}
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("execute legacy trace timestamp template delete request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read legacy trace timestamp template delete response: %w", err)
+	}
+	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
+		return nil
+	}
+	return fmt.Errorf("delete legacy trace timestamp template failed with status %d: %s", resp.StatusCode, string(body))
 }
 
 func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte, error) {
@@ -433,6 +463,15 @@ func (c *Client) EnsureIndex(ctx context.Context, index string, mapping []byte) 
 		return nil
 	}
 	if resp.StatusCode == http.StatusBadRequest && strings.Contains(string(body), "resource_already_exists_exception") {
+		var definition struct {
+			Mappings json.RawMessage `json:"mappings"`
+		}
+		if err := json.Unmarshal(mapping, &definition); err != nil {
+			return fmt.Errorf("decode opensearch index definition: %w", err)
+		}
+		if len(definition.Mappings) == 0 {
+			return nil
+		}
 		return c.ensureMapping(ctx, index, mapping)
 	}
 

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -106,9 +106,7 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 	if traceIndex == "" {
 		return errors.New("trace index is required when trace timestamp pipeline is enabled")
 	}
-	if err := c.deleteLegacyTraceTimestampTemplate(ctx); err != nil {
-		return err
-	}
+	c.deleteLegacyTraceTimestampTemplate(ctx)
 	body, err := json.Marshal(map[string]any{
 		"description": "Repair zero @timestamp on OpenTelemetry SS4O trace spans from startTime.",
 		"processors": []map[string]any{{
@@ -150,27 +148,14 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 		return fmt.Errorf("encode trace index default pipeline setting: %w", err)
 	}
 	settingsURL := fmt.Sprintf("%s/%s/_settings", c.baseURL, url.PathEscape(traceIndex))
-	settingsRequest, err := http.NewRequestWithContext(ctx, http.MethodPut, settingsURL, bytes.NewReader(indexSettingsBody))
+	settingsStatus, settingsBody, err := c.putIndexSettings(ctx, settingsURL, indexSettingsBody)
 	if err != nil {
-		return fmt.Errorf("create trace index default pipeline setting request: %w", err)
-	}
-	settingsRequest.Header.Set("Content-Type", "application/json")
-	if c.auth.Enabled {
-		settingsRequest.SetBasicAuth(c.auth.Username, c.auth.Password)
-	}
-	settingsResponse, err := c.httpClient.Do(settingsRequest)
-	if err != nil {
-		return fmt.Errorf("execute trace index default pipeline setting request: %w", err)
-	}
-	defer func() { _ = settingsResponse.Body.Close() }()
-	settingsBody, err := io.ReadAll(settingsResponse.Body)
-	if err != nil {
-		return fmt.Errorf("read trace index default pipeline setting response: %w", err)
+		return err
 	}
 	// On a fresh installation create the exact Trace index before the Collector
 	// sends its first document. This preserves any generic SS4O template's
 	// mappings while avoiding a second, higher-priority settings-only template.
-	if settingsResponse.StatusCode == http.StatusNotFound {
+	if settingsStatus == http.StatusNotFound {
 		indexDefinition, err := json.Marshal(map[string]any{"settings": indexSettings})
 		if err != nil {
 			return fmt.Errorf("encode trace index default pipeline definition: %w", err)
@@ -178,10 +163,17 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 		if err := c.EnsureIndex(ctx, traceIndex, indexDefinition); err != nil {
 			return fmt.Errorf("create trace index default pipeline: %w", err)
 		}
+		settingsStatus, settingsBody, err = c.putIndexSettings(ctx, settingsURL, indexSettingsBody)
+		if err != nil {
+			return err
+		}
+		if settingsStatus < http.StatusOK || settingsStatus >= http.StatusMultipleChoices {
+			return fmt.Errorf("opensearch trace index default pipeline retry failed with status %d: %s", settingsStatus, string(settingsBody))
+		}
 		return nil
 	}
-	if settingsResponse.StatusCode < http.StatusOK || settingsResponse.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("opensearch trace index default pipeline setting failed with status %d: %s", settingsResponse.StatusCode, string(settingsBody))
+	if settingsStatus < http.StatusOK || settingsStatus >= http.StatusMultipleChoices {
+		return fmt.Errorf("opensearch trace index default pipeline setting failed with status %d: %s", settingsStatus, string(settingsBody))
 	}
 	return nil
 }
@@ -189,28 +181,46 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 // deleteLegacyTraceTimestampTemplate removes the settings-only template used
 // by the first index-level repair implementation. It could suppress matching
 // SS4O mappings because OpenSearch applies only the highest-priority template.
-func (c *Client) deleteLegacyTraceTimestampTemplate(ctx context.Context) error {
+func (c *Client) deleteLegacyTraceTimestampTemplate(ctx context.Context) {
 	requestURL := fmt.Sprintf("%s/_index_template/bkn-trace-timestamp-default", c.baseURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
-		return fmt.Errorf("create legacy trace timestamp template delete request: %w", err)
+		return
 	}
 	if c.auth.Enabled {
 		req.SetBasicAuth(c.auth.Username, c.auth.Password)
 	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("execute legacy trace timestamp template delete request: %w", err)
+		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("read legacy trace timestamp template delete response: %w", err)
+		return
 	}
-	if resp.StatusCode == http.StatusNotFound || (resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices) {
-		return nil
+	_ = body
+}
+
+func (c *Client) putIndexSettings(ctx context.Context, requestURL string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, fmt.Errorf("create trace index default pipeline setting request: %w", err)
 	}
-	return fmt.Errorf("delete legacy trace timestamp template failed with status %d: %s", resp.StatusCode, string(body))
+	req.Header.Set("Content-Type", "application/json")
+	if c.auth.Enabled {
+		req.SetBasicAuth(c.auth.Username, c.auth.Password)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("execute trace index default pipeline setting request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read trace index default pipeline setting response: %w", err)
+	}
+	return resp.StatusCode, responseBody, nil
 }
 
 func (c *Client) Search(ctx context.Context, index string, query []byte) ([]byte, error) {

--- a/bkn-trace/agent-observability/src/infra/opensearch/client.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/client.go
@@ -142,41 +142,6 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 	}
 
 	indexSettings := map[string]string{"index.default_pipeline": name}
-	indexTemplate, err := json.Marshal(map[string]any{
-		"index_patterns": []string{traceIndex},
-		// Generic SS4O templates may also match the Trace index. Keep this
-		// narrowly scoped template above their default priority so the repair
-		// pipeline cannot be displaced by an unrelated template.
-		"priority": 500,
-		"template": map[string]any{
-			"settings": indexSettings,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("encode trace index default pipeline template: %w", err)
-	}
-	templateURL := fmt.Sprintf("%s/_index_template/bkn-trace-timestamp-default", c.baseURL)
-	templateRequest, err := http.NewRequestWithContext(ctx, http.MethodPut, templateURL, bytes.NewReader(indexTemplate))
-	if err != nil {
-		return fmt.Errorf("create trace index default pipeline template request: %w", err)
-	}
-	templateRequest.Header.Set("Content-Type", "application/json")
-	if c.auth.Enabled {
-		templateRequest.SetBasicAuth(c.auth.Username, c.auth.Password)
-	}
-	templateResponse, err := c.httpClient.Do(templateRequest)
-	if err != nil {
-		return fmt.Errorf("execute trace index default pipeline template request: %w", err)
-	}
-	defer func() { _ = templateResponse.Body.Close() }()
-	templateBody, err := io.ReadAll(templateResponse.Body)
-	if err != nil {
-		return fmt.Errorf("read trace index default pipeline template response: %w", err)
-	}
-	if templateResponse.StatusCode < http.StatusOK || templateResponse.StatusCode >= http.StatusMultipleChoices {
-		return fmt.Errorf("opensearch trace index default pipeline template failed with status %d: %s", templateResponse.StatusCode, string(templateBody))
-	}
-
 	indexSettingsBody, err := json.Marshal(indexSettings)
 	if err != nil {
 		return fmt.Errorf("encode trace index default pipeline setting: %w", err)
@@ -199,10 +164,17 @@ func (c *Client) EnsureTraceTimestampPipeline(ctx context.Context, name string, 
 	if err != nil {
 		return fmt.Errorf("read trace index default pipeline setting response: %w", err)
 	}
-	// On a fresh installation the Collector creates the trace index later. The
-	// template above binds the pipeline then; only an existing index needs this
-	// immediate update.
+	// On a fresh installation create the exact Trace index before the Collector
+	// sends its first document. This preserves any generic SS4O template's
+	// mappings while avoiding a second, higher-priority settings-only template.
 	if settingsResponse.StatusCode == http.StatusNotFound {
+		indexDefinition, err := json.Marshal(map[string]any{"settings": indexSettings})
+		if err != nil {
+			return fmt.Errorf("encode trace index default pipeline definition: %w", err)
+		}
+		if err := c.EnsureIndex(ctx, traceIndex, indexDefinition); err != nil {
+			return fmt.Errorf("create trace index default pipeline: %w", err)
+		}
 		return nil
 	}
 	if settingsResponse.StatusCode < http.StatusOK || settingsResponse.StatusCode >= http.StatusMultipleChoices {

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -19,6 +19,9 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		switch {
+		case r.Method == http.MethodDelete && r.URL.Path == "/_index_template/bkn-trace-timestamp-default":
+			w.WriteHeader(http.StatusNotFound)
+			return
 		case r.Method == http.MethodPut && r.URL.Path == "/_ingest/pipeline/bkn-trace-span-timestamp-v1":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
@@ -53,14 +56,20 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
 		t.Fatalf("ensure timestamp pipeline: %v", err)
 	}
-	if requests != 3 {
-		t.Fatalf("expected pipeline, index settings and index creation requests, got %d", requests)
+	if requests != 4 {
+		t.Fatalf("expected legacy cleanup, pipeline, index settings and index creation requests, got %d", requests)
 	}
 }
 
 func TestEnsureTraceTimestampPipelineUpdatesExistingTraceIndex(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/_index_template/bkn-trace-timestamp-default":
+			if r.Method != http.MethodDelete {
+				t.Fatalf("expected legacy template deletion, got %s", r.Method)
+			}
+			w.WriteHeader(http.StatusNotFound)
+			return
 		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1":
 			w.WriteHeader(http.StatusOK)
 		case "/ss4o_traces-default-namespace/_settings":
@@ -81,5 +90,39 @@ func TestEnsureTraceTimestampPipelineUpdatesExistingTraceIndex(t *testing.T) {
 	client := New(server.URL, AuthConfig{}, time.Second)
 	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
 		t.Fatalf("ensure timestamp pipeline: %v", err)
+	}
+}
+
+func TestEnsureTraceTimestampPipelineHandlesConcurrentIndexCreation(t *testing.T) {
+	settingsCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_index_template/bkn-trace-timestamp-default":
+			w.WriteHeader(http.StatusNotFound)
+		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1":
+			w.WriteHeader(http.StatusOK)
+		case "/ss4o_traces-default-namespace/_settings":
+			settingsCalls++
+			if settingsCalls == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		case "/ss4o_traces-default-namespace":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"type":"resource_already_exists_exception"}}`))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.URL, AuthConfig{}, time.Second)
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
+		t.Fatalf("ensure timestamp pipeline after concurrent index creation: %v", err)
+	}
+	if settingsCalls != 1 {
+		t.Fatalf("expected one initial settings update before index creation race, got %d", settingsCalls)
 	}
 }

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T) {
 	requests := 0
+	settingsCalls := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
 		switch {
@@ -35,7 +36,12 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 				t.Fatalf("pipeline must not alter log records: %s", content)
 			}
 		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace/_settings":
-			w.WriteHeader(http.StatusNotFound)
+			settingsCalls++
+			if settingsCalls == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
 			return
 		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace":
 			body, err := io.ReadAll(r.Body)
@@ -56,8 +62,8 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
 		t.Fatalf("ensure timestamp pipeline: %v", err)
 	}
-	if requests != 4 {
-		t.Fatalf("expected legacy cleanup, pipeline, index settings and index creation requests, got %d", requests)
+	if requests != 5 {
+		t.Fatalf("expected legacy cleanup, pipeline, two settings updates and index creation requests, got %d", requests)
 	}
 }
 
@@ -122,7 +128,26 @@ func TestEnsureTraceTimestampPipelineHandlesConcurrentIndexCreation(t *testing.T
 	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
 		t.Fatalf("ensure timestamp pipeline after concurrent index creation: %v", err)
 	}
-	if settingsCalls != 1 {
-		t.Fatalf("expected one initial settings update before index creation race, got %d", settingsCalls)
+	if settingsCalls != 2 {
+		t.Fatalf("expected a settings retry after index creation race, got %d calls", settingsCalls)
+	}
+}
+
+func TestEnsureTraceTimestampPipelineContinuesWhenLegacyTemplateCleanupFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/_index_template/bkn-trace-timestamp-default":
+			w.WriteHeader(http.StatusForbidden)
+		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1", "/ss4o_traces-default-namespace/_settings":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.URL, AuthConfig{}, time.Second)
+	if err := client.EnsureTraceTimestampPipeline(t.Context(), "bkn-trace-span-timestamp-v1", "ss4o_traces-default-namespace"); err != nil {
+		t.Fatalf("legacy template cleanup must not block timestamp repair: %v", err)
 	}
 }

--- a/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
+++ b/bkn-trace/agent-observability/src/infra/opensearch/timestamp_pipeline_test.go
@@ -31,24 +31,17 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 			if !strings.Contains(content, "ctx.containsKey('traceId')") {
 				t.Fatalf("pipeline must not alter log records: %s", content)
 			}
-		case r.Method == http.MethodPut && r.URL.Path == "/_index_template/bkn-trace-timestamp-default":
+		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace/_settings":
+			w.WriteHeader(http.StatusNotFound)
+			return
+		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace":
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
-			content := string(body)
-			if !strings.Contains(content, `"index_patterns":["ss4o_traces-default-namespace"]`) {
-				t.Fatalf("template must target the trace index: %s", content)
+			if !strings.Contains(string(body), `"index.default_pipeline":"bkn-trace-span-timestamp-v1"`) {
+				t.Fatalf("new trace index must configure the timestamp repair pipeline: %s", body)
 			}
-			if !strings.Contains(content, `"index.default_pipeline":"bkn-trace-span-timestamp-v1"`) {
-				t.Fatalf("template must configure the timestamp repair pipeline: %s", content)
-			}
-			if !strings.Contains(content, `"priority":500`) {
-				t.Fatalf("template must take precedence over generic SS4O templates: %s", content)
-			}
-		case r.Method == http.MethodPut && r.URL.Path == "/ss4o_traces-default-namespace/_settings":
-			w.WriteHeader(http.StatusNotFound)
-			return
 		default:
 			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}
@@ -61,14 +54,14 @@ func TestEnsureTraceTimestampPipelineRepairsOnlyZeroSpanTimestamps(t *testing.T)
 		t.Fatalf("ensure timestamp pipeline: %v", err)
 	}
 	if requests != 3 {
-		t.Fatalf("expected pipeline, template and index settings requests, got %d", requests)
+		t.Fatalf("expected pipeline, index settings and index creation requests, got %d", requests)
 	}
 }
 
 func TestEnsureTraceTimestampPipelineUpdatesExistingTraceIndex(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1", "/_index_template/bkn-trace-timestamp-default":
+		case "/_ingest/pipeline/bkn-trace-span-timestamp-v1":
 			w.WriteHeader(http.StatusOK)
 		case "/ss4o_traces-default-namespace/_settings":
 			body, err := io.ReadAll(r.Body)

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -103,7 +103,7 @@ exporters:
 
 注意：官方 `opensearchexporter` 当前支持 `traces` 和 `logs`，默认不为 `metrics` 创建 OpenSearch 导出 pipeline。
 
-Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，并更新已有 Trace 索引；在新安装时会直接创建配置了该默认管道的精确 Trace 索引。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。使用受限 OpenSearch 账号时，该账号还必须有创建 ingest pipeline、创建 Trace 索引以及更新其 index settings 的权限。
+Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，并更新已有 Trace 索引；在新安装时会直接创建配置了该默认管道的精确 Trace 索引。升级时会幂等删除早期版本遗留的 settings-only Trace 模板，避免它压过 SS4O mappings。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。使用受限 OpenSearch 账号时，该账号还必须有创建 ingest pipeline、创建 Trace 索引、更新其 index settings 以及删除该遗留模板的权限。
 
 `scripts/test_config_rollout.sh` 默认使用交付中的 SWR Collector 镜像执行 `validate`；可通过 `OTELCOL_RUNTIME_IMAGE` 覆盖镜像。该校验不会因未设置环境变量而跳过。
 

--- a/bkn-trace/otelcol-contribute-chart/README.md
+++ b/bkn-trace/otelcol-contribute-chart/README.md
@@ -103,7 +103,7 @@ exporters:
 
 注意：官方 `opensearchexporter` 当前支持 `traces` 和 `logs`，默认不为 `metrics` 创建 OpenSearch 导出 pipeline。
 
-Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，再绑定到 Trace 索引及其模板。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。
+Trace 时间戳修复使用 OpenSearch 的 `index.default_pipeline`：由 `agent-observability` 在启动时先创建修复 pipeline，并更新已有 Trace 索引；在新安装时会直接创建配置了该默认管道的精确 Trace 索引。不要向 Collector 的 `opensearch` exporter 注入 `pipeline` 字段；当前交付的 Collector 不支持该配置，启动会失败。使用受限 OpenSearch 账号时，该账号还必须有创建 ingest pipeline、创建 Trace 索引以及更新其 index settings 的权限。
 
 `scripts/test_config_rollout.sh` 默认使用交付中的 SWR Collector 镜像执行 `validate`；可通过 `OTELCOL_RUNTIME_IMAGE` 覆盖镜像。该校验不会因未设置环境变量而跳过。
 

--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -477,6 +477,7 @@ _openbkn_trace_profile_sets() {
                 "opensearch.traceIndex=ss4o_traces-default-namespace"
                 "opensearch.logIndex=ss4o_logs-default-namespace"
                 "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
+                "opensearch.traceTimestampPipelineRevision=index-default-pipeline-v1"
             )
             if [[ "$(_openbkn_trace_opensearch_protocol)" == "https" ]]; then
                 CORE_RELEASE_EXTRA_SETS+=(
@@ -989,6 +990,7 @@ durable = (
     and evidence.get("store") == "opensearch"
     and bool(evidence.get("ingestAuth", {}).get("existingSecret"))
     and bool(opensearch.get("traceTimestampPipeline"))
+    and opensearch.get("traceTimestampPipelineRevision") == "index-default-pipeline-v1"
 )
 sys.exit(0 if durable else 1)
 ' <<<"${values}"

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -57,6 +57,7 @@ contains "AO requires Core DSN Secret" "${ao_sets}" "core.mariadb.existingSecret
 contains "AO persists evidence" "${ao_sets}" "evidence.store=opensearch"
 contains "AO enables projection" "${ao_sets}" "core.projection.enabled=true"
 contains "AO creates the Collector timestamp repair pipeline first" "${ao_sets}" "opensearch.traceTimestampPipeline=bkn-trace-span-timestamp-v1"
+contains "AO records the index-level timestamp repair revision" "${ao_sets}" "opensearch.traceTimestampPipelineRevision=index-default-pipeline-v1"
 not_contains "AO leaves index initialization to runtime" "${ao_sets}" "evidence.indexManagement"
 contains "AO protects evidence producer ingest" "${ao_sets}" "evidence.ingestAuth.existingSecret=bkn-trace-evidence-ingest"
 not_contains "AO has no query gateway Secret" "${ao_sets}" "queryAuth.existingSecret="
@@ -101,6 +102,13 @@ else
 fi
 
 HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
+if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
+    fail "installer must reconcile a durable profile that predates index-level timestamp repair"
+else
+    ok
+fi
+
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1","traceTimestampPipelineRevision":"index-default-pipeline-v1"}}'
 if _openbkn_should_skip_upgrade agent-observability openbkn agent-observability 0.1.4; then
     ok
 else
@@ -194,7 +202,7 @@ else
     fail "repository installer must upgrade a volatile runtime profile"
 fi
 
-HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1"}}'
+HELM_VALUES='{"core":{"store":"mariadb","projection":{"enabled":true}},"evidence":{"store":"opensearch","ingestAuth":{"existingSecret":"bkn-trace-evidence-ingest"}},"opensearch":{"traceTimestampPipeline":"bkn-trace-span-timestamp-v1","traceTimestampPipelineRevision":"index-default-pipeline-v1"}}'
 _install_openbkn_release_local agent-observability /tmp openbkn
 _install_openbkn_release_repo agent-observability openbkn openbkn 0.1.4
 if [[ "${UPGRADE_CALLS}" -eq 2 ]]; then

--- a/deploy/scripts/services/openbkn_trace_profile_test.sh
+++ b/deploy/scripts/services/openbkn_trace_profile_test.sh
@@ -269,6 +269,8 @@ contains "AO profile reads the Collector log index" "${ao_sets}" "opensearch.log
 agent_observability_values="$(<"${SCRIPT_DIR}/../bkn-trace/agent-observability/charts/agent-observability/values.yaml")"
 contains "standalone AO reads the Collector Trace index" "${agent_observability_values}" "traceIndex: ${expected_trace_index}"
 contains "standalone AO reads the Collector log index" "${agent_observability_values}" "logIndex: ${expected_log_index}"
+agent_observability_deployment="$(<"${SCRIPT_DIR}/../bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml")"
+contains "AO Pod template includes timestamp repair revision" "${agent_observability_deployment}" "trace-timestamp-pipeline-revision"
 
 CORE_RELEASE_EXTRA_SETS=()
 _openbkn_trace_profile_sets agent-retrieval


### PR DESCRIPTION
## What Changed

- [x] Added an installer-managed timestamp-repair revision to reconcile same-version deployments after an implementation change.
- [x] Creates the exact Trace index with its default ingest pipeline on fresh installs instead of installing a mappings-displacing index template.
- [x] Added regressions for frozen release profiles and fresh Trace index initialization.
- [x] Documented required OpenSearch permissions for restricted accounts.

---

## Why

- Related Issue: N/A — hardening follow-up to #1137 and release backport #1139.
- Related Feature: BKN Trace timestamp repair.
- Background: release chart versions are frozen, so profile completeness needed an explicit revision; a settings-only high-priority template could exclude generic SS4O mappings.

---

## How

- A durable AO profile now requires `traceTimestampPipelineRevision=index-default-pipeline-v1`.
- Existing Trace indexes receive an index-setting update; absent Trace indexes are created with that setting.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally: `go test ./...` in `bkn-trace/agent-observability`.
- [x] Integration-style validation passed locally: `openbkn_trace_profile_test.sh` (91 checks) and real Collector `validate`.
- [ ] Verified in test environment: pending merge and localhost rollout.

Test notes: `helm lint` and diff checks passed.

---

## Risk & Rollback

- Potential risks: a restricted OpenSearch account needs ingest-pipeline, index-create, and index-settings permissions for the configured Trace index.
- Rollback plan: revert this PR; the existing Trace index setting can be removed manually only if a rollback is required.

---

## Additional Notes

- Related release backport PR: #1139.
- OpenSearch index-template precedence is avoided rather than overridden.