### PR TITLE
fix(context-loader): flatten lifecycle MCP schemas for host compatibility (main)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -152,12 +152,44 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 		{
 			name: "continue without conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue"},
+			wantMessage: "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}",
+		},
+		{
+			name: "continue with empty question", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "", "agent_name": "供应链分析助手", "conversation_mode": "continue", "conversation_id": "conv-1"},
 			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+		},
+		{
+			name: "continue with empty conversation id", toolName: "bkn_start_interaction",
+			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "continue", "conversation_id": ""},
+			wantMessage: "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}",
 		},
 		{
 			name: "new with conversation id", toolName: "bkn_start_interaction",
 			args:        map[string]any{"question": "查询库存", "agent_name": "供应链分析助手", "conversation_mode": "new", "conversation_id": "conv-1"},
-			wantMessage: "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it",
+			wantMessage: "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}",
+		},
+		{
+			name: "completed without answer", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "completed"},
+			wantMessage: "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}",
+		},
+		{
+			name: "completed with empty interaction id", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "", "outcome": "completed", "answer": "库存充足"},
+			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+		},
+		{
+			name: "completed with empty answer", toolName: "bkn_finish_interaction",
+			args:        map[string]any{"interaction_id": "int-1", "outcome": "completed", "answer": ""},
+			wantMessage: "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}",
+		},
+		{
+			name: "start with unsupported lease seconds", toolName: "bkn_start_interaction",
+			args: map[string]any{
+				"question": "查询库存", "agent_name": "供应链分析助手", "lease_seconds": 600,
+			},
+			wantMessage: "bkn_start_interaction received unsupported field(s): lease_seconds. Remove them and retry",
 		},
 		{
 			name: "finish with lifecycle IDs nested in bkn context", toolName: "bkn_finish_interaction",
@@ -185,7 +217,7 @@ func TestLifecycleToolsRejectInvalidArgumentsBeforeCallingCore(t *testing.T) {
 				"interaction_id": "int-1", "outcome": "completed", "answer": "库存充足",
 				"claims": []any{map[string]any{"claim_id": "caller-owned"}},
 			},
-			wantMessage: "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise",
+			wantMessage: "bkn_finish_interaction received unsupported field(s): claims. Remove them and retry",
 		},
 	}
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_schema_test.go
@@ -285,6 +285,21 @@ func TestLifecycleSchemasRequireAnExplicitConversationChoiceAndCompletedAnswer(t
 	}
 }
 
+func TestLifecycleWireSchemasAvoidCompositionKeywords(t *testing.T) {
+	for _, tool := range []string{"bkn_start_interaction", "bkn_finish_interaction"} {
+		input, _ := loadToolSchemas(tool)
+		var schema map[string]any
+		if err := json.Unmarshal(input, &schema); err != nil {
+			t.Fatalf("decode %s input schema: %v", tool, err)
+		}
+		for _, keyword := range []string{"oneOf", "anyOf", "allOf", "if", "then", "else", "dependentRequired"} {
+			if _, found := schema[keyword]; found {
+				t.Fatalf("%s wire schema must not publish %s: %s", tool, keyword, input)
+			}
+		}
+	}
+}
+
 func TestLifecycleInputDescriptionsAreConciseAndActionable(t *testing.T) {
 	wantFields := map[string][]string{
 		"bkn_start_interaction":  {"conversation_id", "conversation_mode", "question", "agent_name"},

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_validation.go
@@ -17,11 +17,13 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/santhosh-tekuri/jsonschema/v6/kind"
 )
 
 var lifecycleArgumentSchemas = sync.OnceValue(func() map[string]*jsonschema.Schema {
@@ -63,10 +65,63 @@ func validateLifecycleArguments(name string, arguments map[string]any) *lifecycl
 	if !ok {
 		return nil
 	}
-	if err := schema.Validate(arguments); err == nil {
+	if err := schema.Validate(arguments); err != nil {
+		if fields := unsupportedLifecycleArgumentFields(err); len(fields) > 0 {
+			return invalidLifecycleArguments(
+				name + " received unsupported field(s): " + strings.Join(fields, ", ") + ". Remove them and retry",
+			)
+		}
+		return invalidLifecycleArguments(lifecycleSchemaArgumentGuidance(name, arguments))
+	}
+	if !validLifecycleFieldCombination(name, arguments) {
+		return invalidLifecycleArguments(lifecycleArgumentGuidance(name, arguments))
+	}
+	return nil
+}
+
+func validLifecycleFieldCombination(name string, arguments map[string]any) bool {
+	switch name {
+	case "bkn_start_interaction":
+		_, hasConversationID := arguments["conversation_id"]
+		switch arguments["conversation_mode"] {
+		case "continue":
+			return hasConversationID
+		case "new":
+			return !hasConversationID
+		}
+	case "bkn_finish_interaction":
+		if arguments["outcome"] == "completed" {
+			answer, ok := arguments["answer"].(string)
+			return ok && answer != ""
+		}
+	}
+	return true
+}
+
+func unsupportedLifecycleArgumentFields(err error) []string {
+	var root *jsonschema.ValidationError
+	if !errors.As(err, &root) {
 		return nil
 	}
-	return invalidLifecycleArguments(lifecycleArgumentGuidance(name))
+	fields := make(map[string]struct{})
+	var visit func(*jsonschema.ValidationError)
+	visit = func(validationErr *jsonschema.ValidationError) {
+		if additional, ok := validationErr.ErrorKind.(*kind.AdditionalProperties); ok {
+			for _, field := range additional.Properties {
+				fields[field] = struct{}{}
+			}
+		}
+		for _, cause := range validationErr.Causes {
+			visit(cause)
+		}
+	}
+	visit(root)
+	result := make([]string, 0, len(fields))
+	for field := range fields {
+		result = append(result, field)
+	}
+	slices.Sort(result)
+	return result
 }
 
 func invalidLifecycleArguments(message string) *lifecycleError {
@@ -85,9 +140,33 @@ func validFinishOutcome(value any) bool {
 	return slices.Contains(finishInteractionOutcomes, outcome)
 }
 
-func lifecycleArgumentGuidance(name string) string {
+func lifecycleArgumentGuidance(name string, arguments map[string]any) string {
 	if name == "bkn_start_interaction" {
+		switch arguments["conversation_mode"] {
+		case "continue":
+			return "bkn_start_interaction with conversation_mode=continue requires a non-empty conversation_id returned by the previous start call. Example: {\"conversation_mode\":\"continue\",\"question\":\"...\",\"agent_name\":\"...\",\"conversation_id\":\"conv_...\"}"
+		case "new":
+			if _, hasConversationID := arguments["conversation_id"]; hasConversationID {
+				return "bkn_start_interaction with conversation_mode=new must omit conversation_id. Example: {\"conversation_mode\":\"new\",\"question\":\"...\",\"agent_name\":\"...\"}"
+			}
+		}
 		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
+	}
+	if name == "bkn_finish_interaction" && arguments["outcome"] == "completed" {
+		return "bkn_finish_interaction with outcome=completed requires a non-empty answer. Example: {\"interaction_id\":\"int_...\",\"outcome\":\"completed\",\"answer\":\"...\"}"
+	}
+	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
+}
+
+func lifecycleSchemaArgumentGuidance(name string, arguments map[string]any) string {
+	if name == "bkn_start_interaction" {
+		if arguments["conversation_mode"] == "continue" && arguments["conversation_id"] == "" {
+			return lifecycleArgumentGuidance(name, arguments)
+		}
+		return "bkn_start_interaction expects top-level agent_name, question, and conversation_mode; use continue with conversation_id or new without it"
+	}
+	if arguments["outcome"] == "completed" && arguments["answer"] == "" {
+		return lifecycleArgumentGuidance(name, arguments)
 	}
 	return "bkn_finish_interaction expects top-level interaction_id and outcome, plus answer for completed or optional reason otherwise"
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -143,23 +143,13 @@ func lifecycleToolSchemas(toolKey string) (json.RawMessage, json.RawMessage, boo
 			"type": "string", "description": "Briefly explain a non-completed outcome.",
 		}
 	}
-	// Tool schemas are a byte-stable wire contract: the untouched declaration
-	// must remain identical to the embedded community schema.
+	// Lifecycle schemas cross an MCP host/function-calling boundary. Keep the
+	// published declaration flat: some hosts do not preserve JSON Schema
+	// composition when converting it to their local tool representation.
+	// Cross-field lifecycle rules are enforced by validateLifecycleArguments.
 	inputSchema := map[string]any{
 		"type": "object", "properties": properties, "required": required,
 		"additionalProperties": false,
-	}
-	switch toolKey {
-	case "bkn_start_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "continue"}}, "required": []string{"conversation_id"}},
-			{"properties": map[string]any{"conversation_mode": map[string]any{"const": "new"}}, "not": map[string]any{"required": []string{"conversation_id"}}},
-		}
-	case "bkn_finish_interaction":
-		inputSchema["oneOf"] = []map[string]any{
-			{"properties": map[string]any{"outcome": map[string]any{"const": "completed"}}, "required": []string{"answer"}},
-			{"properties": map[string]any{"outcome": map[string]any{"enum": []string{"failed", "cancelled", "handed_off"}}}},
-		}
 	}
 	input, _ := sonic.ConfigStd.Marshal(inputSchema)
 	output, _ := sonic.ConfigStd.Marshal(lifecycleOutputSchema(toolKey))


### PR DESCRIPTION
## What Changed

Port of #1156 (base `release/0.1.4`) to `main`.

- Flatten the published `bkn_start_interaction` and `bkn_finish_interaction` input schemas: properties, required fields, enums, length bounds and `additionalProperties: false` all stay; only the composition keywords go.
- Enforce the cross-field rules in server validation instead: `continue` requires `conversation_id`, `new` omits it, `completed` requires a non-empty `answer`.
- Carry the unsupported-field guidance that landed on `release/0.1.4` but never reached `main`, so the two lines are identical on this surface.
- Regression coverage: the published wire schemas carry no composition keyword, and invalid calls still never reach Trace Core.

## Why

Some MCP hosts destructively flatten a root `oneOf` before running their own tool-argument validation — a branch's `properties` replaces the root's, every sibling field then reads as an additional property, and a schema-legal `new` start call is rejected inside the host. The request never reaches ContextLoader.

Verified on the test server (`agent-retrieval:0.1.4-release`, same image as the reporting deployment):

- The published schema does carry `oneOf` alongside `additionalProperties: false`.
- The same arguments succeed through three clients that do not flatten destructively (CLI, raw JSON-RPC over HTTP, and an MCP host that drops `oneOf` while keeping the root properties), so the server itself is healthy.
- Replaying the flattening locally against the same schema reproduces the reported `root: must not have additional properties`, naming `question` and `agent_name`.

#1156 fixes the 0.1.4 line. Without this port, `main` still ships the defect and the next line cut from it reintroduces the outage.

## How

No public lifecycle behavior changes. The rules previously expressed with JSON Schema `oneOf` are enforced explicitly after generic schema validation, and the field descriptions continue to state them for the model.

## Testing

- [x] `go test ./server/driveradapters/mcp -count=1`
- [x] `go vet ./server/driveradapters/mcp`
- [x] `gofmt -l`

## Risk & Rollback

- Risk: an integration introspecting `oneOf` no longer sees those conditional rules in the wire schema; the descriptions and the recoverable `invalid_params` errors remain the contract.
- Rollback: revert this commit; `release/0.1.4` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)