### PR TITLE
fix(deploy): add 0.1.4 release manifests

### DIFF
--- a/deploy/release-manifests/0.1.4/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.4/bkn-foundry.yaml
@@ -1,0 +1,58 @@
+# Release lockfile for bkn-foundry 0.1.4 — pins the chart version of every
+# component that makes up the product. Consumed by:
+#     deploy.sh openbkn install --version=0.1.4
+# All charts are published at 0.1.4 by the v0.1.4 tag build.
+apiVersion: deploy.openbkn.ai/v0.1.4
+kind: VersionSet
+product: bkn-foundry
+version: 0.1.4
+source:
+  type: oci
+  registry: oci://ghcr.io/openbkn-ai/charts
+releases:
+  core-data-migrator:
+    chart: core-data-migrator
+    version: 0.1.4
+    stage: pre
+  bkn-safe:
+    chart: bkn-safe
+    version: 0.1.4
+  mf-model-manager:
+    chart: mf-model-manager
+    version: 0.1.4
+  mf-model-api:
+    chart: mf-model-api
+    version: 0.1.4
+  vega-backend:
+    chart: vega-backend
+    version: 0.1.4
+  bkn-backend:
+    chart: bkn-backend
+    version: 0.1.4
+  ontology-query:
+    chart: ontology-query
+    version: 0.1.4
+  agent-operator-integration:
+    chart: agent-operator-integration
+    version: 0.1.4
+  oss-gateway-backend:
+    chart: oss-gateway-backend
+    version: 0.1.4
+  sandbox:
+    chart: sandbox
+    version: 0.1.4
+  agent-retrieval:
+    chart: agent-retrieval
+    version: 0.1.4
+  bkn-agent:
+    chart: bkn-agent
+    version: 0.1.4
+  agent-observability:
+    chart: agent-observability
+    version: 0.1.4
+  otelcol-contrib:
+    chart: otelcol-contrib
+    version: 0.1.4
+  bkn-studio:
+    chart: bkn-studio
+    version: 0.1.4


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add deploy/release-manifests/0.1.4/bkn-foundry.yaml from the v0.1.4 tag to main
- [x] Change all component versions from 0.1.4-release to 0.1.4

---

## Why

Make the 0.1.4 release manifest available on the main branch and align chart versions with the published 0.1.4 artifacts.

---

## How

- Copied the manifest from the v0.1.4 tag
- Replaced 15 component version values
- No API, database, or runtime code changes

---

## Testing

- [x] Verified the copied file matches v0.1.4 except for the requested version replacements
- [x] Verified no 0.1.4-release values remain

Test notes: Manifest-only change; no runtime tests required.

---

## Risk & Rollback

- Potential risks: Incorrect chart version resolution during 0.1.4 deployment
- Rollback plan: Revert this commit

---

## Additional Notes

The commit is signed with the configured SSH signing key.