### PR TITLE
feat(bkn-trace): record why a lifecycle request was refused

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors.go
@@ -33,7 +33,45 @@ type DomainError struct {
 	Message              string
 	CurrentStatus        string
 	CurrentInteractionID string
+
+	// Cause names the specific check that failed. It never reaches the client.
+	//
+	// resource_not_disclosed deliberately answers "not found in the authorized
+	// scope" to a missing resource and to one that exists but belongs to someone
+	// else alike, because saying which would confirm the resource exists. That
+	// posture is right for the caller and useless for whoever has to diagnose the
+	// failure: a single code and a single sentence cover a missing conversation, an
+	// owner mismatch, an interaction under a different conversation and several
+	// more, and nothing on the server distinguishes them either. Carry the reason
+	// out of the domain so the transport can log it while still returning the same
+	// opaque answer.
+	Cause string
 }
+
+// Causes for CodeResourceNotDisclosed. Server-side diagnostics only.
+const (
+	CauseConversationNotFound            = "conversation_not_found"
+	CauseConversationOwnerMismatch       = "conversation_owner_mismatch"
+	CauseInteractionNotFound             = "interaction_not_found"
+	CauseInteractionNotInConversation    = "interaction_missing_or_not_in_conversation"
+	CauseOperationNotFound               = "operation_not_found"
+	CauseOperationNotInConversation      = "operation_missing_or_not_in_conversation"
+	CauseParentOperationNotFound         = "parent_operation_not_found"
+	CauseParentOperationOtherInteraction = "parent_operation_in_other_interaction"
+	CauseOperationCallFactNotFound       = "operation_call_fact_not_found"
+	CauseReceiptNotFound                 = "receipt_not_found"
+	CauseReceiptNotInScope               = "receipt_not_in_scope"
+)
+
+// Causes for CodeOperationRequired. That code is the catch-all of this table: a
+// malformed body, a missing protocol field, an unknown operation route, a
+// non-positive attempt and a full interaction all answer with it and all map to
+// required_action=ensure_operation, while every other code names an action the
+// caller can actually take. Until that is split, the cause is what tells the
+// operator which of them happened.
+const (
+	CauseOperationCapacityReached = "interaction_operation_capacity_reached"
+)
 
 func (e *DomainError) Error() string {
 	return e.Message
@@ -46,4 +84,8 @@ func IsCode(err error, code ErrorCode) bool {
 
 func domainError(code ErrorCode, message string) error {
 	return &DomainError{Code: code, Message: message}
+}
+
+func domainErrorWithCause(code ErrorCode, message, cause string) error {
+	return &DomainError{Code: code, Message: message, Cause: cause}
 }

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors_cause_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/errors_cause_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package sessionsvc
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestResourceNotDisclosedCarriesCause locks the two halves of the contract:
+// every caller gets the same opaque answer, and the server can still tell the
+// cases apart. A conversation that does not exist and one that exists under a
+// different owner are the pair that matters - four rounds of a supply-chain run
+// were spent chasing the second while reading the error as the first.
+func TestResourceNotDisclosedCarriesCause(t *testing.T) {
+	missing := resourceNotDisclosed(CauseConversationNotFound)
+	mismatch := resourceNotDisclosed(CauseConversationOwnerMismatch)
+
+	var a, b *DomainError
+	if !errors.As(missing, &a) || !errors.As(mismatch, &b) {
+		t.Fatal("resourceNotDisclosed must return a *DomainError")
+	}
+
+	if a.Code != b.Code {
+		t.Fatalf("callers must not be able to tell the cases apart: %s vs %s", a.Code, b.Code)
+	}
+	if a.Message != b.Message {
+		t.Fatalf("messages diverged: %q vs %q", a.Message, b.Message)
+	}
+	if a.Cause == b.Cause {
+		t.Fatalf("both causes are %q; the server cannot tell them apart either", a.Cause)
+	}
+	if a.Cause != CauseConversationNotFound || b.Cause != CauseConversationOwnerMismatch {
+		t.Fatalf("causes not carried: %q %q", a.Cause, b.Cause)
+	}
+}
+
+// TestDomainErrorCauseIsNotSerialised guards the disclosure boundary: the
+// transport encodes lifecycleError, never DomainError, so the cause can only
+// escape if someone starts marshalling the domain type directly.
+func TestDomainErrorCauseIsNotSerialised(t *testing.T) {
+	err := resourceNotDisclosed(CauseConversationOwnerMismatch)
+	var domainErr *DomainError
+	if !errors.As(err, &domainErr) {
+		t.Fatal("expected a *DomainError")
+	}
+	if domainErr.Error() != domainErr.Message {
+		t.Fatalf("Error() must expose only the opaque message, got %q", domainErr.Error())
+	}
+}

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -405,7 +405,7 @@ func (s *Service) GetInteraction(ctx context.Context, owner sessionvo.Owner, int
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		interaction, found := tx.PeekInteraction(interactionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, interaction.ConversationID); err != nil {
 			return err
@@ -421,7 +421,7 @@ func (s *Service) GetOperation(ctx context.Context, owner sessionvo.Owner, opera
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		operation, found := tx.PeekOperation(operationID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, operation.ConversationID); err != nil {
 			return err
@@ -441,7 +441,7 @@ func (s *Service) ListOperationCallFacts(
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		interaction, found := tx.PeekInteraction(interactionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, interaction.ConversationID); err != nil {
 			return err
@@ -465,14 +465,14 @@ func (s *Service) GetOperationCallFact(
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		operation, found := tx.PeekOperation(operationID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, operation.ConversationID); err != nil {
 			return err
 		}
 		fact, found := tx.FindOperationCallFact(operationID, attempt)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationCallFactNotFound)
 		}
 		result = fact
 		return nil
@@ -618,7 +618,7 @@ func (s *Service) GetReceipt(ctx context.Context, owner sessionvo.Owner, receipt
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		receipt, found := tx.PeekReceipt(receiptID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseReceiptNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, receipt.ConversationID); err != nil {
 			return err
@@ -777,7 +777,7 @@ func (s *Service) TerminateInteraction(ctx context.Context, command TerminateInt
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		interactionRef, found := tx.PeekInteraction(command.InteractionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		conversation, err := ownedConversation(tx, command.Owner, interactionRef.ConversationID)
 		if err != nil {
@@ -785,7 +785,7 @@ func (s *Service) TerminateInteraction(ctx context.Context, command TerminateInt
 		}
 		interaction, found := tx.FindInteraction(command.InteractionID)
 		if !found || interaction.ConversationID != conversation.ID {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotInConversation)
 		}
 		if interaction.IsTerminal() && command.DeriveManifest {
 			if managedTerminalReplayMatches(interaction, command) {
@@ -986,7 +986,7 @@ func (s *Service) EnsureOperationWithDisposition(
 		}
 		interaction, found := tx.FindInteraction(command.InteractionID)
 		if !found || interaction.ConversationID != conversation.ID {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotInConversation)
 		}
 		if interaction.ExecutionStatus != sessionvo.InteractionActive ||
 			!interaction.LeaseExpiresAt.After(tx.Now()) {
@@ -1000,13 +1000,13 @@ func (s *Service) EnsureOperationWithDisposition(
 		if command.ParentOperationID != "" {
 			parent, found := tx.FindOperation(command.ParentOperationID)
 			if !found {
-				return resourceNotDisclosed()
+				return resourceNotDisclosed(CauseParentOperationNotFound)
 			}
 			if _, err := ownedConversation(tx, command.Owner, parent.ConversationID); err != nil {
 				return err
 			}
 			if parent.InteractionID != interaction.ID {
-				return resourceNotDisclosed()
+				return resourceNotDisclosed(CauseParentOperationOtherInteraction)
 			}
 		}
 		// Capacity is checked before the lease is renewed, and only for a key that
@@ -1017,7 +1017,8 @@ func (s *Service) EnsureOperationWithDisposition(
 		// it has no rollback and keeps the renewal written by the failed call.
 		if _, found := tx.FindOperationByKey(interaction.ID, command.OperationKey); !found &&
 			len(tx.ListOperations(interaction.ID)) >= s.capacity.MaxOperationsPerInteraction {
-			return domainError(CodeOperationRequired, "interaction operation capacity was reached")
+			return domainErrorWithCause(CodeOperationRequired,
+				"interaction operation capacity was reached", CauseOperationCapacityReached)
 		}
 		renewInteractionLease(tx, &interaction)
 		if existing, found := tx.FindOperationByKey(interaction.ID, command.OperationKey); found {
@@ -1137,7 +1138,7 @@ func (s *Service) StartOperationAttempt(ctx context.Context, command StartAttemp
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		operationRef, found := tx.PeekOperation(command.OperationID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotFound)
 		}
 		conversation, err := ownedConversation(tx, command.Owner, operationRef.ConversationID)
 		if err != nil {
@@ -1148,12 +1149,12 @@ func (s *Service) StartOperationAttempt(ctx context.Context, command StartAttemp
 		}
 		interaction, found := tx.FindInteraction(operationRef.InteractionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		current, found := tx.FindOperation(command.OperationID)
 		if !found || current.ConversationID != conversation.ID ||
 			current.InteractionID != interaction.ID {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotInConversation)
 		}
 		if interaction.ExecutionStatus != sessionvo.InteractionActive ||
 			!interaction.LeaseExpiresAt.After(tx.Now()) {
@@ -1260,7 +1261,7 @@ func (s *Service) finishOperationAttempt(ctx context.Context, command FinishAtte
 	err = s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		operationRef, found := tx.PeekOperation(command.OperationID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotFound)
 		}
 		conversation, err := ownedConversation(tx, command.Owner, operationRef.ConversationID)
 		if err != nil {
@@ -1268,12 +1269,12 @@ func (s *Service) finishOperationAttempt(ctx context.Context, command FinishAtte
 		}
 		interaction, found := tx.FindInteraction(operationRef.InteractionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		current, found := tx.FindOperation(command.OperationID)
 		if !found || current.ConversationID != conversation.ID ||
 			current.InteractionID != interaction.ID {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseOperationNotInConversation)
 		}
 		if interaction.ExecutionStatus == sessionvo.InteractionActive &&
 			!interaction.LeaseExpiresAt.After(tx.Now()) {
@@ -1281,7 +1282,7 @@ func (s *Service) finishOperationAttempt(ctx context.Context, command FinishAtte
 		}
 		claimedReceipt, found := tx.FindReceipt(command.ReceiptID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseReceiptNotFound)
 		}
 		if _, err := ownedConversation(tx, command.Owner, claimedReceipt.ConversationID); err != nil {
 			return err
@@ -1289,14 +1290,14 @@ func (s *Service) finishOperationAttempt(ctx context.Context, command FinishAtte
 		if claimedReceipt.ConversationID != conversation.ID ||
 			claimedReceipt.InteractionID != interaction.ID ||
 			claimedReceipt.OperationID != current.ID {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseReceiptNotInScope)
 		}
 		if current.Attempt != command.Attempt {
 			return domainError(CodeIdempotencyConflict, "operation attempt or receipt does not match")
 		}
 		currentReceipt, found := tx.FindReceiptByOperationAttempt(current.ID, command.Attempt)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseReceiptNotFound)
 		}
 		if currentReceipt.ID != claimedReceipt.ID {
 			return domainError(CodeIdempotencyConflict, "operation attempt or receipt does not match")
@@ -1639,7 +1640,7 @@ func (s *Service) ListAssemblyRevisions(ctx context.Context, owner sessionvo.Own
 	err := s.store.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
 		interaction, found := tx.PeekInteraction(interactionID)
 		if !found {
-			return resourceNotDisclosed()
+			return resourceNotDisclosed(CauseInteractionNotFound)
 		}
 		if _, err := ownedConversation(tx, owner, interaction.ConversationID); err != nil {
 			return err
@@ -1790,22 +1791,23 @@ func evidenceReferenceCount(receipts []sessionvo.Receipt, replacingReceiptID str
 func ownedConversation(tx isessionstore.Transaction, owner sessionvo.Owner, conversationID string) (sessionvo.Conversation, error) {
 	conversation, found := tx.FindConversation(conversationID)
 	if !found {
-		return sessionvo.Conversation{}, domainError(
-			CodeResourceNotDisclosed,
-			"request was not found in the authorized scope",
-		)
+		return sessionvo.Conversation{}, resourceNotDisclosed(CauseConversationNotFound)
 	}
+	// Owner is compared whole: tenant, business domain, application principal,
+	// effective subject type and id, delegation. One differing field is enough, and
+	// the same OAuth client reaching in from another process is the usual way that
+	// happens - which reads to the caller exactly like the conversation not existing.
 	if !conversation.Owner.Equal(owner) {
-		return sessionvo.Conversation{}, domainError(
-			CodeResourceNotDisclosed,
-			"request was not found in the authorized scope",
-		)
+		return sessionvo.Conversation{}, resourceNotDisclosed(CauseConversationOwnerMismatch)
 	}
 	return conversation, nil
 }
 
-func resourceNotDisclosed() error {
-	return domainError(CodeResourceNotDisclosed, "request was not found in the authorized scope")
+// resourceNotDisclosed answers the caller with one deliberately opaque sentence and
+// records, for the server alone, which check actually failed. cause never leaves the
+// process; see DomainError.Cause.
+func resourceNotDisclosed(cause string) error {
+	return domainErrorWithCause(CodeResourceNotDisclosed, "request was not found in the authorized scope", cause)
 }
 
 func requireActiveConversation(conversation sessionvo.Conversation) error {

--- a/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
+++ b/bkn-trace/agent-observability/src/driveradapter/api/httphandler/session_handler.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -727,6 +728,13 @@ func writeSessionDomainError(w http.ResponseWriter, r *http.Request, err error) 
 		return
 	}
 	status, action, retryable := lifecycleErrorContract(domainErr.Code)
+	// The response stays deliberately opaque; the cause is recorded here so a
+	// failure can be diagnosed without the caller learning which check tripped.
+	if domainErr.Cause != "" {
+		slog.Warn("lifecycle request rejected",
+			"code", string(domainErr.Code), "cause", domainErr.Cause,
+			"request_id", requestIDFromRequest(r), "path", r.URL.Path)
+	}
 	writeJSON(w, r, status, lifecycleErrorEnvelope{Error: lifecycleError{
 		Code: string(domainErr.Code), Message: domainErr.Message,
 		CurrentStatus: domainErr.CurrentStatus, CurrentInteractionID: domainErr.CurrentInteractionID,


### PR DESCRIPTION
## Problem

`resource_not_disclosed` answers "request was not found in the authorized scope" to a resource that does not exist and to one that exists but belongs to someone else alike. That opacity is deliberate — naming the difference would confirm the resource exists — but it was opaque to the server too. Twenty-one call sites and both branches of `ownedConversation` returned the same code and the same sentence, and nothing was recorded anywhere.

A supply-chain evaluation run spent four attempts reading an owner mismatch as a data-authorization problem, then worked around it by switching execution paths. The information needed to end that in one attempt existed at the moment of refusal and was thrown away.

`Owner` is compared whole — tenant, business domain, application principal, effective subject type and id, delegation. One differing field is enough, and the same account reaching in through a different OAuth client is the ordinary way that happens. To the caller it reads exactly like the conversation not existing.

## Changes

- `DomainError` carries a `Cause`. It is never serialised and never reaches the client.
- All twenty-one `resourceNotDisclosed()` sites name the check that failed; the signature change makes the compiler enforce it. `ownedConversation` splits its two branches.
- `writeSessionDomainError` logs the cause. The response is byte-for-byte unchanged: same code, message, status, `required_action` and `retryable`.
- `operation_required` gets a cause too, for a different reason — it is the catch-all of this table. A malformed body, a missing protocol field, an unknown route, a non-positive attempt and a full interaction all answer with it and all map to `required_action=ensure_operation`, while every other code names an action the caller can act on. Splitting that is a contract change; until then the cause tells an operator which one happened.

`conversation_owner_mismatch` stays unused. It is defined and mapped to 403, but returning it would disclose exactly what `resource_not_disclosed` exists to withhold.

## Tests

The new test locks both halves at once: callers must not be able to tell the cases apart (same code, same message), and the server must be able to (different causes). Breaking either direction fails it. A second test asserts `Error()` exposes only the opaque message, so the cause cannot escape by marshalling the domain type directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)