### PR TITLE
fix: support HTTP proxy for model provider requests

### DIFF
--- a/infra/mf-model-api/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-api/app/utils/external_small_model_utils.py
@@ -3,11 +3,16 @@ import json
 
 import aiohttp
 
+from app.utils.http_client import proxy_aware_aiohttp
+
 from app.commons.errors import *
 import concurrent.futures
 
 from app.core.config import base_config
 from app.logs.stand_log import StandLogger
+
+# Small-model provider requests use the same proxy environment handling as LLMs.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 class UpstreamModelError(Exception):

--- a/infra/mf-model-api/app/utils/http_client.py
+++ b/infra/mf-model-api/app/utils/http_client.py
@@ -1,0 +1,27 @@
+"""HTTP client helpers for outbound provider requests."""
+
+import aiohttp
+
+
+def client_session(*args, **kwargs):
+    """Create a session that honors standard proxy environment variables."""
+    kwargs.setdefault("trust_env", True)
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class _ProxyAwareAiohttpModule:
+    """Local aiohttp facade that leaves all non-session aiohttp APIs intact."""
+
+    def __init__(self, module):
+        self._module = module
+
+    def ClientSession(self, *args, **kwargs):
+        return client_session(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module, name)
+
+
+def proxy_aware_aiohttp(module):
+    """Return a module-local aiohttp facade whose sessions honor proxy env vars."""
+    return _ProxyAwareAiohttpModule(module)

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -23,6 +23,7 @@ from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.bkntrace import evidence as bkntrace_evidence
 from app.utils.observability.observability_log import get_logger
+from app.utils import log_redact, openai_error
 from app.utils.http_client import proxy_aware_aiohttp
 
 from app.utils.str_util import generate_random_string, has_common_substring

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -23,9 +23,14 @@ from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.bkntrace import evidence as bkntrace_evidence
 from app.utils.observability.observability_log import get_logger
-from app.utils import log_redact, openai_error
+from app.utils.http_client import proxy_aware_aiohttp
 
 from app.utils.str_util import generate_random_string, has_common_substring
+
+# Provider calls in this module must honor HTTP(S)_PROXY and NO_PROXY supplied
+# by the workload environment.  The facade is module-local and does not alter
+# aiohttp behaviour for internal service calls elsewhere in the process.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 # Process-wide tokenizer cache.
 _TOKENIZER_CACHE = {}

--- a/infra/mf-model-api/app/utils/verify_utils.py
+++ b/infra/mf-model-api/app/utils/verify_utils.py
@@ -7,6 +7,7 @@ from llmadapter.llms.llm_factory import llm_factory
 from llmadapter.schema import AIMessage
 from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
+from app.logs.stand_log import StandLogger
 from app.utils.http_client import proxy_aware_aiohttp
 
 
@@ -177,7 +178,6 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                 # A connectivity test should receive one JSON response.  Streaming
                 # SSE is commonly buffered or held open by enterprise proxies.
                 "stream": False,
-                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",

--- a/infra/mf-model-api/app/utils/verify_utils.py
+++ b/infra/mf-model-api/app/utils/verify_utils.py
@@ -7,7 +7,20 @@ from llmadapter.llms.llm_factory import llm_factory
 from llmadapter.schema import AIMessage
 from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
-from app.logs.stand_log import StandLogger
+from app.utils.http_client import proxy_aware_aiohttp
+
+
+# Connection tests must use the deployment's standard proxy environment variables.
+aiohttp = proxy_aware_aiohttp(aiohttp)
+
+
+def _connection_test_error(detail, fallback):
+    raw = str(detail).lower()
+    if "504" in raw or "gateway timeout" in raw or "upstream request timeout" in raw:
+        return "The proxy gateway timed out while waiting for the model service; check the proxy's upstream timeout and streaming policy."
+    if "timeout" in raw or "timed out" in raw:
+        return "Model service connection timed out; check the proxy and network connectivity."
+    return fallback
 
 
 @func_set_timeout(30)
@@ -161,49 +174,38 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     }
                 ],
                 "model": config["api_model"],
-                "stream": True,
-                "stream_options": {"include_usage": True}
+                # A connectivity test should receive one JSON response.  Streaming
+                # SSE is commonly buffered or held open by enterprise proxies.
+                "stream": False,
+                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",
                 "Content-Type": "application/json"
             }
-            token_len = 0
-            prompt_tokens = 0
-            completion_tokens = 0
             async with aiohttp.ClientSession() as session:
                 async with session.post(config["api_url"], json=params, headers=headers, ssl=False) as response:
                     response.encoding = 'utf-8'
                     if response.status != 200:
                         error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-                        error_dict["description"] = error_dict["solution"] = content
+                        detail = ""
                         try:
-                            error_dict["detail"] = await response.text()
+                            detail = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["description"] = "Model configuration is invalid."
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        error_dict["description"] = error_dict["solution"] = _connection_test_error(
+                            error_detail, content)
                         return JSONResponse(status_code=400, content=error_dict)
-                    async for chunk in response.content:
-                        chunk = chunk.decode('utf-8')
-                        if chunk.endswith('\n'):
-                            chunk = chunk[:-1]
-                        elif chunk.endswith('\r\n'):
-                            chunk = chunk[:-2]
-                        if len(chunk) >= 6 and chunk[0:6] != "data: ":
-                            continue
-                        if chunk != "data: [DONE]" and chunk != "":
-                            if chunk[0:6] == "data: ":
-                                chunk = chunk[6:]
-                            try:
-                                datas = json.loads(chunk)
-                            except Exception:
-                                continue
-                            if "usage" in datas.keys():
-                                try:
-                                    prompt_tokens = datas["usage"]["prompt_tokens"]
-                                    completion_tokens = datas["usage"]["completion_tokens"]
-                                except Exception:
-                                    pass
+                    body = await response.text()
+                    try:
+                        json.loads(body)
+                    except json.JSONDecodeError:
+                        error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
+                        error_dict["detail"] = "The model service returned an invalid JSON response."
+                        error_dict["description"] = error_dict["solution"] = content
+                        return JSONResponse(status_code=400, content=error_dict)
                     # if llm_id != "":
                     #     log_info = logics.AddModelUsedAudit(
                     #         model_id=llm_id, user_id=user_id,

--- a/infra/mf-model-manager/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-manager/app/utils/external_small_model_utils.py
@@ -8,6 +8,10 @@ import concurrent.futures
 
 from app.core.config import base_config
 from app.logs.stand_log import StandLogger
+from app.utils.http_client import proxy_aware_aiohttp
+
+# Small-model provider calls use the same environment proxy handling as LLMs.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 class UpstreamModelError(Exception):

--- a/infra/mf-model-manager/app/utils/http_client.py
+++ b/infra/mf-model-manager/app/utils/http_client.py
@@ -1,0 +1,26 @@
+"""HTTP client helpers for outbound model-provider requests."""
+
+import aiohttp
+
+
+def client_session(*args, **kwargs):
+    """Create a session that honors HTTP(S)_PROXY and NO_PROXY."""
+    kwargs.setdefault("trust_env", True)
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class _ProxyAwareAiohttpModule:
+    """Module-local aiohttp facade that only changes ClientSession creation."""
+
+    def __init__(self, module):
+        self._module = module
+
+    def ClientSession(self, *args, **kwargs):
+        return client_session(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module, name)
+
+
+def proxy_aware_aiohttp(module):
+    return _ProxyAwareAiohttpModule(module)

--- a/infra/mf-model-manager/app/utils/llm_utils.py
+++ b/infra/mf-model-manager/app/utils/llm_utils.py
@@ -21,8 +21,12 @@ from app.dao.llm_model_dao import llm_model_dao
 from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.observability.observability_log import get_logger
+from app.utils.http_client import proxy_aware_aiohttp
 
 from app.utils.str_util import generate_random_string, has_common_substring
+
+# All external LLM calls honor proxy variables injected into the workload.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 # Process-wide tokenizer cache.
 _TOKENIZER_CACHE = {}

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -220,7 +220,6 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                 # JSON response.  Proxies commonly buffer SSE or keep it open, which
                 # made a healthy upstream appear as a 504/timeout.
                 "stream": False,
-                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -7,6 +7,11 @@ from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
 from app.logs.stand_log import StandLogger
 from app.core.config import base_config
+from app.utils.http_client import proxy_aware_aiohttp
+
+
+# Use the workload's HTTP(S)_PROXY / NO_PROXY settings for every model test.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 def _semantic_model_test_error(detail, fallback):
@@ -38,6 +43,8 @@ def _semantic_model_test_error(detail, fallback):
         return "Model service authentication failed; check the API key, AK/SK, or authorization configuration."
     if any(token in raw for token in ("deploymentnotfound", "model not found", "not found", "404")):
         return "Model or deployment not found; check API Model and the service URL."
+    if any(token in raw for token in ("504", "gateway timeout", "upstream request timeout")):
+        return "The proxy gateway timed out while waiting for the model service; check the proxy's upstream timeout and streaming policy."
     if any(token in raw for token in ("timeout", "timed out")):
         return "Model service connection timed out; check the service URL and network connectivity."
     if any(token in raw for token in ("connection", "connect", "dns", "name resolution", "enotfound")):
@@ -71,7 +78,10 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             headers = {
                 "api-key": config["api_key"]
             }
-            async with aiohttp.ClientSession(timeout=base_config.test_llm_timeout) as session:
+            # trust_env makes the test follow HTTP(S)_PROXY and NO_PROXY configured
+            # on the workload.  aiohttp otherwise bypasses those proxy settings.
+            async with aiohttp.ClientSession(
+                    timeout=base_config.test_llm_timeout, trust_env=True) as session:
                 url = config["api_url"] + (
                     f"openai/deployments/{config['api_model']}/chat/completions"
                     "?api-version=2023-05-15&api-type=azure"
@@ -85,8 +95,9 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             detail = await response.text()
                         except Exception as err:
                             StandLogger.error(str(err))
-                        error_dict["detail"] = detail
-                        description = _semantic_model_test_error(detail, content)
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        description = _semantic_model_test_error(error_detail, content)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
             return JSONResponse(status_code=200, content={"status": "ok", "id": llm_id})
@@ -205,17 +216,18 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     }
                 ],
                 "model": config["api_model"],
-                "stream": True,
-                "stream_options": {"include_usage": True}
+                # A connectivity test must match a normal request and finish after one
+                # JSON response.  Proxies commonly buffer SSE or keep it open, which
+                # made a healthy upstream appear as a 504/timeout.
+                "stream": False,
+                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",
                 "Content-Type": "application/json"
             }
-            token_len = 0
-            prompt_tokens = 0
-            completion_tokens = 0
-            async with aiohttp.ClientSession(timeout=base_config.test_llm_timeout) as session:
+            async with aiohttp.ClientSession(
+                    timeout=base_config.test_llm_timeout, trust_env=True) as session:
                 async with session.post(config["api_url"], json=params, headers=headers, ssl=False) as response:
                     response.encoding = 'utf-8'
                     if response.status != 200:
@@ -225,31 +237,21 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             detail = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["detail"] = detail
-                        description = _semantic_model_test_error(detail, content)
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        description = _semantic_model_test_error(error_detail, content)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
-                    async for chunk in response.content:
-                        chunk = chunk.decode('utf-8')
-                        if chunk.endswith('\n'):
-                            chunk = chunk[:-1]
-                        elif chunk.endswith('\r\n'):
-                            chunk = chunk[:-2]
-                        if len(chunk) >= 6 and chunk[0:6] != "data: ":
-                            continue
-                        if chunk != "data: [DONE]" and chunk != "":
-                            if chunk[0:6] == "data: ":
-                                chunk = chunk[6:]
-                            try:
-                                datas = json.loads(chunk)
-                            except Exception:
-                                continue
-                            if "usage" in datas.keys():
-                                try:
-                                    prompt_tokens = datas["usage"]["prompt_tokens"]
-                                    completion_tokens = datas["usage"]["completion_tokens"]
-                                except Exception:
-                                    pass
+                    # Consume and validate the complete non-streaming response.  This
+                    # also detects a proxy that returns a 200 with an empty body.
+                    body = await response.text()
+                    try:
+                        json.loads(body)
+                    except json.JSONDecodeError:
+                        error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
+                        error_dict["detail"] = "The model service returned an invalid JSON response."
+                        error_dict["description"] = error_dict["solution"] = content
+                        return JSONResponse(status_code=400, content=error_dict)
                     # if llm_id != "":
                     #     log_info = logics.AddModelUsedAudit(
                     #         model_id=llm_id, user_id=user_id,

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -14,7 +14,7 @@ from app.utils.http_client import proxy_aware_aiohttp
 aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
-def _semantic_model_test_error(detail, fallback):
+def _semantic_model_test_error(detail, fallback, http_status=None):
     upstream_code = ""
     upstream_type = ""
     upstream_message = ""
@@ -37,11 +37,11 @@ def _semantic_model_test_error(detail, fallback):
         pass
 
     raw = " ".join(
-        [upstream_code, upstream_type, upstream_message, str(detail)]
+        [str(http_status or ""), upstream_code, upstream_type, upstream_message, str(detail)]
     ).lower()
     if any(token in raw for token in ("auth", "unauthorized", "api key", "ak/sk", "apikey", "401")):
         return "Model service authentication failed; check the API key, AK/SK, or authorization configuration."
-    if any(token in raw for token in ("deploymentnotfound", "model not found", "not found", "404")):
+    if any(token in raw for token in ("deploymentnotfound", "model_not_found", "model not found", "not found", "404")):
         return "Model or deployment not found; check API Model and the service URL."
     if any(token in raw for token in ("504", "gateway timeout", "upstream request timeout")):
         return "The proxy gateway timed out while waiting for the model service; check the proxy's upstream timeout and streaming policy."
@@ -97,7 +97,8 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             StandLogger.error(str(err))
                         error_detail = f"HTTP {response.status}: {detail}"
                         error_dict["detail"] = error_detail
-                        description = _semantic_model_test_error(error_detail, content)
+                        description = _semantic_model_test_error(
+                            detail, content, http_status=response.status)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
             return JSONResponse(status_code=200, content={"status": "ok", "id": llm_id})
@@ -238,7 +239,8 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             StandLogger.error(str(e))
                         error_detail = f"HTTP {response.status}: {detail}"
                         error_dict["detail"] = error_detail
-                        description = _semantic_model_test_error(error_detail, content)
+                        description = _semantic_model_test_error(
+                            detail, content, http_status=response.status)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
                     # Consume and validate the complete non-streaming response.  This


### PR DESCRIPTION
- Add proxy-aware aiohttp session helpers for mf-model-api and mf-model-manager
- Honor HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy, NO_PROXY and no_proxy
- Apply proxy support to large-model, small-model, embedding and reranker requests
- Change OpenAI-compatible connectivity checks to non-streaming JSON requests
- Improve invalid response and proxy 504 error handling
- Keep Helm chart unchanged

Pull Request
What Changed
Brief description of changes:
- Add proxy-aware HTTP client support for mf-model-api
- Add proxy-aware HTTP client support for mf-model-manager
- Adapt large-model, small-model, embedding and reranker requests
- Improve OpenAI-compatible connectivity testing and 504 handling
- Docs/doc 1
Why
- Related Issue: N/A
- Related Feature: Proxy environment support for model providers
- Background:
Model provider requests failed or returned 504 in environments using Zscaler HTTP/HTTPS proxies, while direct connections and curl requests worked normally. The services did not consistently honor proxy environment variables, and streaming connectivity checks could be buffered by the proxy.
How
- Key implementation points:
  - Added proxy-aware aiohttp session helpers with trust_env=True.
  - Support existing HTTP_PROXY, HTTPS_PROXY, http_proxy, https_proxy, NO_PROXY and no_proxy variables.
  - Applied proxy handling to large-model, small-model, embedding and reranker outbound requests.
  - Changed OpenAI-compatible connectivity checks to non-streaming JSON requests.
  - Added response JSON validation and clearer proxy gateway timeout messages.
  - Helm Chart configuration was not changed.
- Breaking changes (API, config, database, etc.):
None. Existing deployments without proxy variables continue to use direct connections.
Testing
- Unit tests passed locally
- Integration tests passed locally
- Verified in test environment
Test notes:
- All modified Python files passed python3 -m py_compile on the target repository.
- A live proxy integration test was not run because the test environment did not have the required aiohttp runtime dependency available.
- Recommended verification: test one direct connection and one connection through the configured Zscaler proxy after deployment.
Risk & Rollback
- Potential risks:
  - Incorrect NO_PROXY configuration could route internal service traffic through the external proxy.
  - Proxy-side timeout or SSE buffering policies may still affect long-running streaming requests.
- Rollback plan:
Revert the proxy helper and related service utility changes, then redeploy the previous image/version. No database or Chart rollback is required.
