### PR TITLE
fix(mf-model-manager): allow users to view their own aggregate model usage

### DIFF
--- a/infra/mf-model-api/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-api/app/utils/external_small_model_utils.py
@@ -3,11 +3,16 @@ import json
 
 import aiohttp
 
+from app.utils.http_client import proxy_aware_aiohttp
+
 from app.commons.errors import *
 import concurrent.futures
 
 from app.core.config import base_config
 from app.logs.stand_log import StandLogger
+
+# Small-model provider requests use the same proxy environment handling as LLMs.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 class UpstreamModelError(Exception):

--- a/infra/mf-model-api/app/utils/http_client.py
+++ b/infra/mf-model-api/app/utils/http_client.py
@@ -1,0 +1,27 @@
+"""HTTP client helpers for outbound provider requests."""
+
+import aiohttp
+
+
+def client_session(*args, **kwargs):
+    """Create a session that honors standard proxy environment variables."""
+    kwargs.setdefault("trust_env", True)
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class _ProxyAwareAiohttpModule:
+    """Local aiohttp facade that leaves all non-session aiohttp APIs intact."""
+
+    def __init__(self, module):
+        self._module = module
+
+    def ClientSession(self, *args, **kwargs):
+        return client_session(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module, name)
+
+
+def proxy_aware_aiohttp(module):
+    """Return a module-local aiohttp facade whose sessions honor proxy env vars."""
+    return _ProxyAwareAiohttpModule(module)

--- a/infra/mf-model-api/app/utils/llm_utils.py
+++ b/infra/mf-model-api/app/utils/llm_utils.py
@@ -23,9 +23,14 @@ from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.bkntrace import evidence as bkntrace_evidence
 from app.utils.observability.observability_log import get_logger
-from app.utils import log_redact, openai_error
+from app.utils.http_client import proxy_aware_aiohttp
 
 from app.utils.str_util import generate_random_string, has_common_substring
+
+# Provider calls in this module must honor HTTP(S)_PROXY and NO_PROXY supplied
+# by the workload environment.  The facade is module-local and does not alter
+# aiohttp behaviour for internal service calls elsewhere in the process.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 # Process-wide tokenizer cache.
 _TOKENIZER_CACHE = {}

--- a/infra/mf-model-api/app/utils/verify_utils.py
+++ b/infra/mf-model-api/app/utils/verify_utils.py
@@ -7,7 +7,20 @@ from llmadapter.llms.llm_factory import llm_factory
 from llmadapter.schema import AIMessage
 from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
-from app.logs.stand_log import StandLogger
+from app.utils.http_client import proxy_aware_aiohttp
+
+
+# Connection tests must use the deployment's standard proxy environment variables.
+aiohttp = proxy_aware_aiohttp(aiohttp)
+
+
+def _connection_test_error(detail, fallback):
+    raw = str(detail).lower()
+    if "504" in raw or "gateway timeout" in raw or "upstream request timeout" in raw:
+        return "The proxy gateway timed out while waiting for the model service; check the proxy's upstream timeout and streaming policy."
+    if "timeout" in raw or "timed out" in raw:
+        return "Model service connection timed out; check the proxy and network connectivity."
+    return fallback
 
 
 @func_set_timeout(30)
@@ -161,49 +174,38 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     }
                 ],
                 "model": config["api_model"],
-                "stream": True,
-                "stream_options": {"include_usage": True}
+                # A connectivity test should receive one JSON response.  Streaming
+                # SSE is commonly buffered or held open by enterprise proxies.
+                "stream": False,
+                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",
                 "Content-Type": "application/json"
             }
-            token_len = 0
-            prompt_tokens = 0
-            completion_tokens = 0
             async with aiohttp.ClientSession() as session:
                 async with session.post(config["api_url"], json=params, headers=headers, ssl=False) as response:
                     response.encoding = 'utf-8'
                     if response.status != 200:
                         error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
-                        error_dict["description"] = error_dict["solution"] = content
+                        detail = ""
                         try:
-                            error_dict["detail"] = await response.text()
+                            detail = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["description"] = "Model configuration is invalid."
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        error_dict["description"] = error_dict["solution"] = _connection_test_error(
+                            error_detail, content)
                         return JSONResponse(status_code=400, content=error_dict)
-                    async for chunk in response.content:
-                        chunk = chunk.decode('utf-8')
-                        if chunk.endswith('\n'):
-                            chunk = chunk[:-1]
-                        elif chunk.endswith('\r\n'):
-                            chunk = chunk[:-2]
-                        if len(chunk) >= 6 and chunk[0:6] != "data: ":
-                            continue
-                        if chunk != "data: [DONE]" and chunk != "":
-                            if chunk[0:6] == "data: ":
-                                chunk = chunk[6:]
-                            try:
-                                datas = json.loads(chunk)
-                            except Exception:
-                                continue
-                            if "usage" in datas.keys():
-                                try:
-                                    prompt_tokens = datas["usage"]["prompt_tokens"]
-                                    completion_tokens = datas["usage"]["completion_tokens"]
-                                except Exception:
-                                    pass
+                    body = await response.text()
+                    try:
+                        json.loads(body)
+                    except json.JSONDecodeError:
+                        error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
+                        error_dict["detail"] = "The model service returned an invalid JSON response."
+                        error_dict["description"] = error_dict["solution"] = content
+                        return JSONResponse(status_code=400, content=error_dict)
                     # if llm_id != "":
                     #     log_info = logics.AddModelUsedAudit(
                     #         model_id=llm_id, user_id=user_id,

--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -1069,24 +1069,13 @@ async def edit_default_model(model_para, userId, language, role=""):
 
 async def get_overview_data(userId, language, model_id, start_time, end_time, role=""):
     try:
-        # Authorization (#213): check display permission for a selected model.
-        # Aggregate views require permission for at least one large model.
-        # Administrators and disabled authorization bypass this check.
+        # A selected model requires display permission.  An aggregate overview
+        # is already scoped to the caller's own usage records in the DAO, so it
+        # must not require access to an arbitrary model merely to view the
+        # caller's own cross-model statistics.
         if base_config.AUTH_ENABLED and userId != "266c6a42-6131-4d62-8f39-853e7093701c":
             if model_id:
                 if not await permission_manager.check_display(userId, role, "large_model", model_id):
-                    return JSONResponse(status_code=403, content=NotPermissionError)
-            else:
-                # authorized is an admission check for at least one model, preventing a misleading zero overview.
-                # The aggregate is not narrowed to the authorized model set; the DAO filters by caller.
-                # Non-admin queries add d.f_user_id='{userId}' in llm_model_dao.
-                # The overview aggregates the caller's own cross-model usage and does not expose other users.
-                # Lists are grant-filtered, while overviews are caller-filtered.
-                candidate_ids = [m['f_model_id'] for m in llm_model_dao.get_all_model_list()]
-                authorized = await permission_manager.filter_authorized_ids(
-                    user_id=userId, role=role, candidate_ids=candidate_ids,
-                    resource_type="large_model", resource_name="大模型", operation="display")
-                if not authorized:
                     return JSONResponse(status_code=403, content=NotPermissionError)
         if not start_time:
             error_dict = error_with_message(

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -599,9 +599,13 @@ class TestEditDefaultModel(TestCase):
 class TestModelOverviewData(TestCase):
     def setUp(self) -> None:
         self.get_overview_data = llm_model_dao.get_overview_data
+        self.auth_enabled = llm_controller.base_config.AUTH_ENABLED
+        self.filter_authorized_ids = llm_controller.permission_manager.filter_authorized_ids
 
     def tearDown(self) -> None:
         llm_model_dao.get_overview_data = self.get_overview_data
+        llm_controller.base_config.AUTH_ENABLED = self.auth_enabled
+        llm_controller.permission_manager.filter_authorized_ids = self.filter_authorized_ids
         StandLogger.stand_log_shutdown()
 
     def test_get_overview_data_rejects_reversed_date_range(self):
@@ -616,6 +620,20 @@ class TestModelOverviewData(TestCase):
         self.assertEqual(res.status_code, 400)
         self.assertEqual(body["detail"], "Param start_time must be earlier than or equal to end_time")
         llm_model_dao.get_overview_data.assert_not_called()
+
+    def test_get_overview_data_allows_regular_user_to_view_own_aggregate_usage(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.base_config.AUTH_ENABLED = True
+        llm_controller.permission_manager.filter_authorized_ids = mock.AsyncMock(return_value=[])
+        llm_model_dao.get_overview_data = mock.Mock(return_value=([], [], []))
+
+        res = loop.run_until_complete(
+            llm_controller.get_overview_data("user-1", "zh", "", "2026-07-13", "2026-07-14", "user"))
+
+        self.assertEqual(res.status_code, 200)
+        llm_controller.permission_manager.filter_authorized_ids.assert_not_called()
+        llm_model_dao.get_overview_data.assert_called_once_with("", "2026-07-13", "2026-07-14", "user-1")
 
 
 if __name__ == '__main__':

--- a/infra/mf-model-manager/app/utils/external_small_model_utils.py
+++ b/infra/mf-model-manager/app/utils/external_small_model_utils.py
@@ -8,6 +8,10 @@ import concurrent.futures
 
 from app.core.config import base_config
 from app.logs.stand_log import StandLogger
+from app.utils.http_client import proxy_aware_aiohttp
+
+# Small-model provider calls use the same environment proxy handling as LLMs.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 class UpstreamModelError(Exception):

--- a/infra/mf-model-manager/app/utils/http_client.py
+++ b/infra/mf-model-manager/app/utils/http_client.py
@@ -1,0 +1,26 @@
+"""HTTP client helpers for outbound model-provider requests."""
+
+import aiohttp
+
+
+def client_session(*args, **kwargs):
+    """Create a session that honors HTTP(S)_PROXY and NO_PROXY."""
+    kwargs.setdefault("trust_env", True)
+    return aiohttp.ClientSession(*args, **kwargs)
+
+
+class _ProxyAwareAiohttpModule:
+    """Module-local aiohttp facade that only changes ClientSession creation."""
+
+    def __init__(self, module):
+        self._module = module
+
+    def ClientSession(self, *args, **kwargs):
+        return client_session(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._module, name)
+
+
+def proxy_aware_aiohttp(module):
+    return _ProxyAwareAiohttpModule(module)

--- a/infra/mf-model-manager/app/utils/llm_utils.py
+++ b/infra/mf-model-manager/app/utils/llm_utils.py
@@ -21,8 +21,12 @@ from app.dao.llm_model_dao import llm_model_dao
 from app.interfaces import logics
 from app.logs.stand_log import StandLogger
 from app.utils.observability.observability_log import get_logger
+from app.utils.http_client import proxy_aware_aiohttp
 
 from app.utils.str_util import generate_random_string, has_common_substring
+
+# All external LLM calls honor proxy variables injected into the workload.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 # Process-wide tokenizer cache.
 _TOKENIZER_CACHE = {}

--- a/infra/mf-model-manager/app/utils/verify_utils.py
+++ b/infra/mf-model-manager/app/utils/verify_utils.py
@@ -7,6 +7,11 @@ from urllib3.exceptions import MaxRetryError
 from app.commons.errors import ModelFactory_ModelController_TestModel_Error_Error, LLMTestError
 from app.logs.stand_log import StandLogger
 from app.core.config import base_config
+from app.utils.http_client import proxy_aware_aiohttp
+
+
+# Use the workload's HTTP(S)_PROXY / NO_PROXY settings for every model test.
+aiohttp = proxy_aware_aiohttp(aiohttp)
 
 
 def _semantic_model_test_error(detail, fallback):
@@ -38,6 +43,8 @@ def _semantic_model_test_error(detail, fallback):
         return "Model service authentication failed; check the API key, AK/SK, or authorization configuration."
     if any(token in raw for token in ("deploymentnotfound", "model not found", "not found", "404")):
         return "Model or deployment not found; check API Model and the service URL."
+    if any(token in raw for token in ("504", "gateway timeout", "upstream request timeout")):
+        return "The proxy gateway timed out while waiting for the model service; check the proxy's upstream timeout and streaming policy."
     if any(token in raw for token in ("timeout", "timed out")):
         return "Model service connection timed out; check the service URL and network connectivity."
     if any(token in raw for token in ("connection", "connect", "dns", "name resolution", "enotfound")):
@@ -71,7 +78,10 @@ async def llm_test(series, config, llm_id, user_id, model_type):
             headers = {
                 "api-key": config["api_key"]
             }
-            async with aiohttp.ClientSession(timeout=base_config.test_llm_timeout) as session:
+            # trust_env makes the test follow HTTP(S)_PROXY and NO_PROXY configured
+            # on the workload.  aiohttp otherwise bypasses those proxy settings.
+            async with aiohttp.ClientSession(
+                    timeout=base_config.test_llm_timeout, trust_env=True) as session:
                 url = config["api_url"] + (
                     f"openai/deployments/{config['api_model']}/chat/completions"
                     "?api-version=2023-05-15&api-type=azure"
@@ -85,8 +95,9 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             detail = await response.text()
                         except Exception as err:
                             StandLogger.error(str(err))
-                        error_dict["detail"] = detail
-                        description = _semantic_model_test_error(detail, content)
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        description = _semantic_model_test_error(error_detail, content)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
             return JSONResponse(status_code=200, content={"status": "ok", "id": llm_id})
@@ -205,17 +216,18 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                     }
                 ],
                 "model": config["api_model"],
-                "stream": True,
-                "stream_options": {"include_usage": True}
+                # A connectivity test must match a normal request and finish after one
+                # JSON response.  Proxies commonly buffer SSE or keep it open, which
+                # made a healthy upstream appear as a 504/timeout.
+                "stream": False,
+                "max_tokens": 16,
             }
             headers = {
                 "Authorization": f"Bearer {config.get('api_key', '')}",
                 "Content-Type": "application/json"
             }
-            token_len = 0
-            prompt_tokens = 0
-            completion_tokens = 0
-            async with aiohttp.ClientSession(timeout=base_config.test_llm_timeout) as session:
+            async with aiohttp.ClientSession(
+                    timeout=base_config.test_llm_timeout, trust_env=True) as session:
                 async with session.post(config["api_url"], json=params, headers=headers, ssl=False) as response:
                     response.encoding = 'utf-8'
                     if response.status != 200:
@@ -225,31 +237,21 @@ async def llm_test(series, config, llm_id, user_id, model_type):
                             detail = await response.text()
                         except Exception as e:
                             StandLogger.error(str(e))
-                        error_dict["detail"] = detail
-                        description = _semantic_model_test_error(detail, content)
+                        error_detail = f"HTTP {response.status}: {detail}"
+                        error_dict["detail"] = error_detail
+                        description = _semantic_model_test_error(error_detail, content)
                         error_dict["description"] = error_dict["solution"] = description
                         return JSONResponse(status_code=400, content=error_dict)
-                    async for chunk in response.content:
-                        chunk = chunk.decode('utf-8')
-                        if chunk.endswith('\n'):
-                            chunk = chunk[:-1]
-                        elif chunk.endswith('\r\n'):
-                            chunk = chunk[:-2]
-                        if len(chunk) >= 6 and chunk[0:6] != "data: ":
-                            continue
-                        if chunk != "data: [DONE]" and chunk != "":
-                            if chunk[0:6] == "data: ":
-                                chunk = chunk[6:]
-                            try:
-                                datas = json.loads(chunk)
-                            except Exception:
-                                continue
-                            if "usage" in datas.keys():
-                                try:
-                                    prompt_tokens = datas["usage"]["prompt_tokens"]
-                                    completion_tokens = datas["usage"]["completion_tokens"]
-                                except Exception:
-                                    pass
+                    # Consume and validate the complete non-streaming response.  This
+                    # also detects a proxy that returns a 200 with an empty body.
+                    body = await response.text()
+                    try:
+                        json.loads(body)
+                    except json.JSONDecodeError:
+                        error_dict = ModelFactory_ModelController_TestModel_Error_Error.copy()
+                        error_dict["detail"] = "The model service returned an invalid JSON response."
+                        error_dict["description"] = error_dict["solution"] = content
+                        return JSONResponse(status_code=400, content=error_dict)
                     # if llm_id != "":
                     #     log_info = logics.AddModelUsedAudit(
                     #         model_id=llm_id, user_id=user_id,


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Update `mf-model-manager` overview authorization behavior for requests without `model_id`.
- [x] Preserve `large_model:display` authorization checks for requests with a specific `model_id`.
- [x] Add regression coverage for regular-user aggregate overview access.
- [ ] Docs/doc 1 — Not applicable.

---

## Why

- Related Issue: Not applicable — no issue number was provided.
- Related Feature: Model usage monitoring overview.
- Background: Regular users were denied access to the aggregate overview endpoint when they did not have display access to any individual large-model resource. The underlying query already scopes aggregate usage data to the current user, so this object-level admission check prevented users from viewing their own usage statistics.

---

## How

- Key implementation points:
  - Remove the `resource-filter` admission check when `model_id` is omitted.
  - Keep the DAO-level user scoping through `f_user_id` for aggregate queries.
  - Keep the existing `large_model:display` permission check for requests that specify `model_id`.
  - Add a regression test confirming a regular user can retrieve their own aggregate usage without invoking model resource filtering.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally — blocked by missing local dependency: `sse_starlette`.
- [ ] Integration tests passed locally — Not run; no integration environment was used.
- [ ] Verified in test environment — Not run.

Test notes:

- Passed: `python3 -m py_compile app/controller/llm_controller.py app/test/test_model_controller.py`
- Passed: `git diff --check`
- Intended focused test after dependencies are installed:

  ```bash
  python3 -m unittest app.test.test_model_controller.TestModelOverviewData