### PR TITLE
fix(deploy): auto-upgrade legacy OpenSearch image

### DIFF
--- a/deploy/scripts/services/opensearch.sh
+++ b/deploy/scripts/services/opensearch.sh
@@ -11,10 +11,54 @@ _opensearch_resolve_image_defaults() {
     fi
 }
 
+# Upgrade only the stock OpenSearch 2.19.4 image installed before the platform
+# image became the default. Other image tags are intentionally left alone: they
+# may be user-pinned builds and must not be overwritten by a regular install.
+_opensearch_upgrade_legacy_image() {
+    if [[ -n "${OPENSEARCH_IMAGE}" ]]; then
+        log_info "OpenSearch uses an explicit OPENSEARCH_IMAGE; skipping automatic image upgrade."
+        return 0
+    fi
+
+    local statefulset_name="${OPENSEARCH_CLUSTER_NAME}-${OPENSEARCH_NODE_GROUP}"
+    local current_image
+    current_image="$(kubectl get statefulset "${statefulset_name}" -n "${OPENSEARCH_NAMESPACE}" \
+        -o jsonpath='{.spec.template.spec.containers[?(@.name=="opensearch")].image}' 2>/dev/null || true)"
+    local current_tag="${current_image##*:}"
+    if [[ -z "${current_image}" || "${current_tag}" == "${current_image}" ]]; then
+        log_warn "Could not determine the image for existing OpenSearch release; skipping automatic image upgrade."
+        return 0
+    fi
+    if [[ "${current_tag}" != "2.19.4" ]]; then
+        log_info "OpenSearch is already installed with image ${current_image}; skipping automatic image upgrade."
+        return 0
+    fi
+
+    _opensearch_resolve_image_defaults
+    local os_image_repo="${OPENSEARCH_IMAGE%:*}"
+    local os_image_tag="${OPENSEARCH_IMAGE##*:}"
+    if [[ "${os_image_repo}" == "${OPENSEARCH_IMAGE}" || -z "${os_image_tag}" ]]; then
+        log_error "Invalid OPENSEARCH_IMAGE (expected repo:tag): ${OPENSEARCH_IMAGE}"
+        return 1
+    fi
+
+    log_info "Upgrading existing OpenSearch image from ${current_image} to ${OPENSEARCH_IMAGE}."
+    # Do not use `helm upgrade` here: even with --reuse-values Helm re-renders
+    # and reconciles the whole chart. This targeted patch changes only the main
+    # OpenSearch container image and lets the StatefulSet perform the rollout.
+    kubectl set image statefulset "${statefulset_name}" -n "${OPENSEARCH_NAMESPACE}" \
+        "opensearch=${os_image_repo}:${os_image_tag}"
+}
+
 install_opensearch() {
     log_info "Installing OpenSearch via Helm..."
 
     local fresh_install="true"
+
+    if is_helm_installed "${OPENSEARCH_RELEASE_NAME}" "${OPENSEARCH_NAMESPACE}"; then
+        _opensearch_upgrade_legacy_image || return 1
+        return 0
+    fi
 
     # OpenSearch password handling
     local existing_pass=$(config_yaml_dep_field opensearch password)
@@ -24,12 +68,6 @@ install_opensearch() {
     else
         OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(generate_random_password 10)
         log_info "Generated random 10-character OpenSearch password"
-    fi
-
-    if is_helm_installed "${OPENSEARCH_RELEASE_NAME}" "${OPENSEARCH_NAMESPACE}"; then
-        fresh_install="false"
-        log_info "OpenSearch is already installed. Skipping installation."
-        return 0
     fi
 
     if [[ -z "${OPENSEARCH_INITIAL_ADMIN_PASSWORD}" ]]; then

--- a/deploy/scripts/services/opensearch_upgrade_test.sh
+++ b/deploy/scripts/services/opensearch_upgrade_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/opensearch.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+log_info() { :; }
+log_warn() { :; }
+log_error() { :; }
+resolve_openbkn_image_registry() { printf '%s' "ghcr.io/openbkn-ai"; }
+compose_image_ref() { printf '%s/%s:%s' "$1" "$2" "$3"; }
+
+reset_env() {
+    OPENSEARCH_IMAGE=""
+    OPENSEARCH_IMAGE_REGISTRY=""
+    OPENSEARCH_IMAGE_REPOSITORY="opensearch"
+    OPENSEARCH_IMAGE_TAG="2.19.4-main.20260818163046.shaaeb5d56"
+    OPENSEARCH_INIT_IMAGE=""
+    OPENSEARCH_INIT_IMAGE_REPOSITORY="busybox"
+    OPENSEARCH_INIT_IMAGE_TAG="1.36.1"
+    OPENSEARCH_RELEASE_NAME="opensearch"
+    OPENSEARCH_NAMESPACE="resource"
+    OPENSEARCH_CLUSTER_NAME="opensearch-cluster"
+    OPENSEARCH_NODE_GROUP="master"
+    KUBECTL_SET_IMAGE_CALL=""
+}
+
+kubectl() {
+    if [[ "$1" == "get" && "$2" == "statefulset" ]]; then
+        printf '%s' "${CURRENT_IMAGE}"
+    elif [[ "$1" == "set" && "$2" == "image" && "$3" == "statefulset" ]]; then
+        KUBECTL_SET_IMAGE_CALL="$*"
+    fi
+}
+
+reset_env
+CURRENT_IMAGE="ghcr.io/openbkn-ai/opensearchproject/opensearch:2.19.4"
+_opensearch_upgrade_legacy_image
+[[ "${KUBECTL_SET_IMAGE_CALL}" == *"set image statefulset opensearch-cluster-master"* ]] || fail "legacy image must update the OpenSearch StatefulSet"
+[[ "${KUBECTL_SET_IMAGE_CALL}" == *"opensearch=ghcr.io/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56"* ]] || fail "upgrade must set the platform image"
+
+reset_env
+CURRENT_IMAGE="ghcr.io/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56"
+_opensearch_upgrade_legacy_image
+[[ -z "${KUBECTL_SET_IMAGE_CALL}" ]] || fail "platform image must not be upgraded again"
+
+reset_env
+CURRENT_IMAGE="ghcr.io/acme/opensearch:2.19.4"
+OPENSEARCH_IMAGE="ghcr.io/acme/opensearch:2.19.4"
+_opensearch_upgrade_legacy_image
+[[ -z "${KUBECTL_SET_IMAGE_CALL}" ]] || fail "explicit image must not be overwritten"
+
+echo "PASS: OpenSearch legacy image upgrade guard"


### PR DESCRIPTION
Automatically replace the existing OpenSearch image only when the deployed container uses tag 2.19.4.

Use kubectl set image to update only the OpenSearch StatefulSet container, preserving PVCs, credentials, configuration, and other Helm-managed resources. Skip custom images and installations already using the platform image.

Add regression coverage for legacy-image upgrade and skip conditions.

fix(deploy): auto-upgrade legacy OpenSearch image

# Pull Request

## What Changed

Brief description of changes:

- [x] Deploy module: automatically upgrade legacy OpenSearch image
- [x] Add regression tests for OpenSearch image upgrade conditions
- [ ] Docs/doc 1 — Not applicable

---

## Why

- Related Issue: Not provided
- Related Feature: Not applicable
- Background:

The deploy script previously skipped existing OpenSearch releases entirely.
Clusters using `opensearchproject/opensearch:2.19.4` therefore could not
automatically switch to the IK-enabled platform image.

---

## How

- Key implementation points:
  - Detect the image used by the existing OpenSearch StatefulSet.
  - Upgrade only when the current tag is exactly `2.19.4`.
  - Use `kubectl set image` to change only the OpenSearch container image.
  - Skip custom images and clusters already using the platform image.
  - Preserve PVCs, credentials, configuration, and other resources.
  - Add regression coverage for upgrade and skip scenarios.

- Breaking changes (API, config, database, etc.):
  - None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable; requires a Kubernetes cluster
- [ ] Verified in test environment — Not yet verified

Test notes:

    bash -n deploy/scripts/services/opensearch.sh \
      deploy/scripts/services/opensearch_upgrade_test.sh

    bash deploy/scripts/services/opensearch_upgrade_test.sh

    git diff --check

The regression test covers:

- Legacy tag `2.19.4` is upgraded.
- The platform image tag is not upgraded again.
- Explicit custom images are not overwritten.

---

## Risk & Rollback

- Potential risks:
  - Existing OpenSearch Pods will undergo a rolling restart.
  - The new image must be available in the configured image registry.
  - If the new image fails to start, OpenSearch availability may be affected during rollout.

- Rollback plan:

    kubectl set image statefulset/opensearch-cluster-master \
      -n <namespace> \
      opensearch=<registry>/opensearchproject/opensearch:2.19.4

Then verify the StatefulSet rollout and OpenSearch health.

---

## Additional Notes

- The upgrade does not modify OpenSearch data, PVCs, credentials, or index mappings.
- The OpenSearch image remains based on version `2.19.4`; the new image adds the IK Chinese analyzer.
- After the image rollout, restart `vega-backend` if required so its analyzer capability detection runs again.