### PR TITLE
docs(redocly): translate lint configuration descriptions to English

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -1,18 +1,24 @@
-# redocly lint 配置 —— 约束 docs/api 下的手写及生成型 OpenAPI 文档。
+# Redocly lint configuration for handwritten and generated OpenAPI documents
+# under docs/api.
 #
-# 目的：守住「结构合法 + $ref（含 _shared 共享 schema）可解析」这条底线，
-# 不因既存的 example/描述类内容瑕疵阻断 CI。内容级修复留给各模块补写批次。
+# Goal: preserve the baseline of valid structure and resolvable $refs,
+# including shared schemas under _shared, without blocking CI on existing
+# example or description-quality issues. Content-level fixes remain with the
+# module-specific documentation update batches.
 rules:
-  # 底线：$ref 必须能解析（迁移后跨文件引用是否搬对，全靠这条兜）。
+  # Baseline: every $ref must resolve. This catches incorrect cross-file
+  # references after migrations.
   no-unresolved-refs: error
-  # 结构性问题保持可见但不阻断（既存文档的 servers/security/重复路径等历史瑕疵）
+  # Keep structural issues visible without blocking CI because existing
+  # documents have historical issues with servers, security, and duplicate paths.
   no-empty-servers: warn
   security-defined: warn
   no-identical-paths: warn
   struct: warn
-  # example 与 schema 的漂移：既存手写 example 的历史问题，降为提示
+  # Existing handwritten examples can drift from schemas; keep this advisory.
   no-invalid-media-type-examples: warn
   operation-2xx-response: warn
   operation-4xx-response: off
-  # operationId 重复（ontology-query 有既存重复）：既存内容瑕疵，降为 warn，待补写时清理
+  # ontology-query has existing duplicate operationIds; keep this advisory until
+  # the affected documentation is updated.
   operation-operationId-unique: warn


### PR DESCRIPTION
## What Changed

- [x] Translated all developer-facing comments in `.redocly.yaml` to English.
- [x] Preserved every Redocly rule name, severity, and effective lint behavior.

---

## Why

- Related Issue: N/A — documentation-maintenance task requested directly.
- Related Feature: Developer-facing API lint configuration globalization.
- Background: Keep repository configuration descriptions consistent and accessible to English-speaking contributors.

---

## How

- Rewrote the configuration overview and rule rationale comments in English.
- No OpenAPI definitions, lint rules, or runtime behavior changed.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally — not applicable for comments-only configuration documentation.
- [x] Integration tests passed locally — `npm run api-docs:lint` completed with existing documentation warnings.
- [ ] Verified in test environment — not applicable; no runtime behavior changed.

Test notes:

- `npm exec redocly lint docs/api/agent-observability/agent-observability.yaml` validated successfully with 7 existing warnings.
- `git diff --check` passed.
- Confirmed `.redocly.yaml` contains no Chinese characters.

---

## Risk & Rollback

- Potential risks: Translation could make an intended rationale less precise.
- Rollback plan: Revert commit `8c1ed84bf`.

---

## Additional Notes

- Only comments in `.redocly.yaml` changed; all lint settings remain identical.