### PR TITLE
feat(context-loader): declare what each MCP tool does to the world

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/annotations.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/annotations.go
@@ -1,0 +1,109 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import "github.com/mark3labs/mcp-go/mcp"
+
+// Tool annotations are the protocol's own field for "what does calling this do
+// to the world". A host uses them to gate, to order a confirmation prompt, or to
+// decide what may run unattended; they are not sent to the model and cost no
+// context.
+//
+// Every hint defaults to the pessimistic answer when absent - not read-only,
+// destructive, not idempotent, open world - so leaving them unset tells a host
+// that reading a schema is as dangerous as running a shell. Twenty-one of these
+// tools only read.
+//
+// destructiveHint and idempotentHint are defined only for tools that are not
+// read-only, so they are set only there. openWorldHint is false wherever a tool
+// stays inside one knowledge network or the resources bound to it, and true
+// where the reachable set is whatever the caller writes.
+var (
+	annTrue  = true
+	annFalse = false
+)
+
+// readOnlyTool annotates a tool that only reads within a bounded domain.
+func readOnlyTool() mcp.ToolAnnotation {
+	return mcp.ToolAnnotation{ReadOnlyHint: &annTrue, OpenWorldHint: &annFalse}
+}
+
+// arbitraryEffectTool annotates a tool whose effect is decided by what the
+// caller submits - registered code, a shell line, a business action. The
+// pessimistic answer is the correct one for all three hints.
+func arbitraryEffectTool() mcp.ToolAnnotation {
+	return mcp.ToolAnnotation{
+		ReadOnlyHint: &annFalse, DestructiveHint: &annTrue,
+		IdempotentHint: &annFalse, OpenWorldHint: &annTrue,
+	}
+}
+
+// lifecycleTool annotates a managed-session transition. It writes, so it is not
+// read-only, but it destroys nothing and never leaves this deployment. Each call
+// advances the session, so it is not idempotent either.
+func lifecycleTool() mcp.ToolAnnotation {
+	return mcp.ToolAnnotation{
+		ReadOnlyHint: &annFalse, DestructiveHint: &annFalse,
+		IdempotentHint: &annFalse, OpenWorldHint: &annFalse,
+	}
+}
+
+// toolAnnotations maps every tool key to its effect class. A tool missing from
+// here is advertised with the pessimistic defaults, which is safe but wrong for
+// a reader; TestEveryToolIsAnnotated fails instead of letting that pass quietly.
+var toolAnnotations = map[string]func() mcp.ToolAnnotation{
+	// Lifecycle: writes managed session state.
+	// Named by literal, as lifecycle_adapter.go does: these two have no key
+	// constant, they are registered from lifecycleToolNames.
+	"bkn_start_interaction":  lifecycleTool,
+	"bkn_finish_interaction": lifecycleTool,
+
+	// Discovery and query: read a knowledge network. run_sql belongs here - it
+	// is read-only SQL against resources already bound to the network, and the
+	// grammar it accepts excludes every write.
+	toolKeyListKnowledgeNetworks:    readOnlyTool,
+	toolKeyGetKnDetail:              readOnlyTool,
+	toolKeySearchSchema:             readOnlyTool,
+	toolKeyGetObjectTypes:           readOnlyTool,
+	toolKeyGetRelationTypes:         readOnlyTool,
+	toolKeySearchInstance:           readOnlyTool,
+	toolKeyQueryObjectInstance:      readOnlyTool,
+	toolKeyQueryInstanceSubgraph:    readOnlyTool,
+	toolKeyExploreSubgraph:          readOnlyTool,
+	toolKeyGetLogicPropertiesValues: readOnlyTool,
+	toolKeyRunSQL:                   readOnlyTool,
+	toolKeyQueryMetric:              readOnlyTool,
+	toolKeyListResources:            readOnlyTool,
+	toolKeyDescribeResource:         readOnlyTool,
+
+	// Actions: reading what an action is and what it did is not doing it.
+	toolKeyGetActionInfo:        readOnlyTool,
+	toolKeyGetActionExecution:   readOnlyTool,
+	toolKeyListActionExecutions: readOnlyTool,
+	toolKeyExecuteAction:        arbitraryEffectTool,
+
+	// Skills: the catalogue and the files are readable; running one is not.
+	toolKeyFindSkills:      readOnlyTool,
+	toolKeyListSkills:      readOnlyTool,
+	toolKeyGetSkillContent: readOnlyTool,
+	toolKeyReadSkillFile:   readOnlyTool,
+	toolKeyExecuteSkill:    arbitraryEffectTool,
+
+	// Execution: the caller supplies the program.
+	toolKeyRunCode:  arbitraryEffectTool,
+	toolKeyRunShell: arbitraryEffectTool,
+}
+
+// annotationFor returns the annotation for a tool key, or the zero value when
+// the key is unknown - an unannotated tool keeps the protocol defaults rather
+// than claiming anything.
+func annotationFor(toolKey string) mcp.ToolAnnotation {
+	if build, ok := toolAnnotations[toolKey]; ok {
+		return build()
+	}
+	return mcp.ToolAnnotation{}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/annotations_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/annotations_test.go
@@ -1,0 +1,88 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package mcp
+
+import "testing"
+
+// TestEveryToolIsAnnotated is the drift guard. A tool added without an entry
+// here is advertised with the protocol defaults - not read-only, destructive,
+// open world - so a host has to treat reading a schema as it would treat a
+// shell. That is safe and wrong, and nothing else would report it.
+func TestEveryToolIsAnnotated(t *testing.T) {
+	for key := range allToolMeta() {
+		if _, ok := toolAnnotations[key]; !ok {
+			t.Errorf("%s has no annotation: it would advertise the pessimistic defaults", key)
+		}
+	}
+}
+
+// TestAnnotationsAreConsistent checks the hints do not contradict each other.
+// destructiveHint and idempotentHint are defined only for tools that write, so
+// a read-only tool must not carry them, and a tool that only reads must not
+// claim an open world.
+func TestAnnotationsAreConsistent(t *testing.T) {
+	for key := range toolAnnotations {
+		a := annotationFor(key)
+		if a.ReadOnlyHint == nil {
+			t.Errorf("%s: readOnlyHint must be stated either way", key)
+			continue
+		}
+		if !*a.ReadOnlyHint {
+			if a.DestructiveHint == nil || a.IdempotentHint == nil {
+				t.Errorf("%s: a writing tool must state destructiveHint and idempotentHint", key)
+			}
+			continue
+		}
+		if a.DestructiveHint != nil || a.IdempotentHint != nil {
+			t.Errorf("%s: destructiveHint and idempotentHint are undefined for a read-only tool", key)
+		}
+		if a.OpenWorldHint == nil || *a.OpenWorldHint {
+			t.Errorf("%s: a read-only knowledge-network tool stays inside a bounded domain", key)
+		}
+	}
+}
+
+// TestReadOnlyToolsOutnumberWriters records the point of the change. Most of
+// this surface only reads; before annotations a host could not tell.
+func TestReadOnlyToolsOutnumberWriters(t *testing.T) {
+	readers, writers := 0, 0
+	for key := range toolAnnotations {
+		if a := annotationFor(key); a.ReadOnlyHint != nil && *a.ReadOnlyHint {
+			readers++
+		} else {
+			writers++
+		}
+	}
+	if readers <= writers {
+		t.Fatalf("expected the surface to be mostly readers, got %d readers / %d writers", readers, writers)
+	}
+	t.Logf("%d read-only tools, %d writing tools", readers, writers)
+}
+
+// TestRunSQLIsReadOnly is called out on its own because the name invites the
+// opposite conclusion. run_sql accepts a single SELECT against resources already
+// bound to the network; its grammar excludes every write and every DDL.
+func TestRunSQLIsReadOnly(t *testing.T) {
+	a := annotationFor(toolKeyRunSQL)
+	if a.ReadOnlyHint == nil || !*a.ReadOnlyHint {
+		t.Fatal("run_sql executes read-only SQL and must be annotated as read-only")
+	}
+}
+
+// TestArbitraryEffectToolsAreNotReadOnly guards the other direction: the tools
+// whose effect is whatever the caller submits must never be marked safe.
+func TestArbitraryEffectToolsAreNotReadOnly(t *testing.T) {
+	for _, key := range []string{toolKeyRunCode, toolKeyRunShell, toolKeyExecuteAction, toolKeyExecuteSkill} {
+		a := annotationFor(key)
+		if a.ReadOnlyHint == nil || *a.ReadOnlyHint {
+			t.Errorf("%s runs what the caller supplies and must not be read-only", key)
+		}
+		if a.DestructiveHint == nil || !*a.DestructiveHint {
+			t.Errorf("%s must be marked destructive", key)
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -283,6 +283,11 @@ func newToolWithSchemas(meta ToolMeta, input, output json.RawMessage) mcp.Tool {
 	tool := mcp.NewToolWithRawSchema(meta.Name, meta.Description, input)
 	tool.RawOutputSchema = output
 	tool.Title = meta.Title
+	// Annotations are keyed by the advertised name, which is also the tool key
+	// in tools_meta.json. Every registration path lands here - the builder, the
+	// PTC execution tools and the lifecycle pair - so one lookup covers them all.
+	tool.Annotations = annotationFor(meta.Name)
+	tool.Annotations.Title = meta.Title
 	if fields := toolDisplayMetaFields(meta); len(fields) > 0 {
 		tool.Meta = &mcp.Meta{AdditionalFields: fields}
 	}


### PR DESCRIPTION
## Problem

Tool annotations are the protocol's own field for the effect of calling a tool, and every hint defaults to the pessimistic answer when absent — not read-only, destructive, not idempotent, open world. None of the twenty-seven tools declared any.

So a host had no basis to distinguish reading a schema from running a shell line: nothing to gate on, nothing to decide what may run unattended, nothing to drive a confirmation prompt.

Twenty-one of them only read.

## Changes

Annotate the whole surface by effect class.

- **Read-only**: discovery, query, resources, and the readable half of actions and skills. `run_sql` belongs here despite the name — it accepts a single SELECT against resources already bound to the network, and its grammar excludes every write and every DDL.
- **Arbitrary effect**: `run_code`, `run_shell`, `execute_action`, `execute_skill`. The caller supplies the program or names the action, so the pessimistic answer is the correct one for all three hints.
- **Lifecycle**: `bkn_start_interaction` / `bkn_finish_interaction` write managed session state, so they are not read-only, but they destroy nothing and never leave the deployment.

`destructiveHint` and `idempotentHint` are defined only for tools that write, so they are set only there. `openWorldHint` is false wherever a tool stays inside one knowledge network or the resources bound to it.

The classes live in Go rather than `tools_meta.json` because they are not localisable and that file has a per-locale copy — the same fact in two files is a fact that drifts. Every registration path already funnels through `newToolWithSchemas` (the builder, the PTC execution tools, and the lifecycle pair registered by the tracing adapter), so a single lookup covers all of them.

Annotations travel in `tools/list` for the host to act on and never enter the model's context, so this costs no tokens.

## Tests

Both directions are guarded. A tool added without an entry is reported rather than quietly advertised as dangerous. The tools whose effect is whatever the caller submits can never be marked safe. A consistency test rejects hints that contradict each other — a read-only tool carrying `destructiveHint`, or claiming an open world.

🤖 Generated with [Claude Code](https://claude.com/claude-code)