### PR TITLE
ci(review): register bkn-trace and data-migrator as code

### DIFF
--- a/.github/workflows/automation-claude-review.yml
+++ b/.github/workflows/automation-claude-review.yml
@@ -34,6 +34,16 @@ name: Claude Code Review
 #
 # pull_request 触发只对代码路径生效；纯配置类改动（release manifest 刷新、镜像同步、
 # workflow 自身调整、文档）不进评审，既省额度也避免噪声。
+#
+# 这份列表是「哪些目录算代码」的唯一声明，漏一个就是整条服务线永不进评审——而且不会
+# 报错，只是安静地什么都不发生。#1201 只改 bkn-trace，opened 与 synchronize 都被 paths
+# 滤掉，作者是发现没人评审才手动触发的；那个 PR 改的是会话归属与错误披露语义，恰好是
+# 最该有人看第二遍的地方。bkn-trace 有 128 个非测试 Go 文件、自己的 CI，只是从来没在
+# 这里登记过。data-migrator 同理（67 个 Python 文件）。
+#
+# 加目录时按「有没有会被执行的代码」判断，不按目录重要性：docs/ 与 ref/ 里的少量脚本
+# 不入列，deploy/ 只收 scripts/ 这一层——其余是 chart 与 manifest，属于上面说的纯配置。
+# 这个文件自身在 .github/ 下，同样不在列表里，所以改它的 PR 不会自我评审。
 # 注意：GitHub Actions 不允许同一事件同时使用 paths 与 paths-ignore，因此这里
 # 只写 include 列表——未列出的路径自动跳过——并用 ! 前缀排除列表内的文档文件。
 # 评论事件不支持 paths 过滤，靠 job if 与 Claude 自身判断相关性。
@@ -45,7 +55,9 @@ on:
       - 'adp/**'
       - 'infra/**'
       - 'bkn-safe/**'
+      - 'bkn-trace/**'
       - 'comm-go/**'
+      - 'data-migrator/**'
       - 'deploy/scripts/**'
       - '!**/*.md'
   issue_comment:


### PR DESCRIPTION
## Problem

The review workflow's `paths` list decides which directories count as code. A directory missing from it is a whole service line that never gets reviewed — and it fails silently: nothing errors, the workflow simply does not run.

`bkn-trace` was missing. #1201 changed only that tree, so both `opened` and `synchronize` were filtered out; the author noticed because no review appeared, not because anything reported it. That PR changed session ownership and error disclosure semantics — the kind of change a second reader is worth the most on.

The tree has 128 non-test Go files and its own CI pipeline. It had simply never been listed here. `data-migrator` is in the same position with 67 Python files.

## Changes

Add `bkn-trace/**` and `data-migrator/**`.

The criterion is whether a directory holds code that runs, not how important it looks:

- `docs/` and `ref/` carry a script or two and stay out.
- `deploy/` keeps only its `scripts/` level; the rest is charts and manifests, which the file's own comment already excludes as configuration.

## Note

This file lives under `.github/`, which is not in the list either, so this PR does not review itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)