### PR TITLE
fix: backport managed BKN functions for supply sample

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_function.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_function.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
@@ -24,6 +25,8 @@ import (
 // Calling the internal endpoint with a service identity would bypass that check,
 // so this request carries the original caller bearer token.
 const executeFunctionURI = "/v1/function/execute"
+
+const executePublishedToolURI = "/v1/tool-box/%s/proxy/%s"
 
 // ErrCallerTokenMissing indicates that the caller token is absent from context.
 //
@@ -74,4 +77,45 @@ func (o *operatorIntegrationClient) ExecuteFunction(
 			infraErr.LocalizedDetail(ctx, "FunctionExecutionResponseInvalid"))
 	}
 	return resp, nil
+}
+
+// ExecutePublishedTool invokes the standard public Toolbox execution endpoint.
+// It deliberately uses the Context Loader caller's raw token instead of a
+// service identity: the Function Runtime then propagates exactly that identity
+// and the validated managed context into the sandbox.
+func (o *operatorIntegrationClient) ExecutePublishedTool(
+	ctx context.Context, req *interfaces.ExecutePublishedToolRequest,
+) (map[string]any, error) {
+	if req == nil || strings.TrimSpace(req.ToolboxID) == "" || strings.TrimSpace(req.ToolID) == "" {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, "toolbox_id and tool_id are required")
+	}
+	if strings.TrimSpace(req.BKNConversationID) == "" || strings.TrimSpace(req.BKNInteractionID) == "" {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, "managed BKN context is required")
+	}
+	token, ok := common.GetRawTokenFromCtx(ctx)
+	if !ok {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusUnauthorized, ErrCallerTokenMissing.Error())
+	}
+
+	header := o.skillHeader(ctx, "operator.published_tool.execute")
+	header["Authorization"] = "Bearer " + token
+	header[common.HeaderBKNConversationID] = req.BKNConversationID
+	header[common.HeaderBKNInteractionID] = req.BKNInteractionID
+	url := fmt.Sprintf(o.baseURL+executePublishedToolURI, req.ToolboxID, req.ToolID)
+	body := req.Parameters
+	if body == nil {
+		body = map[string]any{}
+	}
+	// Toolbox proxy expects HTTPRequestParams. Keep Function business
+	// parameters inside its body field, rather than treating them as proxy
+	// envelope fields (which would leave the proxied request body empty).
+	code, response, err := o.httpClient.Post(ctx, url, header, map[string]any{"body": body})
+	if err != nil {
+		return nil, skillUpstreamError(ctx, code, "PublishedToolExecutionFailed", err)
+	}
+	result, ok := response.(map[string]any)
+	if !ok {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, "published tool response is invalid")
+	}
+	return result, nil
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog.go
@@ -107,20 +107,23 @@ func (o *operatorIntegrationClient) ListPublishedTools(ctx context.Context, req 
 	return resp, nil
 }
 
-// safeInputSchema removes OpenAPI deployment topology. Parameters and request
-// schemas remain intact; callers need those to invoke a Function, while a
-// server address must never be part of the Agent-facing catalogue.
+// safeInputSchema keeps just a Function's business-input contract. Transport
+// topology and security metadata are neither callable business parameters nor
+// useful to an Agent which is already authenticated through Context Loader.
 func safeInputSchema(apiSpec map[string]any) map[string]any {
 	if apiSpec == nil {
 		return nil
 	}
-	copy := make(map[string]any, len(apiSpec))
-	for key, value := range apiSpec {
-		switch strings.ToLower(key) {
-		case "servers", "server_url", "serverurl", "x-server-url":
-			continue
+	input := make(map[string]any, 3)
+	for _, key := range []string{"parameters", "request_body"} {
+		if value, ok := apiSpec[key]; ok {
+			input[key] = value
 		}
-		copy[key] = value
 	}
-	return copy
+	if components, ok := apiSpec["components"].(map[string]any); ok {
+		if schemas, ok := components["schemas"]; ok {
+			input["components"] = map[string]any{"schemas": schemas}
+		}
+	}
+	return input
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog.go
@@ -1,0 +1,126 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package drivenadapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/bytedance/sonic"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/utils"
+)
+
+const (
+	listPublishedToolboxesURI = "/v1/tool-box/list"
+	listPublishedToolsURI     = "/v1/tool-box/%s/tools/list"
+)
+
+// ListPublishedToolboxes calls the standard public Toolbox catalogue with the
+// original MCP credential. Filtering on the server prevents a Context Loader
+// service identity from disclosing another caller's unpublished inventory.
+func (o *operatorIntegrationClient) ListPublishedToolboxes(ctx context.Context, req *interfaces.ListPublishedToolboxesRequest) (*interfaces.ListPublishedToolboxesResponse, error) {
+	token, ok := common.GetRawTokenFromCtx(ctx)
+	if !ok {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusUnauthorized, ErrCallerTokenMissing.Error())
+	}
+	query := url.Values{"status": {"published"}, "metadata_type": {"function"}, "page": {"1"}, "page_size": {"100"}}
+	if req != nil && strings.TrimSpace(req.Keyword) != "" {
+		query.Set("name", strings.TrimSpace(req.Keyword))
+	}
+	header := o.skillHeader(ctx, "operator.published_toolbox.list")
+	header["Authorization"] = "Bearer " + token
+	_, body, err := o.httpClient.Get(ctx, o.baseURL+listPublishedToolboxesURI, query, header)
+	if err != nil {
+		return nil, skillUpstreamError(ctx, http.StatusBadGateway, "PublishedToolboxCatalogRequestFailed", err)
+	}
+	var payload struct {
+		Data []struct {
+			BoxID   string `json:"box_id"`
+			BoxName string `json:"box_name"`
+			BoxDesc string `json:"box_desc"`
+			Status  string `json:"status"`
+		} `json:"data"`
+	}
+	if err := sonic.Unmarshal(utils.ObjectToByte(body), &payload); err != nil {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, "published toolbox catalog response is invalid")
+	}
+	resp := &interfaces.ListPublishedToolboxesResponse{}
+	for _, box := range payload.Data {
+		if box.Status != "published" || strings.TrimSpace(box.BoxID) == "" {
+			continue
+		}
+		resp.Toolboxes = append(resp.Toolboxes, interfaces.PublishedToolboxSummary{ToolboxID: box.BoxID, Name: box.BoxName, Description: box.BoxDesc})
+	}
+	return resp, nil
+}
+
+// ListPublishedTools returns a deliberately narrow Function catalogue. The
+// public API's Metadata also contains service topology; only api_spec is
+// retained, so an Agent learns business parameters without learning internals.
+func (o *operatorIntegrationClient) ListPublishedTools(ctx context.Context, req *interfaces.ListPublishedToolsRequest) (*interfaces.ListPublishedToolsResponse, error) {
+	if req == nil || strings.TrimSpace(req.ToolboxID) == "" {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, "toolbox_id is required")
+	}
+	token, ok := common.GetRawTokenFromCtx(ctx)
+	if !ok {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusUnauthorized, ErrCallerTokenMissing.Error())
+	}
+	query := url.Values{"status": {"enabled"}, "page": {"1"}, "page_size": {"100"}}
+	header := o.skillHeader(ctx, "operator.published_tool.list")
+	header["Authorization"] = "Bearer " + token
+	_, body, err := o.httpClient.Get(ctx, o.baseURL+fmt.Sprintf(listPublishedToolsURI, req.ToolboxID), query, header)
+	if err != nil {
+		return nil, skillUpstreamError(ctx, http.StatusBadGateway, "PublishedToolCatalogRequestFailed", err)
+	}
+	var payload struct {
+		BoxID string `json:"box_id"`
+		Tools []struct {
+			ToolID      string         `json:"tool_id"`
+			Name        string         `json:"name"`
+			Description string         `json:"description"`
+			Status      string         `json:"status"`
+			UseRule     string         `json:"use_rule"`
+			Metadata    map[string]any `json:"metadata"`
+		} `json:"tools"`
+	}
+	if err := sonic.Unmarshal(utils.ObjectToByte(body), &payload); err != nil {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway, "published tool catalog response is invalid")
+	}
+	resp := &interfaces.ListPublishedToolsResponse{ToolboxID: req.ToolboxID}
+	for _, tool := range payload.Tools {
+		if tool.Status != "enabled" || strings.TrimSpace(tool.ToolID) == "" {
+			continue
+		}
+		inputSchema, _ := tool.Metadata["api_spec"].(map[string]any)
+		inputSchema = safeInputSchema(inputSchema)
+		resp.Tools = append(resp.Tools, interfaces.PublishedToolSummary{ToolID: tool.ToolID, Name: tool.Name, Description: tool.Description, UseRule: tool.UseRule, InputSchema: inputSchema})
+	}
+	return resp, nil
+}
+
+// safeInputSchema removes OpenAPI deployment topology. Parameters and request
+// schemas remain intact; callers need those to invoke a Function, while a
+// server address must never be part of the Agent-facing catalogue.
+func safeInputSchema(apiSpec map[string]any) map[string]any {
+	if apiSpec == nil {
+		return nil
+	}
+	copy := make(map[string]any, len(apiSpec))
+	for key, value := range apiSpec {
+		switch strings.ToLower(key) {
+		case "servers", "server_url", "serverurl", "x-server-url":
+			continue
+		}
+		copy[key] = value
+	}
+	return copy
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog_test.go
@@ -1,0 +1,75 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func TestPublishedToolCatalogUsesCallerCredentialAndReturnsSafeFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer caller-appkey" {
+			t.Fatalf("authorization = %q", got)
+		}
+		if got := r.Header.Get("x-business-domain"); got == "" {
+			t.Fatal("x-business-domain is missing")
+		}
+		switch r.URL.Path {
+		case "/api/agent-operator-integration/v1/tool-box/list":
+			if got := r.URL.Query().Get("status"); got != "published" {
+				t.Fatalf("toolbox status = %q", got)
+			}
+			if got := r.URL.Query().Get("metadata_type"); got != "function" {
+				t.Fatalf("toolbox metadata_type = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"data":[{"box_id":"box-1","box_name":"供应链函数","box_desc":"已发布函数","status":"published","box_svc_url":"http://internal"}]}`))
+		case "/api/agent-operator-integration/v1/tool-box/box-1/tools/list":
+			if got := r.URL.Query().Get("status"); got != "enabled" {
+				t.Fatalf("tool status = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"box_id":"box-1","tools":[{"tool_id":"tool-1","name":"标准交期","description":"返回标准交期","status":"enabled","use_rule":"按物料编码查询","metadata":{"server_url":"http://internal","api_spec":{"servers":[{"url":"http://internal"}],"parameters":[{"name":"material_code","required":true,"type":"string"}]}}}]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := &operatorIntegrationClient{
+		baseURL:    server.URL + "/api/agent-operator-integration",
+		httpClient: rest.NewHTTPClientWithRawClient(server.Client()),
+	}
+	ctx := common.SetRawTokenToCtx(context.Background(), "caller-appkey")
+
+	boxes, err := client.ListPublishedToolboxes(ctx, &interfaces.ListPublishedToolboxesRequest{Keyword: "供应链"})
+	if err != nil {
+		t.Fatalf("list toolboxes: %v", err)
+	}
+	if len(boxes.Toolboxes) != 1 || boxes.Toolboxes[0].ToolboxID != "box-1" || boxes.Toolboxes[0].Name != "供应链函数" {
+		t.Fatalf("unexpected toolboxes: %#v", boxes)
+	}
+
+	tools, err := client.ListPublishedTools(ctx, &interfaces.ListPublishedToolsRequest{ToolboxID: "box-1"})
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	if len(tools.Tools) != 1 || tools.Tools[0].ToolID != "tool-1" || tools.Tools[0].InputSchema["parameters"] == nil {
+		t.Fatalf("unexpected tools: %#v", tools)
+	}
+	if _, leaked := tools.Tools[0].InputSchema["server_url"]; leaked {
+		t.Fatalf("internal server URL leaked: %#v", tools.Tools[0])
+	}
+	if _, leaked := tools.Tools[0].InputSchema["servers"]; leaked {
+		t.Fatalf("OpenAPI server topology leaked: %#v", tools.Tools[0])
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_catalog_test.go
@@ -38,7 +38,7 @@ func TestPublishedToolCatalogUsesCallerCredentialAndReturnsSafeFields(t *testing
 			if got := r.URL.Query().Get("status"); got != "enabled" {
 				t.Fatalf("tool status = %q", got)
 			}
-			_, _ = w.Write([]byte(`{"box_id":"box-1","tools":[{"tool_id":"tool-1","name":"标准交期","description":"返回标准交期","status":"enabled","use_rule":"按物料编码查询","metadata":{"server_url":"http://internal","api_spec":{"servers":[{"url":"http://internal"}],"parameters":[{"name":"material_code","required":true,"type":"string"}]}}}]}`))
+			_, _ = w.Write([]byte(`{"box_id":"box-1","tools":[{"tool_id":"tool-1","name":"标准交期","description":"返回标准交期","status":"enabled","use_rule":"按物料编码查询","metadata":{"server_url":"http://internal","api_spec":{"servers":[{"url":"http://internal"}],"security":[{"api_key":[]}],"parameters":[{"name":"material_code","required":true,"type":"string"}]}}}]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -71,5 +71,8 @@ func TestPublishedToolCatalogUsesCallerCredentialAndReturnsSafeFields(t *testing
 	}
 	if _, leaked := tools.Tools[0].InputSchema["servers"]; leaked {
 		t.Fatalf("OpenAPI server topology leaked: %#v", tools.Tools[0])
+	}
+	if _, leaked := tools.Tools[0].InputSchema["security"]; leaked {
+		t.Fatalf("transport security detail leaked: %#v", tools.Tools[0])
 	}
 }

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_tool_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_published_tool_test.go
@@ -1,0 +1,64 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func TestExecutePublishedToolForwardsOriginalCredentialAndManagedContext(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/agent-operator-integration/v1/tool-box/box-1/proxy/tool-1" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer caller-appkey" {
+			t.Fatalf("authorization = %q", got)
+		}
+		if got := r.Header.Get(common.HeaderBKNConversationID); got != "conv-1" {
+			t.Fatalf("conversation header = %q", got)
+		}
+		if got := r.Header.Get(common.HeaderBKNInteractionID); got != "int-1" {
+			t.Fatalf("interaction header = %q", got)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		payload, ok := body["body"].(map[string]any)
+		if !ok || len(body) != 1 || payload["material_code"] != "606-000989" {
+			t.Fatalf("proxy envelope or business body is invalid: %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"body":{"exit_code":0,"result":{"leadtime_days":14}}}`))
+	}))
+	defer server.Close()
+
+	client := &operatorIntegrationClient{
+		baseURL:    server.URL + "/api/agent-operator-integration",
+		httpClient: rest.NewHTTPClientWithRawClient(server.Client()),
+	}
+	ctx := common.SetRawTokenToCtx(context.Background(), "caller-appkey")
+	result, err := client.ExecutePublishedTool(ctx, &interfaces.ExecutePublishedToolRequest{
+		ToolboxID: "box-1", ToolID: "tool-1",
+		Parameters:        map[string]any{"material_code": "606-000989"},
+		BKNConversationID: "conv-1", BKNInteractionID: "int-1",
+	})
+	if err != nil {
+		t.Fatalf("execute published tool: %v", err)
+	}
+	body, ok := result["body"].(map[string]any)
+	if !ok || body["exit_code"].(float64) != 0 {
+		t.Fatalf("unexpected response: %#v", result)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -191,6 +191,11 @@ func newMCPServerForLocale(lifecycleClient *bkntrace.LifecycleClient, locale str
 		b.add(toolKeyExecuteSkill, handleExecuteSkill(skillsService))
 	}
 
+	// A managed bridge for published Function tools. It uses the original MCP
+	// credential, not a separately logged-in CLI credential, so the sandbox
+	// query belongs to the same Interaction owner.
+	b.add(toolKeyExecutePublishedTool, handlePTCPublishedTool(drivenadapters.NewOperatorIntegrationClient(), localeBundle))
+
 	// The lifecycle tools are registered straight onto the server by the tracing
 	// adapter rather than through the builder. Claim their advertised names all
 	// the same, so an enterprise tool cannot shadow one of them — mcp-go's

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -60,6 +60,8 @@ const (
 	toolKeyGetSkillContent          = "get_skill_content"
 	toolKeyReadSkillFile            = "read_skill_file"
 	toolKeyExecuteSkill             = "execute_skill"
+	toolKeyListPublishedToolboxes   = "list_published_toolboxes"
+	toolKeyListPublishedTools       = "list_published_tools"
 	// Bounds the lifetime of mcp-go's in-memory session state.
 	mcpSessionIdleTTL = 30 * time.Minute
 )
@@ -191,10 +193,16 @@ func newMCPServerForLocale(lifecycleClient *bkntrace.LifecycleClient, locale str
 		b.add(toolKeyExecuteSkill, handleExecuteSkill(skillsService))
 	}
 
+	// Published Functions have their own directory, distinct from Skills. The
+	// Agent obtains real IDs here and must never guess IDs or probe candidates.
+	operatorIntegration := drivenadapters.NewOperatorIntegrationClient()
+	b.add(toolKeyListPublishedToolboxes, handleListPublishedToolboxes(operatorIntegration))
+	b.add(toolKeyListPublishedTools, handleListPublishedTools(operatorIntegration))
+
 	// A managed bridge for published Function tools. It uses the original MCP
 	// credential, not a separately logged-in CLI credential, so the sandbox
 	// query belongs to the same Interaction owner.
-	b.add(toolKeyExecutePublishedTool, handlePTCPublishedTool(drivenadapters.NewOperatorIntegrationClient(), localeBundle))
+	b.add(toolKeyExecutePublishedTool, handlePTCPublishedTool(operatorIntegration, localeBundle))
 
 	// The lifecycle tools are registered straight onto the server by the tracing
 	// adapter rather than through the builder. Claim their advertised names all

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -54,6 +54,8 @@ var communityTools = []string{
 	"get_skill_content",
 	"list_action_executions",
 	"list_knowledge_networks",
+	"list_published_toolboxes",
+	"list_published_tools",
 	"list_resources",
 	"list_skills",
 	"query_instance_subgraph",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/community_parity_test.go
@@ -42,6 +42,7 @@ var communityTools = []string{
 	// knowledge network tools.
 	"describe_resource",
 	"execute_action",
+	"execute_published_tool",
 	"explore_subgraph",
 	"find_skills",
 	"get_action_execution",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/inline_ptc_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/inline_ptc_test.go
@@ -22,7 +22,7 @@ func TestInlinePTCToolsAreOnTheBusinessSurface(t *testing.T) {
 	for _, tool := range assembledTools(t) {
 		byName[tool.Name] = true
 	}
-	for _, name := range []string{toolKeyRunCode, toolKeyRunShell} {
+	for _, name := range []string{toolKeyRunCode, toolKeyRunShell, toolKeyExecutePublishedTool} {
 		if !byName[name] {
 			t.Fatalf("tools/list 缺 %s——并进业务工具面的整个意义就是模型能在一次选择里同时看到它和业务工具", name)
 		}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
@@ -130,7 +130,38 @@ func newPTCMCPServerForLocale(
 		}, publishedToolInputSchema(localeBundle.PTCResource("ptc_bkn_context_description.txt")), nil),
 		handlePTCPublishedTool(executor, localeBundle),
 	)
+	// Keep the dedicated programmatic endpoint self-sufficient: an Agent can
+	// discover exactly the Functions it may call before selecting one.
+	mcpServer.AddTool(
+		newToolWithSchemas(ToolMeta{Name: toolKeyListPublishedToolboxes, Description: "List caller-visible published Function toolboxes. Use this before listing tools or executing a Function.", Title: "List published Function toolboxes"}, publishedToolboxCatalogInputSchema(localeBundle.PTCResource("ptc_bkn_context_description.txt")), nil),
+		handleListPublishedToolboxes(executor),
+	)
+	mcpServer.AddTool(
+		newToolWithSchemas(ToolMeta{Name: toolKeyListPublishedTools, Description: "List enabled Functions and input schemas in a published Toolbox. Use the returned exact IDs with execute_published_tool; do not guess IDs.", Title: "List published Functions"}, publishedToolListInputSchema(localeBundle.PTCResource("ptc_bkn_context_description.txt")), nil),
+		handleListPublishedTools(executor),
+	)
 	return mcpServer, nil
+}
+
+func publishedToolboxCatalogInputSchema(contextDescription string) json.RawMessage {
+	return publishedCatalogSchema(map[string]any{"keyword": map[string]any{"type": "string", "description": "Optional toolbox name keyword."}}, []any{"bkn_context"}, contextDescription)
+}
+
+func publishedToolListInputSchema(contextDescription string) json.RawMessage {
+	return publishedCatalogSchema(map[string]any{"toolbox_id": map[string]any{"type": "string", "description": "A toolbox_id returned by list_published_toolboxes."}}, []any{"toolbox_id", "bkn_context"}, contextDescription)
+}
+
+func publishedCatalogSchema(properties map[string]any, required []any, contextDescription string) json.RawMessage {
+	properties["bkn_context"] = map[string]any{
+		"type": "object", "description": contextDescription,
+		"properties": map[string]any{"conversation_id": map[string]any{"type": "string"}, "interaction_id": map[string]any{"type": "string"}},
+		"required":   []any{"conversation_id", "interaction_id"},
+	}
+	encoded, err := sonic.ConfigStd.Marshal(map[string]any{"type": "object", "properties": properties, "required": required})
+	if err != nil {
+		return nil
+	}
+	return encoded
 }
 
 func publishedToolInputSchema(contextDescription string) json.RawMessage {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server.go
@@ -48,7 +48,8 @@ const (
 	// back. PTC_SANDBOX_MCP_URL and PTC_SANDBOX_MCP_HOST override it.
 	defaultPTCServicePort = 30779
 	// ptcMaxTimeout aligns with the execution-factory sandbox timeout.
-	ptcMaxTimeout = 600
+	ptcMaxTimeout               = 600
+	toolKeyExecutePublishedTool = "execute_published_tool"
 )
 
 // NewPTCMCPHandler creates the PTC MCP HTTP handler.
@@ -117,7 +118,75 @@ func newPTCMCPServerForLocale(
 			handlePTCExecuteForLocale(executor, toolkit, tool, localeBundle),
 		)
 	}
+	// This bridge invokes a registered Function through the normal Toolbox
+	// execution path using the MCP caller's credential. It avoids the unsafe
+	// alternative of making a separately logged-in CLI principal look like the
+	// owner of an existing managed Interaction.
+	mcpServer.AddTool(
+		newToolWithSchemas(ToolMeta{
+			Name:        toolKeyExecutePublishedTool,
+			Description: "Invoke an enabled published Toolbox function in the current managed Interaction. Use a toolbox_id and tool_id obtained from the published toolbox catalog; pass only the function's business parameters.",
+			Title:       "Execute published Toolbox function",
+		}, publishedToolInputSchema(localeBundle.PTCResource("ptc_bkn_context_description.txt")), nil),
+		handlePTCPublishedTool(executor, localeBundle),
+	)
 	return mcpServer, nil
+}
+
+func publishedToolInputSchema(contextDescription string) json.RawMessage {
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"toolbox_id": map[string]any{"type": "string", "description": "Published Toolbox ID."},
+			"tool_id":    map[string]any{"type": "string", "description": "Enabled Function tool ID in that Toolbox."},
+			"arguments":  map[string]any{"type": "object", "description": "Business parameters defined by the published Function schema."},
+			"bkn_context": map[string]any{
+				"type": "object", "description": contextDescription,
+				"properties": map[string]any{
+					"conversation_id": map[string]any{"type": "string"},
+					"interaction_id":  map[string]any{"type": "string"},
+				},
+				"required": []any{"conversation_id", "interaction_id"},
+			},
+		},
+		"required": []any{"toolbox_id", "tool_id", "arguments", "bkn_context"},
+	}
+	encoded, err := sonic.ConfigStd.Marshal(schema)
+	if err != nil {
+		return nil
+	}
+	return encoded
+}
+
+func handlePTCPublishedTool(
+	executor interfaces.DrivenOperatorIntegration, _ *mcpLocaleBundle,
+) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		toolboxID := strings.TrimSpace(getStringArg(req, "toolbox_id", ""))
+		toolID := strings.TrimSpace(getStringArg(req, "tool_id", ""))
+		if toolboxID == "" || toolID == "" {
+			return mcp.NewToolResultError("toolbox_id and tool_id are required"), nil
+		}
+		args, ok := req.GetArguments()["arguments"].(map[string]any)
+		if !ok {
+			return mcp.NewToolResultError("arguments must be an object"), nil
+		}
+		businessContext := ptcBusinessContextArg(req)
+		conversationID, _ := businessContext["conversation_id"].(string)
+		interactionID, _ := businessContext["interaction_id"].(string)
+		response, err := executor.ExecutePublishedTool(ctx, &interfaces.ExecutePublishedToolRequest{
+			ToolboxID: toolboxID, ToolID: toolID, Parameters: args,
+			BKNConversationID: conversationID, BKNInteractionID: interactionID,
+		})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(response, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
 }
 
 // ptcToolInputSchemaWithContext adds bkn_context to a tool's input schema.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/ptc_server_test.go
@@ -64,9 +64,11 @@ func TestPTCMCPInitializeUsesRequestLocale(t *testing.T) {
 // fakeExecutor records the last sandbox execution request.
 type fakeExecutor struct {
 	interfaces.DrivenOperatorIntegration
-	last *interfaces.ExecuteFunctionRequest
-	resp *interfaces.ExecuteFunctionResponse
-	err  error
+	last     *interfaces.ExecuteFunctionRequest
+	lastTool *interfaces.ExecutePublishedToolRequest
+	resp     *interfaces.ExecuteFunctionResponse
+	toolResp map[string]any
+	err      error
 }
 
 func (f *fakeExecutor) ExecuteFunction(
@@ -80,6 +82,52 @@ func (f *fakeExecutor) ExecuteFunction(
 		return f.resp, nil
 	}
 	return &interfaces.ExecuteFunctionResponse{Stdout: "ok"}, nil
+}
+
+func (f *fakeExecutor) ExecutePublishedTool(
+	_ context.Context, req *interfaces.ExecutePublishedToolRequest,
+) (map[string]any, error) {
+	f.lastTool = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.toolResp != nil {
+		return f.toolResp, nil
+	}
+	return map[string]any{"body": map[string]any{"exit_code": 0}}, nil
+}
+
+func TestPTCPublishedToolUsesCallerContext(t *testing.T) {
+	executor := &fakeExecutor{toolResp: map[string]any{"body": map[string]any{"result": map[string]any{"leadtime_days": 14}}}}
+	handler := handlePTCPublishedTool(executor, loadMCPLocaleBundle("en-US"))
+	ctx := common.SetRawTokenToCtx(context.Background(), "caller-appkey")
+
+	result, err := handler(ctx, ptcCallRequest("execute_published_tool", map[string]any{
+		"toolbox_id": "box-1",
+		"tool_id":    "tool-1",
+		"arguments":  map[string]any{"material_code": "606-000989"},
+		"bkn_context": map[string]any{
+			"conversation_id": "conv-1", "interaction_id": "int-1",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("call published tool: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("published-tool response marked error: %#v", result)
+	}
+	if executor.lastTool == nil {
+		t.Fatal("published tool was not invoked")
+	}
+	if executor.lastTool.ToolboxID != "box-1" || executor.lastTool.ToolID != "tool-1" {
+		t.Fatalf("wrong published tool target: %#v", executor.lastTool)
+	}
+	if executor.lastTool.BKNConversationID != "conv-1" || executor.lastTool.BKNInteractionID != "int-1" {
+		t.Fatalf("managed context missing from published tool request: %#v", executor.lastTool)
+	}
+	if executor.lastTool.Parameters["material_code"] != "606-000989" {
+		t.Fatalf("business parameters changed: %#v", executor.lastTool.Parameters)
+	}
 }
 
 func ptcCallRequest(name string, args map[string]any) mcp.CallToolRequest {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/published_tool_catalog.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/published_tool_catalog.go
@@ -1,0 +1,53 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package mcp
+
+import (
+	"context"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// handleListPublishedToolboxes exposes the caller-visible Function directory.
+// It is deliberately separate from Skills discovery: a Skill is a reusable
+// procedure, while a published Function is an executable business operation.
+func handleListPublishedToolboxes(executor interfaces.DrivenOperatorIntegration) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		resp, err := executor.ListPublishedToolboxes(ctx, &interfaces.ListPublishedToolboxesRequest{
+			Keyword: strings.TrimSpace(getStringArg(req, "keyword", "")),
+		})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}
+
+func handleListPublishedTools(executor interfaces.DrivenOperatorIntegration) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		toolboxID := strings.TrimSpace(getStringArg(req, "toolbox_id", ""))
+		if toolboxID == "" {
+			return mcp.NewToolResultError("toolbox_id is required"), nil
+		}
+		resp, err := executor.ListPublishedTools(ctx, &interfaces.ListPublishedToolsRequest{ToolboxID: toolboxID})
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		result, err := BuildMCPToolResult(resp, rest.FormatJSON)
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return result, nil
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_published_tool.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/execute_published_tool.json
@@ -1,0 +1,12 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "toolbox_id": {"type": "string", "description": "Published Toolbox ID."},
+      "tool_id": {"type": "string", "description": "Enabled Function tool ID in that Toolbox."},
+      "arguments": {"type": "object", "description": "Business parameters defined by the published Function schema."}
+    },
+    "required": ["toolbox_id", "tool_id", "arguments"]
+  },
+  "output_schema": {"type": "object", "description": "The published Toolbox function response."}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_published_toolboxes.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_published_toolboxes.json
@@ -1,0 +1,14 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "keyword": {"type": "string", "description": "可选：按工具箱名称筛选。"}
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "toolboxes": {"type": "array", "description": "当前调用者可见的已发布函数工具箱；每项含 toolbox_id、name、description。"}
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_published_tools.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/list_published_tools.json
@@ -1,0 +1,16 @@
+{
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "toolbox_id": {"type": "string", "description": "由 list_published_toolboxes 返回的工具箱 ID。"}
+    },
+    "required": ["toolbox_id"]
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "toolbox_id": {"type": "string"},
+      "tools": {"type": "array", "description": "该工具箱内已启用函数；每项含 tool_id、名称、说明、使用规则及已裁剪的 input_schema。"}
+    }
+  }
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -386,6 +386,14 @@
     "output_schema.properties.truncated.description": "Whether the body was truncated for length",
     "output_schema.properties.message.description": "Further detail, such as a binary file with no body returned, or a truncation notice"
   },
+  "list_published_toolboxes": {
+    "input_schema.properties.keyword.description": "Optional toolbox-name keyword.",
+    "output_schema.properties.toolboxes.description": "Published Function toolboxes visible to the current caller. Each item includes toolbox_id, name, and description."
+  },
+  "list_published_tools": {
+    "input_schema.properties.toolbox_id.description": "Toolbox id returned by list_published_toolboxes.",
+    "output_schema.properties.tools.description": "Enabled Functions in this toolbox. Each item includes tool_id, name, description, usage rule, and a sanitized input schema."
+  },
   "search_instance": {
     "input_schema.properties.response_format.description": "Response format: json or toon. Defaults to toon.",
     "input_schema.properties.kn_id.description": "Knowledge network id. The X-Kn-ID request header carries it too.",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -136,5 +136,15 @@
     "title": "Execute Published Function",
     "group_title": "Code Execution",
     "description": "Execute an enabled published Toolbox function in the current managed Interaction. First obtain toolbox_id, tool_id, and the parameter schema from the function toolbox catalog. arguments contains only business parameters—never a token, session ID, snapshot, or resolved_context. The platform uses the current MCP caller identity and propagates the managed context automatically."
+  },
+  "list_published_toolboxes": {
+    "title": "Find Published Function Toolboxes",
+    "group_title": "Network & Schema",
+    "description": "List published Function toolboxes visible to the current caller. Functions and Skills are distinct capabilities: use list_skills for Skills; use this tool to obtain a real toolbox_id. If no match is returned, record it and do not guess a name or ID."
+  },
+  "list_published_tools": {
+    "title": "List Published Functions",
+    "group_title": "Network & Schema",
+    "description": "List enabled Functions and parameter descriptions in one published toolbox. toolbox_id must come from list_published_toolboxes; use the returned exact tool_id with execute_published_tool. Do not guess or enumerate candidate IDs."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/tools_meta.json
@@ -131,5 +131,10 @@
   "run_shell": {
     "title": "Run Command",
     "group_title": "Code Execution"
+  },
+  "execute_published_tool": {
+    "title": "Execute Published Function",
+    "group_title": "Code Execution",
+    "description": "Execute an enabled published Toolbox function in the current managed Interaction. First obtain toolbox_id, tool_id, and the parameter schema from the function toolbox catalog. arguments contains only business parameters—never a token, session ID, snapshot, or resolved_context. The platform uses the current MCP caller identity and propagates the managed context automatically."
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -212,5 +212,13 @@
     "group": "execution",
     "group_title": "代码执行",
     "order": 620
+  },
+  "execute_published_tool": {
+    "name": "execute_published_tool",
+    "title": "执行已发布函数",
+    "group": "execution",
+    "group_title": "代码执行",
+    "order": 600,
+    "description": "在当前受管 Interaction 中执行一个已发布且已启用的 Toolbox 函数。先从函数工具箱目录取得 toolbox_id、tool_id 与参数定义；arguments 只传函数业务参数，不传 Token、会话 ID、快照或 resolved_context。平台以当前 MCP 调用者身份执行并自动传递受管上下文。"
   }
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/tools_meta.json
@@ -220,5 +220,21 @@
     "group_title": "代码执行",
     "order": 600,
     "description": "在当前受管 Interaction 中执行一个已发布且已启用的 Toolbox 函数。先从函数工具箱目录取得 toolbox_id、tool_id 与参数定义；arguments 只传函数业务参数，不传 Token、会话 ID、快照或 resolved_context。平台以当前 MCP 调用者身份执行并自动传递受管上下文。"
+  },
+  "list_published_toolboxes": {
+    "name": "list_published_toolboxes",
+    "title": "查找已发布函数工具箱",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 146,
+    "description": "列出当前调用者可见的、已发布的函数工具箱。函数与 Skill 是两类能力：Skill 用 list_skills，函数先用本工具取得真实 toolbox_id；没有匹配项即如实记录，不得猜测名称或 ID。"
+  },
+  "list_published_tools": {
+    "name": "list_published_tools",
+    "title": "查看已发布函数",
+    "group": "discovery",
+    "group_title": "网络与 Schema",
+    "order": 147,
+    "description": "列出一个已发布函数工具箱内当前可调用的函数及其参数说明。toolbox_id 必须来自 list_published_toolboxes；用返回的精确 tool_id 调 execute_published_tool，不得猜测或枚举候选 ID。"
   }
 }

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
@@ -81,6 +81,42 @@ type ExecutePublishedToolRequest struct {
 	BKNInteractionID  string         `json:"-"`
 }
 
+// ListPublishedToolboxesRequest lists only published Function toolboxes which
+// are visible to the current caller. It intentionally has no service-address
+// or creator fields: this is an Agent discovery contract, not an admin API.
+type ListPublishedToolboxesRequest struct {
+	Keyword string `json:"keyword,omitempty"`
+}
+
+type PublishedToolboxSummary struct {
+	ToolboxID   string `json:"toolbox_id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type ListPublishedToolboxesResponse struct {
+	Toolboxes []PublishedToolboxSummary `json:"toolboxes"`
+}
+
+// ListPublishedToolsRequest lists only enabled Function tools in one published
+// toolbox visible to the current caller.
+type ListPublishedToolsRequest struct {
+	ToolboxID string `json:"toolbox_id"`
+}
+
+type PublishedToolSummary struct {
+	ToolID      string         `json:"tool_id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	UseRule     string         `json:"use_rule,omitempty"`
+	InputSchema map[string]any `json:"input_schema,omitempty"`
+}
+
+type ListPublishedToolsResponse struct {
+	ToolboxID string                 `json:"toolbox_id"`
+	Tools     []PublishedToolSummary `json:"tools"`
+}
+
 // ==================== Driven Adapters Interface ====================
 
 // DrivenOperatorIntegration Operator integration service interface
@@ -105,6 +141,10 @@ type DrivenOperatorIntegration interface {
 	// It is used by Context Loader's managed MCP surface so a Function reads BKN under
 	// the same principal that owns the Interaction.
 	ExecutePublishedTool(ctx context.Context, req *ExecutePublishedToolRequest) (map[string]any, error)
+	// ListPublishedToolboxes provides the caller-visible Function toolbox directory.
+	ListPublishedToolboxes(ctx context.Context, req *ListPublishedToolboxesRequest) (*ListPublishedToolboxesResponse, error)
+	// ListPublishedTools provides safe enabled-Function details for one toolbox.
+	ListPublishedTools(ctx context.Context, req *ListPublishedToolsRequest) (*ListPublishedToolsResponse, error)
 }
 
 // ExecuteFunctionRequest sandbox code execution request.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_operator_integration.go
@@ -69,6 +69,18 @@ type CallMCPToolRequest struct {
 	Parameters map[string]interface{} `json:"parameters"`
 }
 
+// ExecutePublishedToolRequest invokes an enabled, published Toolbox tool on
+// behalf of the authenticated Context Loader caller. The lifecycle IDs come
+// only from a previously validated MCP bkn_context; they are transport context,
+// never business input for the Function.
+type ExecutePublishedToolRequest struct {
+	ToolboxID         string         `json:"toolbox_id"`
+	ToolID            string         `json:"tool_id"`
+	Parameters        map[string]any `json:"parameters"`
+	BKNConversationID string         `json:"-"`
+	BKNInteractionID  string         `json:"-"`
+}
+
 // ==================== Driven Adapters Interface ====================
 
 // DrivenOperatorIntegration Operator integration service interface
@@ -89,6 +101,10 @@ type DrivenOperatorIntegration interface {
 	ExecuteSkill(ctx context.Context, req *ExecuteSkillRequest) (*ExecuteSkillResponse, error)
 	// ExecuteFunction executes a piece of code within the sandbox (PTC's run_code / run_shell)
 	ExecuteFunction(ctx context.Context, req *ExecuteFunctionRequest) (*ExecuteFunctionResponse, error)
+	// ExecutePublishedTool invokes a published Toolbox tool with the caller's original credential.
+	// It is used by Context Loader's managed MCP surface so a Function reads BKN under
+	// the same principal that owns the Interaction.
+	ExecutePublishedTool(ctx context.Context, req *ExecutePublishedToolRequest) (map[string]any, error)
 }
 
 // ExecuteFunctionRequest sandbox code execution request.

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
@@ -161,6 +161,36 @@ func (mr *MockDrivenOperatorIntegrationMockRecorder) ListSkills(ctx, req any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSkills", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ListSkills), ctx, req)
 }
 
+// ListPublishedToolboxes mocks base method.
+func (m *MockDrivenOperatorIntegration) ListPublishedToolboxes(ctx context.Context, req *interfaces.ListPublishedToolboxesRequest) (*interfaces.ListPublishedToolboxesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublishedToolboxes", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ListPublishedToolboxesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublishedToolboxes indicates an expected call of ListPublishedToolboxes.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ListPublishedToolboxes(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublishedToolboxes", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ListPublishedToolboxes), ctx, req)
+}
+
+// ListPublishedTools mocks base method.
+func (m *MockDrivenOperatorIntegration) ListPublishedTools(ctx context.Context, req *interfaces.ListPublishedToolsRequest) (*interfaces.ListPublishedToolsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublishedTools", ctx, req)
+	ret0, _ := ret[0].(*interfaces.ListPublishedToolsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublishedTools indicates an expected call of ListPublishedTools.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ListPublishedTools(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublishedTools", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ListPublishedTools), ctx, req)
+}
+
 // ReadSkillFile mocks base method.
 func (m *MockDrivenOperatorIntegration) ReadSkillFile(ctx context.Context, req *interfaces.ReadSkillFileRequest) (*interfaces.ReadSkillFileResponse, error) {
 	m.ctrl.T.Helper()

--- a/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
+++ b/adp/context-loader/agent-retrieval/server/mocks/driven_operator_integration.go
@@ -71,6 +71,21 @@ func (mr *MockDrivenOperatorIntegrationMockRecorder) ExecuteFunction(ctx, req an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteFunction", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ExecuteFunction), ctx, req)
 }
 
+// ExecutePublishedTool mocks base method.
+func (m *MockDrivenOperatorIntegration) ExecutePublishedTool(ctx context.Context, req *interfaces.ExecutePublishedToolRequest) (map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecutePublishedTool", ctx, req)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExecutePublishedTool indicates an expected call of ExecutePublishedTool.
+func (mr *MockDrivenOperatorIntegrationMockRecorder) ExecutePublishedTool(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutePublishedTool", reflect.TypeOf((*MockDrivenOperatorIntegration)(nil).ExecutePublishedTool), ctx, req)
+}
+
 // ExecuteSkill mocks base method.
 func (m *MockDrivenOperatorIntegration) ExecuteSkill(ctx context.Context, req *interfaces.ExecuteSkillRequest) (*interfaces.ExecuteSkillResponse, error) {
 	m.ctrl.T.Helper()

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/creasty/defaults"
@@ -137,13 +138,37 @@ func inferSchemaExecutionEnv() map[string]any {
 	return env
 }
 
-func buildFunctionProxyExecutionEnv(version string) map[string]any {
+// buildFunctionProxyExecutionEnv forwards the authenticated caller and its managed BKN interaction
+// to a published Function. These values are transport context, never part of the Function's
+// business input schema. A partial interaction is intentionally treated as absent so a pooled
+// sandbox cannot receive a credential without the lifecycle guard it is tied to.
+func buildFunctionProxyExecutionEnv(version, token, conversationID, interactionID string) map[string]any {
 	env := newExecutionEnv()
 	env["source"] = "function_proxy"
 	env["task_id"] = "function_proxy_" + uuid.NewString()
 	env["capability_id"] = "function_version:" + version
 	env["function_version_id"] = version
+	if token != "" && conversationID != "" && interactionID != "" {
+		env["BKN_TOKEN"] = token
+		env["BKN_CONVERSATION_ID"] = conversationID
+		env["BKN_INTERACTION_ID"] = interactionID
+	}
 	return env
+}
+
+// requestCredential mirrors the public authentication precedence. The value only crosses the
+// proxy boundary as a per-execution environment variable; it is never persisted in metadata or
+// exposed in a Tool's business contract.
+func requestCredential(c *gin.Context) string {
+	credential := c.GetHeader("Authorization")
+	if credential == "" {
+		credential = c.GetHeader("X-Authorization")
+	}
+	if credential == "" {
+		credential, _ = c.GetQuery("token")
+		return credential
+	}
+	return strings.TrimPrefix(credential, "Bearer ")
 }
 
 // FunctionExecuteResp function execution response.
@@ -268,11 +293,16 @@ func (h *unifiedProxyHandler) FunctionExecuteProxy(c *gin.Context) {
 		dependencies = utils.JSONToObject[[]*interfaces.DependencyInfo](metadata.GetDependencies())
 	}
 	execReq := &interfaces.ExecuteCodeReq{
-		Code:                  code,
-		Event:                 event,
-		Timeout:               int(req.Timeout / 1000),
-		Language:              scriptType,
-		EnvVars:               buildFunctionProxyExecutionEnv(req.Version),
+		Code:     code,
+		Event:    event,
+		Timeout:  int(req.Timeout / 1000),
+		Language: scriptType,
+		EnvVars: buildFunctionProxyExecutionEnv(
+			req.Version,
+			requestCredential(c),
+			c.GetHeader("bkn-conversation-id"),
+			c.GetHeader("bkn-interaction-id"),
+		),
 		Dependencies:          dependencies,
 		PythonPackageIndexURL: metadata.GetDependenciesURL(),
 	}

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
@@ -1,9 +1,11 @@
 package common
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
@@ -13,7 +15,7 @@ func TestBuildFunctionProxyExecutionEnv(t *testing.T) {
 	Convey("Function proxy execution context should separate task and capability identifiers", t, func() {
 		version := "11111111-1111-4111-8111-111111111111"
 
-		env := buildFunctionProxyExecutionEnv(version)
+		env := buildFunctionProxyExecutionEnv(version, "tok", "conv_1", "int_1")
 
 		So(env["source"], ShouldEqual, "function_proxy")
 		So(env["function_version_id"], ShouldEqual, version)
@@ -21,6 +23,42 @@ func TestBuildFunctionProxyExecutionEnv(t *testing.T) {
 		So(strings.HasPrefix(env["task_id"].(string), "function_proxy_"), ShouldBeTrue)
 		So(env["capability_id"], ShouldNotEqual, version)
 		So(env["capability_id"], ShouldEqual, "function_version:"+version)
+		So(env["BKN_TOKEN"], ShouldEqual, "tok")
+		So(env["BKN_CONVERSATION_ID"], ShouldEqual, "conv_1")
+		So(env["BKN_INTERACTION_ID"], ShouldEqual, "int_1")
+	})
+}
+
+func TestBuildFunctionProxyExecutionEnvClearsAbsentBKNContext(t *testing.T) {
+	Convey("Toolbox execution must clear BKN context when the caller did not supply a managed interaction", t, func() {
+		env := buildFunctionProxyExecutionEnv("11111111-1111-4111-8111-111111111111", "", "", "")
+
+		for _, key := range []string{"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID"} {
+			So(env[key], ShouldEqual, "")
+		}
+	})
+}
+
+func TestRequestCredentialUsesTheAuthenticatedRequestPrecedence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	Convey("Authorization is the primary credential source for a published Function", t, func() {
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = httptest.NewRequest("POST", "/internal-v1/function/exec/version?token=query", nil)
+		ctx.Request.Header.Set("Authorization", "Bearer auth-token")
+		ctx.Request.Header.Set("X-Authorization", "Bearer x-auth-token")
+
+		So(requestCredential(ctx), ShouldEqual, "auth-token")
+	})
+
+	Convey("X-Authorization and query token retain the established fallbacks", t, func() {
+		ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+		ctx.Request = httptest.NewRequest("POST", "/internal-v1/function/exec/version?token=query-token", nil)
+		ctx.Request.Header.Set("X-Authorization", "Bearer x-auth-token")
+		So(requestCredential(ctx), ShouldEqual, "x-auth-token")
+
+		ctx.Request.Header.Del("X-Authorization")
+		So(requestCredential(ctx), ShouldEqual, "query-token")
 	})
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
@@ -624,6 +624,14 @@ func (h *toolBoxHandler) ExecuteTool(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
+	// These fields are server-owned transport context. Do not accept equivalent values from the
+	// Tool body: a Function may use them to read BKN as the authenticated caller.
+	req.RequestAuthorization = c.GetHeader("Authorization")
+	if req.RequestAuthorization == "" {
+		req.RequestAuthorization = c.GetHeader("X-Authorization")
+	}
+	req.BKNConversationID = c.GetHeader("bkn-conversation-id")
+	req.BKNInteractionID = c.GetHeader("bkn-interaction-id")
 	resp, err := h.ToolService.ExecuteTool(c.Request.Context(), req)
 	rest.ReplyWithExecutionMode(c, resp, err)
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -327,11 +327,16 @@ type UpdateToolStatusReq struct {
 
 // ExecuteToolReq Execute tool request.
 type ExecuteToolReq struct {
-	UserID            string `header:"user_id" validate:"required"` // User ID, internal use.
-	BoxID             string `uri:"box_id" validate:"required"`
-	ToolID            string `uri:"tool_id" validate:"required"`
-	Timeout           int    `json:"timeout"` // Timeout time in seconds.
-	HTTPRequestParams `json:",inline"`
+	UserID  string `header:"user_id" validate:"required"` // User ID, internal use.
+	BoxID   string `uri:"box_id" validate:"required"`
+	ToolID  string `uri:"tool_id" validate:"required"`
+	Timeout int    `json:"timeout"` // Timeout time in seconds.
+	// Trusted runtime context captured by the public Toolbox handler. These fields are never
+	// deserialized from a Tool body and are only forwarded to internal Function execution.
+	RequestAuthorization string `json:"-"`
+	BKNConversationID    string `json:"-"`
+	BKNInteractionID     string `json:"-"`
+	HTTPRequestParams    `json:",inline"`
 }
 
 // ConvertOperatorToToolReq operator converts tool request.

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
@@ -342,17 +342,39 @@ func (s *ToolServiceImpl) executeTool(ctx context.Context, req *interfaces.Execu
 	case model.SourceTypeFunction:
 		url = fmt.Sprintf("%s%s", metadata.GetServerURL(), metadata.GetPath())
 	}
+	params := req.HTTPRequestParams
+	if tool.SourceType == model.SourceTypeFunction {
+		params = functionRuntimeHeaders(params, req)
+	}
 	proxyReq := &interfaces.HTTPRequest{
 		ClientID: req.ToolID,
 		HTTPRouter: interfaces.HTTPRouter{
 			URL:    url,
 			Method: metadata.GetMethod(),
 		},
-		HTTPRequestParams: req.HTTPRequestParams,
+		HTTPRequestParams: params,
 		Timeout:           time.Duration(req.Timeout) * time.Second,
 	}
 	resp, err = s.Proxy.HandlerRequest(ctx, proxyReq)
 	return
+}
+
+// functionRuntimeHeaders adds server-captured identity and lifecycle headers only when the
+// complete managed context exists. They override body-supplied values, are never reflected in a
+// Function Tool schema, and are not used for non-Function tools.
+func functionRuntimeHeaders(params interfaces.HTTPRequestParams, req *interfaces.ExecuteToolReq) interfaces.HTTPRequestParams {
+	if req == nil || req.RequestAuthorization == "" || req.BKNConversationID == "" || req.BKNInteractionID == "" {
+		return params
+	}
+	headers := make(map[string]any, len(params.Headers)+3)
+	for key, value := range params.Headers {
+		headers[key] = value
+	}
+	headers["Authorization"] = req.RequestAuthorization
+	headers["bkn-conversation-id"] = req.BKNConversationID
+	headers["bkn-interaction-id"] = req.BKNInteractionID
+	params.Headers = headers
+	return params
 }
 
 func actionExecutionSpanAttrs(ctx context.Context, operation string, err error, refs map[string]interface{}) map[string]interface{} {

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
@@ -141,6 +141,40 @@ func TestDebugTool_ForwardsAllRequestParams(t *testing.T) {
 	})
 }
 
+func TestFunctionRuntimeHeadersUseTrustedRequestContextOnly(t *testing.T) {
+	Convey("Function tools receive the authenticated caller and managed Interaction as internal proxy headers", t, func() {
+		req := &interfaces.ExecuteToolReq{
+			HTTPRequestParams: interfaces.HTTPRequestParams{
+				Headers: map[string]any{
+					"Authorization":       "Bearer caller-controlled",
+					"bkn-conversation-id": "caller-controlled",
+				},
+			},
+			RequestAuthorization: "Bearer trusted-token",
+			BKNConversationID:    "conv_trusted",
+			BKNInteractionID:     "int_trusted",
+		}
+
+		params := functionRuntimeHeaders(req.HTTPRequestParams, req)
+
+		So(params.Headers["Authorization"], ShouldEqual, "Bearer trusted-token")
+		So(params.Headers["bkn-conversation-id"], ShouldEqual, "conv_trusted")
+		So(params.Headers["bkn-interaction-id"], ShouldEqual, "int_trusted")
+		So(req.Headers["Authorization"], ShouldEqual, "Bearer caller-controlled")
+	})
+
+	Convey("Incomplete managed context does not forward a credential to Function execution", t, func() {
+		req := &interfaces.ExecuteToolReq{
+			RequestAuthorization: "Bearer trusted-token",
+			BKNConversationID:    "conv_only",
+		}
+
+		params := functionRuntimeHeaders(req.HTTPRequestParams, req)
+
+		So(params.Headers, ShouldBeNil)
+	})
+}
+
 // TestDebugTool_NoParamsToolSendsEmptyEnvelope verifies that path/query/header will not be created out of thin air when debugging the tool without input parameters (#216 backend side of acceptance criterion 8).
 func TestDebugTool_NoParamsToolSendsEmptyEnvelope(t *testing.T) {
 	Convey("无入参工具调试只发空信封", t, func() {

--- a/deploy/patches/0.1.4-function-bkn-context/README.md
+++ b/deploy/patches/0.1.4-function-bkn-context/README.md
@@ -1,0 +1,110 @@
+# OpenBKN 0.1.4 Function / BKN Context Compatibility Patch
+
+This Helm patch enables a third-party Agent to discover and call published
+Function Toolbox tools through Context Loader MCP. A Function receives only its
+business parameters and reads permitted Knowledge Network data in the sandbox
+using the managed caller identity. It is intended for the supply ontology sample
+and is generic: it does not install the sample, data, toolbox, Skills, or any
+Knowledge Network.
+
+## Compatibility and scope
+
+- Base product: OpenBKN `0.1.4` installed by Helm/Kubernetes.
+- Changed Deployments: `agent-retrieval` and `agent-operator-integration` only.
+- No data migration, no database DDL, and no BKN import/export occurs.
+- The Function Runtime and Sandbox Context Loader address injection already ship
+  in the `0.1.4` base release; do not replace Sandbox images for this patch.
+- The patch image tag must be supplied from the signed release record. Never use
+  a local development tag in a customer cluster.
+
+## Before changing the cluster
+
+1. Record the two currently running image references, especially if your
+   installation uses a private registry:
+
+   ```bash
+   kubectl -n openbkn get deployment agent-retrieval agent-operator-integration \
+     -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.spec.template.spec.containers[0].image}{"\n"}{end}'
+   ```
+
+2. Obtain the published patch image registry, tag, and digest from the release
+   record. Both service images must use the same patch tag.
+3. Ensure the existing Helm releases are named `agent-retrieval` and
+   `agent-operator-integration` in the target namespace.
+
+## Preview and install
+
+```bash
+cd deploy/patches/0.1.4-function-bkn-context
+
+./apply.sh --dry-run \
+  --registry <patch-image-registry> \
+  --tag <published-patch-tag>
+
+./apply.sh --yes \
+  --namespace openbkn \
+  --registry <patch-image-registry> \
+  --tag <published-patch-tag>
+```
+
+For air-gapped installations, first mirror the two published images to the
+customer registry, then pass that registry to `--registry`. The Helm charts stay
+on the normal `0.1.4-release` version; only their image values are replaced.
+
+## Verify
+
+```bash
+./verify.sh --namespace openbkn
+```
+
+Kubernetes readiness is necessary but not sufficient. With an account that can
+query the imported supply Knowledge Network, an Agent must then use Context
+Loader MCP to:
+
+1. start a managed Interaction;
+2. call `list_published_toolboxes` and `list_published_tools` to discover the
+   published supply toolbox and the actual tool IDs;
+3. call `execute_published_tool` for **标准交期** with
+   `{"material_code":"606-000989"}` and the managed `bkn_context`;
+4. verify `exit_code=0` and `leadtime_days=14`, then finish the Interaction.
+
+This validates the full MCP → Toolbox → Function sandbox → Knowledge Network
+path without a token, service address, snapshot, or `resolved_context` in the
+Function arguments.
+
+## Roll back
+
+Use the exact original registry and tag recorded before installation:
+
+```bash
+./rollback.sh --yes \
+  --namespace openbkn \
+  --registry <original-image-registry> \
+  --tag <original-image-tag>
+```
+
+The standard release uses `0.1.4-release`, but a private or previously patched
+installation may use another tag. Rollback changes only the same two Deployments
+and does not remove imported sample data or persisted business data.
+
+## Release record
+
+The release owner must publish the following immutable details alongside this
+directory before customers install it:
+
+| Item | Required value |
+| --- | --- |
+| Patch version | Semantic patch version, e.g. `0.1.4-supply-sample-p1` |
+| Source commit | Commit on `patch/0.1.4-function-bkn-context` |
+| `agent-retrieval` digest | `sha256:…` for amd64 and arm64 manifest list |
+| `agent-operator-integration` digest | `sha256:…` for amd64 and arm64 manifest list |
+| Verification evidence | Unit tests and MCP smoke result |
+
+### Publishing procedure
+
+Review this patch as a PR against `release/0.1.4`, but do **not** merge it in a
+way that overwrites the existing `0.1.4-release` image tag. After approval,
+create the immutable tag `v0.1.4-supply-sample-p1` on the approved patch commit.
+The repository's existing release workflows build multi-architecture images from
+that tag. Copy `release-record.template.yaml` to the delivery record and replace
+every placeholder with the published digest and fresh MCP smoke evidence.

--- a/deploy/patches/0.1.4-function-bkn-context/apply.sh
+++ b/deploy/patches/0.1.4-function-bkn-context/apply.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Apply the OpenBKN 0.1.4 Function/BKN-context compatibility patch.
+#
+# This patch replaces only agent-retrieval and agent-operator-integration
+# container images. It performs no database migration and never imports a
+# sample, toolbox, Skill, or knowledge network.
+set -euo pipefail
+
+namespace="openbkn"
+registry="ghcr.io/openbkn-ai"
+tag=""
+chart_registry="oci://ghcr.io/openbkn-ai/charts"
+chart_version="0.1.4-release"
+timeout="10m"
+dry_run=false
+assume_yes=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  apply.sh --tag <patch-image-tag> [options]
+
+Required:
+  --tag <tag>                 Identical patch image tag for both services.
+
+Options:
+  --namespace <name>          Kubernetes namespace (default: openbkn).
+  --registry <host/path>      Image registry path (default: ghcr.io/openbkn-ai).
+  --chart-registry <oci-url>  Chart OCI prefix (default: oci://ghcr.io/openbkn-ai/charts).
+  --chart-version <version>   Existing 0.1.4 chart version (default: 0.1.4-release).
+  --timeout <duration>        Helm and rollout timeout (default: 10m).
+  --dry-run                   Print the exact target images without changing the cluster.
+  --yes                       Apply without an interactive confirmation.
+  -h, --help                  Show this help.
+
+This patch changes only agent-retrieval and agent-operator-integration. It has
+no schema/data migration. Use rollback.sh with the original image registry/tag
+to revert the two deployments.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 2
+}
+
+need_value() {
+  [[ $# -ge 2 && -n $2 ]] || die "$1 requires a value"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace|--registry|--tag|--chart-registry|--chart-version|--timeout)
+      need_value "$1" "${2:-}"
+      case "$1" in
+        --namespace) namespace="$2" ;;
+        --registry) registry="${2%/}" ;;
+        --tag) tag="$2" ;;
+        --chart-registry) chart_registry="${2%/}" ;;
+        --chart-version) chart_version="$2" ;;
+        --timeout) timeout="$2" ;;
+      esac
+      shift 2
+      ;;
+    --dry-run) dry_run=true; shift ;;
+    --yes) assume_yes=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$tag" ]] || die "--tag is required"
+
+agent_retrieval_image="$registry/agent-retrieval:$tag"
+operator_integration_image="$registry/agent-operator-integration:$tag"
+
+echo "patch=0.1.4-function-bkn-context"
+echo "namespace=$namespace"
+echo "agent-retrieval=$agent_retrieval_image"
+echo "agent-operator-integration=$operator_integration_image"
+
+if [[ "$dry_run" == true ]]; then
+  echo "mode=dry-run"
+  exit 0
+fi
+
+command -v helm >/dev/null || die "helm is required"
+command -v kubectl >/dev/null || die "kubectl is required"
+
+for release in agent-retrieval agent-operator-integration; do
+  helm status "$release" --namespace "$namespace" >/dev/null 2>&1 || \
+    die "expected existing Helm release not found: $release in namespace $namespace"
+done
+
+if [[ "$assume_yes" != true ]]; then
+  read -r -p "Upgrade only the two listed OpenBKN deployments? Type yes: " confirmation
+  [[ "$confirmation" == yes ]] || die "cancelled"
+fi
+
+upgrade() {
+  local release=$1 repository=$2
+  helm upgrade --install "$release" "$chart_registry/$release" \
+    --namespace "$namespace" \
+    --version "$chart_version" \
+    --reuse-values \
+    --set "image.registry=$registry" \
+    --set "image.service.repository=$repository" \
+    --set-string "image.service.tag=$tag" \
+    --wait --timeout "$timeout"
+}
+
+upgrade agent-retrieval agent-retrieval
+upgrade agent-operator-integration agent-operator-integration
+
+kubectl -n "$namespace" rollout status deployment/agent-retrieval --timeout="$timeout"
+kubectl -n "$namespace" rollout status deployment/agent-operator-integration --timeout="$timeout"
+
+echo "patch apply complete"
+echo "Next: run ./verify.sh --namespace $namespace and then the MCP acceptance in README.md."

--- a/deploy/patches/0.1.4-function-bkn-context/release-record.template.yaml
+++ b/deploy/patches/0.1.4-function-bkn-context/release-record.template.yaml
@@ -1,0 +1,23 @@
+# Copy this file to release-record.yaml only after the release tag has built
+# both multi-architecture images. Do not leave placeholder values in a customer
+# delivery package.
+patch:
+  name: 0.1.4-function-bkn-context
+  base_release: 0.1.4
+  source_branch: patch/0.1.4-function-bkn-context
+  source_commit: <approved-commit-sha>
+  release_tag: v0.1.4-supply-sample-p1
+images:
+  agent_retrieval:
+    repository: ghcr.io/openbkn-ai/agent-retrieval
+    tag: 0.1.4-supply-sample-p1
+    manifest_digest: sha256:<published-multi-architecture-manifest-digest>
+  agent_operator_integration:
+    repository: ghcr.io/openbkn-ai/agent-operator-integration
+    tag: 0.1.4-supply-sample-p1
+    manifest_digest: sha256:<published-multi-architecture-manifest-digest>
+verification:
+  script_test: deploy/patches/0.1.4-function-bkn-context/test_patch_scripts.sh
+  context_loader_unit_test: go test ./server/driveradapters/mcp ./server/drivenadapters
+  execution_factory_unit_test: go test ./server/logics/toolbox ./server/driveradapters/toolbox
+  mcp_smoke: <interaction-id-and-result-reference>

--- a/deploy/patches/0.1.4-function-bkn-context/rollback.sh
+++ b/deploy/patches/0.1.4-function-bkn-context/rollback.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Roll back the two deployments changed by apply.sh. No data is deleted.
+set -euo pipefail
+
+namespace="openbkn"
+registry="ghcr.io/openbkn-ai"
+tag=""
+chart_registry="oci://ghcr.io/openbkn-ai/charts"
+chart_version="0.1.4-release"
+timeout="10m"
+assume_yes=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  rollback.sh --tag <original-image-tag> [options]
+
+Use the exact registry/tag recorded before applying the patch. Standard 0.1.4
+installations normally use --tag 0.1.4-release. This command only changes the
+two patched deployments and does not delete data.
+EOF
+}
+
+die() { echo "ERROR: $*" >&2; exit 2; }
+need_value() { [[ $# -ge 2 && -n $2 ]] || die "$1 requires a value"; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace|--registry|--tag|--chart-registry|--chart-version|--timeout)
+      need_value "$1" "${2:-}"
+      case "$1" in
+        --namespace) namespace="$2" ;;
+        --registry) registry="${2%/}" ;;
+        --tag) tag="$2" ;;
+        --chart-registry) chart_registry="${2%/}" ;;
+        --chart-version) chart_version="$2" ;;
+        --timeout) timeout="$2" ;;
+      esac
+      shift 2
+      ;;
+    --yes) assume_yes=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$tag" ]] || die "--tag is required"
+command -v helm >/dev/null || die "helm is required"
+command -v kubectl >/dev/null || die "kubectl is required"
+
+if [[ "$assume_yes" != true ]]; then
+  read -r -p "Restore the two OpenBKN deployments to tag $tag? Type yes: " confirmation
+  [[ "$confirmation" == yes ]] || die "cancelled"
+fi
+
+rollback() {
+  local release=$1 repository=$2
+  helm upgrade --install "$release" "$chart_registry/$release" \
+    --namespace "$namespace" \
+    --version "$chart_version" \
+    --reuse-values \
+    --set "image.registry=$registry" \
+    --set "image.service.repository=$repository" \
+    --set-string "image.service.tag=$tag" \
+    --wait --timeout "$timeout"
+}
+
+rollback agent-retrieval agent-retrieval
+rollback agent-operator-integration agent-operator-integration
+kubectl -n "$namespace" rollout status deployment/agent-retrieval --timeout="$timeout"
+kubectl -n "$namespace" rollout status deployment/agent-operator-integration --timeout="$timeout"
+echo "patch rollback complete"

--- a/deploy/patches/0.1.4-function-bkn-context/test_patch_scripts.sh
+++ b/deploy/patches/0.1.4-function-bkn-context/test_patch_scripts.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+apply_script="$script_dir/apply.sh"
+rollback_script="$script_dir/rollback.sh"
+verify_script="$script_dir/verify.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file=$1 expected=$2
+  grep -F -- "$expected" "$file" >/dev/null || fail "$file does not contain: $expected"
+}
+
+setup_case() {
+  case_dir=$(mktemp -d)
+  mkdir -p "$case_dir/bin"
+  command_log="$case_dir/commands.log"
+  : >"$command_log"
+
+  cat >"$case_dir/bin/helm" <<'EOF'
+#!/usr/bin/env bash
+printf 'helm'
+printf ' %q' "$@"
+printf '\n'
+EOF
+  cat >"$case_dir/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+printf 'kubectl'
+printf ' %q' "$@"
+printf '\n'
+EOF
+  chmod +x "$case_dir/bin/helm" "$case_dir/bin/kubectl"
+}
+
+teardown_case() {
+  rm -rf "$case_dir"
+}
+
+run_script() {
+  local script=$1
+  shift
+  set +e
+  PATH="$case_dir/bin:$PATH" "$script" "$@" >"$case_dir/output.log" 2>"$case_dir/error.log"
+  script_status=$?
+  set -e
+  return "$script_status"
+}
+
+case_dry_run_is_explicit_and_non_mutating() {
+  setup_case
+  if ! run_script "$apply_script" \
+    --dry-run \
+    --registry registry.example/openbkn-ai \
+    --tag 0.1.4-supply-sample-p1; then
+    cat "$case_dir/error.log" >&2
+    fail "dry-run failed"
+  fi
+  assert_contains "$case_dir/output.log" "mode=dry-run"
+  assert_contains "$case_dir/output.log" "agent-retrieval=registry.example/openbkn-ai/agent-retrieval:0.1.4-supply-sample-p1"
+  assert_contains "$case_dir/output.log" "agent-operator-integration=registry.example/openbkn-ai/agent-operator-integration:0.1.4-supply-sample-p1"
+  [[ ! -s $case_dir/error.log ]] || fail "dry-run wrote stderr"
+  teardown_case
+}
+
+case_apply_upgrades_only_the_two_patch_services() {
+  setup_case
+  if ! run_script "$apply_script" \
+    --yes \
+    --namespace demo \
+    --registry registry.example/openbkn-ai \
+    --tag 0.1.4-supply-sample-p1; then
+    cat "$case_dir/error.log" >&2
+    fail "apply failed"
+  fi
+  assert_contains "$case_dir/output.log" "patch apply complete"
+  assert_contains "$case_dir/output.log" "helm upgrade --install agent-retrieval"
+  assert_contains "$case_dir/output.log" "helm upgrade --install agent-operator-integration"
+  assert_contains "$case_dir/output.log" "kubectl -n demo rollout status deployment/agent-retrieval"
+  assert_contains "$case_dir/output.log" "kubectl -n demo rollout status deployment/agent-operator-integration"
+  teardown_case
+}
+
+case_rollback_requires_an_explicit_target_tag() {
+  setup_case
+  if run_script "$rollback_script" --yes --registry registry.example/openbkn-ai; then
+    fail "rollback without --tag succeeded"
+  fi
+  assert_contains "$case_dir/error.log" "--tag is required"
+  teardown_case
+}
+
+case_rollback_changes_only_the_two_patch_services() {
+  setup_case
+  if ! run_script "$rollback_script" \
+    --yes \
+    --namespace demo \
+    --registry registry.example/openbkn-ai \
+    --tag 0.1.4-release; then
+    cat "$case_dir/error.log" >&2
+    fail "rollback failed"
+  fi
+  assert_contains "$case_dir/output.log" "helm upgrade --install agent-retrieval"
+  assert_contains "$case_dir/output.log" "helm upgrade --install agent-operator-integration"
+  assert_contains "$case_dir/output.log" "patch rollback complete"
+  teardown_case
+}
+
+case_verify_checks_both_patched_deployments() {
+  setup_case
+  if ! run_script "$verify_script" --namespace demo; then
+    cat "$case_dir/error.log" >&2
+    fail "verify failed"
+  fi
+  assert_contains "$case_dir/output.log" "kubectl -n demo rollout status deployment/agent-retrieval"
+  assert_contains "$case_dir/output.log" "kubectl -n demo rollout status deployment/agent-operator-integration"
+  assert_contains "$case_dir/output.log" "MCP acceptance is required"
+  teardown_case
+}
+
+case_dry_run_is_explicit_and_non_mutating
+case_apply_upgrades_only_the_two_patch_services
+case_rollback_requires_an_explicit_target_tag
+case_rollback_changes_only_the_two_patch_services
+case_verify_checks_both_patched_deployments
+echo "test_patch_scripts: all checks passed"

--- a/deploy/patches/0.1.4-function-bkn-context/verify.sh
+++ b/deploy/patches/0.1.4-function-bkn-context/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verify that the two patched control-plane deployments are available.
+set -euo pipefail
+
+namespace="openbkn"
+timeout="10m"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  verify.sh [--namespace <name>] [--timeout <duration>]
+
+This checks Kubernetes readiness only. MCP acceptance is required afterwards:
+start an Interaction, discover the published function toolbox, and call
+"标准交期" with material_code=606-000989. The expected result is
+leadtime_days=14 and Function exit_code=0.
+EOF
+}
+
+die() { echo "ERROR: $*" >&2; exit 2; }
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --namespace|--timeout)
+      [[ $# -ge 2 && -n ${2:-} ]] || die "$1 requires a value"
+      [[ "$1" == --namespace ]] && namespace="$2" || timeout="$2"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+command -v kubectl >/dev/null || die "kubectl is required"
+kubectl -n "$namespace" rollout status deployment/agent-retrieval --timeout="$timeout"
+kubectl -n "$namespace" rollout status deployment/agent-operator-integration --timeout="$timeout"
+echo "MCP acceptance is required: use the two published-tool discovery tools and execute_published_tool."

--- a/docs/api/execution-factory/toolbox.yaml
+++ b/docs/api/execution-factory/toolbox.yaml
@@ -644,6 +644,11 @@ paths:
         生产调用入口：由平台代为执行工具并返回结果，调用方不必知道工具背后打的是
         哪个地址。与调试接口的差别在于会走权限校验与审计日志。
 
+        对于函数工具，平台会在本次沙箱执行中自动传递已认证调用者与完整的 BKN
+        Interaction 上下文；它们不是工具的业务参数，也不应写入工具 Schema。函数可借助
+        `sandbox_sdk.bkn` 以调用者权限读取知识网络。若调用没有完整的受管 Interaction，
+        平台会清空这组运行时凭据，函数不得以其他调用者身份读取 BKN。
+
         **返回的是被调服务的原始响应**（`status_code` / `headers` / `body`），
         不是平台自己的信封——上游返 500 时本接口仍是 200，`status_code` 里才是 500。
       parameters:
@@ -1410,7 +1415,9 @@ components:
           additionalProperties: true
           description: |
             函数定义。**`metadata_type=function` 时必填**，结构见
-            [operator.yaml](operator.yaml) 的 `FunctionInput`：入口函数必须叫 `handler`。
+            [operator.yaml](operator.yaml) 的 `FunctionInput`。普通函数使用 `handler(event)`
+            入口；需要用 `sandbox_sdk.bkn` 读取 BKN 的函数使用顶层 `@tool` 装饰器，由
+            `sandbox_sdk.dispatch(event)` 接收平台传入的业务参数与受管运行时上下文。
         data:
           type: string
           description: |

--- a/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
+++ b/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
@@ -11,8 +11,9 @@ Token、服务地址、快照或内部上下文。
 - 基线分支：`release/0.1.4`
 - 基线提交：`96c6d928`
 - 第一段补丁提交：`7da3ee53`（本机提交，尚未推送）
-- 第二段补丁：Toolbox 到 Function Runtime 的受管请求头透传（当前本机工作区，待
-  本机验证完成后再形成补丁提交；未推送）
+- 第二段补丁：`f97f4248`（Toolbox 到 Function Runtime 的受管请求头透传；本机提交，未推送）
+- 第三段补丁：`3f942040`（Context Loader 受管 MCP 调用已发布函数；本机提交，未推送）
+- 第四段补丁：`37f3435b`（Context Loader 发布函数目录；本机提交，未推送）
 - 验证环境：`kind-bkn-dev` / namespace `openbkn`
 
 ## 变更范围
@@ -82,6 +83,21 @@ Function `exit_code=0`、`leadtime_days=14`；MCP 回执为 `completed/durable`�
 `kind load docker-image` 加载；复用相同镜像 tag 时需 `kubectl rollout restart`，否则
 Kubernetes 不会替换已有 Pod。首次误用主机 Darwin 二进制曾导致 `exec format error`，
 已立即回滚并按上述方式重部署，未涉及数据迁移或知识网络修改。
+
+### MCP 函数目录实测（2026-08-29，localhost）
+
+为消除第三方 Agent 猜测函数 UUID 的问题，主 MCP 与 PTC MCP 增加两个只读工具：
+
+1. `list_published_toolboxes`：仅返回当前 MCP 调用者可见的、已发布的 Function
+   Toolbox 的 ID、名称和业务说明；
+2. `list_published_tools`：仅返回所选 Toolbox 内已启用函数的 ID、名称、业务说明、使用
+   规则和已裁剪的输入 Schema；不返回服务地址或其他部署拓扑。
+
+在 localhost 的同一条受管 Interaction 中，按上述目录发现“供应链原生计算函数”、其 13 个
+函数及“标准交期”的真实 ID；再通过 `execute_published_tool` 传入
+`{"material_code":"606-000989"}`，结果为 `leadtime_days=14`、Function `exit_code=0`，
+并成功结束 Interaction。目录和执行均使用 MCP 原调用者凭据；Agent 不需要 CLI、Token、
+服务地址或硬编码 ID。
 
 ### 过程中的问题与处理
 

--- a/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
+++ b/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
@@ -1,0 +1,86 @@
+# 0.1.4 补丁：Function 自主读取 BKN（localhost 验证记录）
+
+## 目标
+
+让已发布的 Function Toolbox 在一次受管 BKN Interaction 中，以调用者身份通过
+`sandbox_sdk.bkn` 查询知识网络。函数 Schema 只保留业务参数；不得要求 Agent 传递
+Token、服务地址、快照或内部上下文。
+
+## 补丁基线
+
+- 基线分支：`release/0.1.4`
+- 基线提交：`96c6d928`
+- 第一段补丁提交：`7da3ee53`（本机提交，尚未推送）
+- 第二段补丁：Toolbox 到 Function Runtime 的受管请求头透传（当前本机工作区，待
+  本机验证完成后再形成补丁提交；未推送）
+- 验证环境：`kind-bkn-dev` / namespace `openbkn`
+
+## 变更范围
+
+1. Function Toolbox 从已认证请求读取凭证及 `bkn-conversation-id`、
+   `bkn-interaction-id`，只把服务器收到的三项可信字段透传给 Function Runtime；
+   不接受业务请求体伪造这些字段。
+2. Function Runtime 仅在三者齐全时，把它们注入本次 Function 沙箱。
+3. 缺失任一受管字段时显式清空三项环境变量，避免池化 Sandbox 复用前一调用者身份。
+4. Sandbox Control Plane 自动向执行环境注入集群内 Context Loader MCP 地址：
+   `http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/`。
+5. Toolbox OpenAPI 文档明确：BKN 上下文是平台运行时上下文，不是工具业务参数；
+   需要读取 BKN 的函数使用 `@tool` 与 `sandbox_sdk.bkn`。
+
+## 本机构建产物
+
+| 组件 | 本地验证镜像 tag |
+|---|---|
+| Agent Operator Integration | `0.1.4-function-bkn-context-patch.2` |
+| Sandbox Control Plane | `0.1.4-function-bkn-context-patch` |
+
+镜像只加载到 localhost 的 kind 集群，不推送镜像仓库。
+
+## 部署前验证
+
+- `go test ./driveradapters/common`：通过。
+- `go test ./logics/toolbox ./driveradapters/toolbox ./driveradapters/common`：通过。
+- Sandbox 标准与 standalone Helm Chart 渲染：通过，均包含
+  `BKN_SANDBOX_MCP_URL`。
+- `docs/api/execution-factory/toolbox.yaml`：YAML 解析通过。
+- 供应链样例全量测试：`249 passed`。
+
+## localhost 部署与端到端验收
+
+部署仅涉及 `agent-operator-integration` 与 `sandbox-control-plane` 的本地测试镜像；
+不迁移数据、不变更样例数据资源、不更新其他服务。实测时两个 Deployment 均为 `1/1`
+就绪。镜像仅加载到本机 kind 集群，不推送镜像仓库。
+
+### 实测结果（2026-08-28，localhost）
+
+| 验收项 | 结果 | 证据 |
+|---|---|---|
+| 预测单前导零兼容 | 通过 | CSV 业务单号 `0000023181` 在 BKN 资源扫描后为数值 `23181`；函数内部归一查询并保留原始业务输入。 |
+| 复杂倒排函数 | 通过 | Interaction `conv_06c66670db1116521416d8c10ad6e024`：`生产计划齐套倒排` HTTP 200、Function `exit_code=0`；返回最大延误 `176` 天及物料级证据。 |
+| 单物料函数 | 通过 | Interaction `conv_ac07e8f0841c05220765597883d43ca4`：`标准交期(815-000002)` HTTP 200、Function `exit_code=0`，返回 `leadtime_days=1`。 |
+| 受管 Interaction 回执 | 通过 | 两次 `bkn_finish_interaction` 均返回 `execution_status=completed`、`evidence_status=complete`。 |
+| 已发布函数目录 | 通过 | `供应链原生计算函数` 工具箱 ID `d060d822-14dc-4914-8f68-b802abe2bab0`，13 个具名 Function 均已更新注册。 |
+
+本次验证的业务请求只含业务参数；未传 Token、内部 MCP 地址、`resolved_context` 或快照。
+函数在沙箱中经 `sandbox_sdk.bkn` 读取已绑定的 `supply_ontology_hand` 知识网络。
+
+### 过程中的问题与处理
+
+1. 初次真实调用报“没有调用方令牌”。根因是公共 Toolbox 入口没有把可信认证头和
+   Interaction 标识传至内部 Function Runtime。第二段补丁补齐这一边界，并有覆盖伪造
+   头与不完整上下文的单元测试。
+2. 初始函数加载器全表扫描多层 BOM，触发单 Interaction 的 128 次操作上限。样例函数
+   改为按产品递归加载 BOM 闭包，并用 `in`/`==` 条件读取相关物料、库存、采购和 MRP 数据。
+3. 预测单号在 BKN 资源类型推断中丢失前导零。样例函数在内部兼容纯数字单号，业务侧仍
+   使用原始单号。
+
+### 交付边界
+
+本记录是 `release/0.1.4` 的本机补丁验证材料，不代表已发布或已合入 release 分支。
+后续应从这两段本机补丁创建独立补丁分支、复跑本记录中的测试，然后通过 PR 审查与发布。
+
+## 回滚
+
+若需撤回本地验证，使用部署前记录的 `0.1.4-main` 镜像 tag 对相同 Helm Release 执行
+`helm upgrade --reuse-values`，然后等待两个 Deployment 回滚就绪。不要以本验证为由
+强制接管或修改无关的 MinIO Helm 资源。

--- a/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
+++ b/docs/patches/0.1.4-function-bkn-context-localhost-validation.md
@@ -26,6 +26,11 @@ Token、服务地址、快照或内部上下文。
    `http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/`。
 5. Toolbox OpenAPI 文档明确：BKN 上下文是平台运行时上下文，不是工具业务参数；
    需要读取 BKN 的函数使用 `@tool` 与 `sandbox_sdk.bkn`。
+6. Context Loader 主 MCP 与专用 PTC MCP 新增 `execute_published_tool`：它只接收
+   已发布 Toolbox 的 `toolbox_id`、`tool_id` 与函数业务参数，并要求已验证的
+   `bkn_context`。Context Loader 使用原 MCP 调用方凭据调用 Toolbox 标准执行入口，
+   使 Function 沙箱内的 BKN 查询与 Interaction 属于同一 application principal。
+   不传递 Token、快照或 `resolved_context` 给函数业务入参，也不放宽任何 ACL。
 
 ## 本机构建产物
 
@@ -63,6 +68,20 @@ Token、服务地址、快照或内部上下文。
 
 本次验证的业务请求只含业务参数；未传 Token、内部 MCP 地址、`resolved_context` 或快照。
 函数在沙箱中经 `sandbox_sdk.bkn` 读取已绑定的 `supply_ontology_hand` 知识网络。
+
+### MCP 桥接实测（2026-08-29，localhost）
+
+主 MCP `/api/agent-retrieval/v1/mcp/` 的 `tools/list` 已返回
+`execute_published_tool`，必填字段为 `toolbox_id`、`tool_id`、`arguments` 与
+`bkn_context`。在一条新建的受管 Interaction 中，经此工具调用已发布“供应链原生计算函数”
+工具箱的“标准交期”：业务参数仅为 `material_code=606-000989`，返回 HTTP 200、
+Function `exit_code=0`、`leadtime_days=14`；MCP 回执为 `completed/durable`，随后
+`bkn_finish_interaction` 返回 `execution_status=completed`、`evidence_status=complete`。
+
+本机 kind 节点为 Linux arm64。补丁镜像必须以 `GOOS=linux GOARCH=arm64` 构建并用
+`kind load docker-image` 加载；复用相同镜像 tag 时需 `kubectl rollout restart`，否则
+Kubernetes 不会替换已有 Pod。首次误用主机 Darwin 二进制曾导致 `exec format error`，
+已立即回滚并按上述方式重部署，未涉及数据迁移或知识网络修改。
 
 ### 过程中的问题与处理
 

--- a/infra/sandbox/deploy/helm/sandbox/templates/configmap.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
   CLEANUP_INTERVAL_SECONDS: {{ .Values.controlPlane.env.CLEANUP_INTERVAL_SECONDS | quote }}
   DISABLE_BWRAP: {{ .Values.controlPlane.env.DISABLE_BWRAP | quote }}
   PYTHONUNBUFFERED: {{ .Values.controlPlane.env.PYTHONUNBUFFERED | quote }}
+  BKN_SANDBOX_MCP_URL: {{ .Values.controlPlane.env.BKN_SANDBOX_MCP_URL | quote }}
   DEFAULT_TEMPLATE_IMAGE_REGISTRY: {{ $templateImageRegistry | quote }}
   DEFAULT_TEMPLATE_IMAGE_REPOSITORY: {{ $pythonBasicTemplate.repository | quote }}
   DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY: {{ $multiLanguageTemplate.repository | quote }}

--- a/infra/sandbox/deploy/helm/sandbox/templates/control-plane-deployment.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/templates/control-plane-deployment.yaml
@@ -245,6 +245,11 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.configMap.name }}
                   key: PYTHONUNBUFFERED
+            - name: BKN_SANDBOX_MCP_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.configMap.name }}
+                  key: BKN_SANDBOX_MCP_URL
             - name: DEFAULT_TEMPLATE_IMAGE_REGISTRY
               valueFrom:
                 configMapKeyRef:

--- a/infra/sandbox/deploy/helm/sandbox/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox/values.yaml
@@ -94,6 +94,9 @@ controlPlane:
     CLEANUP_INTERVAL_SECONDS: "300"
     DISABLE_BWRAP: "true"
     PYTHONUNBUFFERED: "1"
+    # In-cluster Context Loader MCP endpoint used by sandbox_sdk.bkn. This is
+    # deployment configuration, not a Function input or customer setting.
+    BKN_SANDBOX_MCP_URL: "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/"
 
   s3:
     # Note: endpointUrl is dynamically set in secret.yaml using .Values.namespace

--- a/infra/sandbox/deploy/helm/sandbox_standalone/templates/configmap.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
   CLEANUP_INTERVAL_SECONDS: {{ .Values.controlPlane.env.CLEANUP_INTERVAL_SECONDS | quote }}
   DISABLE_BWRAP: {{ .Values.controlPlane.env.DISABLE_BWRAP | quote }}
   PYTHONUNBUFFERED: {{ .Values.controlPlane.env.PYTHONUNBUFFERED | quote }}
+  BKN_SANDBOX_MCP_URL: {{ .Values.controlPlane.env.BKN_SANDBOX_MCP_URL | quote }}
   DEFAULT_TEMPLATE_IMAGE_REGISTRY: {{ $templateImageRegistry | quote }}
   DEFAULT_TEMPLATE_IMAGE_REPOSITORY: {{ $pythonBasicTemplate.repository | quote }}
   DEFAULT_MULTI_LANGUAGE_TEMPLATE_IMAGE_REPOSITORY: {{ $multiLanguageTemplate.repository | quote }}

--- a/infra/sandbox/deploy/helm/sandbox_standalone/templates/control-plane-deployment.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/templates/control-plane-deployment.yaml
@@ -245,6 +245,11 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.configMap.name }}
                   key: PYTHONUNBUFFERED
+            - name: BKN_SANDBOX_MCP_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.configMap.name }}
+                  key: BKN_SANDBOX_MCP_URL
             - name: DEFAULT_TEMPLATE_IMAGE_REGISTRY
               valueFrom:
                 configMapKeyRef:

--- a/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
+++ b/infra/sandbox/deploy/helm/sandbox_standalone/values.yaml
@@ -94,6 +94,9 @@ controlPlane:
     CLEANUP_INTERVAL_SECONDS: "300"
     DISABLE_BWRAP: "true"
     PYTHONUNBUFFERED: "1"
+    # In-cluster Context Loader MCP endpoint used by sandbox_sdk.bkn. This is
+    # deployment configuration, not a Function input or customer setting.
+    BKN_SANDBOX_MCP_URL: "http://agent-retrieval:30779/api/agent-retrieval/v1/mcp/"
 
   s3:
     endpointUrl: "http://minio.sandbox-system.svc.cluster.local:9000"


### PR DESCRIPTION
## Background\nOpenBKN 0.1.4 Function Toolbox calls could not let a sandboxed Function read Knowledge Network data under the managed caller scope. Third-party Agents therefore had to fall back to local calculation or failed with resource_not_disclosed.\n\n## Changes\n- forward server-captured authorization and managed Interaction IDs only for Function Toolbox calls;\n- expose published function Toolbox discovery and execution through Context Loader MCP;\n- add a parameter-only 0.1.4 Helm patch kit for agent-retrieval and agent-operator-integration, including rollback, readiness verification, and release digest record.\n\n## Safety\n- no DDL, data migration, sample import, or Knowledge Network mutation;\n- installation upgrades only the two named deployments with --reuse-values;\n- rollback requires the explicitly recorded original image tag.\n\n## Verification\n- go test -count=1 ./server/driveradapters/mcp ./server/drivenadapters (agent-retrieval)\n- go test -count=1 ./server/logics/toolbox ./server/driveradapters/toolbox (agent-operator-integration)\n- bash deploy/patches/0.1.4-function-bkn-context/test_patch_scripts.sh\n- Helm template image assertions for both charts\n\n## Release note\nAfter review, create immutable tag v0.1.4-supply-sample-p1 on the approved patch commit. Do not merge in a way that overwrites existing 0.1.4-release images.