### PR TITLE
feat(execution-factory): require a description on every function parameter

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
@@ -511,13 +511,11 @@ func createParameterSchema(param *interfaces.ParameterDef) *openapi3.Schema {
 // job; this only stops the field going empty.
 //
 // Outputs are left alone deliberately. A missing output description costs a
-// reader some guessing; a missing input description costs a failed call.
+// reader some guessing; a missing input description costs a failed call. The
+// function's own description is left to ValidateOperatorDesc, which already
+// refuses it with a localised code of its own.
 func validateParameterDescriptions(ctx context.Context, input *interfaces.FunctionInput) error {
-	if strings.TrimSpace(input.Description) == "" {
-		return errors.DefaultHTTPError(ctx, http.StatusBadRequest,
-			"function description is empty: state what the function does, in the docstring")
-	}
-	for _, missing := range undescribedParameters(input.Inputs, "") {
+	for _, missing := range undescribedParameters(input.Inputs, "", "") {
 		return errors.DefaultHTTPError(ctx, http.StatusBadRequest,
 			fmt.Sprintf("input parameter %q has no description: state what the value has to be, not just its type", missing))
 	}
@@ -528,7 +526,15 @@ func validateParameterDescriptions(ctx context.Context, input *interfaces.Functi
 // meaning of a composite argument lives. The demands parameter of a real
 // published function is an array of objects, and its product and qty fields are
 // the ones a caller gets wrong - naming only "demands" would report nothing.
-func undescribedParameters(params []*interfaces.ParameterDef, prefix string) []string {
+//
+// Structural placeholders are skipped. List[X] and Dict[K,V] have no field for
+// the author to describe: the SDK invents a child called items or values to
+// carry the element type, and no docstring or signature can reach it, so
+// demanding a description there would reject a plain List[str] with an error the
+// author cannot act on. createParameterSchema already treats the array case this
+// way, letting items inherit the parent's description. Their own children are
+// still checked - the fields of a List[Demand] element are the author's to name.
+func undescribedParameters(params []*interfaces.ParameterDef, parentType, prefix string) []string {
 	var missing []string
 	for _, param := range params {
 		if param == nil {
@@ -538,10 +544,27 @@ func undescribedParameters(params []*interfaces.ParameterDef, prefix string) []s
 		if prefix != "" {
 			path = prefix + "." + param.Name
 		}
-		if strings.TrimSpace(param.Description) == "" {
+		if !isStructuralPlaceholder(param, parentType, len(params)) &&
+			strings.TrimSpace(param.Description) == "" {
 			missing = append(missing, path)
 		}
-		missing = append(missing, undescribedParameters(param.SubParameters, path)...)
+		missing = append(missing, undescribedParameters(param.SubParameters, string(param.Type), path)...)
 	}
 	return missing
+}
+
+// isStructuralPlaceholder reports whether the SDK invented this node rather than
+// the author declaring it: the sole child of an array is its element type, and
+// the sole child named values under an object is a Dict's value type.
+func isStructuralPlaceholder(param *interfaces.ParameterDef, parentType string, siblings int) bool {
+	if siblings != 1 {
+		return false
+	}
+	switch parentType {
+	case string(interfaces.ParameterTypeArray):
+		return param.Name == "items"
+	case string(interfaces.ParameterTypeObject):
+		return param.Name == "values"
+	}
+	return false
 }

--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,6 +58,9 @@ func (p *pythonFunctionParser) validate(ctx context.Context, inputValue any) (in
 	// Validate parameter definitions.
 	err = p.Validator.ValidatorStruct(ctx, input)
 	if err != nil {
+		return
+	}
+	if err = validateParameterDescriptions(ctx, input); err != nil {
 		return
 	}
 	if input.Inputs == nil {
@@ -484,4 +488,60 @@ func createParameterSchema(param *interfaces.ParameterDef) *openapi3.Schema {
 		}
 	}
 	return propertySchema
+}
+
+// validateParameterDescriptions refuses a function whose parameters say nothing
+// about themselves.
+//
+// A parameter description is the only place a caller can learn what a value has
+// to be before sending it. Not its type - the schema carries that - but its
+// meaning: that demand_end has to equal the forecast order's enddate rather than
+// its startdate, that a product code is the BOM root and an intermediate material
+// will not do. Every one of those is discoverable today only by calling and
+// reading the failure.
+//
+// The link from a docstring to the agent already works: infer-schema lifts it,
+// the catalogue schema stores it, get_action_info delivers it. Nothing ever
+// required anyone to write it, so descriptions filled in once decay as the next
+// function ships without them.
+//
+// This checks that something was written, not that it is right - "demand_end: the
+// demand cut-off date" passes and is exactly the kind of restatement that misled
+// a caller into sending startdate. Keeping the description accurate stays a human
+// job; this only stops the field going empty.
+//
+// Outputs are left alone deliberately. A missing output description costs a
+// reader some guessing; a missing input description costs a failed call.
+func validateParameterDescriptions(ctx context.Context, input *interfaces.FunctionInput) error {
+	if strings.TrimSpace(input.Description) == "" {
+		return errors.DefaultHTTPError(ctx, http.StatusBadRequest,
+			"function description is empty: state what the function does, in the docstring")
+	}
+	for _, missing := range undescribedParameters(input.Inputs, "") {
+		return errors.DefaultHTTPError(ctx, http.StatusBadRequest,
+			fmt.Sprintf("input parameter %q has no description: state what the value has to be, not just its type", missing))
+	}
+	return nil
+}
+
+// undescribedParameters walks into sub_parameters, because that is where the
+// meaning of a composite argument lives. The demands parameter of a real
+// published function is an array of objects, and its product and qty fields are
+// the ones a caller gets wrong - naming only "demands" would report nothing.
+func undescribedParameters(params []*interfaces.ParameterDef, prefix string) []string {
+	var missing []string
+	for _, param := range params {
+		if param == nil {
+			continue
+		}
+		path := param.Name
+		if prefix != "" {
+			path = prefix + "." + param.Name
+		}
+		if strings.TrimSpace(param.Description) == "" {
+			missing = append(missing, path)
+		}
+		missing = append(missing, undescribedParameters(param.SubParameters, path)...)
+	}
+	return missing
 }

--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_description_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_description_test.go
@@ -19,14 +19,17 @@ func described(name string) *interfaces.ParameterDef {
 // and those two fields are the ones that get sent wrong.
 func TestUndescribedParametersReachesIntoSubParameters(t *testing.T) {
 	demands := described("demands")
+	demands.Type = interfaces.ParameterTypeArray
 	demands.SubParameters = []*interfaces.ParameterDef{
-		{Name: "items", Description: "one demand", SubParameters: []*interfaces.ParameterDef{
+		// The element node carries no description of its own and does not need
+		// one; its fields do.
+		{Name: "items", Type: interfaces.ParameterTypeObject, SubParameters: []*interfaces.ParameterDef{
 			described("product"),
 			{Name: "qty", Description: "  "},
 		}},
 	}
 
-	missing := undescribedParameters([]*interfaces.ParameterDef{demands}, "")
+	missing := undescribedParameters([]*interfaces.ParameterDef{demands}, "", "")
 	if len(missing) != 1 || missing[0] != "demands.items.qty" {
 		t.Fatalf("missing = %v, want [demands.items.qty]", missing)
 	}
@@ -48,13 +51,6 @@ func TestValidateParameterDescriptions(t *testing.T) {
 			input: &interfaces.FunctionInput{Description: "returns a constant"},
 		},
 		{
-			// A function that says nothing about itself is worse than a parameter
-			// that does: the caller cannot even tell whether to reach for it.
-			name:    "empty function description is refused",
-			input:   &interfaces.FunctionInput{Description: "  ", Inputs: []*interfaces.ParameterDef{described("product")}},
-			wantErr: "function description is empty",
-		},
-		{
 			name: "empty parameter description is refused",
 			input: &interfaces.FunctionInput{Description: "computes coverage", Inputs: []*interfaces.ParameterDef{
 				described("product"),
@@ -70,6 +66,40 @@ func TestValidateParameterDescriptions(t *testing.T) {
 				{Name: "depth", Description: "\t\n "},
 			}},
 			wantErr: "depth",
+		},
+		{
+			// List[str]. The SDK invents items to carry the element type and no
+			// docstring can reach it, so demanding a description there would
+			// reject the function with an error its author cannot act on.
+			name: "array element placeholder is not required to describe itself",
+			input: &interfaces.FunctionInput{Inputs: []*interfaces.ParameterDef{func() *interfaces.ParameterDef {
+				tags := described("tags")
+				tags.Type = interfaces.ParameterTypeArray
+				tags.SubParameters = []*interfaces.ParameterDef{{Name: "items", Type: interfaces.ParameterTypeString}}
+				return tags
+			}()}},
+		},
+		{
+			// Dict[str, int], where values plays the same role as items above.
+			name: "dict value placeholder is not required to describe itself",
+			input: &interfaces.FunctionInput{Inputs: []*interfaces.ParameterDef{func() *interfaces.ParameterDef {
+				quotas := described("quotas")
+				quotas.Type = interfaces.ParameterTypeObject
+				quotas.SubParameters = []*interfaces.ParameterDef{{Name: "values", Type: interfaces.ParameterTypeNumber}}
+				return quotas
+			}()}},
+		},
+		{
+			// A named field that happens to be called values is the author's to
+			// describe: the placeholder rule only applies to a lone child.
+			name: "a named sibling called values is still required",
+			input: &interfaces.FunctionInput{Inputs: []*interfaces.ParameterDef{func() *interfaces.ParameterDef {
+				cfg := described("cfg")
+				cfg.Type = interfaces.ParameterTypeObject
+				cfg.SubParameters = []*interfaces.ParameterDef{described("mode"), {Name: "values"}}
+				return cfg
+			}()}},
+			wantErr: "cfg.values",
 		},
 	}
 	for _, tc := range cases {

--- a/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_description_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/parsers/py_func_parser_description_test.go
@@ -1,0 +1,92 @@
+package parsers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+func described(name string) *interfaces.ParameterDef {
+	return &interfaces.ParameterDef{Name: name, Description: "what " + name + " has to be"}
+}
+
+// TestUndescribedParametersReachesIntoSubParameters is the case that motivates
+// walking the tree at all. A composite argument names itself and says nothing
+// about the fields a caller actually fills in - the published function whose
+// demands parameter is an array of {product, qty} objects is exactly this shape,
+// and those two fields are the ones that get sent wrong.
+func TestUndescribedParametersReachesIntoSubParameters(t *testing.T) {
+	demands := described("demands")
+	demands.SubParameters = []*interfaces.ParameterDef{
+		{Name: "items", Description: "one demand", SubParameters: []*interfaces.ParameterDef{
+			described("product"),
+			{Name: "qty", Description: "  "},
+		}},
+	}
+
+	missing := undescribedParameters([]*interfaces.ParameterDef{demands}, "")
+	if len(missing) != 1 || missing[0] != "demands.items.qty" {
+		t.Fatalf("missing = %v, want [demands.items.qty]", missing)
+	}
+}
+
+func TestValidateParameterDescriptions(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name    string
+		input   *interfaces.FunctionInput
+		wantErr string
+	}{
+		{
+			name:  "fully described passes",
+			input: &interfaces.FunctionInput{Description: "computes coverage", Inputs: []*interfaces.ParameterDef{described("product")}},
+		},
+		{
+			name:  "no parameters is fine",
+			input: &interfaces.FunctionInput{Description: "returns a constant"},
+		},
+		{
+			// A function that says nothing about itself is worse than a parameter
+			// that does: the caller cannot even tell whether to reach for it.
+			name:    "empty function description is refused",
+			input:   &interfaces.FunctionInput{Description: "  ", Inputs: []*interfaces.ParameterDef{described("product")}},
+			wantErr: "function description is empty",
+		},
+		{
+			name: "empty parameter description is refused",
+			input: &interfaces.FunctionInput{Description: "computes coverage", Inputs: []*interfaces.ParameterDef{
+				described("product"),
+				{Name: "demand_end", Description: ""},
+			}},
+			wantErr: "demand_end",
+		},
+		{
+			// Whitespace is not a description. Accepting it would leave the gate
+			// open to exactly the caller it exists to stop.
+			name: "whitespace parameter description is refused",
+			input: &interfaces.FunctionInput{Description: "computes coverage", Inputs: []*interfaces.ParameterDef{
+				{Name: "depth", Description: "\t\n "},
+			}},
+			wantErr: "depth",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateParameterDescriptions(ctx, tc.input)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected an error, got none")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q does not name %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A parameter description is the only place a caller learns what a value has to be before sending it. Not its type — the schema carries that — but its meaning:

- `demand_end` has to equal the forecast order's `enddate`, not its `startdate`
- a product code means the BOM root; an intermediate material will not do
- a cheaper equivalent exists: `depth=1` already returns the whole-tree count

Each of those was discoverable only by calling the function and reading the failure.

The path from a docstring to the agent already works end to end: `infer-schema` lifts it, the catalogue schema stores it, `get_action_info` delivers it. **Nothing ever required anyone to write it**, so descriptions filled in once decay as the next function ships without them.

## Changes

Refuse to parse a function that leaves a description empty, naming the parameter so the author knows which one.

- **Sub-parameters are walked.** That is where the meaning of a composite argument lives — an array-of-objects argument names itself and says nothing about the fields a caller actually fills in, and those are the ones sent wrong. The reported path is `demands.items.qty`, not `demands`.
- **The function's own description is required too.** Without it a caller cannot tell whether to reach for the function at all.
- Whitespace is not a description.

## What this does not do

It checks that something was written, not that it is right. `demand_end: the demand cut-off date` passes, and is exactly the kind of restatement that misled a caller into sending `startdate`. Keeping a description accurate stays a human job; this only stops the field going empty.

## Compatibility

Import is unaffected — it builds function metadata directly rather than through the parser, so existing functions keep loading. Only interactive publish and edit go through this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)