### PR TITLE
feat(context-loader): let the REST surface be a capability layer

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
@@ -50,6 +50,22 @@ func middlewareLifecycle(client *bkntrace.LifecycleClient) gin.HandlerFunc {
 			})
 			return
 		}
+		// The REST surface is a capability layer. A managed Interaction records one
+		// agent turn - which question was asked, what it read, what it concluded -
+		// and the callers here are not agents: Studio answering a click, a CLI
+		// operator, one service asking another. Minting a conversation and an
+		// interaction to satisfy the guard would produce single-operation records
+		// that dilute the concept rather than document anything, so an absent
+		// bkn_context passes through instead of being refused.
+		//
+		// Naming a session still works and still records, so a caller that had
+		// wired the context up does not silently lose its evidence. The MCP surface,
+		// where an agent actually calls, keeps the requirement: that middleware is
+		// separate and untouched, as is /mcp/proxy/.../call below.
+		if !hasBusinessContext(input) && !isProxyToolCall(c.Request) {
+			c.Next()
+			return
+		}
 		businessContext, apiErr := parseHTTPBusinessContext(input, httpKnowledgeNetworkID(c, input))
 		if apiErr != nil {
 			writeLifecycleHTTPError(c, lifecycleHTTPStatus(apiErr.Code), *apiErr)
@@ -155,8 +171,31 @@ func isLifecycleBusinessRequest(request *http.Request) bool {
 	if request.Method != http.MethodPost {
 		return false
 	}
-	return strings.Contains(request.URL.Path, "/kn/") ||
-		(strings.Contains(request.URL.Path, "/mcp/proxy/") && strings.HasSuffix(request.URL.Path, "/call"))
+	return strings.Contains(request.URL.Path, "/kn/") || isProxyToolCall(request)
+}
+
+// isProxyToolCall reports whether this is a tool call proxied over HTTP. It is an
+// agent calling a tool by another name, so the managed context stays mandatory
+// there even though the transport is the same one the /kn/ capability routes use.
+func isProxyToolCall(request *http.Request) bool {
+	return strings.Contains(request.URL.Path, "/mcp/proxy/") &&
+		strings.HasSuffix(request.URL.Path, "/call")
+}
+
+// hasBusinessContext reports whether the caller named a session to attach to.
+//
+// The rule the caller has to remember is one line: state an id and the call is
+// managed, state none and it is ad hoc. So an absent bkn_context and an empty one
+// mean the same thing, and neither is an error. A partial context is - a caller
+// passing one id and not the other is wiring the context up and got it wrong,
+// which parseHTTPBusinessContext reports rather than letting the call through
+// half-attached.
+func hasBusinessContext(input map[string]any) bool {
+	raw, ok := input["bkn_context"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return httpString(raw["conversation_id"]) != "" || httpString(raw["interaction_id"]) != ""
 }
 
 func parseHTTPBusinessContext(input map[string]any, currentKNID string) (bkntrace.BusinessContext, *bkntrace.APIError) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware.go
@@ -63,6 +63,12 @@ func middlewareLifecycle(client *bkntrace.LifecycleClient) gin.HandlerFunc {
 		// where an agent actually calls, keeps the requirement: that middleware is
 		// separate and untouched, as is /mcp/proxy/.../call below.
 		if !hasBusinessContext(input) && !isProxyToolCall(c.Request) {
+			// io.ReadAll above drained the body. The managed path rebuilds it after
+			// stripping bkn_context; this path has nothing to strip but still has to
+			// hand the handler something to read, or every request this branch exists
+			// to admit reaches it empty and fails to bind.
+			c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+			c.Request.ContentLength = int64(len(raw))
 			c.Next()
 			return
 		}
@@ -182,20 +188,25 @@ func isProxyToolCall(request *http.Request) bool {
 		strings.HasSuffix(request.URL.Path, "/call")
 }
 
-// hasBusinessContext reports whether the caller named a session to attach to.
+// hasBusinessContext reports whether this call has to go through the guard.
 //
 // The rule the caller has to remember is one line: state an id and the call is
-// managed, state none and it is ad hoc. So an absent bkn_context and an empty one
-// mean the same thing, and neither is an error. A partial context is - a caller
-// passing one id and not the other is wiring the context up and got it wrong,
-// which parseHTTPBusinessContext reports rather than letting the call through
-// half-attached.
+// managed, state none and it is ad hoc. Only two shapes are ad hoc - no
+// bkn_context at all, and an empty one. Everything else goes to
+// parseHTTPBusinessContext to be judged, including the shapes that carry no id:
+// one id and not the other, a bkn_context that is not an object, and an object
+// holding only parent_operation_id, business_refs or a misspelt field. Each of
+// those is a caller wiring the context up and getting it wrong, and admitting it
+// as ad hoc would answer a mistake with silence.
 func hasBusinessContext(input map[string]any) bool {
-	raw, ok := input["bkn_context"].(map[string]any)
-	if !ok {
+	value, stated := input["bkn_context"]
+	if !stated {
 		return false
 	}
-	return httpString(raw["conversation_id"]) != "" || httpString(raw["interaction_id"]) != ""
+	if fields, ok := value.(map[string]any); ok && len(fields) == 0 {
+		return false
+	}
+	return true
 }
 
 func parseHTTPBusinessContext(input map[string]any, currentKNID string) (bkntrace.BusinessContext, *bkntrace.APIError) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
@@ -51,10 +51,18 @@ func TestRESTCapabilityRoutesDoNotRequireManagedContext(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.path, func(t *testing.T) {
 			downstreamCalls := 0
+			var seenBody map[string]any
 			router := gin.New()
 			router.Use(middlewareLifecycle(bkntrace.NewLifecycleClient("", nil)))
+			// The handler binds its body the way the real ones do. A stub that
+			// ignores the body cannot tell a request that was let through from one
+			// that arrived drained, which is exactly the gap that let a middleware
+			// consuming the body without putting it back look correct.
 			router.POST("/*path", func(c *gin.Context) {
 				downstreamCalls++
+				if err := c.ShouldBindJSON(&seenBody); err != nil {
+					t.Errorf("%s: handler could not bind the body: %v", tc.path, err)
+				}
 				c.Status(http.StatusNoContent)
 			})
 
@@ -66,6 +74,9 @@ func TestRESTCapabilityRoutesDoNotRequireManagedContext(t *testing.T) {
 			if downstreamCalls != tc.wantCalls {
 				t.Fatalf("%s: downstream calls = %d, want %d (status %d, body %s)",
 					tc.path, downstreamCalls, tc.wantCalls, response.Code, response.Body)
+			}
+			if tc.wantCalls > 0 && seenBody["query"] != "q" {
+				t.Fatalf("%s: handler saw %#v, want the original body", tc.path, seenBody)
 			}
 		})
 	}
@@ -91,6 +102,9 @@ func TestRESTContextOptionalityBoundary(t *testing.T) {
 	}{
 		{"empty context is ad hoc", `{"sql":"select 1","bkn_context":{}}`, 1, ""},
 		{"partial context is refused", `{"sql":"select 1","bkn_context":{"conversation_id":"c1"}}`, 0, "interaction_required"},
+		{"non-object context is refused", `{"sql":"select 1","bkn_context":"c1"}`, 0, "conversation_required"},
+		{"context without ids is refused", `{"sql":"select 1","bkn_context":{"parent_operation_id":"op1"}}`, 0, "conversation_required"},
+		{"misspelt field is refused", `{"sql":"select 1","bkn_context":{"conversationId":"c1"}}`, 0, "invalid_business_context"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/lifecycle_middleware_test.go
@@ -27,16 +27,29 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
-func TestLifecycleMiddlewareFailsClosedAcrossRESTBusinessEntrypoints(t *testing.T) {
+// TestRESTCapabilityRoutesDoNotRequireManagedContext pins the split between the
+// two surfaces this middleware covers.
+//
+// A managed Interaction records one agent turn. The /kn/ routes are the capability
+// layer - Studio answering a click, a CLI operator, one service asking another -
+// and minting a conversation and an interaction for each of those produced
+// single-operation records that documented nothing. They pass through now.
+//
+// A tool call proxied over HTTP is an agent calling a tool by another name, so it
+// keeps the requirement even though it arrives on the same transport.
+func TestRESTCapabilityRoutesDoNotRequireManagedContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	paths := []string{
-		"/api/agent-retrieval/v1/kn/execute_action",
-		"/api/agent-retrieval/v1/kn/run_sql",
-		"/api/agent-retrieval/internal-v1/kn/search_schema",
-		"/api/agent-retrieval/internal-v1/mcp/proxy/mcp-1/tools/tool-1/call",
+	cases := []struct {
+		path      string
+		wantCalls int
+	}{
+		{"/api/agent-retrieval/v1/kn/execute_action", 1},
+		{"/api/agent-retrieval/v1/kn/run_sql", 1},
+		{"/api/agent-retrieval/internal-v1/kn/search_schema", 1},
+		{"/api/agent-retrieval/internal-v1/mcp/proxy/mcp-1/tools/tool-1/call", 0},
 	}
-	for _, path := range paths {
-		t.Run(path, func(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
 			downstreamCalls := 0
 			router := gin.New()
 			router.Use(middlewareLifecycle(bkntrace.NewLifecycleClient("", nil)))
@@ -45,23 +58,74 @@ func TestLifecycleMiddlewareFailsClosedAcrossRESTBusinessEntrypoints(t *testing.
 				c.Status(http.StatusNoContent)
 			})
 
-			request := httptest.NewRequest(http.MethodPost, path, bytes.NewBufferString(`{"query":"unsafe"}`))
+			request := httptest.NewRequest(http.MethodPost, tc.path, bytes.NewBufferString(`{"query":"q"}`))
 			request.Header.Set("Content-Type", "application/json")
 			response := httptest.NewRecorder()
 			router.ServeHTTP(response, request)
 
-			if downstreamCalls != 0 {
-				t.Fatalf("%s bypassed lifecycle guard", path)
+			if downstreamCalls != tc.wantCalls {
+				t.Fatalf("%s: downstream calls = %d, want %d (status %d, body %s)",
+					tc.path, downstreamCalls, tc.wantCalls, response.Code, response.Body)
+			}
+		})
+	}
+}
+
+// TestRESTContextOptionalityBoundary pins where "ad hoc" ends.
+//
+// The rule is one line - state an id and the call is managed, state none and it
+// is ad hoc - so an empty bkn_context is the same as no bkn_context and passes
+// through. A partial one does not: a caller passing one id and not the other is
+// wiring the context up and got it wrong, and half-attaching the call would be
+// worse than refusing it.
+//
+// The second case also guards against making the context inert rather than
+// optional: a stated session must still be validated and recorded.
+func TestRESTContextOptionalityBoundary(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name      string
+		body      string
+		wantCalls int
+		wantCode  string
+	}{
+		{"empty context is ad hoc", `{"sql":"select 1","bkn_context":{}}`, 1, ""},
+		{"partial context is refused", `{"sql":"select 1","bkn_context":{"conversation_id":"c1"}}`, 0, "interaction_required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			downstreamCalls := 0
+			router := gin.New()
+			router.Use(middlewareLifecycle(bkntrace.NewLifecycleClient("", nil)))
+			router.POST("/*path", func(c *gin.Context) {
+				downstreamCalls++
+				c.Status(http.StatusNoContent)
+			})
+
+			request := httptest.NewRequest(
+				http.MethodPost,
+				"/api/agent-retrieval/v1/kn/run_sql",
+				bytes.NewBufferString(tc.body),
+			)
+			request.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, request)
+
+			if downstreamCalls != tc.wantCalls {
+				t.Fatalf("downstream calls = %d, want %d (status %d, body %s)",
+					downstreamCalls, tc.wantCalls, response.Code, response.Body)
+			}
+			if tc.wantCode == "" {
+				return
 			}
 			var envelope struct {
 				Error bkntrace.APIError `json:"error"`
 			}
 			if err := json.Unmarshal(response.Body.Bytes(), &envelope); err != nil {
-				t.Fatalf("%s returned invalid error envelope: %v body=%s", path, err, response.Body.String())
+				t.Fatalf("invalid error envelope: %v body=%s", err, response.Body.String())
 			}
-			if envelope.Error.Code != "conversation_required" ||
-				envelope.Error.RequiredAction != "create_conversation" {
-				t.Fatalf("%s returned wrong lifecycle error: %#v", path, envelope.Error)
+			if envelope.Error.Code != tc.wantCode {
+				t.Fatalf("error code = %q, want %q", envelope.Error.Code, tc.wantCode)
 			}
 		})
 	}
@@ -102,7 +166,7 @@ func (h *countingQueryToolsHandler) RunSQL(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-func TestRegisteredOperatorAndMCPProxyRoutesCannotBypassLifecycle(t *testing.T) {
+func TestRegisteredProxyRouteCannotBypassLifecycle(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	queryTools := &countingQueryToolsHandler{}
 	publicEngine := gin.New()
@@ -129,8 +193,10 @@ func TestRegisteredOperatorAndMCPProxyRoutesCannotBypassLifecycle(t *testing.T) 
 	publicRequest.Header.Set("Content-Type", "application/json")
 	publicResponse := httptest.NewRecorder()
 	publicEngine.ServeHTTP(publicResponse, publicRequest)
-	if queryTools.calls != 0 || publicResponse.Code != http.StatusBadRequest {
-		t.Fatalf("operator toolbox bypassed lifecycle: calls=%d status=%d body=%s",
+	// The capability route reaches its handler now; only the proxied tool call
+	// below still has to be refused.
+	if queryTools.calls != 1 {
+		t.Fatalf("registered capability route did not reach its handler: calls=%d status=%d body=%s",
 			queryTools.calls, publicResponse.Code, publicResponse.Body)
 	}
 


### PR DESCRIPTION
## Problem

A managed Interaction records one agent turn: which question was asked, what was read, what was concluded.

The 24 `/kn/` REST routes are not that. They answer a click in Studio, a CLI operator, one service asking another. Every one of them had to mint a conversation and an interaction first, producing single-operation records that diluted the concept rather than documenting anything — and forcing every caller of a plain capability to learn the managed-session protocol before it could ask a question.

## Changes

The rule a caller has to remember is now one line: **name a session and the call is managed, name none and it is ad hoc.**

- An absent `bkn_context` and an empty one mean the same thing: the call passes through.
- A partial one does not. A caller passing one id and not the other is wiring the context up and got it wrong; half-attaching the call would be worse than refusing it.
- Naming a session still validates and still records, exactly as before, so a caller that had wired the context up does not silently lose its evidence.

The requirement stays where an agent actually calls. The MCP tool surface has its own middleware and is untouched. A tool call proxied over HTTP — `/mcp/proxy/.../call` — is an agent calling a tool by another name, so it keeps the requirement even though it arrives on the same transport as the `/kn/` routes. That is why the check is on the route rather than on the path prefix.

## Compatibility

This only relaxes. Callers that send `bkn_context` today behave identically; callers that did not were getting a 400 and now reach the handler. No existing integration changes behaviour.

## Tests

The two tests that pinned the old fail-closed behaviour now pin the split, from four directions: the capability routes reach their handler, the proxied tool call does not, an empty context is ad hoc, and a partial one is refused. The last two also guard against making the context inert rather than optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)