### PR TITLE
feat(trace): seal historical provenance projection events

### DIFF
--- a/bkn-trace/agent-observability/migrations/mariadb/v019/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v019/init.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS bkn_trace_ee_historical_provenance_projections (
+    interaction_id VARCHAR(64) NOT NULL,
+    facts_hash CHAR(64) NOT NULL,
+    tenant_id VARCHAR(64) NOT NULL,
+    business_domain_id VARCHAR(64) NOT NULL,
+    resolver_version VARCHAR(64) NOT NULL,
+    resolved_at DATETIME(6) NULL,
+    status VARCHAR(16) NOT NULL,
+    graph_payload LONGTEXT NULL,
+    markdown_snapshot LONGTEXT NULL,
+    content_hash CHAR(64) NULL,
+    failure_code VARCHAR(64) NULL,
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (interaction_id, facts_hash),
+    UNIQUE KEY uq_provenance_projection_interaction (interaction_id),
+    UNIQUE KEY uq_provenance_projection_interaction_facts (interaction_id, facts_hash),
+    INDEX idx_provenance_projection_scope (tenant_id, business_domain_id, interaction_id),
+    INDEX idx_provenance_projection_status (status, updated_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS bkn_trace_ee_historical_provenance_tombstones (
+    interaction_id VARCHAR(64) NOT NULL,
+    deleted_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (interaction_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/bkn-trace/agent-observability/migrations/mariadb/v019/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v019/schema.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package v019
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string { return schemaSQL }

--- a/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectionrebuildsvc/service.go
@@ -10,10 +10,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionrebuild"
 )
 
 var ErrProjectionValidation = errors.New("rebuilt projection does not match authoritative state")
+
+const historicalProvenanceBuildRequested = "historical_provenance.build_requested"
 
 type Options struct {
 	BatchSize int
@@ -89,14 +92,21 @@ func (s *Service) Rebuild(ctx context.Context, projectorID, alias, indexVersion 
 			if len(items) == 0 {
 				return Result{}, ErrProjectionValidation
 			}
+			projectable := make([]iprojectionoutbox.Item, 0, len(items))
 			for _, item := range items {
+				checkpoint = item.ID
+				if item.EventType == historicalProvenanceBuildRequested {
+					continue
+				}
 				if err := s.target.ProjectVersion(ctx, indexVersion, item); err != nil {
 					return Result{}, err
 				}
-				checkpoint = item.ID
+				projectable = append(projectable, item)
 			}
-			if err := s.target.ValidateVersion(ctx, indexVersion, items); err != nil {
-				return Result{}, fmt.Errorf("validate projection history: %w", err)
+			if len(projectable) > 0 {
+				if err := s.target.ValidateVersion(ctx, indexVersion, projectable); err != nil {
+					return Result{}, fmt.Errorf("validate projection history: %w", err)
+				}
 			}
 			if err := s.source.SaveProjectionCheckpoint(
 				ctx, projectorID, indexVersion, checkpoint,

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
@@ -17,19 +17,31 @@ import (
 )
 
 type WorkerOptions struct {
-	Now          func() time.Time
-	BatchSize    int
-	LockDuration time.Duration
-	MaxAttempts  uint32
-	MaxRetryAge  time.Duration
-	FullJitter   func(max time.Duration) time.Duration
-	Metrics      icoremetrics.Recorder
+	Now                         func() time.Time
+	BatchSize                   int
+	LockDuration                time.Duration
+	MaxAttempts                 uint32
+	MaxRetryAge                 time.Duration
+	FullJitter                  func(max time.Duration) time.Duration
+	Metrics                     icoremetrics.Recorder
+	HistoricalProvenanceHandler HistoricalProvenanceHandler
+}
+
+const historicalProvenanceBuildRequested = "historical_provenance.build_requested"
+
+// HistoricalProvenanceHandler consumes the enterprise-only provenance build
+// event in the same leased Core outbox worker. It is deliberately separate
+// from the OpenSearch projection sink so one delivery cannot be consumed by
+// both destinations.
+type HistoricalProvenanceHandler interface {
+	HandleHistoricalProvenance(context.Context, iprojectionoutbox.Item) error
 }
 
 type Worker struct {
-	store   iprojectionoutbox.Store
-	sink    iprojectionoutbox.Sink
-	options WorkerOptions
+	store      iprojectionoutbox.Store
+	sink       iprojectionoutbox.Sink
+	provenance HistoricalProvenanceHandler
+	options    WorkerOptions
 }
 
 type RunResult struct {
@@ -61,7 +73,7 @@ func NewWorker(store iprojectionoutbox.Store, sink iprojectionoutbox.Sink, optio
 	if options.Metrics == nil {
 		options.Metrics = icoremetrics.Noop{}
 	}
-	return &Worker{store: store, sink: sink, options: options}
+	return &Worker{store: store, sink: sink, provenance: options.HistoricalProvenanceHandler, options: options}
 }
 
 func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
@@ -75,7 +87,7 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 		if !item.CreatedAt.IsZero() && (oldest.IsZero() || item.CreatedAt.Before(oldest)) {
 			oldest = item.CreatedAt
 		}
-		projectionErr := w.sink.Project(ctx, item)
+		projectionErr := w.project(ctx, item)
 		if projectionErr == nil {
 			if err := w.store.MarkDelivered(ctx, item); err != nil {
 				if errors.Is(err, iprojectionoutbox.ErrLeaseLost) {
@@ -125,6 +137,16 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 		w.options.Metrics.Set(icoremetrics.ProjectionLagSeconds, 0)
 	}
 	return result, nil
+}
+
+func (w *Worker) project(ctx context.Context, item iprojectionoutbox.Item) error {
+	if item.EventType == historicalProvenanceBuildRequested {
+		if w.provenance == nil {
+			return iprojectionoutbox.Permanent(errors.New("historical provenance handler is not assembled"))
+		}
+		return w.provenance.HandleHistoricalProvenance(ctx, item)
+	}
+	return w.sink.Project(ctx, item)
 }
 
 func (w *Worker) Drain(ctx context.Context) (RunResult, error) {

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
@@ -166,6 +166,30 @@ func TestProjectionWorkerContinuesAfterLeaseIsLost(t *testing.T) {
 	}
 }
 
+func TestHistoricalProvenanceEventUsesDedicatedHandlerBeforeDelivery(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{
+		ID: 1, EventID: "evt-provenance", EventType: "historical_provenance.build_requested",
+	}}}
+	sink := &fakeProjectionSink{err: errors.New("OpenSearch must not receive provenance events")}
+	handler := &fakeHistoricalProvenanceHandler{}
+	worker := projectorsvc.NewWorker(store, sink, projectorsvc.WorkerOptions{
+		HistoricalProvenanceHandler: handler,
+	})
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run worker: %v", err)
+	}
+	if result.Delivered != 1 || len(store.delivered) != 1 {
+		t.Fatalf("event was not delivered after handler success: %#v", result)
+	}
+	if handler.calls != 1 || sink.calls != 0 {
+		t.Fatalf("provenance routing leaked to OpenSearch: handler=%d sink=%d", handler.calls, sink.calls)
+	}
+}
+
 type fakeOutboxStore struct {
 	items               []iprojectionoutbox.Item
 	retried             []iprojectionoutbox.Item
@@ -199,10 +223,27 @@ func (s *fakeOutboxStore) MoveToDLQ(_ context.Context, item iprojectionoutbox.It
 	return nil
 }
 
-type fakeProjectionSink struct{ err error }
+type fakeProjectionSink struct {
+	err   error
+	calls int
+}
 
 func (s *fakeProjectionSink) Project(context.Context, iprojectionoutbox.Item) error {
+	s.calls++
 	return s.err
+}
+
+type fakeHistoricalProvenanceHandler struct {
+	err   error
+	calls int
+}
+
+func (h *fakeHistoricalProvenanceHandler) HandleHistoricalProvenance(
+	context.Context,
+	iprojectionoutbox.Item,
+) error {
+	h.calls++
+	return h.err
 }
 
 type projectionTestMetrics struct {

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -41,22 +41,24 @@ var defaultCapacityLimits = CapacityLimits{
 }
 
 type Options struct {
-	Now                     func() time.Time
-	NewID                   func(prefix string) string
-	EvidenceCollectionState func() string
-	AssemblyTimeout         time.Duration
-	Capacity                CapacityLimits
-	Metrics                 icoremetrics.Recorder
+	Now                        func() time.Time
+	NewID                      func(prefix string) string
+	EvidenceCollectionState    func() string
+	EnableHistoricalProvenance bool
+	AssemblyTimeout            time.Duration
+	Capacity                   CapacityLimits
+	Metrics                    icoremetrics.Recorder
 }
 
 type Service struct {
-	store                   isessionstore.Store
-	now                     func() time.Time
-	newID                   func(string) string
-	evidenceCollectionState func() string
-	assemblyTimeout         time.Duration
-	capacity                CapacityLimits
-	metrics                 icoremetrics.Recorder
+	store                      isessionstore.Store
+	now                        func() time.Time
+	newID                      func(string) string
+	evidenceCollectionState    func() string
+	enableHistoricalProvenance bool
+	assemblyTimeout            time.Duration
+	capacity                   CapacityLimits
+	metrics                    icoremetrics.Recorder
 }
 
 func New(store isessionstore.Store, options Options) *Service {
@@ -92,10 +94,11 @@ func New(store isessionstore.Store, options Options) *Service {
 	}
 	return &Service{
 		store: store, now: now, newID: newID,
-		evidenceCollectionState: evidenceCollectionState,
-		assemblyTimeout:         assemblyTimeout,
-		capacity:                capacity,
-		metrics:                 metrics,
+		evidenceCollectionState:    evidenceCollectionState,
+		enableHistoricalProvenance: options.EnableHistoricalProvenance,
+		assemblyTimeout:            assemblyTimeout,
+		capacity:                   capacity,
+		metrics:                    metrics,
 	}
 }
 
@@ -844,6 +847,11 @@ func (s *Service) TerminateInteraction(ctx context.Context, command TerminateInt
 		interaction.UpdatedAt = now
 		interaction.TerminalAt = &now
 		tx.SaveInteraction(interaction)
+		if s.enableHistoricalProvenance {
+			if err := s.appendHistoricalProvenanceBuildRequest(tx, conversation.Owner, interaction); err != nil {
+				return err
+			}
+		}
 		if interaction.EvidenceStatus == sessionvo.EvidenceComplete ||
 			interaction.EvidenceStatus == sessionvo.EvidencePartial ||
 			interaction.EvidenceStatus == sessionvo.EvidenceFailed {
@@ -1918,6 +1926,32 @@ func (s *Service) appendProjection(tx isessionstore.Transaction, aggregateType, 
 		EventID: s.newID("evt"), AggregateType: aggregateType,
 		AggregateID: aggregateID, AggregateVersion: aggregateVersion,
 		EventType: eventType, Payload: payload,
+	})
+	return nil
+}
+
+func (s *Service) appendHistoricalProvenanceBuildRequest(
+	tx isessionstore.Transaction,
+	owner sessionvo.Owner,
+	interaction sessionvo.Interaction,
+) error {
+	request, err := sessionvo.NewHistoricalProvenanceBuildRequest(
+		interaction.ID, owner, tx.ListOperationCallFacts(interaction.ID),
+	)
+	if err != nil {
+		return err
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	tx.AppendProjection(sessionvo.ProjectionMutation{
+		EventID:          s.newID("evt"),
+		AggregateType:    "interaction",
+		AggregateID:      interaction.ID,
+		AggregateVersion: interaction.RowVersion,
+		EventType:        sessionvo.HistoricalProvenanceBuildRequestedEventType,
+		Payload:          payload,
 	})
 	return nil
 }

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
@@ -6,6 +6,7 @@
 package sessionsvc_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
 )
 
@@ -575,6 +577,101 @@ func TestOnlyOneActiveInteractionAndTerminalIsFenced(t *testing.T) {
 	}); !sessionsvc.IsCode(err, sessionsvc.CodeTerminalConflict) {
 		t.Fatalf("expected terminal_conflict, got %v", err)
 	}
+}
+
+func TestTerminalInteractionEnqueuesImmutableHistoricalProvenanceBuildRequest(t *testing.T) {
+	t.Parallel()
+
+	store, service, owner, _, interaction, operation, receipt := mustCreateOperationWithHistoricalProvenance(t)
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: operation.Attempt, ReceiptID: receipt.ID,
+		Output: operationOutput("ok"), EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-provenance", TraceID: validTraceIDOne,
+	}); err != nil {
+		t.Fatalf("complete operation: %v", err)
+	}
+	completed, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-provenance", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{Version: "1", CompletionReason: "answer_returned", ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}}, ExpectedReceipts: []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}}},
+	})
+	if err != nil {
+		t.Fatalf("terminate interaction: %v", err)
+	}
+	items, err := store.Lease(context.Background(), 20, time.Minute)
+	if err != nil {
+		t.Fatalf("lease outbox: %v", err)
+	}
+	var request sessionvo.HistoricalProvenanceBuildRequest
+	found := false
+	for _, item := range items {
+		if item.EventType != sessionvo.HistoricalProvenanceBuildRequestedEventType {
+			continue
+		}
+		if err := json.Unmarshal(item.Payload, &request); err != nil {
+			t.Fatalf("decode provenance request: %v", err)
+		}
+		found = true
+	}
+	if !found {
+		t.Fatalf("terminal interaction did not enqueue %q: %#v", sessionvo.HistoricalProvenanceBuildRequestedEventType, items)
+	}
+	if request.InteractionID != completed.ID || request.TenantID != owner.TenantID || request.BusinessDomainID != owner.BusinessDomainID {
+		t.Fatalf("unexpected request scope: %#v", request)
+	}
+	if request.FactsHash == "" || len(request.Facts) != 1 || request.Facts[0].OperationID != operation.ID {
+		t.Fatalf("request does not contain sealed facts: %#v", request)
+	}
+	if bytes.Contains(itemPayloadForEvent(items, sessionvo.HistoricalProvenanceBuildRequestedEventType), []byte("Bearer")) {
+		t.Fatal("historical provenance request must not serialize a user bearer token")
+	}
+}
+
+func TestLateReceiptDoesNotEnqueueAnotherHistoricalProvenanceBuildRequest(t *testing.T) {
+	t.Parallel()
+
+	store, service, owner, _, interaction, operation, receipt := mustCreateOperationWithHistoricalProvenance(t)
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-late-receipt", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{Version: "1", CompletionReason: "answer_returned", ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}}, ExpectedReceipts: []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}}},
+	}); err != nil {
+		t.Fatalf("terminate interaction: %v", err)
+	}
+	initial, err := store.Lease(context.Background(), 20, time.Minute)
+	if err != nil {
+		t.Fatalf("lease terminal events: %v", err)
+	}
+	for _, item := range initial {
+		if err := store.MarkDelivered(context.Background(), item); err != nil {
+			t.Fatalf("mark initial event delivered: %v", err)
+		}
+	}
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: operation.Attempt, ReceiptID: receipt.ID,
+		Output: operationOutput("late"), EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-late", TraceID: validTraceIDOne,
+	}); err != nil {
+		t.Fatalf("complete late receipt: %v", err)
+	}
+	late, err := store.Lease(context.Background(), 20, time.Minute)
+	if err != nil {
+		t.Fatalf("lease late receipt events: %v", err)
+	}
+	for _, item := range late {
+		if item.EventType == sessionvo.HistoricalProvenanceBuildRequestedEventType {
+			t.Fatalf("late receipt must not enqueue a replacement provenance build request: %#v", item)
+		}
+	}
+}
+
+func itemPayloadForEvent(items []iprojectionoutbox.Item, eventType string) []byte {
+	for _, item := range items {
+		if item.EventType == eventType {
+			return item.Payload
+		}
+	}
+	return nil
 }
 
 func TestStartInteractionRejectsChangedPayloadForSameIdempotencyKey(t *testing.T) {
@@ -2347,6 +2444,18 @@ func mustCreateOperationWithStore(t *testing.T) (*sessionstore.Store, *sessionsv
 	t.Helper()
 	store := sessionstore.New()
 	service := sessionsvc.New(store, sessionsvc.Options{})
+	return mustCreateOperationForService(t, store, service)
+}
+
+func mustCreateOperationWithHistoricalProvenance(t *testing.T) (*sessionstore.Store, *sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {
+	t.Helper()
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{EnableHistoricalProvenance: true})
+	return mustCreateOperationForService(t, store, service)
+}
+
+func mustCreateOperationForService(t *testing.T, store *sessionstore.Store, service *sessionsvc.Service) (*sessionstore.Store, *sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {
+	t.Helper()
 	owner := testOwner()
 	conversation := mustEnsureConversation(t, service, owner, "thread-operation")
 	interaction, err := service.StartInteraction(context.Background(), sessionsvc.StartInteractionCommand{

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package sessionvo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"slices"
+	"sort"
+)
+
+const HistoricalProvenanceBuildRequestedEventType = "historical_provenance.build_requested"
+
+// HistoricalProvenanceBuildRequest is the sealed terminal fact snapshot carried
+// by the Core outbox to the EE projection handler. It deliberately contains no
+// caller credentials or mutable session state.
+type HistoricalProvenanceBuildRequest struct {
+	InteractionID       string              `json:"interaction_id"`
+	TenantID            string              `json:"tenant_id"`
+	BusinessDomainID    string              `json:"business_domain_id"`
+	FactsHash           string              `json:"facts_hash"`
+	KnowledgeNetworkIDs []string            `json:"knowledge_network_ids"`
+	Facts               []OperationCallFact `json:"facts"`
+}
+
+func NewHistoricalProvenanceBuildRequest(
+	interactionID string,
+	owner Owner,
+	facts []OperationCallFact,
+) (HistoricalProvenanceBuildRequest, error) {
+	if interactionID == "" || owner.TenantID == "" || owner.BusinessDomainID == "" {
+		return HistoricalProvenanceBuildRequest{}, errors.New("historical provenance scope is required")
+	}
+	canonicalFacts := append([]OperationCallFact(nil), facts...)
+	slices.SortFunc(canonicalFacts, func(left, right OperationCallFact) int {
+		if result := left.StartedAt.Compare(right.StartedAt); result != 0 {
+			return result
+		}
+		if left.OperationID != right.OperationID {
+			if left.OperationID < right.OperationID {
+				return -1
+			}
+			return 1
+		}
+		return int(left.Attempt) - int(right.Attempt)
+	})
+	canonical, err := json.Marshal(canonicalFacts)
+	if err != nil {
+		return HistoricalProvenanceBuildRequest{}, err
+	}
+	sum := sha256.Sum256(canonical)
+	return HistoricalProvenanceBuildRequest{
+		InteractionID:       interactionID,
+		TenantID:            owner.TenantID,
+		BusinessDomainID:    owner.BusinessDomainID,
+		FactsHash:           hex.EncodeToString(sum[:]),
+		KnowledgeNetworkIDs: explicitKnowledgeNetworkIDs(canonicalFacts),
+		Facts:               canonicalFacts,
+	}, nil
+}
+
+func explicitKnowledgeNetworkIDs(facts []OperationCallFact) []string {
+	set := make(map[string]struct{})
+	for _, fact := range facts {
+		if fact.Input.Mode != PayloadInline {
+			continue
+		}
+		var input struct {
+			KNID               string `json:"kn_id"`
+			KnowledgeNetworkID string `json:"knowledge_network_id"`
+		}
+		if json.Unmarshal(fact.Input.Inline, &input) != nil {
+			continue
+		}
+		if input.KNID != "" {
+			set[input.KNID] = struct{}{}
+			continue
+		}
+		if input.KnowledgeNetworkID != "" {
+			set[input.KnowledgeNetworkID] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for networkID := range set {
+		result = append(result, networkID)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package sessionvo
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHistoricalProvenanceBuildRequestCanonicalizesFactsAndExplicitNetworks(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 8, 29, 10, 0, 0, 0, time.UTC)
+	facts := []OperationCallFact{
+		{OperationID: "op-later", Attempt: 1, StartedAt: startedAt.Add(time.Second), ToolName: "run_sql", Input: mustInlinePayload(t, `{"kn_id":"network-b"}`)},
+		{OperationID: "op-earlier", Attempt: 2, StartedAt: startedAt, ToolName: "run_sql", Input: mustInlinePayload(t, `{"knowledge_network_id":"network-a"}`)},
+		{OperationID: "op-no-network", Attempt: 1, StartedAt: startedAt, ToolName: "run_sql", Input: mustInlinePayload(t, `{"query":"select 1"}`)},
+	}
+
+	request, err := NewHistoricalProvenanceBuildRequest("interaction-1", Owner{
+		TenantID: "tenant-1", BusinessDomainID: "domain-1",
+	}, facts)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	if got, want := request.KnowledgeNetworkIDs, []string{"network-a", "network-b"}; !sameStrings(got, want) {
+		t.Fatalf("knowledge network IDs = %#v, want %#v", got, want)
+	}
+	if len(request.Facts) != 3 || request.Facts[0].OperationID != "op-earlier" || request.Facts[1].OperationID != "op-no-network" || request.Facts[2].OperationID != "op-later" {
+		t.Fatalf("facts were not canonically sorted: %#v", request.Facts)
+	}
+	if request.FactsHash == "" {
+		t.Fatal("facts hash is required")
+	}
+
+	reversed := []OperationCallFact{facts[2], facts[0], facts[1]}
+	second, err := NewHistoricalProvenanceBuildRequest("interaction-1", Owner{
+		TenantID: "tenant-1", BusinessDomainID: "domain-1",
+	}, reversed)
+	if err != nil {
+		t.Fatalf("build reversed request: %v", err)
+	}
+	if second.FactsHash != request.FactsHash {
+		t.Fatalf("facts hash changed with input ordering: %q != %q", second.FactsHash, request.FactsHash)
+	}
+}
+
+func mustInlinePayload(t *testing.T, raw string) PayloadEnvelope {
+	t.Helper()
+	payload, err := InlineJSONPayload([]byte(raw))
+	if err != nil {
+		t.Fatalf("inline payload: %v", err)
+	}
+	return payload
+}
+
+func sameStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range got {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -16,6 +16,7 @@ import (
 	v016 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v016"
 	v017 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v017"
 	v018 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v018"
+	v019 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v019"
 )
 
 // Migration is immutable once released. Every statement in SQL must be safe to
@@ -38,6 +39,7 @@ func Migrations() []Migration {
 		{version: "016", sql: v016.SchemaSQL()},
 		{version: "017", sql: v017.SchemaSQL()},
 		{version: "018", sql: v018.SchemaSQL()},
+		{version: "019", sql: v019.SchemaSQL()},
 	})
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -42,6 +42,10 @@ func TestSchemaFreezesLifecycleAndDurableEvidenceConstraints(t *testing.T) {
 		"PRIMARY KEY (source_id, deployment_id)",
 		"dropped_records BIGINT UNSIGNED NOT NULL DEFAULT 0",
 		"bkn_trace_ee_provenance_analyses",
+		"bkn_trace_ee_historical_provenance_projections",
+		"bkn_trace_ee_historical_provenance_tombstones",
+		"uq_provenance_projection_interaction_facts",
+		"uq_provenance_projection_interaction (interaction_id)",
 		"idx_provenance_analysis_interaction",
 		"ADD COLUMN IF NOT EXISTS locale VARCHAR(16) NOT NULL DEFAULT 'zh-CN'",
 	}
@@ -60,6 +64,7 @@ func TestMigrationsAreOrderedAndChecksumProtected(t *testing.T) {
 		"016": "869da02928bed7950e7d0b2b3e609c806334a3839342e57631548f57b3ac1be4",
 		"017": "f47e2ee9f70f0089c2cd225f5d28cc612b2f0c105d5ba001d55771636c02e349",
 		"018": "9fd4c45b568a2a5c395ee09a4214a240d9e865239e1024f443559f45a97b89b8",
+		"019": "4bdaffbf5877ae560a8aaf13dbcb69b88c7dfe6fd642e06be1da54827f9134a8",
 	}
 	migrations := sessionstore.Migrations()
 	if len(migrations) != len(expectedChecksums) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -62,7 +62,8 @@ func TestMigrationPlanUpgradesExistingCoreSchemaWithProvenanceTable(t *testing.T
 	if err != nil {
 		t.Fatalf("plan provenance schema migration: %v", err)
 	}
-	if len(plan) != 2 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") {
+	if len(plan) != 3 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") ||
+		plan[2].Version != "019" || !strings.Contains(plan[2].SQL, "bkn_trace_ee_historical_provenance_projections") {
 		t.Fatalf("unexpected provenance schema plan: %#v", plan)
 	}
 }
@@ -77,9 +78,10 @@ func TestMigrationPlanAddsLocaleToExistingProvenanceHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan provenance locale migration: %v", err)
 	}
-	if len(plan) != 1 || plan[0].Version != "018" ||
+	if len(plan) != 2 || plan[0].Version != "018" ||
 		!strings.Contains(plan[0].SQL, "ADD COLUMN IF NOT EXISTS locale") ||
-		!strings.Contains(plan[0].SQL, "DEFAULT 'zh-CN'") {
+		!strings.Contains(plan[0].SQL, "DEFAULT 'zh-CN'") ||
+		plan[1].Version != "019" || !strings.Contains(plan[1].SQL, "bkn_trace_ee_historical_provenance_tombstones") {
 		t.Fatalf("unexpected provenance locale migration plan: %#v", plan)
 	}
 }


### PR DESCRIPTION
## Context
Implements the Core contract from [openbkn-ee#31](https://github.com/openbkn-ai/openbkn-ee/issues/31) and design [bkn-docs#81](https://github.com/openbkn-ai/bkn-docs/pull/81).

## Included
- Seal terminal Operation facts into a canonical `facts_hash` Outbox payload.
- Route the dedicated historical-provenance event away from OpenSearch.
- Keep late receipts from replacing the sealed build request.
- Add Core-owned, additive v019 tables for immutable EE projections and tombstones.

## Safety
- Event production is explicitly gated until the EE handler is assembled.
- v019 changes no existing tables or historical facts.

## Verification
`go test ./src/domain/valueobject/sessionvo ./src/domain/service/sessionsvc ./src/domain/service/projectorsvc ./src/drivenadapter/dbaccess/mariadb/sessionstore -count=1`

## Follow-up
The EE builder, handler assembly, and read-path replacement remain in the paired Draft PR. E2E tracking: [bkn-docs#82](https://github.com/openbkn-ai/bkn-docs/issues/82).