### PR TITLE
fix(bkn-safe): let a resource owner look up the colleague they are sharing with

### DIFF
--- a/bkn-safe/server/internal/directory/departments_admin_list.go
+++ b/bkn-safe/server/internal/directory/departments_admin_list.go
@@ -149,9 +149,9 @@ func (s *Service) ListAllDepartments(ctx context.Context, search string, offset,
 	if err := q.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	// Same reason as the user list: the allocation is sized by a constant the
-	// scanner can see, not by the request parameter the clamp happens to bound.
-	deps := make([]model.Department, 0, min(limit, maxDepartmentPageSize))
+	// Same reason as the user list: constant capacity, no request parameter in
+	// the allocation at all.
+	deps := make([]model.Department, 0, defaultDepartmentPageSize)
 	if err := q.Order("parent_id, name").Offset(offset).Limit(limit).Find(&deps).Error; err != nil {
 		return nil, 0, err
 	}

--- a/bkn-safe/server/internal/directory/departments_admin_list.go
+++ b/bkn-safe/server/internal/directory/departments_admin_list.go
@@ -10,6 +10,11 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
+const (
+	defaultDepartmentPageSize = 100
+	maxDepartmentPageSize     = 1000
+)
+
 // DepartmentListItem is the admin list view of a department (snake_case JSON).
 type DepartmentListItem struct {
 	ID                 string `json:"id"`
@@ -128,10 +133,10 @@ func (s *Service) subtreeMemberCounts(ctx context.Context, deptIDs []string) (ma
 // ListAllDepartments returns a flat, paginated department list with member_count.
 func (s *Service) ListAllDepartments(ctx context.Context, search string, offset, limit int) ([]DepartmentListItem, int64, error) {
 	if limit <= 0 {
-		limit = 100
+		limit = defaultDepartmentPageSize
 	}
-	if limit > 1000 {
-		limit = 1000
+	if limit > maxDepartmentPageSize {
+		limit = maxDepartmentPageSize
 	}
 	if offset < 0 {
 		offset = 0
@@ -144,7 +149,9 @@ func (s *Service) ListAllDepartments(ctx context.Context, search string, offset,
 	if err := q.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	deps := make([]model.Department, 0, limit)
+	// Same reason as the user list: the allocation is sized by a constant the
+	// scanner can see, not by the request parameter the clamp happens to bound.
+	deps := make([]model.Department, 0, min(limit, maxDepartmentPageSize))
 	if err := q.Order("parent_id, name").Offset(offset).Limit(limit).Find(&deps).Error; err != nil {
 		return nil, 0, err
 	}

--- a/bkn-safe/server/internal/directory/users_admin_list.go
+++ b/bkn-safe/server/internal/directory/users_admin_list.go
@@ -11,6 +11,13 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
+const (
+	// defaultUserPageSize is what an unspecified limit means; maxUserPageSize is
+	// the ceiling no caller may raise.
+	defaultUserPageSize = 50
+	maxUserPageSize     = 500
+)
+
 // UserListFilter is the admin user-list query (pagination + optional filters).
 type UserListFilter struct {
 	Search         string
@@ -47,10 +54,10 @@ var userSummaryCols = []string{
 func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserSummary, int64, error) {
 	limit := filter.Limit
 	if limit <= 0 {
-		limit = 50
+		limit = defaultUserPageSize
 	}
-	if limit > 500 {
-		limit = 500
+	if limit > maxUserPageSize {
+		limit = maxUserPageSize
 	}
 	offset := filter.Offset
 	if offset < 0 {
@@ -97,7 +104,11 @@ func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserS
 		return nil, 0, err
 	}
 
-	out := make([]UserSummary, 0, limit)
+	// Pre-allocate against the constant ceiling, not the caller's number. The
+	// clamp above already bounds it, but sizing an allocation from a request
+	// parameter is a shape worth not having (CodeQL go/uncontrolled-allocation-size),
+	// and min() makes the bound one the compiler and the scanner can both see.
+	out := make([]UserSummary, 0, min(limit, maxUserPageSize))
 	rows := make([]struct {
 		ID          string
 		Account     string
@@ -106,7 +117,7 @@ func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserS
 		Enabled     bool
 		AccountType string
 		UpdatedAt   time.Time
-	}, 0, limit)
+	}, 0, min(limit, maxUserPageSize))
 	if err := q.Select(userSummaryCols).Order("account").Offset(offset).Limit(limit).Scan(&rows).Error; err != nil {
 		return nil, 0, err
 	}

--- a/bkn-safe/server/internal/directory/users_admin_list.go
+++ b/bkn-safe/server/internal/directory/users_admin_list.go
@@ -104,11 +104,13 @@ func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserS
 		return nil, 0, err
 	}
 
-	// Pre-allocate against the constant ceiling, not the caller's number. The
-	// clamp above already bounds it, but sizing an allocation from a request
-	// parameter is a shape worth not having (CodeQL go/uncontrolled-allocation-size),
-	// and min() makes the bound one the compiler and the scanner can both see.
-	out := make([]UserSummary, 0, min(limit, maxUserPageSize))
+	// Capacity is a constant, not the caller's number. The clamp above already
+	// bounds `limit`, and min(limit, ceiling) would too, but either way the
+	// allocation still reads a request parameter — the shape CodeQL flags as
+	// go/uncontrolled-allocation-size, and the one worth not having at all. A
+	// page larger than the default grows by append; at these sizes that costs
+	// nothing worth measuring.
+	out := make([]UserSummary, 0, defaultUserPageSize)
 	rows := make([]struct {
 		ID          string
 		Account     string
@@ -117,7 +119,7 @@ func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserS
 		Enabled     bool
 		AccountType string
 		UpdatedAt   time.Time
-	}, 0, min(limit, maxUserPageSize))
+	}, 0, defaultUserPageSize)
 	if err := q.Select(userSummaryCols).Order("account").Offset(offset).Limit(limit).Scan(&rows).Error; err != nil {
 		return nil, 0, err
 	}

--- a/bkn-safe/server/internal/httpapi/adminauth.go
+++ b/bkn-safe/server/internal/httpapi/adminauth.go
@@ -169,3 +169,82 @@ func bearerToken(c *gin.Context) string {
 	}
 	return ""
 }
+
+// ctxDirectoryReadAuthority records how a caller earned a directory read on the
+// relaxed group below: "admin" for the platform administrator, "owner" for the
+// holder of a concrete object grant. Handlers branch on it because the two are
+// not entitled to the same rows or the same columns.
+const ctxDirectoryReadAuthority = "directory_read_authority"
+
+const (
+	directoryReadAdmin = "admin"
+	directoryReadOwner = "owner"
+)
+
+// RequireAdminOrResourceOwner guards the directory reads an object owner needs
+// in order to name the person they are sharing with. Administrators pass as they
+// always did; anyone else passes only while holding `authorize` on at least one
+// CONCRETE object.
+//
+// "Concrete" is the whole point, and it is why this reads ListObjectGrants
+// rather than asking the enforcer. A Check/EffectivePermissions answer folds in
+// type-wide role grants, and the seeded network_builder role carries `authorize`
+// on catalog, connector_type, operator, skill and stream_data_pipeline — so
+// every member of that role would pass without owning anything at all, turning
+// "the person who built this may look up a colleague" into "this role may read
+// the directory". ListObjectGrants skips type-wide rows (see its rid == "*"
+// filter), leaving exactly the grants a domain service wrote to a creator.
+//
+// Fail-closed throughout: a lookup error is a refusal, never a pass.
+func RequireAdminOrResourceOwner(v TokenVerifier, e *authz.Enforcer) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		tok := bearerToken(c)
+		if tok == "" {
+			abortPublicError(c, http.StatusUnauthorized)
+			return
+		}
+		sub, err := v.VerifyToken(c.Request.Context(), tok)
+		if err != nil {
+			abortPublicError(c, http.StatusUnauthorized)
+			return
+		}
+		admin, err := e.CanAdmin(sub)
+		if err != nil {
+			abortInternalError(c)
+			return
+		}
+		if admin {
+			c.Set(ctxAccessorID, sub)
+			c.Set(ctxDirectoryReadAuthority, directoryReadAdmin)
+			c.Next()
+			return
+		}
+		grants, err := e.ListObjectGrants(sub, "", "")
+		if err != nil {
+			abortInternalError(c)
+			return
+		}
+		for _, grant := range grants {
+			for _, op := range grant.Operations {
+				if op == opAuthorize {
+					c.Set(ctxAccessorID, sub)
+					c.Set(ctxDirectoryReadAuthority, directoryReadOwner)
+					c.Next()
+					return
+				}
+			}
+		}
+		abortPublicError(c, http.StatusForbidden)
+	}
+}
+
+// requireAdminDirectoryPermission applies the administrator's own permission
+// point when the caller is one. An owner reached the handler through the object
+// grant instead, and holds no admin-user/admin-dept point by construction, so
+// asking would refuse every one of them.
+func requireAdminDirectoryPermission(c *gin.Context, e *authz.Enforcer, resourceType, op string) bool {
+	if c.GetString(ctxDirectoryReadAuthority) == directoryReadOwner {
+		return true
+	}
+	return authorizePermission(c, e, resourceType, op)
+}

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -323,7 +323,13 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 		}
 		if isOwnerDirectoryRead(c) {
 			out := projectDepartmentNodes(deps, ownerDirectoryLimit(c, 0))
-			c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out), "truncated": len(out) < len(deps)})
+			// Compare against the unpaged count, not against `deps`: the page cap
+			// was already applied by the query, so `deps` is at most one page and
+			// the in-memory projection can never be the thing that cut a row. The
+			// flag is a boolean and stays one — an owner is told that more exists,
+			// not how much, and with offset pinned there is no next page to ask
+			// for anyway.
+			c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out), "truncated": int64(len(out)) < total})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"departments": deps, "total": total})

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -244,8 +244,8 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 		users, total, err := dir.ListUsers(ctx, directory.UserListFilter{
 			Search:         c.Query("search"),
 			Enabled:        parseOptionalBool(c.Query("enabled")),
-			DepartmentID:   c.Query("department_id"),
-			IncludeSubtree: c.Query("include_subtree") == "true",
+			DepartmentID:   ownerDirectorySliceFilter(c, c.Query("department_id")),
+			IncludeSubtree: c.Query("include_subtree") == "true" && !isOwnerDirectoryRead(c),
 			RoleID:         ownerDirectoryRoleFilter(c, c.Query("role_id")),
 			Offset:         ownerDirectoryOffset(c, atoiDefault(c.Query("offset"), 0)),
 			Limit:          ownerDirectoryLimit(c, atoiDefault(c.Query("limit"), 0)),
@@ -305,7 +305,10 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 			}
 			if isOwnerDirectoryRead(c) {
 				out := projectDepartmentNodes(deps, ownerDirectoryLimit(c, 0))
-				c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out)})
+				// Say when the cap cut the branch. A tree that is silently short
+				// reads as "this is all of it", and the client cannot tell the
+				// difference from the payload alone.
+				c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out), "truncated": len(out) < len(deps)})
 				return
 			}
 			c.JSON(http.StatusOK, gin.H{"departments": deps, "total": len(deps)})
@@ -320,7 +323,7 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 		}
 		if isOwnerDirectoryRead(c) {
 			out := projectDepartmentNodes(deps, ownerDirectoryLimit(c, 0))
-			c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out)})
+			c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out), "truncated": len(out) < len(deps)})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"departments": deps, "total": total})
@@ -371,6 +374,19 @@ func ownerDirectoryOffset(c *gin.Context, requested int) int {
 		return requested
 	}
 	return 0
+}
+
+// ownerDirectorySliceFilter drops ?department_id= for an owner, and the caller
+// drops ?include_subtree= with it. Pinning offset bounds one axis; a filter that
+// partitions the same table is another axis, and walking the department tree
+// (which this endpoint's sibling hands out) then asking for each department in
+// turn reassembles the roster the page cap was meant to withhold. An owner gets
+// one window into the directory and narrows it by typing, not by slicing.
+func ownerDirectorySliceFilter(c *gin.Context, requested string) string {
+	if !isOwnerDirectoryRead(c) {
+		return requested
+	}
+	return ""
 }
 
 // ownerDirectoryRoleFilter drops ?role_id= for an owner. Listing users is one

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -246,8 +246,8 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 			Enabled:        parseOptionalBool(c.Query("enabled")),
 			DepartmentID:   c.Query("department_id"),
 			IncludeSubtree: c.Query("include_subtree") == "true",
-			RoleID:         c.Query("role_id"),
-			Offset:         atoiDefault(c.Query("offset"), 0),
+			RoleID:         ownerDirectoryRoleFilter(c, c.Query("role_id")),
+			Offset:         ownerDirectoryOffset(c, atoiDefault(c.Query("offset"), 0)),
 			Limit:          ownerDirectoryLimit(c, atoiDefault(c.Query("limit"), 0)),
 		})
 		if err != nil {
@@ -259,7 +259,10 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 			for _, user := range users {
 				out = append(out, projectGranteeCandidate(user))
 			}
-			c.JSON(http.StatusOK, gin.H{"users": out, "total": total})
+			// The count of everyone on the platform is not an answer this caller
+			// asked for, and paired with a stable page it is the number that tells
+			// an enumerator how far to keep going. Report the page.
+			c.JSON(http.StatusOK, gin.H{"users": out, "total": len(out)})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"users": users, "total": total})
@@ -300,12 +303,24 @@ func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Servi
 				serverError(c, err)
 				return
 			}
+			if isOwnerDirectoryRead(c) {
+				out := projectDepartmentNodes(deps, ownerDirectoryLimit(c, 0))
+				c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out)})
+				return
+			}
 			c.JSON(http.StatusOK, gin.H{"departments": deps, "total": len(deps)})
 			return
 		}
-		deps, total, err := dir.ListAllDepartments(ctx, c.Query("search"), atoiDefault(c.Query("offset"), 0), atoiDefault(c.Query("limit"), 0))
+		deps, total, err := dir.ListAllDepartments(ctx, c.Query("search"),
+			ownerDirectoryOffset(c, atoiDefault(c.Query("offset"), 0)),
+			ownerDirectoryLimit(c, atoiDefault(c.Query("limit"), 0)))
 		if err != nil {
 			serverError(c, err)
+			return
+		}
+		if isOwnerDirectoryRead(c) {
+			out := projectDepartmentNodes(deps, ownerDirectoryLimit(c, 0))
+			c.JSON(http.StatusOK, gin.H{"departments": out, "total": len(out)})
 			return
 		}
 		c.JSON(http.StatusOK, gin.H{"departments": deps, "total": total})
@@ -324,6 +339,48 @@ type granteeCandidate struct {
 
 func projectGranteeCandidate(u directory.UserSummary) granteeCandidate {
 	return granteeCandidate{ID: u.ID, Account: u.Account, Name: u.Name}
+}
+
+// departmentNode is the owner-facing projection of a department: enough to draw
+// the tree a grantee picker groups by, and none of the contact detail the admin
+// shape carries (manager, code, email, remark) or the head counts that describe
+// the organisation rather than locate it.
+type departmentNode struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	ParentID string `json:"parent_id"`
+}
+
+func projectDepartmentNodes(deps []directory.DepartmentListItem, maxRows int) []departmentNode {
+	if maxRows > 0 && len(deps) > maxRows {
+		deps = deps[:maxRows]
+	}
+	out := make([]departmentNode, 0, len(deps))
+	for _, d := range deps {
+		out = append(out, departmentNode{ID: d.ID, Name: d.Name, ParentID: d.ParentID})
+	}
+	return out
+}
+
+// ownerDirectoryOffset pins an owner to the first page. Capping the page length
+// alone bounds one response and nothing else: offset=0,50,100… walks the whole
+// table at the same cost, which is the enumeration the cap was meant to prevent.
+// A picker opens on the first page and narrows by typing; it never pages.
+func ownerDirectoryOffset(c *gin.Context, requested int) int {
+	if !isOwnerDirectoryRead(c) {
+		return requested
+	}
+	return 0
+}
+
+// ownerDirectoryRoleFilter drops ?role_id= for an owner. Listing users is one
+// thing; asking which accounts hold a named privileged role is a different
+// question, and answering it hands over a target list.
+func ownerDirectoryRoleFilter(c *gin.Context, requested string) string {
+	if !isOwnerDirectoryRead(c) {
+		return requested
+	}
+	return ""
 }
 
 func isOwnerDirectoryRead(c *gin.Context) bool {

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -177,76 +177,6 @@ func registerDirectory(r *gin.Engine, dir *directory.Service) {
 // surface reaches them through the gateway. The internal (ClusterIP) equivalents
 // stay on /api/safe/v1/directory for service-to-service callers.
 func registerAdminReads(g *gin.RouterGroup, dir *directory.Service, e *authz.Enforcer) {
-	// GET /users — list/search users (paginated), or ?account= for an exact
-	// login lookup. Query: ?search=&offset=&limit= | ?account=
-	// -> { users:[{id,account,name,email,enabled,account_type}], total }
-	g.GET("/users", RequirePermission(e, "admin-user", "view"), func(c *gin.Context) {
-		ctx := c.Request.Context()
-		if acct := c.Query("account"); acct != "" {
-			u, err := dir.FindUserByAccount(ctx, acct)
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				c.JSON(http.StatusOK, gin.H{"users": []directory.UserSummary{}, "total": 0})
-				return
-			}
-			if err != nil {
-				serverError(c, err)
-				return
-			}
-			c.JSON(http.StatusOK, gin.H{"users": []*directory.UserSummary{u}, "total": 1})
-			return
-		}
-		users, total, err := dir.ListUsers(ctx, directory.UserListFilter{
-			Search:         c.Query("search"),
-			Enabled:        parseOptionalBool(c.Query("enabled")),
-			DepartmentID:   c.Query("department_id"),
-			IncludeSubtree: c.Query("include_subtree") == "true",
-			RoleID:         c.Query("role_id"),
-			Offset:         atoiDefault(c.Query("offset"), 0),
-			Limit:          atoiDefault(c.Query("limit"), 0),
-		})
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"users": users, "total": total})
-	})
-
-	// GET /users/:id — full user detail.
-	g.GET("/users/:id", RequirePermission(e, "admin-user", "view"), func(c *gin.Context) {
-		d, err := dir.GetUser(c.Request.Context(), c.Param("id"))
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			replyPublicError(c, http.StatusNotFound)
-			return
-		}
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		c.JSON(http.StatusOK, d)
-	})
-
-	// GET /departments — with ?parent_id= lists that parent's direct children
-	// ("" = roots); without it returns the whole tree flat (paginated/searchable
-	// via ?search=&offset=&limit=) so the client can build the tree.
-	g.GET("/departments", RequirePermission(e, "admin-dept", "view"), func(c *gin.Context) {
-		ctx := c.Request.Context()
-		if _, scoped := c.GetQuery("parent_id"); scoped {
-			deps, err := dir.ListDepartmentsWithCounts(ctx, c.Query("parent_id"))
-			if err != nil {
-				serverError(c, err)
-				return
-			}
-			c.JSON(http.StatusOK, gin.H{"departments": deps, "total": len(deps)})
-			return
-		}
-		deps, total, err := dir.ListAllDepartments(ctx, c.Query("search"), atoiDefault(c.Query("offset"), 0), atoiDefault(c.Query("limit"), 0))
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"departments": deps, "total": total})
-	})
-
 	// GET /departments/:id — single department detail.
 	g.GET("/departments/:id", RequirePermission(e, "admin-dept", "view"), func(c *gin.Context) {
 		d, err := dir.GetDepartmentDetail(c.Request.Context(), c.Param("id"))
@@ -270,6 +200,149 @@ func registerAdminReads(g *gin.RouterGroup, dir *directory.Service, e *authz.Enf
 		}
 		c.JSON(http.StatusOK, gin.H{"users": members, "total": len(members)})
 	})
+}
+
+// registerOwnerVisibleDirectoryReads mounts the directory reads that an object
+// owner needs in order to name the colleague they are sharing with. They keep
+// their /admin paths so the console calls one URL whoever is looking; the group
+// they hang on swaps RequireAdmin for RequireAdminOrResourceOwner, and each
+// handler re-applies the administrator's permission point through
+// requireAdminDirectoryPermission — an owner is exempt from that check, never
+// from the one that let them in.
+//
+// What an owner gets back is narrower than what an administrator gets: id,
+// account and name — the three columns a grantee picker shows. The admin shape
+// carries email, telephone, role and department membership, and opening the
+// directory for the sake of a picker is no reason to hand every resource owner
+// the platform's contact list. The page size is capped for the same reason.
+func registerOwnerVisibleDirectoryReads(g *gin.RouterGroup, dir *directory.Service, e *authz.Enforcer) {
+	// GET /users — list/search users (paginated), or ?account= for an exact
+	// login lookup. Query: ?search=&offset=&limit= | ?account=
+	// -> { users:[{id,account,name,email,enabled,account_type}], total }
+	g.GET("/users", func(c *gin.Context) {
+		if !requireAdminDirectoryPermission(c, e, "admin-user", "view") {
+			return
+		}
+		ctx := c.Request.Context()
+		if acct := c.Query("account"); acct != "" {
+			u, err := dir.FindUserByAccount(ctx, acct)
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusOK, gin.H{"users": []directory.UserSummary{}, "total": 0})
+				return
+			}
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			if isOwnerDirectoryRead(c) {
+				c.JSON(http.StatusOK, gin.H{"users": []granteeCandidate{projectGranteeCandidate(*u)}, "total": 1})
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"users": []*directory.UserSummary{u}, "total": 1})
+			return
+		}
+		users, total, err := dir.ListUsers(ctx, directory.UserListFilter{
+			Search:         c.Query("search"),
+			Enabled:        parseOptionalBool(c.Query("enabled")),
+			DepartmentID:   c.Query("department_id"),
+			IncludeSubtree: c.Query("include_subtree") == "true",
+			RoleID:         c.Query("role_id"),
+			Offset:         atoiDefault(c.Query("offset"), 0),
+			Limit:          ownerDirectoryLimit(c, atoiDefault(c.Query("limit"), 0)),
+		})
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if isOwnerDirectoryRead(c) {
+			out := make([]granteeCandidate, 0, len(users))
+			for _, user := range users {
+				out = append(out, projectGranteeCandidate(user))
+			}
+			c.JSON(http.StatusOK, gin.H{"users": out, "total": total})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"users": users, "total": total})
+	})
+
+	// GET /users/:id — full user detail.
+	g.GET("/users/:id", func(c *gin.Context) {
+		if !requireAdminDirectoryPermission(c, e, "admin-user", "view") {
+			return
+		}
+		d, err := dir.GetUser(c.Request.Context(), c.Param("id"))
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			replyPublicError(c, http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if isOwnerDirectoryRead(c) {
+			c.JSON(http.StatusOK, granteeCandidate{ID: d.ID, Account: d.Account, Name: d.Name})
+			return
+		}
+		c.JSON(http.StatusOK, d)
+	})
+
+	// GET /departments — with ?parent_id= lists that parent's direct children
+	// ("" = roots); without it returns the whole tree flat (paginated/searchable
+	// via ?search=&offset=&limit=) so the client can build the tree.
+	g.GET("/departments", func(c *gin.Context) {
+		if !requireAdminDirectoryPermission(c, e, "admin-dept", "view") {
+			return
+		}
+		ctx := c.Request.Context()
+		if _, scoped := c.GetQuery("parent_id"); scoped {
+			deps, err := dir.ListDepartmentsWithCounts(ctx, c.Query("parent_id"))
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			c.JSON(http.StatusOK, gin.H{"departments": deps, "total": len(deps)})
+			return
+		}
+		deps, total, err := dir.ListAllDepartments(ctx, c.Query("search"), atoiDefault(c.Query("offset"), 0), atoiDefault(c.Query("limit"), 0))
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"departments": deps, "total": total})
+	})
+
+}
+
+// granteeCandidate is the owner-facing projection of a directory user: who they
+// are and what to show in a picker, and nothing that would make this endpoint
+// worth reading for any other purpose.
+type granteeCandidate struct {
+	ID      string `json:"id"`
+	Account string `json:"account"`
+	Name    string `json:"name"`
+}
+
+func projectGranteeCandidate(u directory.UserSummary) granteeCandidate {
+	return granteeCandidate{ID: u.ID, Account: u.Account, Name: u.Name}
+}
+
+func isOwnerDirectoryRead(c *gin.Context) bool {
+	return c.GetString(ctxDirectoryReadAuthority) == directoryReadOwner
+}
+
+// ownerDirectoryMaxPageSize caps what an owner may pull per request. The console
+// asks for 1000 when an administrator drives the same screen; an owner is here
+// to find one person by name.
+const ownerDirectoryMaxPageSize = 50
+
+func ownerDirectoryLimit(c *gin.Context, requested int) int {
+	if !isOwnerDirectoryRead(c) {
+		return requested
+	}
+	if requested <= 0 || requested > ownerDirectoryMaxPageSize {
+		return ownerDirectoryMaxPageSize
+	}
+	return requested
 }
 
 // atoiDefault parses s as an int, returning def on empty/invalid input.

--- a/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
+++ b/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
@@ -155,4 +156,154 @@ func TestOwnerDirectoryUserListProjectedAndCapped(t *testing.T) {
 	if _, ok := adminRows.Users[0]["email"]; !ok {
 		t.Fatalf("the projection leaked onto the administrator: %v", adminRows.Users[0])
 	}
+}
+
+// Capping the page length bounds one response and nothing else: offset=0,50,100…
+// walks the same table at the same cost. An owner is pinned to the first page.
+func TestOwnerDirectoryRefusesToPage(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+	for i := 0; i < ownerDirectoryMaxPageSize*2; i++ {
+		id := fmt.Sprintf("page-%03d", i)
+		if err := db.Create(&model.User{ID: id, Account: id, Name: "Page " + id, Enabled: true}).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	first := ownerAccounts(t, r, ownerID, "/api/safe/v1/admin/users?limit=50&offset=0")
+	second := ownerAccounts(t, r, ownerID, "/api/safe/v1/admin/users?limit=50&offset=50")
+	if len(first) == 0 {
+		t.Fatal("first page came back empty")
+	}
+	if len(second) != len(first) || second[0] != first[0] {
+		t.Fatalf("offset moved the window: first[0]=%q second[0]=%q", first[0], second[0])
+	}
+}
+
+// The platform's head count is not an answer this caller asked for, and paired
+// with a fixed page it is the number that tells an enumerator how far to go.
+func TestOwnerDirectoryTotalReportsThePageOnly(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+	for i := 0; i < ownerDirectoryMaxPageSize+25; i++ {
+		id := fmt.Sprintf("count-%03d", i)
+		if err := db.Create(&model.User{ID: id, Account: id, Name: "Count", Enabled: true}).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/users", nil, ownerID)
+	var out struct {
+		Users []map[string]any `json:"users"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Total != len(out.Users) {
+		t.Fatalf("total=%d leaks a count beyond the %d rows returned", out.Total, len(out.Users))
+	}
+}
+
+// Listing users is one question; asking which accounts hold a named privileged
+// role is another, and answering it hands over a target list.
+func TestOwnerDirectoryIgnoresRoleFilter(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, colleagueID := seedDirectoryPeople(t, db)
+	if err := e.AssignRole(colleagueID, "role-privileged"); err != nil {
+		t.Fatalf("assign role: %v", err)
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	accounts := ownerAccounts(t, r, ownerID, "/api/safe/v1/admin/users?role_id=role-privileged")
+	if len(accounts) < 2 {
+		t.Fatalf("role_id narrowed the list to %v — the filter was honoured", accounts)
+	}
+}
+
+// A department row locates a person; it does not have to describe the
+// organisation. The admin shape keeps manager, code, email, remark and counts.
+func TestOwnerDirectoryDepartmentsProjectedAndCapped(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+	for i := 0; i < ownerDirectoryMaxPageSize+5; i++ {
+		id := fmt.Sprintf("dept-%03d", i)
+		d := model.Department{ID: id, Name: "Dept " + id, ManagerID: "mate-1", Email: id + "@example.com", Code: id, Remark: "secret"}
+		if err := db.Create(&d).Error; err != nil {
+			t.Fatalf("seed dept: %v", err)
+		}
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments?limit=1000", nil, ownerID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("departments = %d (%s)", w.Code, w.Body.String())
+	}
+	var out struct {
+		Departments []map[string]any `json:"departments"`
+		Total       int              `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Departments) > ownerDirectoryMaxPageSize {
+		t.Fatalf("owner pulled %d departments, cap is %d", len(out.Departments), ownerDirectoryMaxPageSize)
+	}
+	if out.Total != len(out.Departments) {
+		t.Fatalf("total=%d beyond the %d rows returned", out.Total, len(out.Departments))
+	}
+	for _, row := range out.Departments {
+		for _, leaked := range []string{"manager_id", "manager_name", "email", "code", "remark", "member_count", "subtree_member_count"} {
+			if _, ok := row[leaked]; ok {
+				t.Fatalf("owner-facing department exposes %q: %v", leaked, row)
+			}
+		}
+	}
+
+	adminResp := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments?limit=1000", nil)
+	var adminOut struct {
+		Departments []map[string]any `json:"departments"`
+	}
+	if err := json.Unmarshal(adminResp.Body.Bytes(), &adminOut); err != nil {
+		t.Fatalf("decode admin: %v", err)
+	}
+	if len(adminOut.Departments) <= ownerDirectoryMaxPageSize {
+		t.Fatalf("the cap leaked onto the administrator: %d rows", len(adminOut.Departments))
+	}
+	if _, ok := adminOut.Departments[0]["member_count"]; !ok {
+		t.Fatalf("the projection leaked onto the administrator: %v", adminOut.Departments[0])
+	}
+}
+
+// ownerAccounts issues an owner-authenticated user list read and returns the
+// accounts it named.
+func ownerAccounts(t *testing.T, r *gin.Engine, token, path string) []string {
+	t.Helper()
+	w := tokReq(t, r, http.MethodGet, path, nil, token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s = %d (%s)", path, w.Code, w.Body.String())
+	}
+	var out struct {
+		Users []struct {
+			Account string `json:"account"`
+		} `json:"users"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	accounts := make([]string, 0, len(out.Users))
+	for _, u := range out.Users {
+		accounts = append(accounts, u.Account)
+	}
+	return accounts
 }

--- a/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
+++ b/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
@@ -253,9 +253,16 @@ func TestOwnerDirectoryDepartmentsProjectedAndCapped(t *testing.T) {
 	var out struct {
 		Departments []map[string]any `json:"departments"`
 		Total       int              `json:"total"`
+		Truncated   bool             `json:"truncated"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
 		t.Fatalf("decode: %v", err)
+	}
+	// More departments exist than this page carries, and the caller cannot page
+	// for the rest — so it has to be told, or it renders a partial org chart as
+	// the whole one.
+	if !out.Truncated {
+		t.Errorf("the flat page was cut at %d of %d without saying so", len(out.Departments), ownerDirectoryMaxPageSize+5)
 	}
 	if len(out.Departments) > ownerDirectoryMaxPageSize {
 		t.Fatalf("owner pulled %d departments, cap is %d", len(out.Departments), ownerDirectoryMaxPageSize)

--- a/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
+++ b/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
@@ -1,0 +1,158 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// seedDirectoryPeople puts two accounts in the directory so a picker has
+// something to return, and gives the caller their ids.
+func seedDirectoryPeople(t *testing.T, db *gorm.DB) (ownerID, colleagueID string) {
+	t.Helper()
+	owner := model.User{ID: "owner-1", Account: "owner", Name: "Owner One", Email: "owner@example.com", Telephone: "13800000001", Enabled: true}
+	colleague := model.User{ID: "mate-1", Account: "mate", Name: "Mate One", Email: "mate@example.com", Telephone: "13800000002", Enabled: true}
+	if err := db.Create(&owner).Error; err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+	if err := db.Create(&colleague).Error; err != nil {
+		t.Fatalf("seed colleague: %v", err)
+	}
+	return owner.ID, colleague.ID
+}
+
+// An owner is someone holding `authorize` on one CONCRETE object — the row a
+// domain service writes to whoever created it. That, and nothing weaker, opens
+// the directory reads.
+func TestOwnerDirectoryReadsGrantedByConcreteObjectGrant(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, colleagueID := seedDirectoryPeople(t, db)
+
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments", nil, ownerID); w.Code != http.StatusForbidden {
+		t.Fatalf("before the grant, departments = %d, want 403", w.Code)
+	}
+
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments", nil, ownerID); w.Code != http.StatusOK {
+		t.Fatalf("departments = %d (%s), want 200", w.Code, w.Body.String())
+	}
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/users/"+colleagueID, nil, ownerID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("user detail = %d (%s), want 200", w.Code, w.Body.String())
+	}
+	// The picker needs a name, not a contact list.
+	var detail map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if detail["account"] != "mate" || detail["name"] != "Mate One" {
+		t.Fatalf("detail lost the identity columns: %v", detail)
+	}
+	for _, leaked := range []string{"email", "telephone", "roles", "departments"} {
+		if _, ok := detail[leaked]; ok {
+			t.Errorf("owner-facing user detail exposes %q: %v", leaked, detail)
+		}
+	}
+}
+
+// A type-wide `authorize` is a role saying "members may share things of this
+// kind". Every seeded network_builder holds one on catalog, connector_type,
+// operator, skill and stream_data_pipeline, so honouring it here would hand the
+// directory to the whole role — including members who have never created
+// anything.
+func TestOwnerDirectoryReadsRefuseTypeWideAuthorize(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+
+	if err := e.Grant(ownerID, "catalog:*", "authorize"); err != nil {
+		t.Fatalf("grant type-wide authorize: %v", err)
+	}
+
+	for _, path := range []string{
+		"/api/safe/v1/admin/departments",
+		"/api/safe/v1/admin/users",
+		"/api/safe/v1/admin/users/mate-1",
+	} {
+		if w := tokReq(t, r, http.MethodGet, path, nil, ownerID); w.Code != http.StatusForbidden {
+			t.Errorf("%s = %d, want 403 for a type-wide-only holder", path, w.Code)
+		}
+	}
+}
+
+// An object grant that carries no `authorize` is not a licence to look anyone up.
+func TestOwnerDirectoryReadsRefuseNonAuthorizeGrant(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "view_detail"); err != nil {
+		t.Fatalf("grant view_detail: %v", err)
+	}
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments", nil, ownerID); w.Code != http.StatusForbidden {
+		t.Fatalf("departments = %d, want 403", w.Code)
+	}
+}
+
+// The list is projected and capped for an owner; an administrator keeps the
+// shape the console has always read.
+func TestOwnerDirectoryUserListProjectedAndCapped(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+	for i := 0; i < ownerDirectoryMaxPageSize+10; i++ {
+		id := fmt.Sprintf("bulk-%03d", i)
+		if err := db.Create(&model.User{ID: id, Account: id, Name: "Bulk " + id, Email: id + "@example.com", Enabled: true}).Error; err != nil {
+			t.Fatalf("seed bulk user: %v", err)
+		}
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/users?limit=1000", nil, ownerID)
+	if w.Code != http.StatusOK {
+		t.Fatalf("users = %d (%s), want 200", w.Code, w.Body.String())
+	}
+	var out struct {
+		Users []map[string]any `json:"users"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode users: %v", err)
+	}
+	if len(out.Users) > ownerDirectoryMaxPageSize {
+		t.Fatalf("owner pulled %d rows, cap is %d", len(out.Users), ownerDirectoryMaxPageSize)
+	}
+	for _, row := range out.Users {
+		if _, ok := row["email"]; ok {
+			t.Fatalf("owner-facing user row exposes email: %v", row)
+		}
+	}
+
+	adminOut := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/users?limit=1000", nil)
+	if adminOut.Code != http.StatusOK {
+		t.Fatalf("admin users = %d, want 200", adminOut.Code)
+	}
+	var adminRows struct {
+		Users []map[string]any `json:"users"`
+	}
+	if err := json.Unmarshal(adminOut.Body.Bytes(), &adminRows); err != nil {
+		t.Fatalf("decode admin users: %v", err)
+	}
+	if len(adminRows.Users) <= ownerDirectoryMaxPageSize {
+		t.Fatalf("the cap leaked onto the administrator: %d rows", len(adminRows.Users))
+	}
+	if _, ok := adminRows.Users[0]["email"]; !ok {
+		t.Fatalf("the projection leaked onto the administrator: %v", adminRows.Users[0])
+	}
+}

--- a/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
+++ b/bkn-safe/server/internal/httpapi/ownerdirectory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -306,4 +307,70 @@ func ownerAccounts(t *testing.T, r *gin.Engine, token, path string) []string {
 		accounts = append(accounts, u.Account)
 	}
 	return accounts
+}
+
+// Pinning offset bounds one axis. A filter that partitions the same table is
+// another: walk the department tree, ask for each department in turn, and the
+// roster reassembles itself. An owner narrows by typing, not by slicing.
+func TestOwnerDirectoryIgnoresDepartmentSlicing(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, colleagueID := seedDirectoryPeople(t, db)
+	if err := db.Create(&model.Department{ID: "dept-a", Name: "A"}).Error; err != nil {
+		t.Fatalf("seed dept: %v", err)
+	}
+	dir := directory.New(db)
+	if err := dir.AddDepartmentMembers(t.Context(), "dept-a", []string{colleagueID}); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	sliced := ownerAccounts(t, r, ownerID, "/api/safe/v1/admin/users?department_id=dept-a")
+	all := ownerAccounts(t, r, ownerID, "/api/safe/v1/admin/users")
+	if len(sliced) != len(all) {
+		t.Fatalf("department_id partitioned the owner's window: %d vs %d rows", len(sliced), len(all))
+	}
+
+	// The administrator still gets the filter they asked for.
+	adminResp := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/users?department_id=dept-a", nil)
+	var adminOut struct {
+		Users []map[string]any `json:"users"`
+	}
+	if err := json.Unmarshal(adminResp.Body.Bytes(), &adminOut); err != nil {
+		t.Fatalf("decode admin: %v", err)
+	}
+	if len(adminOut.Users) != 1 {
+		t.Fatalf("the administrator's department filter stopped working: %d rows", len(adminOut.Users))
+	}
+}
+
+// A tree that is silently short reads as "this is all of it".
+func TestOwnerDirectoryDepartmentsFlagTruncation(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	ownerID, _ := seedDirectoryPeople(t, db)
+	for i := 0; i < ownerDirectoryMaxPageSize+3; i++ {
+		id := fmt.Sprintf("child-%03d", i)
+		if err := db.Create(&model.Department{ID: id, Name: id, ParentID: "root-1"}).Error; err != nil {
+			t.Fatalf("seed child: %v", err)
+		}
+	}
+	if err := e.GrantObjectPermission(ownerID, "knowledge_network", "kn-1", "authorize"); err != nil {
+		t.Fatalf("grant authorize: %v", err)
+	}
+
+	w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments?parent_id=root-1", nil, ownerID)
+	var out struct {
+		Departments []map[string]any `json:"departments"`
+		Truncated   bool             `json:"truncated"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Departments) != ownerDirectoryMaxPageSize {
+		t.Fatalf("expected the cap to bite at %d, got %d rows", ownerDirectoryMaxPageSize, len(out.Departments))
+	}
+	if !out.Truncated {
+		t.Fatal("the branch was cut without saying so")
+	}
 }

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -130,6 +130,17 @@ func New(deps Deps) *gin.Engine {
 		}
 		registerUserAdmin(admin, deps.Users, deps.Enforcer, deps.Directory)
 		registerAdminReads(admin, deps.Directory, deps.Enforcer)
+		// Directory reads an object owner needs to name a grantee. Same prefix,
+		// weaker door: RequireAdminOrResourceOwner in place of RequireAdmin. Kept
+		// off the `admin` group because gin fixes a group's handler chain at
+		// register time — the relaxation has to be its own group or it would be
+		// no relaxation at all.
+		ownerDirectory := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(),
+			RequireAdminOrResourceOwner(verifier, deps.Enforcer))
+		if deps.Audit != nil {
+			ownerDirectory.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
+		}
+		registerOwnerVisibleDirectoryReads(ownerDirectory, deps.Directory, deps.Enforcer)
 		registerDeptAdmin(admin, deps.Directory, deps.Enforcer)
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -130,7 +130,8 @@
       "role_name": "network_builder",
       "resource_type": "catalog",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"]
+      "_note": "无 authorize:同 knowledge_network 的理由。casbin keyMatch 下 catalog:* 匹配任意目录,构建者会在别人建的目录上也拿到转授权,而 authorize 只能由管理员收回。创建者不受影响 —— vega 建目录时把 COMMON_OPERATIONS(含 authorize)写成 catalog:<id> 的对象授权。",
+      "operations": ["view_detail", "create", "modify", "delete", "task_manage", "resource_manage", "query_data"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -648,3 +648,58 @@ func TestNetworkBuilderCannotShareNetworksItDidNotCreate(t *testing.T) {
 		t.Error("the creator's object-level authorize must still decide sharing")
 	}
 }
+
+// The same rule as knowledge networks, arrived at the same way: a type-wide
+// `authorize` on catalog let every network_builder hand out a catalog somebody
+// else created, because casbin's keyMatch makes `catalog:*` match every id.
+// Observed on a live deployment — an account whose only role is network_builder
+// saw the share control on catalogs created by the administrator, and the write
+// behind it succeeded.
+//
+// The creator is unaffected: vega writes COMMON_OPERATIONS, `authorize`
+// included, as a `catalog:<id>` object grant at create time, and the owner
+// surface reads exactly that.
+func TestNetworkBuilderCannotShareCatalogsItDidNotCreate(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		builder = "u-builder"
+		catalog = "cat-someone-elses"
+	)
+	if err := e.AssignRole(builder, "1572fb82-526f-11f0-bde6-e674ec8dde71"); err != nil {
+		t.Fatal(err)
+	}
+
+	if ok, err := e.Check(builder, "catalog", catalog, "authorize"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Error("network_builder must not hold type-wide authorize on catalogs")
+	}
+
+	// Everything else the role needs to run the business plane stays.
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "task_manage", "resource_manage", "query_data"} {
+		ok, err := e.Check(builder, "catalog", catalog, op)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Errorf("network_builder lost %q on catalog", op)
+		}
+	}
+
+	// A catalog the builder created carries the grant on the instance instead.
+	if err := e.GrantObjectPermission(builder, "catalog", "cat-mine", "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := e.Check(builder, "catalog", "cat-mine", "authorize"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Error("the creator's own object grant must still authorize sharing")
+	}
+}


### PR DESCRIPTION
Backport of #1150 to `release/0.1.4`. Cherry-pick of a37240d4, clean; `bkn-safe/server/internal/httpapi` suite green on this base.

## Problem

The owner-facing authorization drawer needs `GET /admin/departments` and `GET /admin/users/:id` to name a grantee. Both sit behind `RequireAdmin`, and an owner holds `authorize` on one object and no admin capability — so both answered 403 and the console rendered an error toast over a working form.

## Change

Those reads move to a second group at the same prefix guarded by `RequireAdminOrResourceOwner`. Paths are unchanged, so the console calls one URL whoever is looking.

Ownership is read from `ListObjectGrants` rather than the enforcer: a `Check` answer folds in type-wide role grants, and the seeded `network_builder` role carries `authorize` on five types — honouring those would open the directory to the whole role rather than to people who actually created something. A lookup error refuses rather than passes.

An owner receives `id`, `account`, `name`, capped at 50 rows; the administrator's shape (email, telephone, roles, departments) is unchanged.

## Why this belongs on the release line

`release/0.1.4` already carries the owner-delegation half (#1135) and bkn-studio `release/0.1.4` carries the drawer (#509). Without this, that feature 403s on every deployment built from this line — which is what happens on 118.196.95.132 today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)