### PR TITLE
fix(deploy): refresh internal install status

### DIFF
--- a/deploy/conf/install-status/merge.jq
+++ b/deploy/conf/install-status/merge.jq
@@ -49,12 +49,16 @@
 # frozen at publish time, so a service that was merely mid-restart during
 # install shows "degraded" forever even after it self-heals. HTTP-sourced
 # entries can't be re-probed here (jq only, no curl), so leave those as-is.
-# serviceHealth names may carry a "-svc" suffix the workload key lacks.
+# serviceHealth names may carry a "-svc" or "-internal" suffix the workload
+# key lacks.
 | .serviceHealth |= ((. // []) | map(
     . as $h
     | if ($h.source == "pod")
       then
-        (($actual[$h.name]) // ($actual[($h.name | rtrimstr("-svc"))]) // null) as $m
+        (($actual[$h.name])
+         // ($actual[($h.name | rtrimstr("-svc"))])
+         // ($actual[($h.name | rtrimstr("-internal"))])
+         // null) as $m
         | if $m == null then .
           else
             . + {ready: "\($m.ready)/\($m.total)",

--- a/deploy/conf/install-status/merge_test.sh
+++ b/deploy/conf/install-status/merge_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Focused regression coverage for the in-cluster install-status live merge.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+merge_filter="${script_dir}/merge.jq"
+
+snapshot='{
+  "releases": [],
+  "serviceHealth": [
+    {"name":"agent-observability-internal","source":"pod","ready":"1/2","state":"degraded"},
+    {"name":"worker-svc","source":"pod","ready":"0/1","state":"down"},
+    {"name":"third-party-internal","source":"pod","ready":"0/1","state":"down"}
+  ]
+}'
+
+workloads='{
+  "items": [
+    {
+      "metadata": {"annotations": {"meta.helm.sh/release-name": "agent-observability"}},
+      "spec": {"replicas": 1, "template": {"spec": {"containers": []}}},
+      "status": {"readyReplicas": 1}
+    },
+    {
+      "metadata": {"annotations": {"meta.helm.sh/release-name": "worker"}},
+      "spec": {"replicas": 2, "template": {"spec": {"containers": []}}},
+      "status": {"readyReplicas": 2}
+    }
+  ]
+}'
+
+result="$(jq -n --arg now '2026-08-29T00:00:00Z' \
+  --slurpfile snap <(printf '%s\n' "${snapshot}") \
+  --slurpfile work <(printf '%s\n' "${workloads}") \
+  -f "${merge_filter}")"
+
+assert_entry() {
+  local name="$1"
+  local ready="$2"
+  local state="$3"
+
+  jq -e --arg name "${name}" --arg ready "${ready}" --arg state "${state}" \
+    'any(.serviceHealth[]; .name == $name and .ready == $ready and .state == $state)' \
+    <<<"${result}" >/dev/null
+}
+
+assert_entry 'agent-observability-internal' '1/1' 'up'
+assert_entry 'worker-svc' '2/2' 'up'
+assert_entry 'third-party-internal' '0/1' 'down'
+
+echo 'install-status live merge regression tests passed'

--- a/docs/plans/2026-08-29-install-status-internal-design.md
+++ b/docs/plans/2026-08-29-install-status-internal-design.md
@@ -1,0 +1,37 @@
+# Install Status Internal Service Mapping Design
+
+## Context
+
+The install-status refresher merges live Deployment and StatefulSet readiness
+into the publish-time service-health snapshot. Service entries are keyed by
+Service name, while workload entries are keyed by Helm release name. The
+existing merge recognizes the legacy `-svc` Service suffix only.
+
+`agent-observability-internal` selects the `agent-observability` workload. It
+therefore retains a stale install-time health value after the workload recovers,
+because its key is not resolved to the workload key.
+
+## Decision
+
+Treat `-internal` as a Service alias suffix in the same fallback lookup used
+for `-svc`. The lookup order remains:
+
+1. exact Service name;
+2. name with `-svc` removed;
+3. name with `-internal` removed.
+
+If no matching workload exists, preserve the publish-time value as today.
+
+## Scope and Safety
+
+Only pod-sourced `serviceHealth` entries are affected. HTTP-sourced entries
+remain unmodified because the refresher does not re-probe application health.
+The fix does not alter Kubernetes workloads, Services, probes, or deployment
+configuration.
+
+## Verification
+
+A focused shell regression test supplies an `agent-observability-internal`
+snapshot with stale `1/2` readiness and a live `agent-observability` workload
+with `1/1` readiness. It asserts the merged entry becomes `1/1` and `up`, and
+also protects the existing `-svc` fallback and unmatched-entry behavior.

--- a/docs/plans/2026-08-29-install-status-internal.md
+++ b/docs/plans/2026-08-29-install-status-internal.md
@@ -1,0 +1,66 @@
+# Install Status Internal Service Mapping Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refresh pod-backed internal Service health from the owning live workload instead of retaining stale install-time readiness.
+
+**Architecture:** `merge.jq` already maps a Service name to a workload key using an exact match and a `-svc` fallback. Add a second fallback for the `-internal` alias. A self-contained shell test runs jq against fixture JSON to keep the dashboard merge contract executable without a cluster.
+
+**Tech Stack:** Bash, jq, Kubernetes install-status manifest data.
+
+---
+
+### Task 1: Add the failing internal-Service regression test
+
+**Files:**
+- Create: `deploy/conf/install-status/merge_test.sh`
+- Test: `deploy/conf/install-status/merge_test.sh`
+
+**Step 1: Write the failing test**
+
+Create fixture JSON containing a pod-sourced `agent-observability-internal`
+entry with `ready: "1/2"` and a live `agent-observability` Deployment with one
+ready replica. Invoke `merge.jq`, then assert that its merged entry is
+`ready: "1/1"` and `state: "up"`. Include existing `-svc` and unmatched cases.
+
+**Step 2: Run the test to verify it fails**
+
+Run: `bash deploy/conf/install-status/merge_test.sh`
+
+Expected: the internal-Service assertion fails because the current fallback
+only strips `-svc`.
+
+### Task 2: Map `-internal` aliases to their live workload
+
+**Files:**
+- Modify: `deploy/conf/install-status/merge.jq:57`
+- Test: `deploy/conf/install-status/merge_test.sh`
+
+**Step 1: Implement the minimal production change**
+
+Extend the workload lookup to try the Service name with `-internal` removed
+after the exact and `-svc` forms, leaving all other merge behavior unchanged.
+
+**Step 2: Run the focused regression test**
+
+Run: `bash deploy/conf/install-status/merge_test.sh`
+
+Expected: all assertions pass.
+
+### Task 3: Verify install-status artifacts
+
+**Files:**
+- Modify: `deploy/conf/install-status/merge.jq`
+- Create: `deploy/conf/install-status/merge_test.sh`
+
+**Step 1: Check jq syntax and render behavior**
+
+Run: `jq -n --arg now '2026-08-29T00:00:00Z' --slurpfile snap <fixture> --slurpfile work <fixture> -f deploy/conf/install-status/merge.jq`
+
+Expected: valid JSON with updated internal-Service readiness.
+
+**Step 2: Inspect the scoped diff**
+
+Run: `git diff --check && git diff -- deploy/conf/install-status/merge.jq deploy/conf/install-status/merge_test.sh docs/plans/2026-08-29-install-status-internal-design.md docs/plans/2026-08-29-install-status-internal.md`
+
+Expected: only the intended mapping, regression test, and implementation documentation are changed.


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Extend install-status live workload lookup with the `-internal` Service alias.
- [x] Add a focused jq regression test for internal, legacy `-svc`, and unmatched Services.
- [x] Document the design and implementation plan.

---

## Why

- Related Issue: Closes #1191
- Related Feature: Install-status live readiness refresh
- Background: `agent-observability-internal` preserved stale install-time `1/2 degraded` status after its backing workload recovered because the live merge only resolved `-svc` aliases.

---

## How

- Key implementation points: resolve a pod-sourced Service by exact name, then `-svc`, then `-internal`; keep unmatched and non-pod entries unchanged.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally: `bash deploy/conf/install-status/merge_test.sh`
- [x] Integration tests passed locally: not applicable; jq merge is covered with deterministic fixtures.
- [ ] Verified in test environment: not performed; no deployment is included.

Test notes:

- `bash -n deploy/conf/install-status/merge_test.sh`
- `git diff --check`
- Independent jq fixture verifies `agent-observability-internal` becomes `1/1 up`.

---

## Risk & Rollback

- Potential risks: a pod-sourced Service ending in `-internal` now resolves to a same-named workload without that suffix. If no such workload exists, behavior remains unchanged.
- Rollback plan: revert commit `36e45a880`.

---

## Additional Notes

- No Kubernetes resources, runtime configuration, data, schema, permissions, or secrets were changed.
- The prior service state remains visible until the updated install-status refresher manifest is deployed through the normal release process.