### PR TITLE
feat(trace): assemble historical provenance handler

### DIFF
--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -190,7 +190,7 @@ func NewApp() (*App, error) {
 	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions(logSources, logOptions), evidenceHandler)
 	provenanceHandler := enterpriseroute.HistoricalProvenanceHandler()
 	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
-		EnableHistoricalProvenance: provenanceHandler != nil,
+		EnableHistoricalProvenance: provenanceHandler != nil && coreConfig.ProjectionEnabled,
 		Capacity: sessionsvc.CapacityLimits{
 			MaxOperationsPerInteraction:   coreConfig.MaxOperationsPerInteraction,
 			MaxClaimsPerInteraction:       coreConfig.MaxClaimsPerInteraction,

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -188,7 +188,9 @@ func NewApp() (*App, error) {
 		logSources = append(logSources, opensearchruntimeaudit.New(openSearchClient, coreConfig.ProjectionIndex))
 	}
 	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions(logSources, logOptions), evidenceHandler)
+	provenanceHandler := enterpriseroute.HistoricalProvenanceHandler()
 	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
+		EnableHistoricalProvenance: provenanceHandler != nil,
 		Capacity: sessionsvc.CapacityLimits{
 			MaxOperationsPerInteraction:   coreConfig.MaxOperationsPerInteraction,
 			MaxClaimsPerInteraction:       coreConfig.MaxClaimsPerInteraction,
@@ -300,9 +302,9 @@ func NewApp() (*App, error) {
 			}
 			return nil, fmt.Errorf("initialize projection alias: %w", err)
 		}
-		worker := projectorsvc.NewWorker(
-			outboxStore, sink, projectorsvc.WorkerOptions{Metrics: metrics},
-		)
+		worker := projectorsvc.NewWorker(outboxStore, sink, projectorsvc.WorkerOptions{
+			Metrics: metrics, HistoricalProvenanceHandler: provenanceHandler,
+		})
 		app.projection = worker
 		app.workers.Add(1)
 		go func() {

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker.go
@@ -142,7 +142,7 @@ func (w *Worker) RunOnce(ctx context.Context) (RunResult, error) {
 func (w *Worker) project(ctx context.Context, item iprojectionoutbox.Item) error {
 	if item.EventType == historicalProvenanceBuildRequested {
 		if w.provenance == nil {
-			return iprojectionoutbox.Permanent(errors.New("historical provenance handler is not assembled"))
+			return errors.New("historical provenance handler is not assembled")
 		}
 		return w.provenance.HandleHistoricalProvenance(ctx, item)
 	}

--- a/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/projectorsvc/worker_test.go
@@ -190,6 +190,28 @@ func TestHistoricalProvenanceEventUsesDedicatedHandlerBeforeDelivery(t *testing.
 	}
 }
 
+func TestHistoricalProvenanceEventRetriesWhenHandlerIsTemporarilyUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 30, 10, 0, 0, 0, time.UTC)
+	store := &fakeOutboxStore{items: []iprojectionoutbox.Item{{
+		ID: 1, EventID: "evt-provenance", EventType: "historical_provenance.build_requested",
+		CreatedAt: now,
+	}}}
+	worker := projectorsvc.NewWorker(store, &fakeProjectionSink{}, projectorsvc.WorkerOptions{
+		Now:        func() time.Time { return now },
+		FullJitter: func(time.Duration) time.Duration { return 0 },
+	})
+
+	result, err := worker.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("run worker: %v", err)
+	}
+	if result.Retried != 1 || result.Dead != 0 || len(store.retried) != 1 || len(store.dead) != 0 {
+		t.Fatalf("unassembled handler must preserve event for retry: %#v", result)
+	}
+}
+
 type fakeOutboxStore struct {
 	items               []iprojectionoutbox.Item
 	retried             []iprojectionoutbox.Item

--- a/bkn-trace/agent-observability/src/extension/enterpriseroute/socket.go
+++ b/bkn-trace/agent-observability/src/extension/enterpriseroute/socket.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 )
 
 // InteractionFacts is the one Core-owned input EE receives for a selected
@@ -81,10 +82,35 @@ type Registrar interface {
 // creates the public route tree.
 type Mounter func(Registrar, Reader)
 
+// HistoricalProvenanceEventHandler is assembled only by the EE overlay. Core
+// retains the outbox lease; the overlay never leases or scans the outbox.
+type HistoricalProvenanceEventHandler interface {
+	HandleHistoricalProvenance(context.Context, iprojectionoutbox.Item) error
+}
+
 var registry struct {
 	sync.Mutex
-	mounter Mounter
-	frozen  bool
+	mounter    Mounter
+	provenance HistoricalProvenanceEventHandler
+	frozen     bool
+}
+
+func RegisterHistoricalProvenanceHandler(handler HistoricalProvenanceEventHandler) {
+	if handler == nil {
+		panic("enterpriseroute: RegisterHistoricalProvenanceHandler(nil)")
+	}
+	registry.Lock()
+	defer registry.Unlock()
+	if registry.frozen || registry.provenance != nil {
+		panic("enterpriseroute: provenance handler already frozen or registered")
+	}
+	registry.provenance = handler
+}
+
+func HistoricalProvenanceHandler() HistoricalProvenanceEventHandler {
+	registry.Lock()
+	defer registry.Unlock()
+	return registry.provenance
 }
 
 // Register installs the one enterprise route mounter for this Core service.
@@ -144,5 +170,6 @@ func ResetForTest() {
 	registry.Lock()
 	defer registry.Unlock()
 	registry.mounter = nil
+	registry.provenance = nil
 	registry.frozen = false
 }

--- a/bkn-trace/agent-observability/src/extension/enterpriseroute/socket_test.go
+++ b/bkn-trace/agent-observability/src/extension/enterpriseroute/socket_test.go
@@ -12,7 +12,27 @@ import (
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 )
+
+func TestHistoricalProvenanceHandlerIsAvailableOnlyWhenRegistered(t *testing.T) {
+	ResetForTest()
+	t.Cleanup(ResetForTest)
+	if HistoricalProvenanceHandler() != nil {
+		t.Fatal("unexpected handler before registration")
+	}
+	handler := projectionHandlerFunc(func(context.Context, iprojectionoutbox.Item) error { return nil })
+	RegisterHistoricalProvenanceHandler(handler)
+	if HistoricalProvenanceHandler() == nil {
+		t.Fatal("registered handler is unavailable")
+	}
+}
+
+type projectionHandlerFunc func(context.Context, iprojectionoutbox.Item) error
+
+func (f projectionHandlerFunc) HandleHistoricalProvenance(ctx context.Context, item iprojectionoutbox.Item) error {
+	return f(ctx, item)
+}
 
 func TestCommunityBuildHasNoEnterpriseRoutes(t *testing.T) {
 	ResetForTest()


### PR DESCRIPTION
Continues openbkn-ee#31 after #1194. EE-only registration enables sealed-facts events only when a handler is assembled; Core keeps the outbox lease/retry/DLQ. Tests: enterpriseroute, boot, projectorsvc, sessionsvc.