### PR TITLE
fix(execution-factory): rebuild Skill dataset with embedding model ID

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/mf_model_external_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/mf_model_external_test.go
@@ -33,7 +33,7 @@ func TestGetEmbeddingModel(t *testing.T) {
 		Convey("parses embedding model from res list", func() {
 			httpClient.EXPECT().Get(gomock.Any(), "http://mf-model-manage:9898/api/private/mf-model-manage/v1/small-model/list",
 				gomock.Any(), map[string]string{
-					"Content-Type":  "application/json",
+					"Content-Type":   "application/json",
 					"x-account-id":   "acc-1",
 					"x-account-type": "user",
 				}).

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend.go
@@ -212,6 +212,22 @@ func (v *vegaBackendClient) CreateResource(ctx context.Context, req *interfaces.
 	return resource, nil
 }
 
+// DeleteResource deletes a Vega resource before a rebuild.
+func (v *vegaBackendClient) DeleteResource(ctx context.Context, id string) error {
+	src := fmt.Sprintf("%s/v1/resources/%s?ignore_missing=true", v.baseURL, url.PathEscape(id))
+	headers := v.buildHeaders(ctx)
+	v.logger.WithContext(ctx).Infof("delete vega resource, resource_id=%s, url=%s", id, src)
+	respCode, respData, err := v.httpClient.DeleteNoUnmarshal(ctx, src, headers)
+	if err != nil {
+		v.logger.WithContext(ctx).Errorf("failed to delete vega resource, resource_id=%s, url=%s, err=%v", id, src, err)
+		return err
+	}
+	if respCode != http.StatusNoContent && respCode != http.StatusOK {
+		return fmt.Errorf("delete resource failed: %s", string(respData))
+	}
+	return nil
+}
+
 func (v *vegaBackendClient) WriteDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error {
 	src := fmt.Sprintf("%s/v1/resources/%s/data", v.baseURL, url.PathEscape(datasetID))
 	headers := v.buildHeaders(ctx)

--- a/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/vega_backend_test.go
@@ -29,7 +29,7 @@ func TestVegaBackendClient(t *testing.T) {
 			AccountType: interfaces.AccessorTypeUser,
 		})
 		headers := map[string]string{
-			"Content-Type":  "application/json",
+			"Content-Type":   "application/json",
 			"x-account-id":   "acc-1",
 			"x-account-type": "user",
 		}
@@ -113,12 +113,19 @@ func TestVegaBackendClient(t *testing.T) {
 			So(resp.ID, ShouldEqual, "bkn_execution_factory_skill_dataset")
 		})
 
+		Convey("deletes a resource before rebuild", func() {
+			httpClient.EXPECT().DeleteNoUnmarshal(gomock.Any(), "http://vega-backend:9898/api/vega-backend/v1/resources/bkn_execution_factory_skill_dataset?ignore_missing=true", headers).
+				Return(http.StatusNoContent, []byte{}, nil)
+
+			So(client.DeleteResource(ctx, "bkn_execution_factory_skill_dataset"), ShouldBeNil)
+		})
+
 		Convey("writes dataset documents", func() {
 			docs := []map[string]any{
 				{"_id": "skill-1", "skill_id": "skill-1", "name": "demo"},
 			}
 			writeHeaders := map[string]string{
-				"Content-Type":            "application/json",
+				"Content-Type":           "application/json",
 				"x-account-id":           "acc-1",
 				"x-account-type":         "user",
 				"X-HTTP-Method-Override": "POST",

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -928,6 +928,7 @@ type VegaBackendClient interface {
 	EnableCatalog(ctx context.Context, id string) error
 	GetResourceByID(ctx context.Context, id string) (*VegaResource, error)
 	CreateResource(ctx context.Context, req *VegaResourceRequest) (*VegaResource, error)
+	DeleteResource(ctx context.Context, id string) error
 	WriteDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error
 	UpdateDatasetDocuments(ctx context.Context, datasetID string, documents []map[string]any) error
 	DeleteDatasetDocumentByID(ctx context.Context, datasetID string, docID string) error

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/dbaccess"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/drivenadapters"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
@@ -26,29 +27,26 @@ const (
 	internalCatalogTag = "internal"
 	// vegaMaxTags is aligned with vega's TAGS_MAX_NUMBER (exceeding 400)
 	vegaMaxTags = 5
-	// embeddingModelConfigKey is the model key in the vector feature config. For read only: once put the model.
-	// The snapshot is written here, but vega will copy the feature config of the vector attribute into OpenSearch as it is.
-	// knn_vector mapping, OpenSearch rejected it with unknown parameter, and the index could not be built.
-	// The write path uses resource-level index_config.default_embedding_model instead.
-	embeddingModelConfigKey = "embedding_model"
-	// embeddingModelTagPrefix is the old vector (resource tag) of this snapshot. Vega's tag verification is disabled.
-	// ':', a dataset creation request with this tag will result in 400, so only the read path is retained to be compatible with the old dataset.
-	embeddingModelTagPrefix = "embedding_model:"
 )
 
 type skillIndexSync struct {
 	modelManager interfaces.MFModelManager
 	modelAPI     interfaces.MFModelAPIClient
 	vegaClient   interfaces.VegaBackendClient
+	skillRepo    model.ISkillRepository
+	releaseRepo  model.ISkillReleaseDB
 	logger       interfaces.Logger
 	mu           sync.RWMutex
 	initialized  bool
 	// datasetID is the dataset ID actually used by this process; an empty value means it has not been parsed yet, and the default value is used.
 	datasetID string
-	// embeddingModelName The embedding model name locked when the system skill dataset is built (system default snapshot),
-	// Protected by mu; upsert reads back the vector it generates, rather than re-fetching the current default each time.
+	// embeddingModelName is the model name accepted by the embeddings API. It must not be replaced by embeddingModelID.
+	// It is protected by mu; upsert uses this build-time snapshot instead of re-fetching the current default.
 	embeddingModelName string
-	retryOnce          sync.Once
+	// restorePending makes the in-process retry rebuild and restore again after a
+	// partial restore failure, instead of accepting the newly-created empty index.
+	restorePending bool
+	retryOnce      sync.Once
 }
 
 var (
@@ -59,12 +57,15 @@ var (
 func NewSkillIndexSyncService() interfaces.SkillIndexSyncService {
 	ssOnce.Do(func() {
 		conf := config.NewConfigLoader()
-		ssInstance = &skillIndexSync{
+		syncer := &skillIndexSync{
 			modelManager: drivenadapters.NewMFModelManager(),
 			modelAPI:     drivenadapters.NewMFModelAPIClient(),
 			vegaClient:   drivenadapters.NewVegaBackendClient(),
+			skillRepo:    dbaccess.NewSkillRepositoryDB(),
+			releaseRepo:  dbaccess.NewSkillReleaseDB(),
 			logger:       conf.GetLogger(),
 		}
+		ssInstance = syncer
 	})
 	return ssInstance
 }
@@ -109,32 +110,45 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 		if err := s.ensureDatasetCatalogEnabled(ctx, resource, catalogID); err != nil {
 			return err
 		}
-		// The dataset already exists: read back the model name locked during creation (model building == model query).
-		// The old dataset is trapped in both forms, and when neither can be retrieved, it falls back to the name "embedding", which is consistent with the behavior before the transformation.
-		modelName := extractEmbeddingModelFromIndexConfig(resource.IndexConfig)
-		if modelName == "" {
-			modelName = extractEmbeddingModelFromSchema(resource.SchemaDefinition)
+		embeddingModel, err := s.resolveBuildEmbeddingModel(ctx)
+		if err != nil {
+			return err
 		}
-		if modelName == "" {
-			modelName = extractEmbeddingModelFromTags(resource.Tags)
+		s.setEmbeddingModel(embeddingModel)
+		if s.isRestorePending() || !sameSkillDatasetDefinition(resource, embeddingModel) {
+			if err := s.rebuildSkillDatasetResource(ctx, datasetID, resource.CatalogID, embeddingModel); err != nil {
+				return err
+			}
 		}
-		if modelName == "" {
-			modelName = interfaces.SmallModelTypeEmbedding
-		}
-		s.setEmbeddingModelName(modelName)
 		initialized = true
-		s.logger.WithContext(ctx).Infof("resource already exists, resource_id=%s, embedding_model=%s", datasetID, modelName)
+		s.logger.WithContext(ctx).Infof("resource already exists, resource_id=%s, embedding_model_id=%s, embedding_model_name=%s", datasetID, embeddingModel.ModelID, embeddingModel.ModelName)
 		return nil
 	}
+
 	// When creating a dataset for the first time: use the system default embedding model (interface configurable); if the default is not configured, it will fall back to the name "embedding".
 	embeddingModel, err := s.resolveBuildEmbeddingModel(ctx)
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("resolve embedding model failed, resource_id=%s, err=%v", datasetID, err)
 		return err
 	}
-	s.logger.WithContext(ctx).Infof("creating skill dataset resource, resource_id=%s, catalog_id=%s, embedding_model=%s, dimension=%d",
-		datasetID, catalogID, embeddingModel.ModelName, embeddingModel.EmbeddingDim)
-	_, err = s.vegaClient.CreateResource(ctx, &interfaces.VegaResourceRequest{
+	s.logger.WithContext(ctx).Infof("creating skill dataset resource, resource_id=%s, catalog_id=%s, embedding_model_id=%s, embedding_model_name=%s, dimension=%d",
+		datasetID, catalogID, embeddingModel.ModelID, embeddingModel.ModelName, embeddingModel.EmbeddingDim)
+	s.setEmbeddingModel(embeddingModel)
+	if err := s.createSkillDatasetResource(ctx, datasetID, catalogID, embeddingModel); err != nil {
+		s.logger.WithContext(ctx).Errorf("create skill dataset resource failed, resource_id=%s, err=%v", datasetID, err)
+		return err
+	}
+	if err := s.restoreSkillDatasetFromSource(ctx); err != nil {
+		s.setRestorePending(true)
+		return fmt.Errorf("restore skill dataset after creating missing resource: %w", err)
+	}
+	s.setRestorePending(false)
+	initialized = true
+	return nil
+}
+
+func (s *skillIndexSync) createSkillDatasetResource(ctx context.Context, datasetID, catalogID string, embeddingModel *interfaces.EmbeddingModel) error {
+	_, err := s.vegaClient.CreateResource(ctx, &interfaces.VegaResourceRequest{
 		ID:               datasetID,
 		CatalogID:        catalogID,
 		Name:             datasetID,
@@ -144,18 +158,12 @@ func (s *skillIndexSync) Init(ctx context.Context) (err error) {
 		Status:           executionFactoryDatasetStatus,
 		SourceIdentifier: datasetID,
 		SchemaDefinition: buildSkillIndexSchema(embeddingModel.EmbeddingDim),
-		// The model name locked at build time is snapshotted into the resource level index_config: vega. Use it when parsing the vector model.
+		// Vega validates the resource-level index_config as a model ID. The embeddings API name remains in memory only.
 		// And it does not enter OpenSearch mapping. You can't put tags (vega tag verification prohibits ':', which will result in 400), and you can't.
 		// Feature config with vector attributes (will be copied into knn_vector mapping, rejected by OpenSearch).
-		IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: embeddingModel.ModelName},
+		IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: embeddingModel.ModelID},
 	})
-	if err != nil {
-		s.logger.WithContext(ctx).Errorf("create skill dataset resource failed, resource_id=%s, err=%v", datasetID, err)
-		return err
-	}
-	s.setEmbeddingModelName(embeddingModel.ModelName)
-	initialized = true
-	return nil
+	return err
 }
 
 // ensureCatalog parses and ensures the existence of the built-in catalog and returns the catalog ID actually used by this process.
@@ -287,45 +295,199 @@ func (s *skillIndexSync) resolveBuildEmbeddingModel(ctx context.Context) (*inter
 	model, err := s.modelManager.GetDefaultEmbeddingModel(ctx, interfaces.SmallModelTypeEmbedding)
 	if err != nil {
 		s.logger.WithContext(ctx).Warnf("get default embedding model failed, fallback to named '%s': %v", interfaces.SmallModelTypeEmbedding, err)
-	} else if model != nil && model.EmbeddingDim > 0 {
-		return model, nil
+	} else if model != nil {
+		return validateEmbeddingModel(model)
 	}
-	return s.modelManager.GetEmbeddingModel(ctx, interfaces.SmallModelTypeEmbedding, interfaces.SmallModelTypeEmbedding)
+	model, err = s.modelManager.GetEmbeddingModel(ctx, interfaces.SmallModelTypeEmbedding, interfaces.SmallModelTypeEmbedding)
+	if err != nil {
+		return nil, err
+	}
+	return validateEmbeddingModel(model)
 }
 
-// extractEmbeddingModelFromIndexConfig reads back the model name locked at build time from resource-level index_config (current writing method)
-func extractEmbeddingModelFromIndexConfig(indexConfig *interfaces.VegaResourceIndexConfig) string {
+func validateEmbeddingModel(model *interfaces.EmbeddingModel) (*interfaces.EmbeddingModel, error) {
+	if model == nil {
+		return nil, fmt.Errorf("embedding model is required")
+	}
+	if strings.TrimSpace(model.ModelID) == "" {
+		return nil, fmt.Errorf("embedding model ID is required")
+	}
+	if strings.TrimSpace(model.ModelName) == "" {
+		return nil, fmt.Errorf("embedding model name is required")
+	}
+	if model.EmbeddingDim <= 0 {
+		return nil, fmt.Errorf("embedding model dimension must be positive")
+	}
+	return model, nil
+}
+
+func sameDefaultEmbeddingModel(indexConfig *interfaces.VegaResourceIndexConfig, expectedModelID string) bool {
 	if indexConfig == nil {
-		return ""
+		return expectedModelID == ""
 	}
-	return indexConfig.DefaultEmbeddingModel
+	return indexConfig.DefaultEmbeddingModel == expectedModelID
 }
 
-// extractEmbeddingModelFromSchema reads back the model name from the vector feature's config.embedding_model.
-// It only serves the dataset that has been written to this location briefly. When creating a new dataset, the model name will no longer be written into the schema.
-func extractEmbeddingModelFromSchema(schema []interfaces.VegaProperty) string {
-	for _, property := range schema {
-		for _, feature := range property.Features {
-			if feature.FeatureType != "vector" || feature.Config == nil {
-				continue
+// sameSkillDatasetDefinition compares the managed dataset definition rather than
+// only its embedding model reference. Property and feature order are not
+// semantically meaningful in Vega, so schema comparison is name based.
+func sameSkillDatasetDefinition(resource *interfaces.VegaResource, embeddingModel *interfaces.EmbeddingModel) bool {
+	if resource == nil || embeddingModel == nil {
+		return false
+	}
+	return sameSkillIndexSchema(buildSkillIndexSchema(embeddingModel.EmbeddingDim), resource.SchemaDefinition) &&
+		sameDefaultEmbeddingModel(resource.IndexConfig, embeddingModel.ModelID)
+}
+
+func sameSkillIndexSchema(expected, actual []interfaces.VegaProperty) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+	actualByName := make(map[string]interfaces.VegaProperty, len(actual))
+	for _, property := range actual {
+		actualByName[property.Name] = property
+	}
+	for _, expectedProperty := range expected {
+		actualProperty, ok := actualByName[expectedProperty.Name]
+		if !ok || !sameSkillIndexProperty(expectedProperty, actualProperty) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameSkillIndexProperty(expected, actual interfaces.VegaProperty) bool {
+	if expected.Name != actual.Name ||
+		expected.Type != actual.Type ||
+		expected.DisplayName != actual.DisplayName ||
+		expected.OriginalName != actual.OriginalName ||
+		expected.Description != actual.Description ||
+		len(expected.Features) != len(actual.Features) {
+		return false
+	}
+	actualFeaturesByName := make(map[string]interfaces.VegaPropertyFeature, len(actual.Features))
+	for _, feature := range actual.Features {
+		actualFeaturesByName[feature.Name] = feature
+	}
+	for _, expectedFeature := range expected.Features {
+		actualFeature, ok := actualFeaturesByName[expectedFeature.Name]
+		if !ok || !sameSkillIndexFeature(expectedFeature, actualFeature) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameSkillIndexFeature(expected, actual interfaces.VegaPropertyFeature) bool {
+	if expected.Name != actual.Name ||
+		expected.DisplayName != actual.DisplayName ||
+		expected.FeatureType != actual.FeatureType ||
+		expected.Description != actual.Description ||
+		expected.RefProperty != actual.RefProperty ||
+		expected.IsDefault != actual.IsDefault ||
+		expected.IsNative != actual.IsNative ||
+		len(expected.Config) != len(actual.Config) {
+		return false
+	}
+	for key, expectedValue := range expected.Config {
+		actualValue, ok := actual.Config[key]
+		if !ok || fmt.Sprintf("%v", expectedValue) != fmt.Sprintf("%v", actualValue) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *skillIndexSync) rebuildSkillDatasetResource(ctx context.Context, datasetID, catalogID string, embeddingModel *interfaces.EmbeddingModel) error {
+	// Preserve the restore intent before deletion. If creation subsequently fails,
+	// the next Init observes a missing resource and restores it after creation.
+	s.setRestorePending(true)
+	if err := s.vegaClient.DeleteResource(ctx, datasetID); err != nil {
+		return fmt.Errorf("delete legacy skill dataset before rebuild: %w", err)
+	}
+	if catalogID == "" {
+		catalogID = executionFactoryCatalogID
+	}
+	if err := s.createSkillDatasetResource(ctx, datasetID, catalogID, embeddingModel); err != nil {
+		return fmt.Errorf("recreate skill dataset with embedding model ID %q: %w", embeddingModel.ModelID, err)
+	}
+	if err := s.restoreSkillDatasetFromSource(ctx); err != nil {
+		s.setRestorePending(true)
+		return fmt.Errorf("restore skill dataset after rebuild: %w", err)
+	}
+	s.setRestorePending(false)
+	s.logger.WithContext(ctx).Infof("rebuilt skill dataset with embedding model ID, resource_id=%s, catalog_id=%s, model_id=%s", datasetID, catalogID, embeddingModel.ModelID)
+	return nil
+}
+
+// restoreSkillDatasetFromSource repopulates a recreated dataset from the Skill
+// repository. Published Skills use their release snapshot when available;
+// editing Skills are indexed only when a published snapshot still exists.
+func (s *skillIndexSync) restoreSkillDatasetFromSource(ctx context.Context) error {
+	if s.skillRepo == nil || s.releaseRepo == nil {
+		return fmt.Errorf("skill repositories are required to restore the skill dataset")
+	}
+	var cursorUpdateTime int64
+	var cursorSkillID string
+	for {
+		skills, err := s.skillRepo.SelectSkillBuildPage(ctx, nil, cursorUpdateTime, cursorSkillID, skillIndexBuildBatchSize)
+		if err != nil {
+			return err
+		}
+		if len(skills) == 0 {
+			return nil
+		}
+		documents := make([]map[string]any, 0, len(skills))
+		for _, skill := range skills {
+			if skill == nil {
+				return fmt.Errorf("skill index restore received nil skill")
 			}
-			if name, ok := feature.Config[embeddingModelConfigKey].(string); ok && name != "" {
-				return name
+			payload, err := s.skillIndexPayload(ctx, skill)
+			if err != nil {
+				return fmt.Errorf("resolve skill %s for index restore: %w", skill.SkillID, err)
+			}
+			if payload != nil {
+				document, err := s.buildSkillDocument(ctx, payload)
+				if err != nil {
+					return fmt.Errorf("build skill %s document for index restore: %w", skill.SkillID, err)
+				}
+				documents = append(documents, document)
+			}
+			cursorUpdateTime = skill.UpdateTime
+			cursorSkillID = skill.SkillID
+		}
+		if len(documents) > 0 {
+			if err := s.vegaClient.WriteDatasetDocuments(ctx, s.getDatasetID(), documents); err != nil {
+				return fmt.Errorf("write %d skill documents for index restore: %w", len(documents), err)
 			}
 		}
 	}
-	return ""
 }
 
-// extractEmbeddingModelFromTags parses the build-time locked embedding model names from resource tags.
-// It only serves the old dataset created during the tag snapshot period, and the new dataset will no longer write this tag.
-func extractEmbeddingModelFromTags(tags []string) string {
-	for _, t := range tags {
-		if strings.HasPrefix(t, embeddingModelTagPrefix) {
-			return strings.TrimPrefix(t, embeddingModelTagPrefix)
+func (s *skillIndexSync) skillIndexPayload(ctx context.Context, skill *model.SkillRepositoryDB) (*model.SkillRepositoryDB, error) {
+	if skill.IsDeleted {
+		return nil, nil
+	}
+	switch interfaces.BizStatus(skill.Status) {
+	case interfaces.BizStatusPublished:
+		release, err := s.releaseRepo.SelectBySkillID(ctx, nil, skill.SkillID)
+		if err != nil {
+			return nil, err
+		}
+		if release != nil {
+			return releaseToSkillRepository(release), nil
+		}
+		return skill, nil
+	case interfaces.BizStatusEditing:
+		release, err := s.releaseRepo.SelectBySkillID(ctx, nil, skill.SkillID)
+		if err != nil {
+			return nil, err
+		}
+		if release != nil {
+			return releaseToSkillRepository(release), nil
 		}
 	}
-	return ""
+	return nil, nil
 }
 
 func (s *skillIndexSync) getEmbeddingModelName() string {
@@ -337,10 +499,22 @@ func (s *skillIndexSync) getEmbeddingModelName() string {
 	return s.embeddingModelName
 }
 
-func (s *skillIndexSync) setEmbeddingModelName(name string) {
+func (s *skillIndexSync) setEmbeddingModel(model *interfaces.EmbeddingModel) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.embeddingModelName = name
+	s.embeddingModelName = model.ModelName
+}
+
+func (s *skillIndexSync) isRestorePending() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.restorePending
+}
+
+func (s *skillIndexSync) setRestorePending(pending bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.restorePending = pending
 }
 
 // getDatasetID returns the dataset ID actually used by this process; if it is not parsed, it takes the new default value.

--- a/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/index_sync_test.go
@@ -30,6 +30,7 @@ func TestSkillIndexSync(t *testing.T) {
 				vegaClient:   mockVegaClient,
 				logger:       logger.DefaultLogger(),
 			}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(nil, nil)
 			mockVegaClient.EXPECT().CreateCatalog(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaCatalogRequest) (*interfaces.VegaCatalog, error) {
 				createdCatalog = req
@@ -40,7 +41,7 @@ func TestSkillIndexSync(t *testing.T) {
 			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
 				Return(nil, nil)
 			mockModelManager.EXPECT().GetEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding, interfaces.SmallModelTypeEmbedding).
-				Return(&interfaces.EmbeddingModel{ModelName: interfaces.SmallModelTypeEmbedding, EmbeddingDim: 768}, nil)
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
 			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
 				createdResource = req
 				return &interfaces.VegaResource{ID: req.ID}, nil
@@ -64,12 +65,9 @@ func TestSkillIndexSync(t *testing.T) {
 				So(tag, ShouldNotContainSubstring, ":")
 			}
 			So(createdResource.IndexConfig, ShouldNotBeNil)
-			So(createdResource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, interfaces.SmallModelTypeEmbedding)
-			So(extractEmbeddingModelFromSchema(createdResource.SchemaDefinition), ShouldBeEmpty)
+			So(createdResource.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "embedding-model-id")
 			for _, property := range createdResource.SchemaDefinition {
 				for _, feature := range property.Features {
-					_, ok := feature.Config[embeddingModelConfigKey]
-					So(ok, ShouldBeFalse)
 					So(feature.RefProperty, ShouldBeEmpty)
 				}
 			}
@@ -97,10 +95,17 @@ func TestSkillIndexSync(t *testing.T) {
 			So(descriptionProperty.Features[0].FeatureType, ShouldEqual, "keyword")
 			So(descriptionProperty.Features[0].Config["ignore_above"], ShouldEqual, 1024)
 			So(descriptionProperty.Features[1].Name, ShouldEqual, "fulltext_description")
+
+			mockModelAPI.EXPECT().Embeddings(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *interfaces.EmbeddingReq) (*interfaces.EmbeddingResp, error) {
+				So(req.Model, ShouldEqual, "text-embedding-v4")
+				return &interfaces.EmbeddingResp{Data: []interfaces.EmbeddingData{{Embedding: []float32{0.1}}}}, nil
+			})
+			mockVegaClient.EXPECT().WriteDatasetDocuments(gomock.Any(), executionFactorySkillDataset, gomock.Any()).Return(nil)
+			So(syncer.UpsertSkill(context.Background(), &model.SkillRepositoryDB{SkillID: "skill-1", Name: "demo"}), ShouldBeNil)
 			So(descriptionProperty.Features[1].FeatureType, ShouldEqual, "fulltext")
 		})
 
-		Convey("EnsureDataset succeeds without embedding lookup when resource already exists", func() {
+		Convey("Init rebuilds a dataset without an embedding model ID", func() {
 			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockModelAPI := mocks.NewMockMFModelAPIClient(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
@@ -110,6 +115,7 @@ func TestSkillIndexSync(t *testing.T) {
 				vegaClient:   mockVegaClient,
 				logger:       logger.DefaultLogger(),
 			}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
 					ID:      executionFactoryCatalogID,
@@ -119,6 +125,10 @@ func TestSkillIndexSync(t *testing.T) {
 				}, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
 				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
@@ -126,9 +136,11 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
 		})
 
-		Convey("Init reads the model snapshot from index_config first, then schema, then tag", func() {
+		Convey("Init rebuilds when the stored embedding model is not the current model ID", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			syncer := &skillIndexSync{modelManager: mockModelManager, vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
 					ID:      executionFactoryCatalogID,
@@ -140,21 +152,165 @@ func TestSkillIndexSync(t *testing.T) {
 				Return(&interfaces.VegaResource{
 					ID:          executionFactorySkillDataset,
 					Name:        executionFactorySkillDataset,
+					CatalogID:   executionFactoryCatalogID,
+					Category:    "dataset",
+					Status:      executionFactoryDatasetStatus,
 					IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "text-embedding-v4"},
-					// The old snapshots in schema and tag are all there, index_config takes priority.
-					SchemaDefinition: []interfaces.VegaProperty{{
-						Name: "_vector",
-						Type: "vector",
-						Features: []interfaces.VegaPropertyFeature{{
-							FeatureType: "vector",
-							Config:      map[string]any{embeddingModelConfigKey: "stale-from-schema"},
-						}},
-					}},
-					Tags: []string{embeddingModelTagPrefix + "stale-from-tag"},
 				}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
+				So(req.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "embedding-model-id")
+				return &interfaces.VegaResource{ID: req.ID}, nil
+			})
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
+		})
+
+		Convey("Init keeps a dataset when the stored embedding model matches the current model ID", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
+			mockModelAPI := mocks.NewMockMFModelAPIClient(ctrl)
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			syncer := &skillIndexSync{modelManager: mockModelManager, modelAPI: mockModelAPI, vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: executionFactoryCatalogID, Tags: []string{internalCatalogTag}, Enabled: true}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{
+					ID:               executionFactorySkillDataset,
+					SchemaDefinition: buildSkillIndexSchema(768),
+					IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "embedding-model-id"},
+				}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			mockModelAPI.EXPECT().Embeddings(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *interfaces.EmbeddingReq) (*interfaces.EmbeddingResp, error) {
+				So(req.Model, ShouldEqual, "text-embedding-v4")
+				return &interfaces.EmbeddingResp{Data: []interfaces.EmbeddingData{{Embedding: []float32{0.1}}}}, nil
+			})
+			mockVegaClient.EXPECT().WriteDatasetDocuments(gomock.Any(), executionFactorySkillDataset, gomock.Any()).Return(nil)
+			So(syncer.UpsertSkill(context.Background(), &model.SkillRepositoryDB{SkillID: "skill-1", Name: "demo"}), ShouldBeNil)
+		})
+
+		Convey("Init rebuilds when the stored schema differs despite matching embedding model ID", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
+			mockModelAPI := mocks.NewMockMFModelAPIClient(ctrl)
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
+			mockReleaseRepo := mocks.NewMockISkillReleaseDB(ctrl)
+			syncer := &skillIndexSync{
+				modelManager: mockModelManager,
+				modelAPI:     mockModelAPI,
+				vegaClient:   mockVegaClient,
+				skillRepo:    mockSkillRepo,
+				releaseRepo:  mockReleaseRepo,
+				logger:       logger.DefaultLogger(),
+			}
+			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
+				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: executionFactoryCatalogID, Tags: []string{internalCatalogTag}, Enabled: true}, nil)
+			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
+				Return(&interfaces.VegaResource{
+					ID: executionFactorySkillDataset,
+					SchemaDefinition: []interfaces.VegaProperty{
+						{Name: "obsolete", Type: "keyword"},
+					},
+					IndexConfig: &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "embedding-model-id"},
+				}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
+				So(req.SchemaDefinition, ShouldResemble, buildSkillIndexSchema(768))
+				So(req.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "embedding-model-id")
+				return &interfaces.VegaResource{ID: req.ID}, nil
+			})
+			mockSkillRepo.EXPECT().SelectSkillBuildPage(gomock.Any(), gomock.Nil(), int64(0), "", skillIndexBuildBatchSize).Return(nil, nil)
+
+			So(syncer.Init(context.Background()), ShouldBeNil)
+		})
+
+		Convey("Init restores the dataset when recreation previously failed after deletion", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
+			mockReleaseRepo := mocks.NewMockISkillReleaseDB(ctrl)
+			syncer := &skillIndexSync{
+				modelManager: mockModelManager,
+				vegaClient:   mockVegaClient,
+				skillRepo:    mockSkillRepo,
+				releaseRepo:  mockReleaseRepo,
+				logger:       logger.DefaultLogger(),
+			}
+			catalog := &interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: executionFactoryCatalogID, Tags: []string{internalCatalogTag}, Enabled: true}
+			model := &interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}
+			gomock.InOrder(
+				mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(catalog, nil),
+				mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil),
+				mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(model, nil),
+				mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil),
+				mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(nil, errors.New("vega unavailable")),
+				mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).Return(catalog, nil),
+				mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(nil, nil),
+				mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(model, nil),
+				mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil),
+				mockSkillRepo.EXPECT().SelectSkillBuildPage(gomock.Any(), gomock.Nil(), int64(0), "", skillIndexBuildBatchSize).Return(nil, nil),
+			)
+
+			So(syncer.Init(context.Background()), ShouldNotBeNil)
+			So(syncer.isRestorePending(), ShouldBeTrue)
+			So(syncer.Init(context.Background()), ShouldBeNil)
+			So(syncer.isRestorePending(), ShouldBeFalse)
+			So(syncer.isInitialized(), ShouldBeTrue)
+		})
+
+		Convey("restoreSkillDatasetFromSource restores published snapshots and skips non-indexable skills", func() {
+			mockModelAPI := mocks.NewMockMFModelAPIClient(ctrl)
+			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			mockSkillRepo := mocks.NewMockISkillRepository(ctrl)
+			mockReleaseRepo := mocks.NewMockISkillReleaseDB(ctrl)
+			syncer := &skillIndexSync{
+				modelAPI:           mockModelAPI,
+				vegaClient:         mockVegaClient,
+				skillRepo:          mockSkillRepo,
+				releaseRepo:        mockReleaseRepo,
+				logger:             logger.DefaultLogger(),
+				datasetID:          executionFactorySkillDataset,
+				embeddingModelName: "text-embedding-v4",
+			}
+			mockSkillRepo.EXPECT().SelectSkillBuildPage(gomock.Any(), gomock.Nil(), int64(0), "", skillIndexBuildBatchSize).Return([]*model.SkillRepositoryDB{
+				{SkillID: "published", Name: "draft-name", Status: interfaces.BizStatusPublished.String(), UpdateTime: 10},
+				{SkillID: "editing", Name: "draft-editing", Status: interfaces.BizStatusEditing.String(), UpdateTime: 20},
+				{SkillID: "offline", Name: "offline", Status: interfaces.BizStatusOffline.String(), UpdateTime: 30},
+			}, nil)
+			mockSkillRepo.EXPECT().SelectSkillBuildPage(gomock.Any(), gomock.Nil(), int64(30), "offline", skillIndexBuildBatchSize).Return(nil, nil)
+			mockReleaseRepo.EXPECT().SelectBySkillID(gomock.Any(), gomock.Nil(), "published").Return(&model.SkillReleaseDB{SkillID: "published", Name: "published-name", Description: "published-desc"}, nil)
+			mockReleaseRepo.EXPECT().SelectBySkillID(gomock.Any(), gomock.Nil(), "editing").Return(&model.SkillReleaseDB{SkillID: "editing", Name: "editing-name", Description: "editing-desc"}, nil)
+			mockModelAPI.EXPECT().Embeddings(gomock.Any(), gomock.Any()).Times(2).DoAndReturn(func(_ context.Context, req *interfaces.EmbeddingReq) (*interfaces.EmbeddingResp, error) {
+				So(req.Model, ShouldEqual, "text-embedding-v4")
+				return &interfaces.EmbeddingResp{Data: []interfaces.EmbeddingData{{Embedding: []float32{0.1}}}}, nil
+			})
+			writtenIDs := make([]string, 0, 2)
+			mockVegaClient.EXPECT().WriteDatasetDocuments(gomock.Any(), executionFactorySkillDataset, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, documents []map[string]any) error {
+				for _, document := range documents {
+					writtenIDs = append(writtenIDs, document["skill_id"].(string))
+				}
+				return nil
+			})
+
+			So(syncer.restoreSkillDatasetFromSource(context.Background()), ShouldBeNil)
+			So(writtenIDs, ShouldResemble, []string{"published", "editing"})
+		})
+
+		Convey("rejects incomplete embedding models before creating a dataset", func() {
+			for _, embeddingModel := range []*interfaces.EmbeddingModel{
+				{ModelName: "text-embedding-v4", EmbeddingDim: 768},
+				{ModelID: "embedding-model-id", EmbeddingDim: 768},
+				{ModelID: "embedding-model-id", ModelName: "text-embedding-v4"},
+			} {
+				_, err := validateEmbeddingModel(embeddingModel)
+				So(err, ShouldNotBeNil)
+			}
 		})
 
 		Convey("Init fails when the catalog cannot be enabled, so the retry loop takes over", func() {
@@ -176,8 +332,10 @@ func TestSkillIndexSync(t *testing.T) {
 
 		// When the data set is hung in another directory, writing is governed by its own parent directory, and disabled must be enabled.
 		Convey("Init enables the dataset's own catalog when it lives elsewhere", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			syncer := &skillIndexSync{modelManager: mockModelManager, vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
 					ID:      executionFactoryCatalogID,
@@ -194,6 +352,9 @@ func TestSkillIndexSync(t *testing.T) {
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), "other_catalog").
 				Return(&interfaces.VegaCatalog{ID: "other_catalog", Name: "other_catalog", Enabled: false}, nil)
 			mockVegaClient.EXPECT().EnableCatalog(gomock.Any(), "other_catalog").Return(nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
@@ -221,8 +382,10 @@ func TestSkillIndexSync(t *testing.T) {
 
 		Convey("Init skips the internal tag backfill when the catalog already has 5 tags", func() {
 			var reconciled *interfaces.VegaCatalogRequest
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			syncer := &skillIndexSync{modelManager: mockModelManager, vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			fullTags := []string{"a", "b", "c", "d", "e"}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
@@ -238,6 +401,9 @@ func TestSkillIndexSync(t *testing.T) {
 			})
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
 				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			// If the tag exceeds the limit, don’t block it. The main goal of changing the name cannot be taken away with 400.
@@ -250,10 +416,13 @@ func TestSkillIndexSync(t *testing.T) {
 		Convey("Init backfills the internal tag when only the tag is missing", func() {
 			var reconciled *interfaces.VegaCatalogRequest
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			syncer := &skillIndexSync{
-				vegaClient: mockVegaClient,
-				logger:     logger.DefaultLogger(),
+				modelManager: mockModelManager,
+				vegaClient:   mockVegaClient,
+				logger:       logger.DefaultLogger(),
 			}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
 					ID:         executionFactoryCatalogID,
@@ -268,6 +437,9 @@ func TestSkillIndexSync(t *testing.T) {
 			})
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
 				Return(&interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
@@ -277,16 +449,22 @@ func TestSkillIndexSync(t *testing.T) {
 		})
 
 		Convey("Init survives a failed catalog rename, which is cosmetic", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
 			syncer := &skillIndexSync{
-				vegaClient: mockVegaClient,
-				logger:     logger.DefaultLogger(),
+				modelManager: mockModelManager,
+				vegaClient:   mockVegaClient,
+				logger:       logger.DefaultLogger(),
 			}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			resource := &interfaces.VegaResource{ID: executionFactorySkillDataset, Name: executionFactorySkillDataset}
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Name: "stale_display_name", Enabled: true}, nil)
 			mockVegaClient.EXPECT().UpdateCatalog(gomock.Any(), gomock.Any()).Return(errors.New("vega 500"))
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).Return(resource, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(&interfaces.VegaResource{ID: executionFactorySkillDataset}, nil)
 
 			err := syncer.Init(context.Background())
 			So(err, ShouldBeNil)
@@ -294,10 +472,11 @@ func TestSkillIndexSync(t *testing.T) {
 			So(syncer.getDatasetID(), ShouldEqual, executionFactorySkillDataset)
 		})
 
-		// The model snapshot of the old dataset only falls on the resource tag, and the read path still needs to be covered.
-		Convey("Init reads the model snapshot from a tag when nothing else carries it", func() {
+		Convey("Init rebuilds a legacy dataset without index_config", func() {
+			mockModelManager := mocks.NewMockMFModelManager(ctrl)
 			mockVegaClient := mocks.NewMockVegaBackendClient(ctrl)
-			syncer := &skillIndexSync{vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			syncer := &skillIndexSync{modelManager: mockModelManager, vegaClient: mockVegaClient, logger: logger.DefaultLogger()}
+			configureEmptySkillDatasetRestore(ctrl, syncer)
 			mockVegaClient.EXPECT().GetCatalogByID(gomock.Any(), executionFactoryCatalogID).
 				Return(&interfaces.VegaCatalog{
 					ID:      executionFactoryCatalogID,
@@ -307,10 +486,19 @@ func TestSkillIndexSync(t *testing.T) {
 				}, nil)
 			mockVegaClient.EXPECT().GetResourceByID(gomock.Any(), executionFactorySkillDataset).
 				Return(&interfaces.VegaResource{
-					ID:   executionFactorySkillDataset,
-					Name: executionFactorySkillDataset,
-					Tags: []string{embeddingModelTagPrefix + "text-embedding-v4"},
+					ID:        executionFactorySkillDataset,
+					Name:      executionFactorySkillDataset,
+					CatalogID: executionFactoryCatalogID,
+					Category:  "dataset",
+					Status:    executionFactoryDatasetStatus,
 				}, nil)
+			mockModelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), interfaces.SmallModelTypeEmbedding).
+				Return(&interfaces.EmbeddingModel{ModelID: "embedding-model-id", ModelName: "text-embedding-v4", EmbeddingDim: 768}, nil)
+			mockVegaClient.EXPECT().DeleteResource(gomock.Any(), executionFactorySkillDataset).Return(nil)
+			mockVegaClient.EXPECT().CreateResource(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
+				So(req.IndexConfig.DefaultEmbeddingModel, ShouldEqual, "embedding-model-id")
+				return &interfaces.VegaResource{ID: req.ID}, nil
+			})
 
 			So(syncer.Init(context.Background()), ShouldBeNil)
 			So(syncer.getEmbeddingModelName(), ShouldEqual, "text-embedding-v4")
@@ -439,4 +627,12 @@ func TestSkillIndexSync(t *testing.T) {
 			So(updatedDocs[0]["_vector"], ShouldResemble, []float32{0.3, 0.4})
 		})
 	})
+}
+
+func configureEmptySkillDatasetRestore(ctrl *gomock.Controller, syncer *skillIndexSync) {
+	skillRepo := mocks.NewMockISkillRepository(ctrl)
+	skillRepo.EXPECT().SelectSkillBuildPage(gomock.Any(), gomock.Nil(), gomock.Any(), gomock.Any(), skillIndexBuildBatchSize).
+		AnyTimes().Return(nil, nil)
+	syncer.skillRepo = skillRepo
+	syncer.releaseRepo = mocks.NewMockISkillReleaseDB(ctrl)
 }

--- a/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/mocks/drivenadapters.go
@@ -813,6 +813,20 @@ func (mr *MockVegaBackendClientMockRecorder) DeleteDatasetDocumentByID(ctx, data
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDatasetDocumentByID", reflect.TypeOf((*MockVegaBackendClient)(nil).DeleteDatasetDocumentByID), ctx, datasetID, docID)
 }
 
+// DeleteResource mocks base method.
+func (m *MockVegaBackendClient) DeleteResource(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResource", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResource indicates an expected call of DeleteResource.
+func (mr *MockVegaBackendClientMockRecorder) DeleteResource(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResource", reflect.TypeOf((*MockVegaBackendClient)(nil).DeleteResource), ctx, id)
+}
+
 // EnableCatalog mocks base method.
 func (m *MockVegaBackendClient) EnableCatalog(ctx context.Context, id string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Cherry-pick the #1165 release fix into `main`.
- [x] Write ModelID to Vega while retaining ModelName for the embeddings API.
- [x] Rebuild mismatched Skill datasets and restore index documents from the Skill source of truth.
- [x] Docs/doc 1: N/A，release bug fix 回合，无新增用户文档。

---

## Why

- Related Issue: Closes #1162
- Related Feature: Skill index initialization
- Background: #1165 已合入 `release/0.1.4`；本 PR 将同一修复回合到 `main`，避免发布分支与主线行为漂移。

---

## How

- Key implementation points:
  - 以 ModelID 校验并创建 Vega Dataset，以 ModelName 调 embeddings。
  - schema 或默认模型 ID 不匹配时 DELETE + CREATE，不走 update。
  - 删除幂等；重建或缺失资源创建后分页回灌已发布 Skill 索引。
- Breaking changes (API, config, database, etc.): 无外部 API、配置或数据库 schema 变更。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally（模块 `./project.sh -t`）
- [ ] Verified in test environment（待 CI / 测试环境验证）

Test notes:

- `go test ./server/logics/skill ./server/drivenadapters`
- `./project.sh -t`
- `git diff origin/main...HEAD --check`

---

## Risk & Rollback

- Potential risks: Dataset 重建会产生全量 embedding 回灌负载。
- Rollback plan: 回退本 PR 的 cherry-pick 提交；必要时触发完整 Skill 索引构建。

---

## Additional Notes

- Cherry-picked from release PR #1165 (commit `96c6d9282`)。
- CODEOWNERS：`adp/execution-factory/**` 由 @criller 负责评审。
- 远端 CI 尚未运行完成。