### PR TITLE
fix(bkn-backend): pass embedding model ID to Vega

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -38,7 +38,7 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 			return errors.New("GetDefaultModel return nil")
 		}
 		vectorDim = smallModel.EmbeddingDim
-		defaultEmbeddingModel = smallModel.ModelName
+		defaultEmbeddingModel = smallModel.ModelID
 		logger.Infof("Small model enabled, vector dimension: %d", vectorDim)
 	}
 
@@ -85,9 +85,12 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 		logger.Infof("Dataset %s created successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 	} else {
 		logger.Infof("Dataset %s found, ID: %s", interfaces.BKN_DATASET_NAME, dataset.ID)
-		// Deep compare schema
-		if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) {
-			logger.Infof("Schema mismatch detected, deleting and recreating dataset...")
+		// Compare the schema and the resource-level embedding model reference.
+		// Vega interprets DefaultEmbeddingModel as a model ID, so a historical
+		// model name must trigger recreation even when the schema is unchanged.
+		if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) ||
+			!sameDefaultEmbeddingModel(dataset.IndexConfig, defaultEmbeddingModel) {
+			logger.Infof("Dataset definition mismatch detected, deleting and recreating dataset...")
 			// Delete dataset
 			err = VBA.DeleteResource(ctx, dataset.ID)
 			if err != nil {
@@ -104,12 +107,19 @@ func Init(ctx context.Context, appSetting *common.AppSetting) error {
 			}
 			logger.Infof("Dataset %s recreated successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 		} else {
-			logger.Infof("Schema matches, no need to recreate dataset")
+			logger.Infof("Dataset definition matches, no need to recreate dataset")
 		}
 	}
 
 	logger.Info("Init BKN Dataset Success")
 	return nil
+}
+
+func sameDefaultEmbeddingModel(indexConfig *interfaces.VegaResourceIndexConfig, expectedModelID string) bool {
+	if indexConfig == nil {
+		return expectedModelID == ""
+	}
+	return indexConfig.DefaultEmbeddingModel == expectedModelID
 }
 
 // bknConceptDatasetRequest builds an independent resource request for the BKN

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -76,6 +76,7 @@ func TestInitPassesResolvedEmbeddingModelToVega(t *testing.T) {
 
 		ctx := context.Background()
 		mfs.EXPECT().GetDefaultModel(ctx).Return(&interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
 			ModelName:    "text-embedding-v4",
 			EmbeddingDim: 1024,
 		}, nil)
@@ -84,7 +85,7 @@ func TestInitPassesResolvedEmbeddingModelToVega(t *testing.T) {
 		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
 			So(resource.IndexConfig, ShouldNotBeNil)
 			So(resource.IndexConfig.DefaultFulltextAnalyzer, ShouldEqual, "standard")
-			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "text-embedding-v4")
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "2091780333946146816")
 			return nil
 		})
 
@@ -108,6 +109,7 @@ func TestInitPassesResolvedEmbeddingModelWhenRecreatingDataset(t *testing.T) {
 
 		ctx := context.Background()
 		mfs.EXPECT().GetDefaultModel(ctx).Return(&interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
 			ModelName:    "text-embedding-v4",
 			EmbeddingDim: 1024,
 		}, nil)
@@ -118,9 +120,78 @@ func TestInitPassesResolvedEmbeddingModelWhenRecreatingDataset(t *testing.T) {
 		}, nil)
 		vegaBackend.EXPECT().DeleteResource(ctx, interfaces.BKN_DATASET_ID).Return(nil)
 		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
-			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "text-embedding-v4")
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "2091780333946146816")
 			return nil
 		})
+
+		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}})
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestInitRecreatesDatasetWhenEmbeddingModelIDDiffers(t *testing.T) {
+	Convey("Init recreates the dataset when its embedding model reference differs (issue #1142)\n", t, func() {
+		ctrl := gomock.NewController(t)
+		mfs := mock_interfaces.NewMockModelFactoryService(ctrl)
+		vegaBackend := mock_interfaces.NewMockVegaBackendAccess(ctrl)
+		previousVBA := VBA
+		VBA = vegaBackend
+		patches := gomonkey.ApplyFunc(model_factory.NewModelFactoryService, func(_ *common.AppSetting, _ interfaces.ModelFactoryAccess) interfaces.ModelFactoryService { return mfs })
+		Reset(func() {
+			patches.Reset()
+			VBA = previousVBA
+		})
+
+		ctx := context.Background()
+		model := &interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
+			ModelName:    "text-embedding-v4",
+			EmbeddingDim: 1024,
+		}
+		mfs.EXPECT().GetDefaultModel(ctx).Return(model, nil)
+		vegaBackend.EXPECT().GetCatalogByID(ctx, interfaces.BKN_CATALOG_ID).Return(&interfaces.Catalog{ID: interfaces.BKN_CATALOG_ID}, nil)
+		vegaBackend.EXPECT().GetResourceByID(ctx, interfaces.BKN_DATASET_ID).Return(&interfaces.VegaResource{
+			ID:               interfaces.BKN_DATASET_ID,
+			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelName},
+		}, nil)
+		vegaBackend.EXPECT().DeleteResource(ctx, interfaces.BKN_DATASET_ID).Return(nil)
+		vegaBackend.EXPECT().CreateResource(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, resource *interfaces.VegaResource) error {
+			So(resource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, model.ModelID)
+			return nil
+		})
+
+		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}})
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestInitKeepsDatasetWhenSchemaAndEmbeddingModelIDMatch(t *testing.T) {
+	Convey("Init keeps the dataset when its schema and embedding model ID match (issue #1142)\n", t, func() {
+		ctrl := gomock.NewController(t)
+		mfs := mock_interfaces.NewMockModelFactoryService(ctrl)
+		vegaBackend := mock_interfaces.NewMockVegaBackendAccess(ctrl)
+		previousVBA := VBA
+		VBA = vegaBackend
+		patches := gomonkey.ApplyFunc(model_factory.NewModelFactoryService, func(_ *common.AppSetting, _ interfaces.ModelFactoryAccess) interfaces.ModelFactoryService { return mfs })
+		Reset(func() {
+			patches.Reset()
+			VBA = previousVBA
+		})
+
+		ctx := context.Background()
+		model := &interfaces.SmallModel{
+			ModelID:      "2091780333946146816",
+			ModelName:    "text-embedding-v4",
+			EmbeddingDim: 1024,
+		}
+		mfs.EXPECT().GetDefaultModel(ctx).Return(model, nil)
+		vegaBackend.EXPECT().GetCatalogByID(ctx, interfaces.BKN_CATALOG_ID).Return(&interfaces.Catalog{ID: interfaces.BKN_CATALOG_ID}, nil)
+		vegaBackend.EXPECT().GetResourceByID(ctx, interfaces.BKN_DATASET_ID).Return(&interfaces.VegaResource{
+			ID:               interfaces.BKN_DATASET_ID,
+			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelID},
+		}, nil)
 
 		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}})
 		So(err, ShouldBeNil)


### PR DESCRIPTION
## What Changed

- [x] Forward-port the #1143 BKN Dataset embedding-model ID fix from release/0.1.4 to main.
- [x] Keep creation, recreation, historical model-name reconciliation, and matching-no-rebuild regression coverage.
- [ ] Documentation: not applicable; no public API or configuration change.

---

## Why

- Related Issue: #1142 (fixed in release/0.1.4; this PR synchronizes main).
- Related Feature: N/A
- Background: Vega validates index_config.default_embedding_model as a model ID.

---

## How

- Key implementation points: cherry-pick the release/0.1.4 merge commit 0e5ad9bcb onto main.
- Breaking changes (API, config, database, etc.): None; this aligns the existing internal BKN-to-Vega contract.

---

## Testing

- [x] Unit tests passed locally (before the identical release fix was merged)
- [ ] Integration tests passed locally (not run; mocked unit coverage is applicable)
- [ ] Verified in test environment (not run)

Test notes:

- go test ./logics
- golangci-lint run ./logics
- git diff --check

---

## Risk & Rollback

- Potential risks: an existing Dataset whose embedding model reference is a name will be deleted and recreated during initialization; this data-impacting behavior was explicitly confirmed for #1143.
- Rollback plan: revert commit 6261dc0f3.

---

## Additional Notes

- This is a focused forward-port of the merged release/0.1.4 fix.