### PR TITLE
fix(deploy): compare the whole Node version, not just the major

### DIFF
--- a/deploy/onboard.sh
+++ b/deploy/onboard.sh
@@ -105,8 +105,11 @@ fi
 # Override: ONBOARD_TEST_USER_PASSWORD; rename default: ONBOARD_DEFAULT_TEST_USER_PASSWORD
 : "${ONBOARD_DEFAULT_TEST_USER_PASSWORD:=111111}"
 
-# Same requirement as @openbkn/bkn-sdk on npm (node >= 22). https://www.npmjs.com/package/@openbkn/bkn-sdk
-ONBOARD_MIN_NODE_MAJOR="${ONBOARD_MIN_NODE_MAJOR:-22}"
+# Same requirement as @openbkn/bkn-sdk on npm. https://www.npmjs.com/package/@openbkn/bkn-sdk
+# A full version, not a major: 22.0.0 clears a `>= 22` bar and still cannot
+# install the CLI, because npm resolves past a release whose `engines` the
+# runtime misses and hands back an older one without an error.
+ONBOARD_MIN_NODE="${ONBOARD_MIN_NODE:-${OPENBKN_NODE_MIN_SEMVER}}"
 
 # Node/bkn bootstrap prompts use the terminal (even with --config); -y skips those prompts; no TTY + no -y = error.
 onboard_is_bootstrap_tty() {
@@ -227,7 +230,7 @@ onboard_bkn_tls_insecure_args_to_array() {
 usage() {
     echo "Usage: sudo bash ./onboard.sh [options]   # Linux (matches sudo deploy.sh)"
     echo "       bash ./dev/mac.sh onboard           # macOS dev (kind path; no sudo)"
-    echo "  Requires: Node 22+ (see @openbkn/bkn-sdk on npm), openbkn, kubectl, python3; run from deploy/"
+    echo "  Requires: Node ${ONBOARD_MIN_NODE}+ (see @openbkn/bkn-sdk on npm), openbkn, kubectl, python3; run from deploy/"
     echo "  Config YAML: unset CONFIG_YAML_PATH and onboard uses \$HOME/.openbkn-ai/config.yaml when that file exists (same as deploy.sh); otherwise scripts/lib/common.sh default (deploy/conf/config.yaml)."
     echo "  Why sudo on Linux: deploy.sh runs as root and writes \$HOME/.openbkn-ai/config.yaml under /root/.openbkn-ai/ (mode 700); onboard.sh also writes \$HOME/.bkn auth state. sudo keeps both pointing at the same root home (silence the startup hint with ONBOARD_SUDO_HINT_DISABLED=1; not needed on macOS dev)."
     echo "  (no flags)                Interactive: nvm+Node 22 and npm -g (Y/n) in your terminal, then models/BKN"
@@ -246,7 +249,7 @@ usage() {
     echo "  --skip-bkn               With --config: register models but skip BKN + rollout"
     echo "  -h, --help"
     echo ""
-    echo "  Environment: ONBOARD_SKIP_NODE_INSTALL=true  skip nvm in onboard (fail if Node < ${ONBOARD_MIN_NODE_MAJOR})"
+    echo "  Environment: ONBOARD_SKIP_NODE_INSTALL=true  skip nvm in onboard (fail if Node < ${ONBOARD_MIN_NODE})"
     echo "                ONBOARD_SKIP_OPENBKN_INSTALL=true  never run npm -g for openbkn in onboard"
     echo "                ONBOARD_SKIP_OPENBKN_ADMIN_INSTALL=true  do not auto/offer  npm -g  openbkn admin  (also skipped with  -y )"
     echo "                ONBOARD_SKIP_TEST_USER=true  same as --skip-test-user"
@@ -278,20 +281,11 @@ for _ob_arg in "$@"; do
     esac
 done
 
-onboard_node_major() {
-    if ! command -v node &>/dev/null; then
-        echo 0
-        return
-    fi
-    local v
-    v="$(node -v 2>/dev/null)"
-    v="${v#v}"
-    v="${v%%.*}"
-    if [[ "${v}" =~ ^[0-9]+$ ]]; then
-        echo "${v}"
-    else
-        echo 0
-    fi
+onboard_node_ok() {
+    local have
+    have="$(bkn_node_semver)"
+    [[ -n "${have}" ]] || return 1
+    bkn_semver_ge "${have}" "${ONBOARD_MIN_NODE}"
 }
 
 # This script is not a login shell: ~/.zshrc / .bashrc are not sourced, so nvm's node is often missing
@@ -335,7 +329,7 @@ onboard_bootstrap_node_path() {
 # Install nvm + Node 22 in the current user (no sudo; same idea as preflight's node-22 fix, user-local).
 onboard_install_node22_nvm() {
     if ! command -v curl &>/dev/null; then
-        log_error "curl is required to install nvm. Install curl, or install Node ${ONBOARD_MIN_NODE_MAJOR}+ from https://nodejs.org/"
+        log_error "curl is required to install nvm. Install curl, or install Node ${ONBOARD_MIN_NODE}+ from https://nodejs.org/"
         return 1
     fi
     if ! command -v bash &>/dev/null; then
@@ -367,40 +361,37 @@ onboard_install_node22_nvm() {
 
 # If not sudo bash ./preflight.sh --fix, still help: offer (or with -y, run) nvm+Node 22 in this user.
 onboard_ensure_node_22() {
-    local mj
     onboard_bootstrap_node_path
-    mj="$(onboard_node_major)"
-    if command -v node &>/dev/null && [[ -n "${mj}" && $(( 10#${mj} )) -ge ${ONBOARD_MIN_NODE_MAJOR} ]]; then
+    if command -v node &>/dev/null && onboard_node_ok; then
         log_info "Using $(node -v) ($(command -v node))"
         return 0
     fi
 
     if [[ "${ONBOARD_SKIP_NODE_INSTALL:-false}" == "true" ]]; then
-        log_error "Node is $(node -v 2>/dev/null || echo missing) but Node.js ${ONBOARD_MIN_NODE_MAJOR}+ is required. Unset ONBOARD_SKIP_NODE_INSTALL or install Node manually."
+        log_error "Node is $(node -v 2>/dev/null || echo missing) but Node.js ${ONBOARD_MIN_NODE}+ is required. Unset ONBOARD_SKIP_NODE_INSTALL or install Node manually."
         exit 1
     fi
 
     # Interactive on a TTY: always ask, including when --config is set. No TTY: must pass -y to auto-install.
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
-        log_info "Node ${ONBOARD_MIN_NODE_MAJOR}+ not active; installing via nvm (-y)…"
+        log_info "Node ${ONBOARD_MIN_NODE}+ not active; installing via nvm (-y)…"
     elif onboard_is_bootstrap_tty; then
         echo ""
-        read -r -p "Node.js ${ONBOARD_MIN_NODE_MAJOR}+ is required for openbkn/onboard. Install nvm and Node 22 in this user account now? [Y/n]: " _obn
+        read -r -p "Node.js ${ONBOARD_MIN_NODE}+ is required for openbkn/onboard. Install nvm and Node 22 (latest 22.x) in this user account now? [Y/n]: " _obn
         if [[ "${_obn}" =~ ^[Nn] ]]; then
-            log_error "Install Node ${ONBOARD_MIN_NODE_MAJOR}+ (e.g. nvm install 22), or use another machine with Node 22+ on PATH, or run: sudo bash ./preflight.sh --fix on the host where you need system-wide Node."
+            log_error "Install Node ${ONBOARD_MIN_NODE}+ (e.g. nvm install 22 — the latest 22.x clears it), or use another machine with a new enough Node on PATH, or run: sudo bash ./preflight.sh --fix on the host where you need system-wide Node."
             exit 1
         fi
     else
-        log_error "Node ${ONBOARD_MIN_NODE_MAJOR}+ required (or missing). In a real terminal you get a Y/n prompt; without a TTY pass  $0 -y  (e.g. CI), or install Node / nvm first. Or: sudo bash ./preflight.sh --fix (onboard-tooling) on a server."
+        log_error "Node ${ONBOARD_MIN_NODE}+ required (or missing). In a real terminal you get a Y/n prompt; without a TTY pass  $0 -y  (e.g. CI), or install Node / nvm first. Or: sudo bash ./preflight.sh --fix (onboard-tooling) on a server."
         exit 1
     fi
 
     if ! onboard_install_node22_nvm; then
         exit 1
     fi
-    mj="$(onboard_node_major)"
-    if ! command -v node &>/dev/null || [[ -z "${mj}" || $(( 10#${mj} )) -lt ${ONBOARD_MIN_NODE_MAJOR} ]]; then
-        log_error "Node is still < ${ONBOARD_MIN_NODE_MAJOR} in this process. In a new terminal run:  source \"\$NVM_DIR/nvm.sh\" && nvm use 22  then:  $0  again."
+    if ! command -v node &>/dev/null || ! onboard_node_ok; then
+        log_error "Node is still < ${ONBOARD_MIN_NODE} in this process. In a new terminal run:  source \"\$NVM_DIR/nvm.sh\" && nvm use 22  then:  $0  again."
         exit 1
     fi
     # After a fresh nvm install in this function, the success message is similar
@@ -422,24 +413,24 @@ onboard_ensure_bkn_cli() {
         exit 1
     fi
     if [[ "${ONBOARD_SKIP_OPENBKN_INSTALL:-false}" == "true" ]]; then
-        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk  (or unset ONBOARD_SKIP_OPENBKN_INSTALL to allow this script to run npm -g.)"
+        log_error "openbkn not in PATH. Install: npm i -g @openbkn/bkn-sdk@latest  (or unset ONBOARD_SKIP_OPENBKN_INSTALL to allow this script to run npm -g.)"
         exit 1
     fi
     if [[ "${ONBOARD_ASSUME_YES}" == "true" ]]; then
         log_info "Installing @openbkn/bkn-sdk globally (-y)…"
     elif onboard_is_bootstrap_tty; then
         echo ""
-        read -r -p "openbkn CLI not in PATH. Install @openbkn/bkn-sdk globally now? (npm i -g) [Y/n]: " _obk
+        read -r -p "openbkn CLI not in PATH. Install @openbkn/bkn-sdk globally now? (npm i -g …@latest) [Y/n]: " _obk
         if [[ "${_obk}" =~ ^[Nn] ]]; then
-            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk"
+            log_error "openbkn is required. Run:  npm i -g @openbkn/bkn-sdk@latest"
             exit 1
         fi
     else
-        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk"
+        log_error "openbkn not in PATH. In a TTY you get a Y/n prompt; without a TTY use  $0 -y  or install: npm i -g @openbkn/bkn-sdk@latest"
         exit 1
     fi
-    if ! npm i -g @openbkn/bkn-sdk; then
-        log_error "npm i -g @openbkn/bkn-sdk failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
+    if ! npm i -g @openbkn/bkn-sdk@latest; then
+        log_error "npm i -g @openbkn/bkn-sdk@latest failed. Check registry/proxy, or EACCES (avoid sudo; use nvm user prefix.)"
         exit 1
     fi
     hash -r 2>/dev/null || true
@@ -466,8 +457,8 @@ onboard_upgrade_bkn_cli() {
     if ! command -v openbkn &>/dev/null; then
         return 0
     fi
-    if ! npm i -g @openbkn/bkn-sdk; then
-        log_warn "npm i -g @openbkn/bkn-sdk failed; continuing with the existing openbkn CLI."
+    if ! npm i -g @openbkn/bkn-sdk@latest; then
+        log_warn "npm i -g @openbkn/bkn-sdk@latest failed; continuing with the existing openbkn CLI."
         return 0
     fi
     hash -r 2>/dev/null || true

--- a/deploy/preflight.sh
+++ b/deploy/preflight.sh
@@ -32,7 +32,7 @@ usage() {
     echo "Options:"
     echo "  -h, --help           Show this help"
     echo "  --check-only         Only run checks, do not modify the system (default; still requires root)"
-    echo "  --fix                Check + apply fixes (K8s/sysctl/etc.); also offers optional Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ + bkn CLIs (each ask y/N unless -y)"
+    echo "  --fix                Check + apply fixes (K8s/sysctl/etc.); also offers optional Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ + bkn CLIs (each ask y/N unless -y)"
     echo "  -y, --yes            Auto-approve every fix (skip per-fix y/N prompt)"
     echo "  -n, --no             Auto-decline every fix (preview risk text, change nothing)"
     echo "  --fix-allow=LIST     Comma-separated fix names to auto-approve (others are skipped)."
@@ -42,7 +42,7 @@ usage() {
     echo "  --list-fixes         Run checks then list fixes that would be offered (no changes; requires root)"
     echo "  --output=json        Emit JSON summary to stdout (human logs to stderr); requires python3"
     echo "  --role=target|admin|both  Target = kubectl/helm only; admin = bkn/node/npm; both = all (default)"
-    echo "                              openbkn CLI needs Node.js ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (per @openbkn/bkn-sdk on npm; help/zh/install.md)"
+    echo "                              openbkn CLI needs Node.js ${PREFLIGHT_OPENBKN_MIN_NODE}+ (per @openbkn/bkn-sdk on npm; help/zh/install.md)"
     echo "  --no-recheck         Do not re-run full checks after applying fixes"
     echo "  --lenient            Downgrade install-blocking [FAIL] items (sysctl, ip_forward, kernel modules,"
     echo "                       containerd, kubectl, helm, swap, broken apt sources, missing k8s/containerd"
@@ -304,7 +304,7 @@ if [[ "${PREFLIGHT_OUTPUT_JSON}" != "true" ]]; then
         if [[ "${_pf_bad}" -eq 0 ]]; then
             echo ""
             echo "  Suggested next step (skip install, just configure / verify):"
-            echo "    - Node/bkn on an admin host: default preflight is check-only; run sudo bash ./preflight.sh --fix to opt in to help installing Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ and CLIs (y/N per step)"
+            echo "    - Node/bkn on an admin host: default preflight is check-only; run sudo bash ./preflight.sh --fix to opt in to help installing Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ and CLIs (y/N per step)"
             echo "    - Configure models / BKN search:    sudo bash ./onboard.sh   (Linux; macOS dev: bash ./dev/mac.sh onboard)"
             echo "    - Check status:                     sudo bash ./deploy.sh bkn-foundry status"
             echo "    - Only if you really want to upgrade: sudo bash ./deploy.sh openbkn install --force-upgrade"
@@ -320,7 +320,7 @@ if [[ "${PREFLIGHT_OUTPUT_JSON}" != "true" ]]; then
             echo "  No BKN Foundry releases detected. Environment looks ready for a first-time install:"
             echo "    sudo bash ./deploy.sh openbkn install              # install the full stack"
             echo ""
-            echo "  After deploy: from this repo's deploy/ directory run sudo bash ./onboard.sh (Linux; macOS dev uses plain bash; needs Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ + bkn CLI on that host)."
+            echo "  After deploy: from this repo's deploy/ directory run sudo bash ./onboard.sh (Linux; macOS dev uses plain bash; needs Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ + bkn CLI on that host)."
             echo "  If this host still lacks Node/CLIs: sudo bash ./preflight.sh --fix"
         else
             echo "  No BKN Foundry releases detected, but preflight above is NOT all clear — fix that before treating deploy as ready."
@@ -329,7 +329,7 @@ if [[ "${PREFLIGHT_OUTPUT_JSON}" != "true" ]]; then
             echo "    sudo bash ./preflight.sh --check-only   # re-check until blocking [FAIL] items are addressed (or sudo bash ./preflight.sh --check-only --lenient if you accept the caveats)"
             echo "  Only then install:"
             echo "    sudo bash ./deploy.sh openbkn install              # install the full stack"
-            echo "  Finally: sudo bash ./onboard.sh from deploy/ (Linux; macOS dev uses plain bash. Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ + bkn on PATH; sudo bash ./preflight.sh --fix helps install tooling on this machine)."
+            echo "  Finally: sudo bash ./onboard.sh from deploy/ (Linux; macOS dev uses plain bash. Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ + bkn on PATH; sudo bash ./preflight.sh --fix helps install tooling on this machine)."
         fi
     fi
     echo "${_PF_BAR}"

--- a/deploy/scripts/lib/common.sh
+++ b/deploy/scripts/lib/common.sh
@@ -116,11 +116,24 @@ bkn_helm_uninstall_if_not_deployed() {
 # (older clients may parse templates as empty → Helm error "no objects visited").
 OPENBKN_HELM_MIN_SEMVER="${OPENBKN_HELM_MIN_SEMVER:-3.10.0}"
 
+# The openbkn CLI's own floor, and the one npm enforces when resolving it. Kept
+# as a full version on purpose: comparing only the major number accepts 22.0.0,
+# where `npm i -g @openbkn/bkn-sdk` silently installs an older release instead
+# of failing — npm skips a version whose `engines` the runtime cannot meet and
+# says nothing. 22.19.0 is what `@openbkn/bkn-sdk` declares (undici's own floor).
+OPENBKN_NODE_MIN_SEMVER="${OPENBKN_NODE_MIN_SEMVER:-22.19.0}"
+
 bkn_semver_ge() {
     local have="$1"
     local need="$2"
     [[ -n "${have}" && -n "${need}" ]] || return 1
     [[ "$(printf '%s\n' "${need}" "${have}" | sort -V | head -1)" == "${need}" ]]
+}
+
+# Full `node -v` as x.y.z, or empty when node is absent or unparseable.
+bkn_node_semver() {
+    command -v node &>/dev/null || return 0
+    node -v 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true
 }
 
 bkn_helm_client_semver() {

--- a/deploy/scripts/lib/onboard_cli_test.sh
+++ b/deploy/scripts/lib/onboard_cli_test.sh
@@ -28,23 +28,26 @@ out="$(
         onboard_upgrade_bkn_cli
 )"
 [[ "${out}" == *"npm-called"* ]] || fail "installed CLI should attempt npm upgrade"
-[[ "${out}" == *"warn:npm i -g @openbkn/bkn-sdk failed"* ]] || fail "upgrade failure should warn"
+[[ "${out}" == *"warn:npm i -g @openbkn/bkn-sdk@latest failed"* ]] || fail "upgrade failure should warn"
 
 # Explicit skip, offline mode, and BKN-only mode must never invoke npm.
+# Patterns are written `(x)` rather than `x)`: bash 3.2, still the macOS system
+# shell and a supported way to run these scripts, otherwise reads the pattern's
+# `)` as the end of the enclosing `$( )` and the whole loop never runs.
 for mode in skip offline bkn-only; do
     out="$(
         openbkn() { :; }
         npm() { echo "unexpected-npm"; return 99; }
         case "${mode}" in
-            skip)
+            (skip)
                 ONBOARD_SKIP_OPENBKN_INSTALL=true OFFLINE_MODE=false ENABLE_BKN_ONLY=false \
                     onboard_upgrade_bkn_cli
                 ;;
-            offline)
+            (offline)
                 ONBOARD_SKIP_OPENBKN_INSTALL=false OFFLINE_MODE=true ENABLE_BKN_ONLY=false \
                     onboard_upgrade_bkn_cli
                 ;;
-            bkn-only)
+            (bkn-only)
                 ONBOARD_SKIP_OPENBKN_INSTALL=false OFFLINE_MODE=false ENABLE_BKN_ONLY=true \
                     onboard_upgrade_bkn_cli
                 ;;

--- a/deploy/scripts/lib/preflight_checks.sh
+++ b/deploy/scripts/lib/preflight_checks.sh
@@ -17,14 +17,16 @@ declare -a PREFLIGHT_JSON_FIXED=()
 declare -a PREFLIGHT_JSON_DECLINED=()
 declare -a PREFLIGHT_FAIL_SNAPSHOT=()
 
-# Node major for openbkn / onboard in this deploy path (default 22: aligns with
-# @openbkn/bkn-sdk; same bar even if npm lists >=18). Override for experiments.
-PREFLIGHT_OPENBKN_MIN_NODE_MAJOR="${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR:-22}"
+# Node floor for openbkn / onboard in this deploy path — aligned with
+# @openbkn/bkn-sdk. A full version, not a major: 22.0.0 passes a `>= 22` test
+# and still cannot install the CLI, because npm resolves past a release whose
+# `engines` the runtime misses and installs an older one without an error.
+PREFLIGHT_OPENBKN_MIN_NODE="${PREFLIGHT_OPENBKN_MIN_NODE:-${OPENBKN_NODE_MIN_SEMVER:-22.19.0}}"
 # Minimum CPython for deploy/scripts/lib/onboard_*.py; enforced when python3 is on PATH.
 PREFLIGHT_MIN_PYTHON_MAJOR="${PREFLIGHT_MIN_PYTHON_MAJOR:-3}"
 PREFLIGHT_MIN_PYTHON_MINOR="${PREFLIGHT_MIN_PYTHON_MINOR:-6}"
 # If the user does not install Node 22+ on the server they ran preflight on, they need *some* environment with it.
-PREFLIGHT_OFFHOST_NODE22_HINT="If you do not upgrade Node on this host, run ./onboard.sh and the openbkn CLI from a machine (or job) where Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ is on PATH — e.g. your laptop, a jump box with nvm, a devcontainer, or CI."
+PREFLIGHT_OFFHOST_NODE22_HINT="If you do not upgrade Node on this host, run ./onboard.sh and the openbkn CLI from a machine (or job) where Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ is on PATH — e.g. your laptop, a jump box with nvm, a devcontainer, or CI."
 
 # Strict mode (default true): items that block install AND are auto-fixable by --fix
 # are reported as [FAIL] instead of [WARN], so check-only exits 1 (not 2) and operators
@@ -1405,6 +1407,13 @@ preflight_check_target_tools() {
 }
 
 # Node major from `node -v` (0 if missing or unparseable). Align with npm `engines` (default: 22+). Check only unless --fix + confirm.
+preflight_node_ok() {
+    local have
+    have="$(bkn_node_semver)"
+    [[ -n "${have}" ]] || return 1
+    bkn_semver_ge "${have}" "${PREFLIGHT_OPENBKN_MIN_NODE}"
+}
+
 preflight_node_major() {
     if ! command -v node &>/dev/null; then
         echo 0
@@ -1423,19 +1432,19 @@ preflight_node_major() {
 
 preflight_check_admin_tools() {
     preflight_skip "admin-tools" && return 0
-    log_info "Checking admin / optional tools (node, npm, openbkn) — target Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+; below that is [WARN] only (not [FAIL])..."
+    log_info "Checking admin / optional tools (node, npm, openbkn) — target Node ${PREFLIGHT_OPENBKN_MIN_NODE}+; below that is [WARN] only (not [FAIL])..."
 
     local _nmj
     _nmj=""
     if command -v node &>/dev/null; then
         _nmj="$(preflight_node_major)"
-        if [[ -n "${_nmj}" && $(( 10#${_nmj} )) -ge ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
-            preflight_ok "node: $(node -v 2>/dev/null) (>= ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}; openbkn CLI + onboard)"
+        if preflight_node_ok; then
+            preflight_ok "node: $(node -v 2>/dev/null) (>= ${PREFLIGHT_OPENBKN_MIN_NODE}; openbkn CLI + onboard)"
         else
-            preflight_warn "node: $(node -v 2>/dev/null) (need ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+. Not a hard failure. Fix: sudo bash ./preflight.sh --fix → allow onboard-tooling, then accept node-22 (nvm/NodeSource), or upgrade Node yourself. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+            preflight_warn "node: $(node -v 2>/dev/null) (need ${PREFLIGHT_OPENBKN_MIN_NODE}+. Not a hard failure. Fix: sudo bash ./preflight.sh --fix → allow onboard-tooling, then accept node-22 (nvm/NodeSource), or upgrade Node yourself. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         fi
     else
-        preflight_warn "node not in PATH (need Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ for CLIs / onboard. [WARN] only. Fix: sudo bash ./preflight.sh --fix and opt in to nodejs-npm + node-22 when prompted. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+        preflight_warn "node not in PATH (need Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ for CLIs / onboard. [WARN] only. Fix: sudo bash ./preflight.sh --fix and opt in to nodejs-npm + node-22 when prompted. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
     fi
 
     if command -v npm &>/dev/null; then
@@ -1447,13 +1456,13 @@ preflight_check_admin_tools() {
     if command -v openbkn &>/dev/null; then
         if ! command -v node &>/dev/null; then
             preflight_ok "openbkn: $(openbkn --version 2>/dev/null | head -1 || echo ok) (node issue called out above)"
-        elif [[ -n "${_nmj}" && $(( 10#${_nmj} )) -ge ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+        elif preflight_node_ok; then
             preflight_ok "openbkn: $(openbkn --version 2>/dev/null | head -1 || echo ok) (provides 'openbkn admin')"
         else
-            preflight_warn "openbkn on PATH, but Node is < ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} — prefer upgrading to Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (npm i -g and onboard expect that here). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+            preflight_warn "openbkn on PATH, but Node is < ${PREFLIGHT_OPENBKN_MIN_NODE} — prefer upgrading to Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ (npm i -g and onboard expect that here). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         fi
     else
-        preflight_warn "openbkn CLI not in PATH (npm i -g @openbkn/bkn-sdk; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+). 'openbkn admin' ships with it. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+        preflight_warn "openbkn CLI not in PATH (npm i -g @openbkn/bkn-sdk@latest; or sudo bash ./preflight.sh --fix after Node ${PREFLIGHT_OPENBKN_MIN_NODE}+). 'openbkn admin' ships with it. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
     fi
 }
 
@@ -1935,13 +1944,12 @@ preflight_fix_helm_v3() {
 
 # Install distro nodejs + npm (opt-in via preflight --fix + y/N; before npm -g bkn).
 preflight_fix_node_npm() {
-    local _ok=true _mj
-    _mj="$(preflight_node_major)"
+    local _ok=true
     if command -v npm &>/dev/null && command -v node &>/dev/null; then
-        if [[ -n "${_mj}" && $(( 10#${_mj} )) -ge ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+        if preflight_node_ok; then
             return 0
         fi
-        preflight_warn "Node is $(node -v 2>/dev/null) but bkn CLIs need ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+; 'nodejs-npm' only adds distro packages and will not replace an old Node. Use node-22 fix or nvm/Node LTS. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+        preflight_warn "Node is $(node -v 2>/dev/null) but bkn CLIs need ${PREFLIGHT_OPENBKN_MIN_NODE}+; 'nodejs-npm' only adds distro packages and will not replace an old Node. Use node-22 fix or nvm/Node LTS. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         return 0
     fi
     if command -v apt-get &>/dev/null; then
@@ -1969,9 +1977,8 @@ preflight_fix_node_npm() {
             preflight_warn "node is present but npm is still missing"
         fi
     fi
-    _mj="$(preflight_node_major)"
-    if command -v node &>/dev/null && [[ -n "${_mj}" && $(( 10#${_mj} )) -lt ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
-        preflight_warn "node after install: $(node -v 2>/dev/null) (still < ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}; run the node-22 fix if you agreed to it, or nvm/Node 22+). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+    if command -v node &>/dev/null && ! preflight_node_ok; then
+        preflight_warn "node after install: $(node -v 2>/dev/null) (still < ${PREFLIGHT_OPENBKN_MIN_NODE}; run the node-22 fix if you agreed to it, or nvm/Node 22+). ${PREFLIGHT_OFFHOST_NODE22_HINT}"
     fi
 }
 
@@ -2003,11 +2010,11 @@ preflight_fix_node_22() {
     fi
     hash -r 2>/dev/null || true
     m="$(preflight_node_major)"
-    if command -v node &>/dev/null && [[ -n "${m}" && $(( 10#${m} )) -ge ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+    if command -v node &>/dev/null && preflight_node_ok; then
         preflight_fixed "Node.js $(node -v) via nvm (NVM_DIR=${NVM_DIR}, $(command -v node); npm $(npm -v 2>/dev/null))"
         return 0
     fi
-    preflight_warn "nvm did not yield Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ in this shell; falling back to NodeSource (adds a third-party OS repo)…"
+    preflight_warn "nvm did not yield Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ in this shell; falling back to NodeSource (adds a third-party OS repo)…"
     preflight_fix_node_22_nodesource
 }
 
@@ -2056,7 +2063,7 @@ preflight_fix_node_22_nodesource() {
     hash -r 2>/dev/null || true
     local m
     m="$(preflight_node_major)"
-    if command -v node &>/dev/null && [[ -n "${m}" && $(( 10#${m} )) -ge ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+    if command -v node &>/dev/null && preflight_node_ok; then
         preflight_fixed "Node.js is now $(node -v) at $(command -v node) (includes npm $(npm -v 2>/dev/null))"
     else
         preflight_warn "NodeSource step finished but node is still ${m:-0}: $(node -v 2>/dev/null)"
@@ -2213,9 +2220,7 @@ preflight_onboard_tooling_needed() {
     if ! command -v node &>/dev/null || ! command -v npm &>/dev/null; then
         return 0
     fi
-    local _om
-    _om="$(preflight_node_major)"
-    if [[ -n "${_om}" && $(( 10#${_om} )) -lt ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+    if ! preflight_node_ok; then
         return 0
     fi
     if ! command -v openbkn &>/dev/null; then
@@ -2633,12 +2638,12 @@ preflight_apply_safe_fixes() {
         if preflight_fix_allow_includes_onboard_step; then
             _ot_run=true
         elif preflight_confirm_fix "onboard-tooling" \
-            "Will you run ./onboard.sh (and optionally the openbkn CLI) on this machine? We standardize on Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (openbkn CLI, onboard); we can nvm/NodeSource → npm -g in the next prompts if you say Yes" \
-            "Choose No if you will run onboard/CLIs on another host with Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (nvm, container, laptop, etc.). If you stay on this machine without node-22, you still need that other environment. Yes = may run node-22 and global npm; each step y/N unless -y. Saying No is REMEMBERED — preflight will not ask again until you remove the sentinel."; then
+            "Will you run ./onboard.sh (and optionally the openbkn CLI) on this machine? We standardize on Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ (openbkn CLI, onboard); we can nvm/NodeSource → npm -g in the next prompts if you say Yes" \
+            "Choose No if you will run onboard/CLIs on another host with Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ (nvm, container, laptop, etc.). If you stay on this machine without node-22, you still need that other environment. Yes = may run node-22 and global npm; each step y/N unless -y. Saying No is REMEMBERED — preflight will not ask again until you remove the sentinel."; then
             _ot_run=true
         else
             preflight_remember_no "onboard-tooling"
-            log_info "Skipped preparing this host for onboard (onboard-tooling: No). You still need Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ somewhere for ./onboard.sh and the CLIs — use another machine, nvm in your user, a devcontainer, or CI."
+            log_info "Skipped preparing this host for onboard (onboard-tooling: No). You still need Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ somewhere for ./onboard.sh and the CLIs — use another machine, nvm in your user, a devcontainer, or CI."
         fi
     else
         _ot_run=true
@@ -2654,14 +2659,12 @@ preflight_apply_safe_fixes() {
     fi
 
     if command -v node &>/dev/null; then
-        local _nmj22
-        _nmj22="$(preflight_node_major)"
-        if [[ -n "${_nmj22}" && $(( 10#${_nmj22} )) -lt ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
+        if ! preflight_node_ok; then
             if preflight_was_declined "node-22"; then
                 log_info "  -> skipping node-22: previously declined ($(_preflight_decision_file node-22)). Re-prompt: sudo rm $(_preflight_decision_file node-22)"
             elif preflight_confirm_fix "node-22" \
                 "nvm in \$HOME/.nvm + nvm install 22 (LTS); if nvm fails, NodeSource 22.x (adds OS repo; needs HTTPS)" \
-                "For hosts below Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}. nvm: GitHub+nodejs.org; NodeSource: third-party apt/dnf. Air-gapped: install Node 22+ manually. Saying No is REMEMBERED — preflight will not ask again until you remove the sentinel. ${PREFLIGHT_OFFHOST_NODE22_HINT}"; then
+                "For hosts below Node ${PREFLIGHT_OPENBKN_MIN_NODE}. nvm: GitHub+nodejs.org; NodeSource: third-party apt/dnf. Air-gapped: install Node 22+ manually. Saying No is REMEMBERED — preflight will not ask again until you remove the sentinel. ${PREFLIGHT_OFFHOST_NODE22_HINT}"; then
                 preflight_fix_node_22
             else
                 preflight_remember_no "node-22"
@@ -2670,19 +2673,17 @@ preflight_apply_safe_fixes() {
     fi
 
     if command -v npm &>/dev/null; then
-        local _npmj
-        _npmj="$(preflight_node_major)"
-        if [[ -z "${_npmj}" || $(( 10#${_npmj} )) -lt ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR} ]]; then
-            preflight_warn "Skipping openbkn CLI (@openbkn/bkn-sdk) global npm install: need Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
+        if ! preflight_node_ok; then
+            preflight_warn "Skipping openbkn CLI (@openbkn/bkn-sdk) global npm install: need Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ (current: $(node -v 2>/dev/null || echo 'no node')). Run node-22 fix with consent, or upgrade Node manually, then re-run preflight --fix. ${PREFLIGHT_OFFHOST_NODE22_HINT}"
         else
         if ! command -v openbkn &>/dev/null; then
             if preflight_confirm_fix "bkn-sdk" \
-                "npm install -g @openbkn/bkn-sdk" \
-                "User accepted: installs the openbkn CLI (provides 'openbkn admin'). Requires working npm and Node ${PREFLIGHT_OPENBKN_MIN_NODE_MAJOR}+ on PATH in this root shell (same as https://www.npmjs.com/package/@openbkn/bkn-sdk)."; then
-                if npm install -g @openbkn/bkn-sdk; then
+                "npm install -g @openbkn/bkn-sdk@latest" \
+                "User accepted: installs the openbkn CLI (provides 'openbkn admin'). Requires working npm and Node ${PREFLIGHT_OPENBKN_MIN_NODE}+ on PATH in this root shell (same as https://www.npmjs.com/package/@openbkn/bkn-sdk)."; then
+                if npm install -g @openbkn/bkn-sdk@latest; then
                     preflight_fixed "Installed @openbkn/bkn-sdk ($(openbkn --version 2>/dev/null | head -n1 || echo ok))"
                 else
-                    preflight_warn "npm install -g @openbkn/bkn-sdk failed (check npm registry / proxy)"
+                    preflight_warn "npm install -g @openbkn/bkn-sdk@latest failed (check npm registry / proxy)"
                 fi
             fi
         fi

--- a/deploy/scripts/lib/preflight_checks_test.sh
+++ b/deploy/scripts/lib/preflight_checks_test.sh
@@ -74,6 +74,50 @@ PREFLIGHT_FIX_ALLOW="|other|"
 PREFLIGHT_ASSUME_NO=false PREFLIGHT_ASSUME_YES=false preflight_confirm_fix "t" "a" "r" && fail "not in allowlist" || true
 PREFLIGHT_FIX_ALLOW=""
 
+# --- Node floor: full version, not just the major ---
+# 22.0.0 clears a `>= 22` test and still cannot install the CLI: npm resolves
+# past a release whose `engines` the runtime misses and installs an older one
+# without an error, which is how a deploy ends up running a stale openbkn while
+# every check reports green.
+[[ "${OPENBKN_NODE_MIN_SEMVER}" == "22.19.0" ]] || fail "node floor is ${OPENBKN_NODE_MIN_SEMVER}, expected 22.19.0"
+
+bkn_semver_ge "22.19.0" "${OPENBKN_NODE_MIN_SEMVER}" || fail "22.19.0 must satisfy the floor"
+bkn_semver_ge "22.22.0" "${OPENBKN_NODE_MIN_SEMVER}" || fail "22.22.0 must satisfy the floor"
+bkn_semver_ge "24.15.0" "${OPENBKN_NODE_MIN_SEMVER}" || fail "24.15.0 must satisfy the floor"
+bkn_semver_ge "22.11.0" "${OPENBKN_NODE_MIN_SEMVER}" && fail "22.11.0 must NOT satisfy the floor (major-only check let this through)"
+bkn_semver_ge "22.0.0" "${OPENBKN_NODE_MIN_SEMVER}" && fail "22.0.0 must NOT satisfy the floor"
+bkn_semver_ge "20.19.0" "${OPENBKN_NODE_MIN_SEMVER}" && fail "20.19.0 must NOT satisfy the floor"
+
+# preflight_node_ok reads the running node, so drive it through a stub.
+_node_stub_dir="$(mktemp -d)"
+_stub_node() {
+  printf '#!/usr/bin/env bash\necho "v%s"\n' "$1" > "${_node_stub_dir}/node"
+  chmod +x "${_node_stub_dir}/node"
+}
+_stub_node "22.11.0"
+PATH="${_node_stub_dir}:${PATH}" preflight_node_ok && fail "preflight_node_ok accepted 22.11.0" || true
+_stub_node "22.19.0"
+PATH="${_node_stub_dir}:${PATH}" preflight_node_ok || fail "preflight_node_ok rejected 22.19.0"
+rm -rf "${_node_stub_dir}"
+
+# The floor is a full version, so it must never reach an arithmetic test:
+# `[[ $(( 10#$m )) -ge 22.19.0 ]]` is a runtime error, not a false result, and
+# every caller that compared a major had to move to preflight_node_ok.
+_pf="${SCRIPT_DIR}/scripts/lib/preflight_checks.sh"
+grep -nE '\$\(\(.*\)\).*(-ge|-lt|-gt|-le) *\$\{PREFLIGHT_OPENBKN_MIN_NODE\}' "${_pf}" \
+  && fail "preflight_checks.sh compares the Node floor arithmetically (it is a full version)" || true
+
+# A bare `npm i -g` reinstalls whatever the global already resolves to.
+grep -nE 'npm (i|install) -g @openbkn/bkn-sdk([^@]|$)' "${_pf}" \
+  && fail "preflight_checks.sh installs @openbkn/bkn-sdk without @latest" || true
+
+# The onboard script must enforce the same floor and pin the CLI install.
+_onboard="${SCRIPT_DIR}/onboard.sh"
+grep -q 'ONBOARD_MIN_NODE="\${ONBOARD_MIN_NODE:-\${OPENBKN_NODE_MIN_SEMVER}}"' "${_onboard}" \
+  || fail "onboard.sh does not take its Node floor from OPENBKN_NODE_MIN_SEMVER"
+grep -qE 'npm i -g @openbkn/bkn-sdk([^@]|$)' "${_onboard}" \
+  && fail "onboard.sh installs @openbkn/bkn-sdk without @latest (a stale global blocks the upgrade)" || true
+
 if [[ ${ONE_FAILED} -ne 0 ]]; then
   exit 1
 fi

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -32,7 +32,7 @@ Prepare the host, network, and client tooling before you deploy.
 | Tool | Expectation |
 | --- | --- |
 | **Git** | `deploy.sh` / `preflight.sh` **do not** call `git`. Install Git only if you are working from **a cloned repository**. Deployments from an **extracted product tarball** or artifact **do not** require Git on the install host. |
-| **Node.js** | **22+** aligns with **`@openbkn/bkn-sdk`** npm [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk), **`deploy/onboard.sh`**, and preflight checks (`PREFLIGHT_OPENBKN_MIN_NODE_MAJOR`, default **22**). Bringing up Kubernetes/Helm on the server **does not** require Node; preflight warns if Node is missing or older than **22** (**[WARN]** only—you can run onboard from another machine or install Node via **`preflight.sh --fix`** opt-ins). See **Client tooling** below. |
+| **Node.js** | **22.19.0+** aligns with **`@openbkn/bkn-sdk`** npm [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk), **`deploy/onboard.sh`**, and preflight checks (`PREFLIGHT_OPENBKN_MIN_NODE`, default **22.19.0**). The full version is compared, not the major: 22.0.0 clears a `>= 22` bar and still cannot install the CLI, because npm skips a release whose `engines` the runtime misses and installs an older one without an error. Bringing up Kubernetes/Helm on the server **does not** require Node; preflight warns if Node is missing or older than **22** (**[WARN]** only—you can run onboard from another machine or install Node via **`preflight.sh --fix`** opt-ins). See **Client tooling** below. |
 | **Python** **3** | **Optional** for normal `preflight` / `deploy.sh`. **`python3`** is **required** if you pass **`deploy/preflight.sh --output=json`** (stdout JSON is emitted via Python). When **`python3`** is on PATH, preflight **requires CPython 3.6+** (same bar as `deploy/scripts/lib/onboard_*.py`; override **`PREFLIGHT_MIN_PYTHON_MAJOR`** / **`PREFLIGHT_MIN_PYTHON_MINOR`**, default **3** / **6**). A few kubectl-related helpers also use Python when available. |
 
 **`deploy/scripts/lib/onboard_*.py` (invoked by `onboard.sh`)** are written for **CPython 3.6 through current 3.x** — including **CentOS 7’s 3.6.x** — and avoid 3.7-only `subprocess` flags, **PEP 563** annotations, **`yaml.dump(..., sort_keys=...)`** (needs newer PyYAML), etc. **Python 3.5 and older are not supported** (f-strings, among other things). Maintainer/CI: **`bash deploy/scripts/lib/preflight_checks_test.sh`** includes a `py_compile` pass on these files when `python3` is available; set **`EXTRA_PYTHONS="python3.9 python3.12"`** to repeat with more interpreters.
@@ -80,7 +80,7 @@ npm install -g @openbkn/bkn-sdk
 # or: npx openbkn --help
 ```
 
-> **Node.js 22+** is required. This matches the [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk) field of `@openbkn/bkn-sdk` on npm (`node >= 22`); Node 18 will get `EBADENGINE` or runtime issues.
+> **Node.js 22.19.0+** is required, matching the [`engines`](https://www.npmjs.com/package/@openbkn/bkn-sdk) field of `@openbkn/bkn-sdk` on npm. Below that, **`npm i -g @openbkn/bkn-sdk` does not fail** — it quietly installs an older release instead. Check `openbkn --version` after installing, or install `@openbkn/bkn-sdk@latest` directly.
 
 - **curl** — for raw HTTP API calls
 
@@ -116,7 +116,7 @@ Common flags:
 | Flag | Meaning |
 | --- | --- |
 | `--check-only` | Only run checks, do not modify the system (default) |
-| `--fix` | Check + apply fixes (K8s / sysctl / containerd / Helm / firewall / SELinux / system tuning / sysctl …); also offers Node 22+ + `openbkn` |
+| `--fix` | Check + apply fixes (K8s / sysctl / containerd / Helm / firewall / SELinux / system tuning / sysctl …); also offers Node 22.19+ + `openbkn` |
 | `-y` / `--yes` | Auto-approve **every** fix prompt |
 | `-n` / `--no` | Auto-decline every fix (preview risk text only) |
 | `--fix-allow=LIST` | Comma-separated fix names to auto-approve, others are skipped (e.g. `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,bkn-sdk`; legacy alias `k8s-apt-source`). Run `sudo bash deploy/preflight.sh --list-fixes` to see all fix names available on this host. |

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -32,7 +32,7 @@
 | 工具 | 说明 |
 | --- | --- |
 | **Git** | `deploy.sh` / `preflight.sh` **不会**调用 `git`。只有从 **Git 仓库 clone** 开发/更新时才需要本机装 Git；使用**已解压的产品包**或构建产物时，**安装目标机可以不装 Git**。 |
-| **Node.js** | **22+** 与 **`@openbkn/bkn-sdk`** 的 npm `engines`、`deploy/onboard.sh` 及 preflight 检查一致（环境变量 **`PREFLIGHT_OPENBKN_MIN_NODE_MAJOR`**，默认 **22**）。**仅起 K8s / Helm** 时，目标机**可以不装 Node**；缺 Node 或版本低于 22 时 preflight 多为 **[WARN]**（非阻塞），也可在**另一台已装 Node 22+ 的机器**上跑 `onboard.sh`，或通过 **`preflight.sh --fix`** 里与 Node 相关的可选项安装。详见下文 **客户端工具**。 |
+| **Node.js** | **22.19.0+** 与 **`@openbkn/bkn-sdk`** 的 npm `engines`、`deploy/onboard.sh` 及 preflight 检查一致（环境变量 **`PREFLIGHT_OPENBKN_MIN_NODE`**，默认 **22.19.0**）。比的是完整版本而不是主版本号：22.0.0 能过「≥22」却装不上 CLI —— npm 遇到运行时满足不了 `engines` 的版本会跳过它、装一个旧的，且不报错。**仅起 K8s / Helm** 时，目标机**可以不装 Node**；缺 Node 或版本低于 22 时 preflight 多为 **[WARN]**（非阻塞），也可在**另一台已装 Node 22+ 的机器**上跑 `onboard.sh`，或通过 **`preflight.sh --fix`** 里与 Node 相关的可选项安装。详见下文 **客户端工具**。 |
 | **Python** **3** | 日常跑 **`preflight` / `deploy.sh` 不强制**要求。若使用 **`deploy/preflight.sh --output=json`**（JSON 输出依赖 **`python3`**），则**必须**安装 Python 3。若目标机 **PATH 上已有 `python3`**，preflight 会检查其版本为 **CPython 3.6+**（与 `deploy/scripts/lib/onboard_*.py` 一致；可用 **`PREFLIGHT_MIN_PYTHON_MAJOR`** / **`PREFLIGHT_MIN_PYTHON_MINOR`** 覆盖，默认 **3** / **6**）。部分与 `kubectl` 相关的辅助解析在存在 `python3` 时也会使用。 |
 
 **`deploy/scripts/lib/onboard_*.py`（供 `onboard.sh` 调用）**：实现上约定 **CPython 3.6 起至当前主线 3.x** 可调（兼容 CentOS 7 自带的 **3.6.x**；**3.5 及以下**不适用，因其缺少 f-string 等语法）。不向 **PyYAML 5.1 以后**才有的 `yaml.dump(..., sort_keys=...)` 等参数。维护者或 CI 可执行 **`bash deploy/scripts/lib/preflight_checks_test.sh`**，在存在 **`python3`** 时会对这两个文件做一次 **`py_compile`**；本机若有多个解释器，可 **`EXTRA_PYTHONS="python3.9 python3.12"`** 再跑一遍以覆盖多版本。
@@ -81,7 +81,7 @@ npm install -g @openbkn/bkn-sdk
 npx openbkn --help
 ```
 
-> 需要 **Node.js 22+**，与 npm 上 [`@openbkn/bkn-sdk`](https://www.npmjs.com/package/@openbkn/bkn-sdk) 的 `engines`（`node >= 22`）一致；使用 Node 18 会 `EBADENGINE` 或运行期报错。
+> 需要 **Node.js 22.19.0+**，与 npm 上 [`@openbkn/bkn-sdk`](https://www.npmjs.com/package/@openbkn/bkn-sdk) 的 `engines` 一致。低于这个版本时 **`npm i -g @openbkn/bkn-sdk` 不会报错**，而是静默装上一个旧版本 —— 所以安装后请用 `openbkn --version` 核对，或直接 `npm i -g @openbkn/bkn-sdk@latest`。
 
 - 🌐 **curl** — 直接调用 HTTP API
 
@@ -117,7 +117,7 @@ sudo bash deploy/preflight.sh --help         # 全部参数
 | 参数 | 含义 |
 | --- | --- |
 | `--check-only` | 仅检查，不改系统（默认） |
-| `--fix` | 检查 + 应用修复（K8s / sysctl / containerd / Helm / 防火墙 / SELinux / 系统调优 / sysctl 等）；同时按需提示安装 Node 22+ + `openbkn` |
+| `--fix` | 检查 + 应用修复（K8s / sysctl / containerd / Helm / 防火墙 / SELinux / 系统调优 / sysctl 等）；同时按需提示安装 Node 22.19+ + `openbkn` |
 | `-y` / `--yes` | **全部**修复项自动确认 |
 | `-n` / `--no` | 全部修复项自动拒绝（仅查看风险描述，不改东西） |
 | `--fix-allow=LIST` | 仅自动确认指定修复项（其余跳过），如 `k8s-pkgs-repo,k8s-bins,containerd-install,helm-v3,nofile-limits,nodejs-npm,bkn-sdk`（旧名 `k8s-apt-source` 仍可作别名）。可用 `sudo bash deploy/preflight.sh --list-fixes` 查看本机当前可用的全部修复名 |


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] `deploy/onboard.sh` / `deploy/scripts/lib/preflight_checks.sh`：Node 门槛从「主版本 ≥22」改为完整版本 `≥22.19.0`
- [x] `deploy/scripts/lib/common.sh`：新增 `OPENBKN_NODE_MIN_SEMVER` 与 `bkn_node_semver`，两个脚本共用一处定义
- [x] 全部 4 处 `npm i -g @openbkn/bkn-sdk` 改为 `@openbkn/bkn-sdk@latest`
- [x] `onboard_cli_test.sh`：修掉 bash 3.2 下的解析问题（三条断言此前从未执行）
- [x] `preflight_checks_test.sh`：新增 6 类回归
- [x] `help/zh/install.md`、`help/en/install.md` 同步

---

## Why

- Related Issue: N/A（由 `@openbkn/bkn-sdk` 0.1.4 的线上问题反查到）
- Related Feature: N/A
- Background:

onboard 会装 Node 22，然后 `npm i -g @openbkn/bkn-sdk`。而两个脚本的门槛检查**只比主版本**：

```bash
v="${v%%.*}"                                          # "22.11.0" -> "22"
[[ $(( 10#${mj} )) -ge ${ONBOARD_MIN_NODE_MAJOR} ]]   # 22 >= 22 -> 通过
```

`@openbkn/bkn-sdk` 声明的是 `engines.node >= 22.19.0`（`undici` 自己的下限）。**Node 22.0.0 能过这个检查，却装不上 CLI** —— npm 遇到运行时满足不了 `engines` 的版本**不会报错**，它跳过该版本、装一个更旧的，一声不吭。

结果是：一台机器所有检查全绿，跑的却是过期的 openbkn，全链路没有任何地方会指出问题。

---

## How

- Key implementation points:
  - 门槛改为完整版本，用仓库里已有的 `bkn_semver_ge`（Helm 检查用的就是它）比较；`onboard.sh` 与 `preflight_checks.sh` 都从 `common.sh` 取同一个值
  - **preflight 里 8 处比较**迁到 `preflight_node_ok`：4 处 `-ge`、4 处 `-lt`。它们全都是把主版本整数拿去比，一旦变量值变成 `22.19.0` 就是**运行时算术错误**（`bash -n` 查不出来）
  - 4 处安装点加 `@latest`，含 onboard 的「保持最新」分支和 preflight 的 `bkn-sdk` 修复项 —— 不加 tag 时，已解析到旧版本的全局安装不会被顶掉
- Breaking changes:
  - 环境变量改名：`PREFLIGHT_OPENBKN_MIN_NODE_MAJOR` → `PREFLIGHT_OPENBKN_MIN_NODE`，`ONBOARD_MIN_NODE_MAJOR` → `ONBOARD_MIN_NODE`（值从主版本变成完整版本）
  - **没有做兼容映射**：把旧的 `22` 读成 `22.0.0` 恰好会把这个洞原样放回来

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（这三个脚本就是本模块的测试入口，无独立集成层）
- [ ] Verified in test environment（未在真实主机跑 onboard/preflight；改动集中在版本比较与安装命令）

Test notes:

```
bash deploy/scripts/lib/preflight_checks_test.sh   OK
bash deploy/scripts/lib/onboard_cli_test.sh        OK   ← 此前在 macOS 上根本跑不起来
bash deploy/scripts/lib/registry_test.sh           OK
shellcheck -S error（改动涉及的 6 个文件）           4 个 error，与基线持平（均为原有）
```

新增回归覆盖：门槛取值、semver 边界（**22.11.0 必须被拒** —— 主版本比较正是放它过去的）、`preflight_node_ok` 用桩 node 驱动、禁止该变量出现在算术上下文、禁止裸 `npm i -g`、onboard 门槛与公共定义联动。

逐条反向验证：任一改动退回原状都会让测试变红（4 处 / 1 处 / 1 处 / 1 处），恢复后为 0。

**关于 `onboard_cli_test.sh`**：bash 3.2（macOS 系统 shell，也是本仓库文档写明的运行方式之一）把 `$( )` 里裸写的 `case` 模式的 `)` 当成命令替换结束，导致其中三条断言从未执行。改成 `(skip)` 这种可移植写法后它们才真正运行 —— 而它抓到的第一件事，就是本 PR 改了告警文案却没同步断言。

---

## Risk & Rollback

- Potential risks：门槛抬高后，Node 在 22.0–22.18 之间的主机会从「通过」变为「警告 / 提示安装」。这正是意图 —— 那些主机本来就装不到正确的 CLI，只是此前不被告知。`preflight` 对 Node 仍是 `[WARN]` 而非 `[FAIL]`，不会阻断部署
- Rollback plan：单个 commit，`git revert` 即可；无状态、无数据迁移

---

## Additional Notes

配套的 SDK 侧修复见 [openbkn-ai/bkn-sdk#75](https://github.com/openbkn-ai/bkn-sdk/pull/75) —— 0.1.4 曾把 `engines` 抬到 `>=24.19.0`，正是它让所有 Node 22 的部署静默退回 0.1.3。SDK 已改回 `>=22.19.0`（0.1.5），本 PR 让部署脚本与之对齐并按完整版本校验。

🤖 Generated with [Claude Code](https://claude.com/claude-code)