### PR TITLE
fix(context-loader): support MCP hosts that flatten lifecycle schemas

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -160,6 +160,11 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
 		},
 		{
+			name: "continue with empty conversation id", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue", "conversation_id": ""},
+			wantMessage: "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}",
+		},
+		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
 			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}",
@@ -173,6 +178,11 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 			name: "completed with empty interaction id", toolName: "bkn_finish_interaction",
 			args:        map[string]any{"interaction_id": "", "outcome": "completed", "answer": "库存充足"},
 			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+		{
+			name: "completed with empty answer", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "completed", "answer": ""},
+			wantMessage: "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -155,6 +155,11 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 			wantMessage: "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}",
 		},
 		{
+			name: "continue with empty question", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "", "agent_name": "供应链分析助手", "conversation_mode": "continue", "conversation_id": "conv-1"},
+			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+		},
+		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
 			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}",
@@ -163,6 +168,11 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 			name: "completed without answer", toolName: "bkn_finish_interaction",
 			args:        map[string]any{"interaction_id": "int-1", "outcome": "completed"},
 			wantMessage: "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}",
+		},
+		{
+			name: "completed with empty interaction id", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "", "outcome": "completed", "answer": "库存充足"},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -152,12 +152,17 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 		{
 			name: "continue without conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}",
 		},
 		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}",
+		},
+		{
+			name: "completed without answer", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "completed"},
+			wantMessage: "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}",
 		},
 		{
 			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -285,6 +285,21 @@ func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t
 	}
 }
 
+func TestLifecycleWireSchemasAvoidCompositionKeywords(t *testing.T) {
+	for _, tool := range []string{"bkn_start_interaction", "bkn_finish_interaction"} {
+		input, _ := loadToolSchemas(tool)
+		var schema map[string]any
+		if err := json.Unmarshal(input, &schema); err != nil {
+			t.Fatalf("decode %s input schema: %v", tool, err)
+		}
+		for _, keyword := range []string{"oneOf", "anyOf", "allOf", "if", "then", "else", "dependentRequired"} {
+			if _, found := schema[keyword]; found {
+				t.Fatalf("%s wire schema must not publish %s: %s", tool, keyword, input)
+			}
+		}
+	}
+}
+
 func TestLifecycleInputDescriptionsAreConciseAndActionable(t *testing.T) {
 	wantFields := map[string][]string{
 		"bkn_start_interaction":  {"conversation_id", "conversation_mode", "question", "agent_name"},

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -71,7 +71,7 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 				name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
 			)
 		}
-		return invalidLifecycleArguments(lifecycleSchemaArgumentGuidance(name))
+		return invalidLifecycleArguments(lifecycleSchemaArgumentGuidance(name, arguments))
 	}
 	if !validLifecycleFieldCombination(name, arguments) {
 		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
@@ -158,9 +158,15 @@ func lifecycleArgumentGuidance(name string, arguments map[string]any) string {
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }
 
-func lifecycleSchemaArgumentGuidance(name string) string {
+func lifecycleSchemaArgumentGuidance(name string, arguments map[string]any) string {
 	if name == "bkn_start_interaction" {
+		if arguments["conversation_mode"] == "continue" && arguments["conversation_id"] == "" {
+			return lifecycleArgumentGuidance(name, arguments)
+		}
 		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
+	}
+	if arguments["outcome"] == "completed" && arguments["answer"] == "" {
+		return lifecycleArgumentGuidance(name, arguments)
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -65,14 +65,37 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 	if !ok {
 		return nil
 	}
-	if err := schema.Validate(arguments); err == nil {
-		return nil
-	} else if fields := unsupportedLifecycleArgumentFields(err); len(fields) > 0 {
-		return invalidLifecycleArguments(
-			name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
-		)
+	if err := schema.Validate(arguments); err != nil {
+		if fields := unsupportedLifecycleArgumentFields(err); len(fields) > 0 {
+			return invalidLifecycleArguments(
+				name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
+			)
+		}
+		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
 	}
-	return invalidLifecycleArguments(lifecycleArgumentGuidance(name))
+	if !validLifecycleFieldCombination(name, arguments) {
+		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
+	}
+	return nil
+}
+
+func validLifecycleFieldCombination(name string, arguments map[string]any) bool {
+	switch name {
+	case "bkn_start_interaction":
+		_, hasConversationID := arguments["conversation_id"]
+		switch arguments["conversation_mode"] {
+		case "continue":
+			return hasConversationID
+		case "new":
+			return !hasConversationID
+		}
+	case "bkn_finish_interaction":
+		if arguments["outcome"] == "completed" {
+			answer, ok := arguments["answer"].(string)
+			return ok && answer != ""
+		}
+	}
+	return true
 }
 
 func unsupportedLifecycleArgumentFields(err error) []string {
@@ -117,9 +140,20 @@ func validFinishOutcome(value any) bool {
 	return slices.Contains(finishInteractionOutcomes, outcome)
 }
 
-func lifecycleArgumentGuidance(name string) string {
+func lifecycleArgumentGuidance(name string, arguments map[string]any) string {
 	if name == "bkn_start_interaction" {
+		switch arguments["conversation_mode"] {
+		case "continue":
+			return "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}"
+		case "new":
+			if _, hasConversationID := arguments["conversation_id"]; hasConversationID {
+				return "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}"
+			}
+		}
 		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
+	}
+	if name == "bkn_finish_interaction" && arguments["outcome"] == "completed" {
+		return "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -71,7 +71,7 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 				name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
 			)
 		}
-		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
+		return invalidLifecycleArguments(lifecycleSchemaArgumentGuidance(name))
 	}
 	if !validLifecycleFieldCombination(name, arguments) {
 		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
@@ -154,6 +154,13 @@ func lifecycleArgumentGuidance(name string, arguments map[string]any) string {
 	}
 	if name == "bkn_finish_interaction" && arguments["outcome"] == "completed" {
 		return "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
+	}
+	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
+}
+
+func lifecycleSchemaArgumentGuidance(name string) string {
+	if name == "bkn_start_interaction" {
+		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -143,23 +143,13 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 			"type": "string", "description": "Briefly explain a non-completed outcome.",
 		}
 	}
-	// Tool schemas are a byte-stable wire contract: the untouched declaration
-	// must remain identical to the embedded community schema.
+	// Lifecycle schemas cross an MCP host/function-calling boundary. Keep the
+	// published declaration flat: some hosts do not preserve JSON Schema
+	// composition when converting it to their local tool representation.
+	// Cross-field lifecycle rules are enforced by validateLifecycleArguments.
 	inputSchema := map[string]any{
 		"type": "object", "properties": properties, "required": required,
 		"additionalProperties": false,
-	}
-	switch toolKey {
-	case "bkn_start_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "continue"}}, "required": []string{"conversation_id"}},
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "new"}}, "not": map[string]any{"required": []string{"conversation_id"}}},
-		}
-	case "bkn_finish_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"outcome": map[string]any{"const": "completed"}}, "required": []string{"answer"}},
-			{"properties": map[string]any{"outcome": map[string]any{"enum": []string{"failed", "cancelled", "handed_off"}}}},
-		}
 	}
 	input, _ := sonic.ConfigStd.Marshal(inputSchema)
 	output, _ := sonic.ConfigStd.Marshal(lifecycleOutputSchema(toolKey))


### PR DESCRIPTION
## What Changed

- Flatten the public `bkn_start_interaction` and `bkn_finish_interaction` input schemas: retain properties, required fields, enums, length checks, and `additionalProperties: false`; remove composition keywords.
- Enforce lifecycle field combinations in server validation: `continue` requires `conversation_id`, `new` omits it, and `completed` requires a non-empty `answer`.
- Return actionable `invalid_params` guidance with a correct call example for each cross-field error.
- Add regression coverage that the published wire schemas contain no composition keywords and that invalid calls never reach Trace Core.

## Why

Some MCP hosts destructively flatten root `oneOf` before their local tool-argument validation. They then reject a valid `new` start call because `question` and `agent_name` are incorrectly treated as additional properties. The request never reaches ContextLoader. This keeps the wire schema portable while preserving the lifecycle contract server-side.

## How

No public lifecycle behavior changes. Cross-field rules previously expressed using JSON Schema `oneOf` are enforced explicitly after generic schema validation.

## Testing

- [x] `make test`
- [x] `go test ./server/driveradapters/mcp -count=1`
- [x] `go vet ./server/driveradapters/mcp`
- [x] `git diff --check`

## Risk & Rollback

- Risk: an integration relying on introspecting `oneOf` will no longer see those conditional rules in the wire schema; the tool descriptions and recoverable validation errors remain the contract.
- Rollback: revert commit `f18faa553`.

## Additional Notes

This PR targets `release/0.1.4` and is intentionally not merged by this change.