### PR TITLE
fix(deploy): bootstrap business provenance agent

### DIFF
--- a/.github/workflows/release-infra-bkn-agent.yml
+++ b/.github/workflows/release-infra-bkn-agent.yml
@@ -34,6 +34,15 @@ jobs:
       stack: python
       python-version: '3.12'
 
+  chart-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+      - name: Verify provenance bootstrap credential contract
+        working-directory: infra/bkn-agent
+        run: bash scripts/test_business_provenance_bootstrap_chart.sh charts
+
   build:
     needs: test
     uses: ./.github/workflows/reusable-build.yml
@@ -47,7 +56,7 @@ jobs:
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
 
   chart:
-    needs: [test, build]
+    needs: [test, build, chart-contract]
     uses: ./.github/workflows/reusable-chart.yml
     with:
       service-path: infra/bkn-agent

--- a/bkn-safe/server/internal/httpapi/builtinadmin_test.go
+++ b/bkn-safe/server/internal/httpapi/builtinadmin_test.go
@@ -44,3 +44,39 @@ func TestBuiltInAdminUserProtected(t *testing.T) {
 		t.Errorf("admin state wrong after guarded edits: %+v", got)
 	}
 }
+
+func TestBusinessProvenanceAppPrincipalProtected(t *testing.T) {
+	for name, request := range map[string]struct {
+		method string
+		suffix string
+		body   any
+	}{
+		"delete":      {method: http.MethodDelete},
+		"disable":     {method: http.MethodPut, body: map[string]any{"enabled": false}},
+		"change type": {method: http.MethodPut, body: map[string]any{"account_type": "other"}},
+		"rename":      {method: http.MethodPut, body: map[string]any{"name": "Customer Service"}},
+		"set password": {
+			method: http.MethodPut,
+			suffix: "/password",
+			body:   map[string]any{"password": "must-not-become-a-login"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			r, _, db, _ := newAdminServer(t)
+			if err := db.Create(&model.User{
+				ID:          seed.BusinessProvenanceOwnerID,
+				Account:     "openbkn-business-provenance",
+				Name:        "OpenBKN Business Provenance Service",
+				Enabled:     true,
+				Source:      model.SourceLocal,
+				AccountType: model.AccountTypeApp,
+			}).Error; err != nil {
+				t.Fatal(err)
+			}
+			path := "/api/safe/v1/admin/users/" + seed.BusinessProvenanceOwnerID + request.suffix
+			if w := adminReq(t, r, request.method, path, request.body); w.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d (%s)", w.Code, w.Body.String())
+			}
+		})
+	}
+}

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -104,6 +104,10 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		if !bind(c, &req) {
 			return
 		}
+		if c.Param("id") == seed.BusinessProvenanceOwnerID {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
 		if err := users.ResetPassword(c.Request.Context(), c.Param("id"), req.Password); err != nil {
 			serverError(c, err)
 			return
@@ -139,6 +143,13 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		// refuse to disable it (other edits like rename are fine). The frontend
 		// hides the control, but the API must not rely on that.
 		if id == seed.AdminUserID && req.Enabled != nil && !*req.Enabled {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
+		if id == seed.BusinessProvenanceOwnerID &&
+			((req.Enabled != nil && !*req.Enabled) ||
+				(req.AccountType != nil && *req.AccountType != string(model.AccountTypeApp)) ||
+				(req.Name != nil && *req.Name != seed.BusinessProvenanceOwnerName)) {
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}
@@ -203,7 +214,7 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		id := c.Param("id")
 		// Defense in depth: never delete the built-in admin (deleting the only
 		// super-admin locks everyone out). The frontend hides the control too.
-		if id == seed.AdminUserID {
+		if id == seed.AdminUserID || id == seed.BusinessProvenanceOwnerID {
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -38,6 +39,12 @@ import (
 const (
 	adminUserID  = "266c6a42-6131-4d62-8f39-853e7093701c"
 	adminAccount = "admin"
+
+	// BusinessProvenanceOwnerID is the non-login application identity that owns
+	// the deployment-managed business provenance Agent in bkn-agent.
+	BusinessProvenanceOwnerID      = "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb"
+	BusinessProvenanceOwnerAccount = "openbkn-business-provenance"
+	BusinessProvenanceOwnerName    = "OpenBKN Business Provenance Service"
 )
 
 var deprecatedSeedRoleIDs = []string{
@@ -139,7 +146,37 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedAdminUser(db); err != nil {
 		return fmt.Errorf("seed admin user: %w", err)
 	}
+	if err := seedBusinessProvenanceOwner(db); err != nil {
+		return fmt.Errorf("seed business provenance owner: %w", err)
+	}
 	return nil
+}
+
+func seedBusinessProvenanceOwner(db *gorm.DB) error {
+	var existing model.User
+	err := db.First(&existing, "id = ?", BusinessProvenanceOwnerID).Error
+	if err == nil {
+		if existing.Account != BusinessProvenanceOwnerAccount ||
+			existing.Name != BusinessProvenanceOwnerName ||
+			!existing.Enabled ||
+			existing.Source != model.SourceLocal ||
+			existing.AccountType != model.AccountTypeApp ||
+			existing.PasswordHash != "" {
+			return fmt.Errorf("fixed app principal %s conflicts with the deployment contract", BusinessProvenanceOwnerID)
+		}
+		return nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	return db.Create(&model.User{
+		ID:          BusinessProvenanceOwnerID,
+		Account:     BusinessProvenanceOwnerAccount,
+		Name:        BusinessProvenanceOwnerName,
+		Enabled:     true,
+		Source:      model.SourceLocal,
+		AccountType: model.AccountTypeApp,
+	}).Error
 }
 
 // seedAdminUser creates the built-in admin login the FIRST time only. If a row

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -154,9 +154,12 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 
 func seedBusinessProvenanceOwner(db *gorm.DB) error {
 	var existing model.User
-	err := db.First(&existing, "id = ?", BusinessProvenanceOwnerID).Error
+	err := db.Where(
+		"id = ? OR account = ?", BusinessProvenanceOwnerID, BusinessProvenanceOwnerAccount,
+	).First(&existing).Error
 	if err == nil {
-		if existing.Account != BusinessProvenanceOwnerAccount ||
+		if existing.ID != BusinessProvenanceOwnerID ||
+			existing.Account != BusinessProvenanceOwnerAccount ||
 			existing.Name != BusinessProvenanceOwnerName ||
 			!existing.Enabled ||
 			existing.Source != model.SourceLocal ||

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -5,6 +5,7 @@
 package seed
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -309,6 +310,29 @@ func TestApplyRejectsConflictingBusinessProvenancePrincipal(t *testing.T) {
 
 	if err := Apply(db, e); err == nil {
 		t.Fatal("expected conflicting fixed principal to fail seed")
+	}
+}
+
+func TestApplyReportsBusinessProvenanceAccountCollision(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.User{
+		ID:          "customer-created-id",
+		Account:     BusinessProvenanceOwnerAccount,
+		Name:        "Customer Account",
+		Enabled:     true,
+		Source:      model.SourceLocal,
+		AccountType: model.AccountTypeApp,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	err = Apply(db, e)
+	if err == nil || !strings.Contains(err.Error(), "conflicts with the deployment contract") {
+		t.Fatalf("expected actionable fixed principal conflict, got %v", err)
 	}
 }
 

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -259,6 +259,59 @@ func TestSeedsAdminUser(t *testing.T) {
 	}
 }
 
+func TestApplySeedsBusinessProvenanceAppPrincipal(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	var principal model.User
+	if err := db.First(&principal, "id = ?", "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb").Error; err != nil {
+		t.Fatalf("business provenance app principal not seeded: %v", err)
+	}
+	if principal.Account != "openbkn-business-provenance" {
+		t.Errorf("account = %q", principal.Account)
+	}
+	if principal.Name != "OpenBKN Business Provenance Service" {
+		t.Errorf("name = %q", principal.Name)
+	}
+	if principal.AccountType != model.AccountTypeApp {
+		t.Errorf("account type = %q, want app", principal.AccountType)
+	}
+	if !principal.Enabled {
+		t.Error("principal must be enabled")
+	}
+	if principal.PasswordHash != "" {
+		t.Error("app principal must not have a login password")
+	}
+}
+
+func TestApplyRejectsConflictingBusinessProvenancePrincipal(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.User{
+		ID:          "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb",
+		Account:     "customer-owned-account",
+		Name:        "Customer Account",
+		Enabled:     true,
+		Source:      model.SourceLocal,
+		AccountType: model.AccountTypeOther,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(db, e); err == nil {
+		t.Fatal("expected conflicting fixed principal to fail seed")
+	}
+}
+
 // TestApplyIdempotent runs the seed twice; the second run must not error or
 // duplicate roles.
 func TestApplyIdempotent(t *testing.T) {

--- a/bkn-trace/agent-observability/Makefile
+++ b/bkn-trace/agent-observability/Makefile
@@ -64,6 +64,7 @@ docker-build:
 
 helm-lint:
 	helm lint $(CHART_PATH)
+	bash scripts/test_business_provenance_bootstrap.sh $(CHART_PATH)
 	bash scripts/test_evidence_index_governance.sh $(CHART_PATH)
 	bash ../scripts/test_secure_opensearch_contract.sh
 

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/business-provenance-bootstrap-job.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/business-provenance-bootstrap-job.yaml
@@ -1,0 +1,52 @@
+{{- /*
+Copyright (c) 2026 OpenBKN
+SPDX-License-Identifier: LicenseRef-OpenBKN
+Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+*/ -}}
+{{- if and .Values.enterpriseBusinessProvenance.enabled .Values.enterpriseBusinessProvenance.bootstrap.enabled }}
+{{- $bootstrap := .Values.enterpriseBusinessProvenance.bootstrap }}
+{{- $registry := default .Values.image.registry $bootstrap.image.registry }}
+{{- $tag := default .Values.image.tag $bootstrap.image.tag }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-business-provenance-bootstrap" (include "agent-observability.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "agent-observability.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 300
+  template:
+    metadata:
+      labels:
+        {{- include "agent-observability.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: business-provenance-bootstrap
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: business-provenance-bootstrap
+          image: {{ printf "%s/%s:%s" $registry $bootstrap.image.repository $tag | quote }}
+          imagePullPolicy: {{ $bootstrap.image.pullPolicy }}
+          command: ["python", "-m", "app.bootstrap.business_provenance"]
+          env:
+            - name: BKN_PROVENANCE_OWNER_ID
+              value: {{ required "enterpriseBusinessProvenance.bootstrap.ownerID is required" $bootstrap.ownerID | quote }}
+            - name: BKN_SAFE_URL
+              value: {{ required "enterpriseBusinessProvenance.bootstrap.bknSafeURL is required" $bootstrap.bknSafeURL | quote }}
+            - name: BKN_AGENT_URL
+              value: {{ required "enterpriseBusinessProvenance.bootstrap.bknAgentURL is required" $bootstrap.bknAgentURL | quote }}
+            - name: BKN_PROVENANCE_BOOTSTRAP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "enterpriseBusinessProvenance.bootstrap.auth.existingSecret is required" $bootstrap.auth.existingSecret | quote }}
+                  key: {{ required "enterpriseBusinessProvenance.bootstrap.auth.secretKey is required" $bootstrap.auth.secretKey | quote }}
+{{- end }}

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/business-provenance-bootstrap-job.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/business-provenance-bootstrap-job.yaml
@@ -7,7 +7,7 @@ Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
 {{- if and .Values.enterpriseBusinessProvenance.enabled .Values.enterpriseBusinessProvenance.bootstrap.enabled }}
 {{- $bootstrap := .Values.enterpriseBusinessProvenance.bootstrap }}
 {{- $registry := default .Values.image.registry $bootstrap.image.registry }}
-{{- $tag := default .Values.image.tag $bootstrap.image.tag }}
+{{- $tag := required "enterpriseBusinessProvenance.bootstrap.image.tag is required" $bootstrap.image.tag }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 1
-  activeDeadlineSeconds: 300
+  activeDeadlineSeconds: 420
   template:
     metadata:
       labels:

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -101,11 +101,12 @@ enterpriseBusinessProvenance:
       existingSecret: bkn-agent-provenance-bootstrap
       secretKey: token
     image:
-      # Empty values inherit the release-wide registry/tag overrides used by
-      # private and offline EE installations.
+      # Registry inherits the release-wide private/offline override. The tag is
+      # explicitly the bkn-agent release version; it must not inherit an
+      # agent-observability-only hotfix tag.
       registry: ""
       repository: bkn-agent
-      tag: ""
+      tag: "__VERSION__"
       pullPolicy: IfNotPresent
 
 observability:

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -92,6 +92,21 @@ enterpriseBusinessProvenance:
   agentURL: ""
   agentID: ""
   agentName: ""
+  bootstrap:
+    enabled: true
+    ownerID: bdd59f76-19c3-58b0-bf5f-082c4c3cbddb
+    bknSafeURL: http://bkn-safe:3000/api/safe/v1
+    bknAgentURL: http://bkn-agent:30800/api/bkn-agent/v1
+    auth:
+      existingSecret: bkn-agent-provenance-bootstrap
+      secretKey: token
+    image:
+      # Empty values inherit the release-wide registry/tag overrides used by
+      # private and offline EE installations.
+      registry: ""
+      repository: bkn-agent
+      tag: ""
+      pullPolicy: IfNotPresent
 
 observability:
   # Configure the same Secret on every replica so signed pagination cursors

--- a/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
+++ b/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 OpenBKN
+# SPDX-License-Identifier: LicenseRef-OpenBKN
+# Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+# Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+set -euo pipefail
+
+chart_dir="${1:-charts/agent-observability}"
+
+disabled="$(helm template agent-observability "${chart_dir}")"
+if grep -q 'business-provenance-bootstrap' <<<"${disabled}"; then
+    echo "bootstrap Job must stay absent when Enterprise provenance is disabled" >&2
+    exit 1
+fi
+
+enabled="$(helm template agent-observability "${chart_dir}" \
+    --set enterpriseBusinessProvenance.enabled=true \
+    --set enterpriseBusinessProvenance.agentURL=http://bkn-agent:30800 \
+    --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
+    --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer)"
+
+for required in \
+    'name: agent-observability-business-provenance-bootstrap' \
+    '"helm.sh/hook": post-install,post-upgrade' \
+    'value: "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb"' \
+    'value: "http://bkn-safe:3000/api/safe/v1"' \
+    'value: "http://bkn-agent:30800/api/bkn-agent/v1"' \
+    'name: "bkn-agent-provenance-bootstrap"' \
+    'app.bootstrap.business_provenance'; do
+    grep -q "${required}" <<<"${enabled}" || {
+        echo "rendered bootstrap Job missing: ${required}" >&2
+        exit 1
+    }
+done
+
+private_registry="$(helm template agent-observability "${chart_dir}" \
+    --set image.registry=registry.internal/openbkn \
+    --set enterpriseBusinessProvenance.enabled=true \
+    --set enterpriseBusinessProvenance.agentURL=http://bkn-agent:30800 \
+    --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
+    --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer \
+    --show-only templates/business-provenance-bootstrap-job.yaml)"
+grep -q 'image: "registry.internal/openbkn/bkn-agent:__VERSION__"' <<<"${private_registry}" || {
+    echo "bootstrap image must inherit the release registry" >&2
+    exit 1
+}
+
+long_name="rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr"
+long_render="$(helm template "${long_name}" "${chart_dir}" \
+    --set enterpriseBusinessProvenance.enabled=true \
+    --set enterpriseBusinessProvenance.agentURL=http://bkn-agent:30800 \
+    --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
+    --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer \
+    --show-only templates/business-provenance-bootstrap-job.yaml)"
+job_name="$(awk '$1 == "name:" { print $2; exit }' <<<"${long_render}")"
+if [[ -z "${job_name}" ]] || (( ${#job_name} > 63 )); then
+    echo "bootstrap Job name must fit the DNS label limit: ${job_name}" >&2
+    exit 1
+fi
+
+echo "business provenance bootstrap chart contract: PASS"

--- a/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
+++ b/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
@@ -23,6 +23,7 @@ enabled="$(helm template agent-observability "${chart_dir}" \
 for required in \
     'name: agent-observability-business-provenance-bootstrap' \
     '"helm.sh/hook": post-install,post-upgrade' \
+    'activeDeadlineSeconds: 420' \
     'value: "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb"' \
     'value: "http://bkn-safe:3000/api/safe/v1"' \
     'value: "http://bkn-agent:30800/api/bkn-agent/v1"' \
@@ -36,13 +37,14 @@ done
 
 private_registry="$(helm template agent-observability "${chart_dir}" \
     --set image.registry=registry.internal/openbkn \
+    --set image.tag=observability-hotfix \
     --set enterpriseBusinessProvenance.enabled=true \
     --set enterpriseBusinessProvenance.agentURL=http://bkn-agent:30800 \
     --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
     --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer \
     --show-only templates/business-provenance-bootstrap-job.yaml)"
 grep -q 'image: "registry.internal/openbkn/bkn-agent:__VERSION__"' <<<"${private_registry}" || {
-    echo "bootstrap image must inherit the release registry" >&2
+    echo "bootstrap image must inherit the release registry but keep its own tag" >&2
     exit 1
 }
 

--- a/infra/bkn-agent/Dockerfile
+++ b/infra/bkn-agent/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install --no-cache-dir -i ${PIP_INDEX_URL} -r requirements.txt
 COPY VERSION .
 COPY main.py .
 COPY app ./app
+COPY deploy ./deploy
 
 EXPOSE 30800
 CMD ["python", "main.py"]

--- a/infra/bkn-agent/app/auth.py
+++ b/infra/bkn-agent/app/auth.py
@@ -1,11 +1,15 @@
 from contextvars import ContextVar
 from dataclasses import dataclass
+from secrets import compare_digest
 
 from fastapi import Request
 
 from app.errors import err
+from app.config import config
 
 _ALLOWED_TYPES = {"user", "app"}
+_PROVENANCE_OWNER_ID = "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb"
+_PROVENANCE_TOKEN_HEADER = "x-bkn-provenance-bootstrap-token"
 
 # The caller's Authorization header, forwarded verbatim.
 #
@@ -61,4 +65,14 @@ def get_account(request: Request) -> Account:
     account_type = (request.headers.get("x-account-type") or "").strip()
     if not account_id or account_type not in _ALLOWED_TYPES:
         raise err(401, "BknAgent.Auth.AccountRequired")
+    if account_id == _PROVENANCE_OWNER_ID:
+        supplied = (request.headers.get(_PROVENANCE_TOKEN_HEADER) or "").strip()
+        expected = config.PROVENANCE_BOOTSTRAP_TOKEN
+        if (
+            account_type != "app"
+            or not expected
+            or not supplied
+            or not compare_digest(supplied, expected)
+        ):
+            raise err(401, "BknAgent.Auth.AccountRequired")
     return Account(account_id=account_id, account_type=account_type)

--- a/infra/bkn-agent/app/bootstrap/__init__.py
+++ b/infra/bkn-agent/app/bootstrap/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment bootstrap commands for built-in Agents."""

--- a/infra/bkn-agent/app/bootstrap/business_provenance.py
+++ b/infra/bkn-agent/app/bootstrap/business_provenance.py
@@ -18,12 +18,20 @@ class BootstrapError(RuntimeError):
 
 
 class JsonClient:
-    def __init__(self, attempts: int = 30, delay_s: float = 2.0):
+    def __init__(self, attempts: int = 10, delay_s: float = 2.0):
         self.attempts = attempts
         self.delay_s = delay_s
 
-    def get_json(self, url: str, headers: dict[str, str] | None = None):
-        return self._request(Request(url, headers={"Accept": "application/json", **(headers or {})}))
+    def get_json(
+        self,
+        url: str,
+        headers: dict[str, str] | None = None,
+        retry_statuses: set[int] | None = None,
+    ):
+        return self._request(
+            Request(url, headers={"Accept": "application/json", **(headers or {})}),
+            retry_statuses=retry_statuses,
+        )
 
     def post_json(self, url: str, body: dict, headers: dict[str, str]):
         return self._request(
@@ -35,14 +43,15 @@ class JsonClient:
             )
         )
 
-    def _request(self, request: Request):
+    def _request(self, request: Request, retry_statuses: set[int] | None = None):
+        retry_statuses = retry_statuses or set()
         for attempt in range(1, self.attempts + 1):
             try:
                 with urlopen(request, timeout=10) as response:
                     return json.load(response)
             except HTTPError as exc:
                 detail = exc.read().decode("utf-8", errors="replace")
-                if exc.code < 500 or attempt == self.attempts:
+                if (exc.code < 500 and exc.code not in retry_statuses) or attempt == self.attempts:
                     raise BootstrapError(f"HTTP {exc.code} from {request.full_url}: {detail}") from exc
             except (URLError, TimeoutError) as exc:
                 if attempt == self.attempts:
@@ -116,7 +125,13 @@ def bootstrap(
     item = package["items"][0]
     agent_id = item["agent_id"]
 
-    owner = client.get_json(_join(bkn_safe_url, f"directory/users/{owner_id}"))
+    # During a rolling upgrade an old bkn-safe Pod can still answer before the
+    # new fixed principal has been seeded. Only that owner-read 404 is transient;
+    # every other 4xx remains a deterministic contract failure.
+    owner = client.get_json(
+        _join(bkn_safe_url, f"directory/users/{owner_id}"),
+        retry_statuses={404},
+    )
     _validate_owner(owner, owner_id)
 
     owner_headers = {

--- a/infra/bkn-agent/app/bootstrap/business_provenance.py
+++ b/infra/bkn-agent/app/bootstrap/business_provenance.py
@@ -1,0 +1,160 @@
+"""Idempotently import and verify the Enterprise business-provenance Agent."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+EXPECTED_OWNER_ACCOUNT = "openbkn-business-provenance"
+EXPECTED_OWNER_NAME = "OpenBKN Business Provenance Service"
+
+
+class BootstrapError(RuntimeError):
+    """A deterministic bootstrap contract failure."""
+
+
+class JsonClient:
+    def __init__(self, attempts: int = 30, delay_s: float = 2.0):
+        self.attempts = attempts
+        self.delay_s = delay_s
+
+    def get_json(self, url: str, headers: dict[str, str] | None = None):
+        return self._request(Request(url, headers={"Accept": "application/json", **(headers or {})}))
+
+    def post_json(self, url: str, body: dict, headers: dict[str, str]):
+        return self._request(
+            Request(
+                url,
+                data=json.dumps(body, ensure_ascii=False).encode("utf-8"),
+                headers={"Content-Type": "application/json", **headers},
+                method="POST",
+            )
+        )
+
+    def _request(self, request: Request):
+        for attempt in range(1, self.attempts + 1):
+            try:
+                with urlopen(request, timeout=10) as response:
+                    return json.load(response)
+            except HTTPError as exc:
+                detail = exc.read().decode("utf-8", errors="replace")
+                if exc.code < 500 or attempt == self.attempts:
+                    raise BootstrapError(f"HTTP {exc.code} from {request.full_url}: {detail}") from exc
+            except (URLError, TimeoutError) as exc:
+                if attempt == self.attempts:
+                    raise BootstrapError(f"cannot reach {request.full_url}: {exc}") from exc
+            time.sleep(self.delay_s)
+        raise AssertionError("unreachable")
+
+
+def _join(base: str, path: str) -> str:
+    return f"{base.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _validate_owner(owner: dict, owner_id: str) -> None:
+    expected = {
+        "id": owner_id,
+        "account": EXPECTED_OWNER_ACCOUNT,
+        "name": EXPECTED_OWNER_NAME,
+        "enabled": True,
+        "account_type": "app",
+    }
+    for field, value in expected.items():
+        if owner.get(field) != value:
+            raise BootstrapError(
+                f"business provenance owner {field} is {owner.get(field)!r}, expected {value!r}"
+            )
+
+
+def _validate_import_result(result: dict, agent_id: str) -> str:
+    entries = result.get("results")
+    if not isinstance(entries, list) or len(entries) != 1:
+        raise BootstrapError("Agent import must return exactly one result")
+    entry = entries[0]
+    if entry.get("agent_id") != agent_id:
+        raise BootstrapError(f"Agent import returned unexpected id {entry.get('agent_id')!r}")
+    if entry.get("action") not in {"created", "updated"}:
+        raise BootstrapError(entry.get("error") or f"Agent import action is {entry.get('action')!r}")
+    if entry.get("prompt_action") not in {"created", "version_published", "unchanged"}:
+        raise BootstrapError(
+            f"Agent import prompt action is {entry.get('prompt_action')!r}"
+        )
+    warnings = result.get("warnings") or []
+    if warnings:
+        raise BootstrapError(f"Agent import returned warnings: {warnings}")
+    return entry["action"]
+
+
+def _validate_agent(actual: dict, package_item: dict, owner_id: str) -> None:
+    expected = package_item["spec"]
+    for field, value in expected.items():
+        if actual.get(field) != value:
+            raise BootstrapError(
+                f"Agent {package_item['agent_id']} {field} is {actual.get(field)!r}, expected {value!r}"
+            )
+    if actual.get("create_user") != owner_id:
+        raise BootstrapError(
+            f"Agent {package_item['agent_id']} owner is {actual.get('create_user')!r}, expected {owner_id!r}"
+        )
+
+
+def bootstrap(
+    client,
+    package_path,
+    bkn_safe_url: str,
+    bkn_agent_url: str,
+    owner_id: str,
+    bootstrap_token: str,
+) -> str:
+    package = json.loads(Path(package_path).read_text(encoding="utf-8"))
+    if package.get("format") != "bkn-agent/v1" or len(package.get("items") or []) != 1:
+        raise BootstrapError("business provenance package must contain exactly one bkn-agent/v1 item")
+    item = package["items"][0]
+    agent_id = item["agent_id"]
+
+    owner = client.get_json(_join(bkn_safe_url, f"directory/users/{owner_id}"))
+    _validate_owner(owner, owner_id)
+
+    owner_headers = {
+        "x-account-id": owner_id,
+        "x-account-type": "app",
+        "x-bkn-provenance-bootstrap-token": bootstrap_token,
+    }
+    result = client.post_json(
+        _join(bkn_agent_url, "import"),
+        {"package": package},
+        owner_headers,
+    )
+    action = _validate_import_result(result, agent_id)
+    actual = client.get_json(_join(bkn_agent_url, f"agents/{agent_id}"), owner_headers)
+    _validate_agent(actual, item, owner_id)
+    return action
+
+
+def main() -> int:
+    service_root = Path(__file__).resolve().parents[2]
+    try:
+        action = bootstrap(
+            JsonClient(),
+            os.getenv(
+                "BKN_PROVENANCE_PACKAGE",
+                str(service_root / "deploy" / "agents" / "business-provenance-optimizer.json"),
+            ),
+            os.environ["BKN_SAFE_URL"],
+            os.environ["BKN_AGENT_URL"],
+            os.environ["BKN_PROVENANCE_OWNER_ID"],
+            os.environ["BKN_PROVENANCE_BOOTSTRAP_TOKEN"],
+        )
+    except (BootstrapError, KeyError, OSError, ValueError) as exc:
+        print(f"business provenance bootstrap failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"business provenance bootstrap complete: {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/infra/bkn-agent/app/config.py
+++ b/infra/bkn-agent/app/config.py
@@ -25,6 +25,11 @@ class Config:
     )
     DEFAULT_MODEL = _env("BKN_AGENT_DEFAULT_MODEL", "")
 
+    # Possession proof for the deployment-managed provenance owner. Normal
+    # internal callers keep using the established /in identity headers; the
+    # fixed high-value owner additionally requires this chart-managed secret.
+    PROVENANCE_BOOTSTRAP_TOKEN = _env("BKN_PROVENANCE_BOOTSTRAP_TOKEN", "")
+
     # Operator factory (operator-integration): both the tool surface and the
     # skill surface go through its internal-v1 route (#322 moved the skill
     # surface over from capabilities-lab).

--- a/infra/bkn-agent/app/test/test_business_provenance_bootstrap.py
+++ b/infra/bkn-agent/app/test/test_business_provenance_bootstrap.py
@@ -2,7 +2,9 @@
 
 import json
 import asyncio
+from io import BytesIO
 from pathlib import Path
+from urllib.error import HTTPError
 
 import pytest
 from fastapi import HTTPException
@@ -10,7 +12,8 @@ from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from starlette.requests import Request
 
-from app.bootstrap.business_provenance import BootstrapError, bootstrap
+from app.bootstrap import business_provenance
+from app.bootstrap.business_provenance import BootstrapError, JsonClient, bootstrap
 from app.auth import get_account
 from app.config import config
 from app.db import get_session
@@ -56,7 +59,7 @@ class FakeClient:
         self.import_headers = None
         self.agent_get_headers = None
 
-    def get_json(self, url, headers=None):
+    def get_json(self, url, headers=None, retry_statuses=None):
         if "/directory/users/" in url:
             return self.owner
         self.agent_get_headers = headers
@@ -161,6 +164,25 @@ def test_bootstrap_rejects_agent_spec_drift_after_import():
         bootstrap(
             client, PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
         )
+
+
+def test_json_client_retries_owner_not_found_during_rolling_upgrade(monkeypatch):
+    calls = 0
+
+    def urlopen(request, timeout):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise HTTPError(request.full_url, 404, "not found", {}, BytesIO(b"not ready"))
+        return BytesIO(b'{"id":"ready"}')
+
+    monkeypatch.setattr(business_provenance, "urlopen", urlopen)
+
+    assert JsonClient(attempts=2, delay_s=0).get_json(
+        "http://safe/directory/users/owner",
+        retry_statuses={404},
+    ) == {"id": "ready"}
+    assert calls == 2
 
 
 def _request(headers: dict[str, str]) -> Request:

--- a/infra/bkn-agent/app/test/test_business_provenance_bootstrap.py
+++ b/infra/bkn-agent/app/test/test_business_provenance_bootstrap.py
@@ -1,0 +1,254 @@
+"""Enterprise business-provenance Agent bootstrap validation."""
+
+import json
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from starlette.requests import Request
+
+from app.bootstrap.business_provenance import BootstrapError, bootstrap
+from app.auth import get_account
+from app.config import config
+from app.db import get_session
+from app.main import app
+from app.models import AgentRow, Base, PromptRow
+
+
+PACKAGE = (
+    Path(__file__).resolve().parents[2]
+    / "deploy"
+    / "agents"
+    / "business-provenance-optimizer.json"
+)
+OWNER_ID = "bdd59f76-19c3-58b0-bf5f-082c4c3cbddb"
+BOOTSTRAP_TOKEN = "deployment-bootstrap-secret"
+
+
+class FakeClient:
+    def __init__(self, owner=None, import_result=None, agent=None):
+        self.owner = owner or {
+            "id": OWNER_ID,
+            "account": "openbkn-business-provenance",
+            "name": "OpenBKN Business Provenance Service",
+            "enabled": True,
+            "account_type": "app",
+        }
+        package_item = json.loads(PACKAGE.read_text(encoding="utf-8"))["items"][0]
+        self.import_result = import_result or {
+            "results": [
+                {
+                    "agent_id": package_item["agent_id"],
+                    "action": "created",
+                    "prompt_action": "created",
+                }
+            ],
+            "warnings": [],
+        }
+        self.agent = agent or {
+            **package_item["spec"],
+            "agent_id": package_item["agent_id"],
+            "create_user": OWNER_ID,
+        }
+        self.import_headers = None
+        self.agent_get_headers = None
+
+    def get_json(self, url, headers=None):
+        if "/directory/users/" in url:
+            return self.owner
+        self.agent_get_headers = headers
+        return self.agent
+
+    def post_json(self, url, body, headers):
+        self.import_headers = headers
+        return self.import_result
+
+
+def test_bootstrap_imports_and_verifies_the_canonical_agent():
+    client = FakeClient()
+
+    result = bootstrap(
+        client,
+        package_path=PACKAGE,
+        bkn_safe_url="http://bkn-safe:3000/api/safe/v1",
+        bkn_agent_url="http://bkn-agent:30800/api/bkn-agent/v1",
+        owner_id=OWNER_ID,
+        bootstrap_token=BOOTSTRAP_TOKEN,
+    )
+
+    assert result == "created"
+    assert client.import_headers == {
+        "x-account-id": OWNER_ID,
+        "x-account-type": "app",
+        "x-bkn-provenance-bootstrap-token": BOOTSTRAP_TOKEN,
+    }
+    assert client.agent_get_headers == client.import_headers
+
+
+def test_repeated_upgrade_updates_agent_without_new_prompt_version():
+    client = FakeClient()
+    client.import_result["results"][0].update(
+        action="updated",
+        prompt_action="unchanged",
+    )
+
+    result = bootstrap(
+        client, PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
+    )
+
+    assert result == "updated"
+
+
+def test_bootstrap_does_not_require_a_package_specific_default_model():
+    package = json.loads(PACKAGE.read_text(encoding="utf-8"))
+    assert package["items"][0]["spec"]["model"] == ""
+
+    assert (
+        bootstrap(
+            FakeClient(), PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
+        )
+        == "created"
+    )
+
+
+@pytest.mark.parametrize(
+    "owner_change",
+    [
+        {"enabled": False},
+        {"account_type": "other"},
+        {"account": "wrong-account"},
+    ],
+)
+def test_bootstrap_rejects_missing_or_conflicting_owner(owner_change):
+    client = FakeClient()
+    client.owner.update(owner_change)
+
+    with pytest.raises(BootstrapError, match="owner"):
+        bootstrap(
+            client, PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
+        )
+
+
+def test_bootstrap_rejects_per_item_import_failure_even_when_http_succeeded():
+    client = FakeClient(
+        import_result={
+            "results": [
+                {
+                    "agent_id": "business_provenance_optimizer",
+                    "action": "failed",
+                    "prompt_action": "none",
+                    "error": "owned by another account",
+                }
+            ],
+            "warnings": [],
+        }
+    )
+
+    with pytest.raises(BootstrapError, match="owned by another account"):
+        bootstrap(
+            client, PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
+        )
+
+
+def test_bootstrap_rejects_agent_spec_drift_after_import():
+    client = FakeClient()
+    client.agent["status"] = "draft"
+
+    with pytest.raises(BootstrapError, match="status"):
+        bootstrap(
+            client, PACKAGE, "http://safe", "http://agent", OWNER_ID, BOOTSTRAP_TOKEN
+        )
+
+
+def _request(headers: dict[str, str]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/bkn-agent/v1/import",
+            "headers": [(key.lower().encode(), value.encode()) for key, value in headers.items()],
+        }
+    )
+
+
+def test_fixed_owner_identity_requires_the_deployment_secret(monkeypatch):
+    monkeypatch.setattr(config, "PROVENANCE_BOOTSTRAP_TOKEN", BOOTSTRAP_TOKEN)
+    identity = {"x-account-id": OWNER_ID, "x-account-type": "app"}
+
+    for headers in (
+        identity,
+        {**identity, "x-bkn-provenance-bootstrap-token": "forged"},
+        {
+            **identity,
+            "x-account-type": "user",
+            "x-bkn-provenance-bootstrap-token": BOOTSTRAP_TOKEN,
+        },
+    ):
+        with pytest.raises(HTTPException) as exc:
+            get_account(_request(headers))
+        assert exc.value.status_code == 401
+
+    account = get_account(
+        _request({**identity, "x-bkn-provenance-bootstrap-token": BOOTSTRAP_TOKEN})
+    )
+    assert account.account_id == OWNER_ID
+    assert account.account_type == "app"
+
+
+def test_canonical_package_import_is_idempotent_with_real_database(tmp_path, monkeypatch):
+    database = tmp_path / "bkn-agent.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{database}")
+    sessions = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def prepare():
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+
+    async def session_override():
+        async with sessions() as session:
+            yield session
+
+    asyncio.run(prepare())
+    app.dependency_overrides[get_session] = session_override
+    monkeypatch.setattr(config, "PROVENANCE_BOOTSTRAP_TOKEN", BOOTSTRAP_TOKEN)
+    package = json.loads(PACKAGE.read_text(encoding="utf-8"))
+    headers = {
+        "x-account-id": OWNER_ID,
+        "x-account-type": "app",
+        "x-bkn-provenance-bootstrap-token": BOOTSTRAP_TOKEN,
+    }
+    client = TestClient(app)
+    try:
+        fresh = client.post("/api/bkn-agent/v1/import", json={"package": package}, headers=headers)
+        repeat = client.post("/api/bkn-agent/v1/import", json={"package": package}, headers=headers)
+        foreign = client.post(
+            "/api/bkn-agent/v1/import",
+            json={"package": package},
+            headers={"x-account-id": "foreign-owner", "x-account-type": "app"},
+        )
+
+        assert fresh.status_code == repeat.status_code == foreign.status_code == 200
+        assert fresh.json()["results"][0]["prompt_action"] == "created"
+        repeat_item = repeat.json()["results"][0]
+        assert repeat_item["action"] == "updated"
+        assert repeat_item["prompt_action"] == "unchanged"
+        assert foreign.json()["results"][0]["action"] == "failed"
+
+        async def verify():
+            async with sessions() as session:
+                agent = await session.get(AgentRow, "business_provenance_optimizer")
+                prompt = await session.get(PromptRow, "business_provenance_optimizer_prompt")
+                return agent, prompt
+
+        agent, prompt = asyncio.run(verify())
+        assert agent.f_create_user == OWNER_ID
+        assert agent.f_model == ""
+        assert agent.f_status == "published"
+        assert agent.f_tools == package["items"][0]["spec"]["tools"]
+        assert prompt.f_current_version == 1
+    finally:
+        app.dependency_overrides.pop(get_session, None)
+        asyncio.run(engine.dispose())

--- a/infra/bkn-agent/charts/templates/deployment.yaml
+++ b/infra/bkn-agent/charts/templates/deployment.yaml
@@ -78,6 +78,11 @@ spec:
               value: {{ .Values.runtime.contextLoaderMcpUrl | quote }}
             - name: BKN_AGENT_DEFAULT_MODEL
               value: {{ .Values.runtime.defaultModel | quote }}
+            - name: BKN_PROVENANCE_BOOTSTRAP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "provenanceBootstrap.auth.existingSecret is required" .Values.provenanceBootstrap.auth.existingSecret | quote }}
+                  key: {{ required "provenanceBootstrap.auth.secretKey is required" .Values.provenanceBootstrap.auth.secretKey | quote }}
             - name: CHECKPOINTER_BACKEND
               value: {{ .Values.runtime.checkpointerBackend | quote }}
             - name: CHECKPOINTER_ALLOW_RUNTIME_DDL

--- a/infra/bkn-agent/charts/templates/provenance-bootstrap-secret.yaml
+++ b/infra/bkn-agent/charts/templates/provenance-bootstrap-secret.yaml
@@ -1,0 +1,22 @@
+{{- /*
+Copyright (c) 2026 OpenBKN
+SPDX-License-Identifier: LicenseRef-OpenBKN
+Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+*/ -}}
+{{- $auth := .Values.provenanceBootstrap.auth -}}
+{{- if $auth.createSecret }}
+{{- $name := required "provenanceBootstrap.auth.existingSecret is required" $auth.existingSecret -}}
+{{- $key := required "provenanceBootstrap.auth.secretKey is required" $auth.secretKey -}}
+{{- $existing := lookup "v1" "Secret" .Values.namespace $name -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ .Values.namespace | quote }}
+  annotations:
+    "helm.sh/resource-policy": keep
+type: Opaque
+data:
+  {{ $key }}: {{ if and $existing (index $existing.data $key) }}{{ index $existing.data $key }}{{ else }}{{ randAlphaNum 48 | b64enc }}{{ end }}
+{{- end }}

--- a/infra/bkn-agent/charts/values.yaml
+++ b/infra/bkn-agent/charts/values.yaml
@@ -55,6 +55,12 @@ runtime:
   # it back to false after the tables are captured in a migration.
   checkpointerAllowRuntimeDdl: "false"
 
+provenanceBootstrap:
+  auth:
+    createSecret: true
+    existingSecret: bkn-agent-provenance-bootstrap
+    secretKey: token
+
 observability:
   otelEnabled: "true"
   otlpEndpoint: "http://otelcol-contrib:4318"

--- a/infra/bkn-agent/scripts/test_business_provenance_bootstrap_chart.sh
+++ b/infra/bkn-agent/scripts/test_business_provenance_bootstrap_chart.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 OpenBKN
+# SPDX-License-Identifier: LicenseRef-OpenBKN
+# Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+# Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+set -euo pipefail
+
+chart_dir="${1:-charts}"
+rendered="$(helm template bkn-agent "${chart_dir}")"
+
+for required in \
+    'name: "bkn-agent-provenance-bootstrap"' \
+    'name: BKN_PROVENANCE_BOOTSTRAP_TOKEN' \
+    'key: "token"'; do
+    grep -q "${required}" <<<"${rendered}" || {
+        echo "bkn-agent bootstrap credential contract missing: ${required}" >&2
+        exit 1
+    }
+done
+
+echo "bkn-agent provenance bootstrap credential contract: PASS"

--- a/infra/bkn-agent/test-requirements.txt
+++ b/infra/bkn-agent/test-requirements.txt
@@ -2,3 +2,4 @@
 # 运行时依赖（pyyaml/jsonschema 等）在 requirements.txt。
 pytest~=8.3
 httpx~=0.27
+aiosqlite~=0.20


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] bkn-safe 预置并保护固定的业务溯源 app principal
- [x] Enterprise install / upgrade 通过 Helm hook 幂等导入并验收 `business_provenance_optimizer`
- [x] bkn-agent 与 bootstrap Job 共享跨升级保留的认证 Secret，拒绝伪造固定 owner
- [x] 覆盖 fresh / repeat / owner conflict / empty default model / private registry 回归

---

## Why

- Related Issue: Closes #1141
- Related Feature: Enterprise business provenance analysis
- Background: 企业版 Deployment 已声明固定 Agent 依赖，但安装/升级链路没有创建运行时 Agent，首次 analysis 因 Agent 不存在返回 502。

---

## How

- Key implementation points:
  - bkn-safe 启动时以固定 UUID 创建无密码、`account_type=app` 的 principal；检测到字段冲突时启动失败，管理 API 禁止删除、禁用、改名、改类型或设置密码。
  - bkn-agent 镜像携带 canonical package，并提供带重试的 bootstrap 命令；导入后逐字段校验 Agent spec、owner 和 import/prompt action。
  - bkn-agent Chart 生成并通过 `lookup` 复用 48 字符 Secret；固定 principal 调用必须同时提供该 Secret，比较使用 constant-time 校验。
  - agent-observability Chart 在 Enterprise 能力启用时运行 `post-install,post-upgrade` Job；失败 Job 保留用于诊断，私有 registry/tag 继承发布级覆盖。
- Breaking changes (API, config, database, etc.): 无公开 API 破坏；新增内部固定 principal、Chart Secret 和 Enterprise bootstrap hook。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./... -count=1` — bkn-safe/server
- `go test ./... -count=1` — bkn-trace/agent-observability
- `go vet ./...` — both Go services
- `pytest -q` — infra/bkn-agent: 251 passed
- `make helm-lint` — agent-observability chart and deployment contracts
- `helm lint charts` + bootstrap credential contract — bkn-agent chart
- Canonical package real SQLite/API test asserts fresh create, repeat update with Prompt version remaining 1, and foreign owner rejection.
- Rendered against `openbkn-ee` release/0.1.4 values; bootstrap Job, owner, Secret reference, URLs and image contract are present.

---

## Risk & Rollback

- Potential risks: bkn-safe will fail fast if the fixed UUID was already occupied with conflicting identity data; Enterprise Helm upgrade fails if bkn-safe/bkn-agent is unavailable, the shared Secret is absent, import fails, ownership conflicts, or the final Agent spec drifts.
- Rollback plan: roll back both bkn-agent and agent-observability Charts plus bkn-safe image to the previous release. The generated bootstrap Secret is intentionally retained; it contains no user credential and can be removed manually after all rolled-back workloads stop referencing it.

---

## Additional Notes

- AppKey was evaluated but is intentionally not reused: the current AppKey contract is scoped to Context Loader only. The bootstrap uses a dedicated chart-managed S2S possession secret while retaining the platform's existing `/in` identity convention.
- Live-cluster `/analysis` SSE validation remains for the test environment because it requires a running Enterprise entitlement and model service.
