### PR TITLE
fix(deploy): wait for OpenSearch image upgrade

### DIFF
--- a/deploy/scripts/services/opensearch.sh
+++ b/deploy/scripts/services/opensearch.sh
@@ -43,11 +43,47 @@ _opensearch_upgrade_legacy_image() {
     fi
 
     log_info "Upgrading existing OpenSearch image from ${current_image} to ${OPENSEARCH_IMAGE}."
-    # Do not use `helm upgrade` here: even with --reuse-values Helm re-renders
-    # and reconciles the whole chart. This targeted patch changes only the main
-    # OpenSearch container image and lets the StatefulSet perform the rollout.
-    kubectl set image statefulset "${statefulset_name}" -n "${OPENSEARCH_NAMESPACE}" \
-        "opensearch=${os_image_repo}:${os_image_tag}"
+    # Keep the Helm release values in sync so a later Helm upgrade does not
+    # restore the legacy image. --reuse-values preserves the existing release
+    # configuration; the only value intentionally changed here is the image.
+    local chart_ref="opensearch/opensearch"
+    local use_local_chart="false"
+    if [[ -f "${OPENSEARCH_CHART_TGZ}" ]]; then
+        chart_ref="${OPENSEARCH_CHART_TGZ}"
+        use_local_chart="true"
+    elif [[ "${OFFLINE_MODE}" == "true" ]]; then
+        log_error "Offline mode requires local OpenSearch chart: ${OPENSEARCH_CHART_TGZ}"
+        return 1
+    else
+        helm repo add --force-update opensearch "${HELM_REPO_OPENSEARCH}"
+        helm repo update
+    fi
+
+    local -a helm_args
+    helm_args=(
+        upgrade "${OPENSEARCH_RELEASE_NAME}" "${chart_ref}"
+        --namespace "${OPENSEARCH_NAMESPACE}"
+        --reuse-values
+        --set image.repository="${os_image_repo}"
+        --set image.tag="${os_image_tag}"
+        --wait --timeout=900s
+    )
+    if [[ "${OPENSEARCH_HELM_ATOMIC}" == "true" ]]; then
+        helm_args+=(--atomic)
+    fi
+    if [[ "${use_local_chart}" != "true" ]]; then
+        helm_args+=(--version "${OPENSEARCH_CHART_VERSION}")
+    fi
+    if ! helm "${helm_args[@]}"; then
+        log_error "OpenSearch image upgrade failed; the existing image remains in use."
+        return 1
+    fi
+
+    if ! kubectl rollout status statefulset "${statefulset_name}" \
+        -n "${OPENSEARCH_NAMESPACE}" --timeout=900s; then
+        log_error "OpenSearch image upgrade did not become ready within 900s."
+        return 1
+    fi
 }
 
 install_opensearch() {

--- a/deploy/scripts/services/opensearch_upgrade_test.sh
+++ b/deploy/scripts/services/opensearch_upgrade_test.sh
@@ -27,7 +27,14 @@ reset_env() {
     OPENSEARCH_NAMESPACE="resource"
     OPENSEARCH_CLUSTER_NAME="opensearch-cluster"
     OPENSEARCH_NODE_GROUP="master"
+    OPENSEARCH_CHART_TGZ="${SCRIPT_DIR}/../../charts/opensearch-2.36.0.tgz"
+    OPENSEARCH_CHART_VERSION="2.36.0"
+    OPENSEARCH_HELM_ATOMIC="false"
+    OFFLINE_MODE="false"
+    HELM_REPO_OPENSEARCH="https://opensearch-project.github.io/helm-charts/"
     KUBECTL_SET_IMAGE_CALL=""
+    HELM_CALL=""
+    ROLLOUT_CALL=""
 }
 
 kubectl() {
@@ -35,24 +42,34 @@ kubectl() {
         printf '%s' "${CURRENT_IMAGE}"
     elif [[ "$1" == "set" && "$2" == "image" && "$3" == "statefulset" ]]; then
         KUBECTL_SET_IMAGE_CALL="$*"
+    elif [[ "$1" == "rollout" && "$2" == "status" ]]; then
+        ROLLOUT_CALL="$*"
     fi
+}
+
+helm() {
+    HELM_CALL="$*"
 }
 
 reset_env
 CURRENT_IMAGE="ghcr.io/openbkn-ai/opensearchproject/opensearch:2.19.4"
 _opensearch_upgrade_legacy_image
-[[ "${KUBECTL_SET_IMAGE_CALL}" == *"set image statefulset opensearch-cluster-master"* ]] || fail "legacy image must update the OpenSearch StatefulSet"
-[[ "${KUBECTL_SET_IMAGE_CALL}" == *"opensearch=ghcr.io/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56"* ]] || fail "upgrade must set the platform image"
+[[ "${HELM_CALL}" == *"upgrade opensearch ${OPENSEARCH_CHART_TGZ}"* ]] || fail "legacy image must run helm upgrade"
+[[ "${HELM_CALL}" == *"--reuse-values"* ]] || fail "upgrade must preserve existing values"
+[[ "${HELM_CALL}" == *"--set image.repository=ghcr.io/openbkn-ai/opensearch"* ]] || fail "upgrade must set platform repository"
+[[ "${HELM_CALL}" == *"--set image.tag=2.19.4-main.20260818163046.shaaeb5d56"* ]] || fail "upgrade must set platform tag"
+[[ "${HELM_CALL}" == *"--wait --timeout=900s"* ]] || fail "upgrade must wait for helm readiness"
+[[ "${ROLLOUT_CALL}" == *"rollout status statefulset opensearch-cluster-master"* ]] || fail "upgrade must verify StatefulSet rollout"
 
 reset_env
 CURRENT_IMAGE="ghcr.io/openbkn-ai/opensearch:2.19.4-main.20260818163046.shaaeb5d56"
 _opensearch_upgrade_legacy_image
-[[ -z "${KUBECTL_SET_IMAGE_CALL}" ]] || fail "platform image must not be upgraded again"
+[[ -z "${HELM_CALL}" ]] || fail "platform image must not be upgraded again"
 
 reset_env
 CURRENT_IMAGE="ghcr.io/acme/opensearch:2.19.4"
 OPENSEARCH_IMAGE="ghcr.io/acme/opensearch:2.19.4"
 _opensearch_upgrade_legacy_image
-[[ -z "${KUBECTL_SET_IMAGE_CALL}" ]] || fail "explicit image must not be overwritten"
+[[ -z "${HELM_CALL}" ]] || fail "explicit image must not be overwritten"
 
 echo "PASS: OpenSearch legacy image upgrade guard"


### PR DESCRIPTION
Use Helm upgrade with --reuse-values to update the OpenSearch image while preserving existing release configuration.

Wait up to 900 seconds for Helm and StatefulSet rollout completion, and return an error when the new image cannot be pulled or the Pod does not become ready.

Keep the Helm release image values synchronized to prevent future upgrades from reverting to the legacy 2.19.4 image. Add regression coverage for upgrade, skip, and rollout verification conditions.

fix(deploy): 等待 OpenSearch 镜像升级完成

# Pull Request

## What Changed

变更说明：

- [x] Deploy 模块：完善 OpenSearch 旧镜像自动升级流程
- [x] 使用 Helm `--reuse-values` 同步更新镜像配置
- [x] 增加 Helm 和 StatefulSet rollout 等待及校验
- [x] 增加 OpenSearch 镜像升级回归测试
- [ ] 文档变更：不适用

---

## Why

- Related Issue: 未提供
- Related Feature: 不适用
- Background:

此前 OpenSearch 已安装时，deploy 脚本会直接跳过安装流程。对于仍使用
`opensearchproject/opensearch:2.19.4` 的集群，无法自动切换到包含 IK 中文
分词插件的平台镜像。

同时，原有镜像升级逻辑没有等待 Pod rollout 完成，镜像拉取失败时仍可能
返回成功；并且仅修改 StatefulSet 会导致 Helm release 中仍保存旧的
`image.tag`，后续 Helm upgrade 可能将镜像回退到旧版本。

---

## How

- 关键实现：
  - 检测现有 OpenSearch StatefulSet 实际使用的镜像 tag。
  - 仅当当前 tag 精确为 `2.19.4` 时触发升级。
  - 使用 `helm upgrade --reuse-values` 更新镜像，同时保留已有 Helm 配置。
  - 使用 `--wait --timeout=900s` 等待 Helm 操作完成。
  - 使用 `kubectl rollout status --timeout=900s` 显式校验 StatefulSet rollout。
  - 已使用新镜像、使用自定义镜像或无法确定镜像时跳过自动升级。
  - 增加升级、跳过和 rollout 校验相关测试。

- Breaking changes（API、配置、数据库等）：
  - 无 API、数据库或索引结构变更。
  - 已有 OpenSearch Pod 会执行一次滚动重启。

---

## Testing

- [x] 本地单元测试通过
- [ ] 集成测试通过：未执行，需要 Kubernetes 集群
- [ ] 测试环境验证：尚未执行

测试命令：

    bash -n deploy/scripts/services/opensearch.sh \
      deploy/scripts/services/opensearch_upgrade_test.sh

    bash deploy/scripts/services/opensearch_upgrade_test.sh

    git diff --check

测试覆盖：

- 当前镜像 tag 为 `2.19.4` 时执行升级。
- 当前已经是平台镜像时跳过升级。
- 显式配置自定义镜像时不覆盖。
- 升级使用 `--reuse-values`。
- 升级等待 Helm 和 StatefulSet rollout 完成。

---

## Risk & Rollback

- 潜在风险：
  - OpenSearch 单副本 StatefulSet 会执行滚动重启，期间可能出现短暂不可用。
  - 新镜像必须能够从当前配置的镜像仓库正常拉取。
  - 如果新镜像启动失败，OpenSearch rollout 会超时并返回错误。

- 回滚方案：

    helm upgrade opensearch <chart> \
      -n <namespace> \
      --reuse-values \
      --set image.repository=<registry>/opensearchproject/opensearch \
      --set image.tag=2.19.4 \
      --wait \
      --timeout=900s

    kubectl rollout status statefulset/opensearch-cluster-master \
      -n <namespace> \
      --timeout=900s

  回滚后确认 StatefulSet rollout 成功，并检查 OpenSearch 健康状态。

---

## Additional Notes

- 本次升级不会删除或迁移 OpenSearch 数据。
- PVC、凭证、索引及索引映射均不会被修改。
- OpenSearch 基础版本仍为 `2.19.4`，新镜像额外包含 IK 中文分词插件。
- 镜像升级完成后，如需重新探测分析器能力，建议重启 `vega-backend`。