### PR TITLE
feat(trace): persist provenance analysis locale

### DIFF
--- a/bkn-trace/agent-observability/migrations/mariadb/v018/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v018/init.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bkn_trace_ee_provenance_analyses
+    ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN' AFTER agent_id;

--- a/bkn-trace/agent-observability/migrations/mariadb/v018/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v018/init.sql
@@ -1,2 +1,2 @@
 ALTER TABLE bkn_trace_ee_provenance_analyses
-    ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN' AFTER agent_id;
+    ADD COLUMN IF NOT EXISTS locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN';

--- a/bkn-trace/agent-observability/migrations/mariadb/v018/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v018/schema.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package v018
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string { return schemaSQL }

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -15,6 +15,7 @@ import (
 	v015 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v015"
 	v016 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v016"
 	v017 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v017"
+	v018 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v018"
 )
 
 // Migration is immutable once released. Every statement in SQL must be safe to
@@ -36,6 +37,7 @@ func Migrations() []Migration {
 		{version: "015", sql: v015.SchemaSQL()},
 		{version: "016", sql: v016.SchemaSQL()},
 		{version: "017", sql: v017.SchemaSQL()},
+		{version: "018", sql: v018.SchemaSQL()},
 	})
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -43,7 +43,7 @@ func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
 		"dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0",
 		"bkn_trace_ee_provenance_analyses",
 		"idx_provenance_analysis_interaction",
-		"ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN'",
+		"ADD COLUMN IF NOT EXISTS locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN'",
 	}
 	for _, fragment := range required {
 		if !strings.Contains(schema, fragment) {
@@ -59,7 +59,7 @@ func TestMigrationsAreOrderedAndChecksumProtected(t *testing.T) {
 		"015": "408e6cb3445f6116995da9852116f1795563f5ea17a65da667b6ec42a33dec2e",
 		"016": "869da02928bed7950e7d0b2b3e609c806334a3839342e57631548f57b3ac1be4",
 		"017": "f47e2ee9f70f0089c2cd225f5d28cc612b2f0c105d5ba001d55771636c02e349",
-		"018": "e56a69e4f6ef6d750684067b6c6cb59cf57375bb4d7c862a5a487221898519f5",
+		"018": "9fd4c45b568a2a5c395ee09a4214a240d9e865239e1024f443559f45a97b89b8",
 	}
 	migrations := sessionstore.Migrations()
 	if len(migrations) != len(expectedChecksums) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -43,6 +43,7 @@ func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
 		"dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0",
 		"bkn_trace_ee_provenance_analyses",
 		"idx_provenance_analysis_interaction",
+		"ADD COLUMN locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN'",
 	}
 	for _, fragment := range required {
 		if !strings.Contains(schema, fragment) {
@@ -58,6 +59,7 @@ func TestMigrationsAreOrderedAndChecksumProtected(t *testing.T) {
 		"015": "408e6cb3445f6116995da9852116f1795563f5ea17a65da667b6ec42a33dec2e",
 		"016": "869da02928bed7950e7d0b2b3e609c806334a3839342e57631548f57b3ac1be4",
 		"017": "f47e2ee9f70f0089c2cd225f5d28cc612b2f0c105d5ba001d55771636c02e349",
+		"018": "e56a69e4f6ef6d750684067b6c6cb59cf57375bb4d7c862a5a487221898519f5",
 	}
 	migrations := sessionstore.Migrations()
 	if len(migrations) != len(expectedChecksums) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -54,16 +54,33 @@ func TestMigrationPlanReturnsOnlyUnappliedVersions(t *testing.T) {
 
 func TestMigrationPlanUpgradesExistingCoreSchemaWithProvenanceTable(t *testing.T) {
 	migrations := Migrations()
-	applied := make(map[string]string, len(migrations)-1)
-	for _, migration := range migrations[:len(migrations)-1] {
+	applied := make(map[string]string, 4)
+	for _, migration := range migrations[:4] {
 		applied[migration.Version] = migration.Checksum
 	}
 	plan, err := migrationPlan(migrations, applied)
 	if err != nil {
 		t.Fatalf("plan provenance schema migration: %v", err)
 	}
-	if len(plan) != 1 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") {
+	if len(plan) != 2 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") {
 		t.Fatalf("unexpected provenance schema plan: %#v", plan)
+	}
+}
+
+func TestMigrationPlanAddsLocaleToExistingProvenanceHistory(t *testing.T) {
+	migrations := Migrations()
+	applied := make(map[string]string, 5)
+	for _, migration := range migrations[:5] {
+		applied[migration.Version] = migration.Checksum
+	}
+	plan, err := migrationPlan(migrations, applied)
+	if err != nil {
+		t.Fatalf("plan provenance locale migration: %v", err)
+	}
+	if len(plan) != 1 || plan[0].Version != "018" ||
+		!strings.Contains(plan[0].SQL, "ADD COLUMN locale") ||
+		!strings.Contains(plan[0].SQL, "DEFAULT 'zh-CN'") {
+		t.Fatalf("unexpected provenance locale migration plan: %#v", plan)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -78,7 +78,7 @@ func TestMigrationPlanAddsLocaleToExistingProvenanceHistory(t *testing.T) {
 		t.Fatalf("plan provenance locale migration: %v", err)
 	}
 	if len(plan) != 1 || plan[0].Version != "018" ||
-		!strings.Contains(plan[0].SQL, "ADD COLUMN locale") ||
+		!strings.Contains(plan[0].SQL, "ADD COLUMN IF NOT EXISTS locale") ||
 		!strings.Contains(plan[0].SQL, "DEFAULT 'zh-CN'") {
 		t.Fatalf("unexpected provenance locale migration plan: %#v", plan)
 	}


### PR DESCRIPTION
## Summary
- add additive MariaDB v018 migration for `bkn_trace_ee_provenance_analyses.locale`
- expose the migration in the schema manifest
- cover the schema and migration checksum contract

## Verification
- `go test ./src/drivenadapter/dbaccess/mariadb/sessionstore`

Related EE change: Business Provenance i18n for the 0.1.5 mainline.