### PR TITLE
fix(bkn-backend): pass embedding model ID to Vega

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -85,9 +85,12 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 		logger.Infof("Dataset %s created successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 	} else {
 		logger.Infof("Dataset %s found, ID: %s", interfaces.BKN_DATASET_NAME, dataset.ID)
-		// Deep compare schema
-		if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) {
-			logger.Infof("Schema mismatch detected, deleting and recreating dataset...")
+		// Compare the schema and the resource-level embedding model reference.
+		// Vega interprets DefaultEmbeddingModel as a model ID, so a historical
+		// model name must trigger recreation even when the schema is unchanged.
+		if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) ||
+			!sameDefaultEmbeddingModel(dataset.IndexConfig, defaultEmbeddingModel) {
+			logger.Infof("Dataset definition mismatch detected, deleting and recreating dataset...")
 			// Delete dataset
 			err = VBA.DeleteResource(ctx, dataset.ID)
 			if err != nil {
@@ -104,12 +107,19 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 			}
 			logger.Infof("Dataset %s recreated successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 		} else {
-			logger.Infof("Schema matches, no need to recreate dataset")
+			logger.Infof("Dataset definition matches, no need to recreate dataset")
 		}
 	}
 
 	logger.Info("Init BKN Dataset Success")
 	return nil
+}
+
+func sameDefaultEmbeddingModel(indexConfig *interfaces.VegaResourceIndexConfig, expectedModelID string) bool {
+	if indexConfig == nil {
+		return expectedModelID == ""
+	}
+	return indexConfig.DefaultEmbeddingModel == expectedModelID
 }
 
 // bknConceptDatasetRequest builds an independent resource request for the BKN

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -38,7 +38,7 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 			return errors.New("GetDefaultModel return nil")
 		}
 		vectorDim = smallModel.EmbeddingDim
-		defaultEmbeddingModel = smallModel.ModelName
+		defaultEmbeddingModel = smallModel.ModelID
 		logger.Infof("Small model enabled, vector dimension: %d", vectorDim)
 	}
 

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -166,6 +166,38 @@ func TestInitRecreatesDatasetWhenEmbeddingModelIDDiffers(t *testing.T) {
 	})
 }
 
+func TestInitKeepsDatasetWhenSchemaAndEmbeddingModelIDMatch(t *testing.T) {
+	Convey("Init keeps the dataset when its schema and embedding model ID match (issue #1142)\n", t, func() {
+		ctrl := gomock.NewController(t)
+		mfs := mock_interfaces.NewMockModelFactoryService(ctrl)
+		vegaBackend := mock_interfaces.NewMockVegaBackendAccess(ctrl)
+		previousVBA := VBA
+		VBA = vegaBackend
+		patches := gomonkey.ApplyFunc(model_factory.NewModelFactoryService, func(_ *common.AppSetting, _ interfaces.ModelFactoryAccess) interfaces.ModelFactoryService { return mfs })
+		Reset(func() {
+			patches.Reset()
+			VBA = previousVBA
+		})
+
+		ctx := context.Background()
+		model := &interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
+			ModelName:    "text-embedding-v4",
+			EmbeddingDim: 1024,
+		}
+		mfs.EXPECT().GetDefaultModel(ctx).Return(model, nil)
+		vegaBackend.EXPECT().GetCatalogByID(ctx, interfaces.BKN_CATALOG_ID).Return(&interfaces.Catalog{ID: interfaces.BKN_CATALOG_ID}, nil)
+		vegaBackend.EXPECT().GetResourceByID(ctx, interfaces.BKN_DATASET_ID).Return(&interfaces.VegaResource{
+			ID:               interfaces.BKN_DATASET_ID,
+			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelID},
+		}, nil)
+
+		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}})
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestBKNConceptDatasetRequest(t *testing.T) {
 	Convey("Dataset request keeps the global template immutable\n", t, func() {
 		request := bknConceptDatasetRequest(nil, "text-embedding-v4")

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -76,6 +76,7 @@ func TestInitPassesResolvedEmbeddingModelToVega(t *testing.T) {
 
 		ctx := context.Background()
 		mfs.EXPECT().GetDefaultModel(ctx).Return(&interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
 			ModelName:    "text-embedding-v4",
 			EmbeddingDim: 1024,
 		}, nil)
@@ -84,7 +85,7 @@ func TestInitPassesResolvedEmbeddingModelToVega(t *testing.T) {
 		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
 			So(resource.IndexConfig, ShouldNotBeNil)
 			So(resource.IndexConfig.DefaultFulltextAnalyzer, ShouldEqual, "standard")
-			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "text-embedding-v4")
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "2091780333946146816")
 			return nil
 		})
 
@@ -108,6 +109,7 @@ func TestInitPassesResolvedEmbeddingModelWhenRecreatingDataset(t *testing.T) {
 
 		ctx := context.Background()
 		mfs.EXPECT().GetDefaultModel(ctx).Return(&interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
 			ModelName:    "text-embedding-v4",
 			EmbeddingDim: 1024,
 		}, nil)
@@ -118,7 +120,7 @@ func TestInitPassesResolvedEmbeddingModelWhenRecreatingDataset(t *testing.T) {
 		}, nil)
 		vegaBackend.EXPECT().DeleteResource(ctx, interfaces.BKN_DATASET_ID).Return(nil)
 		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
-			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "text-embedding-v4")
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "2091780333946146816")
 			return nil
 		})
 

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -129,6 +129,43 @@ func TestInitPassesResolvedEmbeddingModelWhenRecreatingDataset(t *testing.T) {
 	})
 }
 
+func TestInitRecreatesDatasetWhenEmbeddingModelIDDiffers(t *testing.T) {
+	Convey("Init recreates the dataset when its embedding model reference differs (issue #1142)\n", t, func() {
+		ctrl := gomock.NewController(t)
+		mfs := mock_interfaces.NewMockModelFactoryService(ctrl)
+		vegaBackend := mock_interfaces.NewMockVegaBackendAccess(ctrl)
+		previousVBA := VBA
+		VBA = vegaBackend
+		patches := gomonkey.ApplyFunc(model_factory.NewModelFactoryService, func(_ *common.AppSetting, _ interfaces.ModelFactoryAccess) interfaces.ModelFactoryService { return mfs })
+		Reset(func() {
+			patches.Reset()
+			VBA = previousVBA
+		})
+
+		ctx := context.Background()
+		model := &interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
+			ModelName:    "text-embedding-v4",
+			EmbeddingDim: 1024,
+		}
+		mfs.EXPECT().GetDefaultModel(ctx).Return(model, nil)
+		vegaBackend.EXPECT().GetCatalogByID(ctx, interfaces.BKN_CATALOG_ID).Return(&interfaces.Catalog{ID: interfaces.BKN_CATALOG_ID}, nil)
+		vegaBackend.EXPECT().GetResourceByID(ctx, interfaces.BKN_DATASET_ID).Return(&interfaces.VegaResource{
+			ID:               interfaces.BKN_DATASET_ID,
+			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelName},
+		}, nil)
+		vegaBackend.EXPECT().DeleteResource(ctx, interfaces.BKN_DATASET_ID).Return(nil)
+		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, model.ModelID)
+			return nil
+		})
+
+		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}})
+		So(err, ShouldBeNil)
+	})
+}
+
 func TestBKNConceptDatasetRequest(t *testing.T) {
 	Convey("Dataset request keeps the global template immutable\n", t, func() {
 		request := bknConceptDatasetRequest(nil, "text-embedding-v4")


### PR DESCRIPTION
## What Changed

- [x] Pass the resolved embedding model ID from BKN Dataset initialization to Vega.
- [x] Cover Dataset creation and schema-mismatch recreation with distinct model ID and name values.
- [ ] Documentation: not applicable; no public API or configuration change.

---

## Why

- Related Issue: Closes #1142
- Related Feature: N/A
- Background: Vega validates index_config.default_embedding_model as a model ID, while bkn-backend previously passed the model name.

---

## How

- Key implementation points: use smallModel.ModelID when building the BKN Dataset index configuration; assert that Vega receives the ID in both initialization paths.
- Breaking changes (API, config, database, etc.): None; this aligns the existing internal BKN-to-Vega contract.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; mocked unit coverage is applicable)
- [ ] Verified in test environment (not run)

Test notes:

- go test ./logics -run TestInitPassesResolvedEmbeddingModel -count=1 -v
- go test ./logics -count=1
- golangci-lint run ./logics
- git diff --check
- make lint was blocked because local golangci-lint v2.12.2 does not support the Makefile --exclude-dirs flag; the compatible package-level lint passed.

---

## Risk & Rollback

- Potential risks: an existing Dataset whose embedding model reference is a name will be deleted and recreated during initialization; this data-impacting behavior was explicitly confirmed.
- Rollback plan: revert commit 1cc5f5378.

---

## Additional Notes

- The PR is intentionally scoped to bkn-backend; Vega already enforces the intended ID contract.