### PR TITLE
fix(trace): remove provenance projection tenant scope

### DIFF
--- a/bkn-trace/agent-observability/migrations/mariadb/v021/init.sql
+++ b/bkn-trace/agent-observability/migrations/mariadb/v021/init.sql
@@ -1,0 +1,5 @@
+-- Historical provenance projections are task-scoped by interaction_id and
+-- facts_hash. They must not retain tenant as an invented authorization scope.
+DROP INDEX IF EXISTS idx_provenance_projection_scope_tenant ON bkn_trace_ee_historical_provenance_projections;
+ALTER TABLE bkn_trace_ee_historical_provenance_projections
+    DROP COLUMN IF EXISTS tenant_id;

--- a/bkn-trace/agent-observability/migrations/mariadb/v021/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v021/schema.go
@@ -1,6 +1,7 @@
-// Copyright openbkn.ai
-//
-// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
 
 package v021
 

--- a/bkn-trace/agent-observability/migrations/mariadb/v021/schema.go
+++ b/bkn-trace/agent-observability/migrations/mariadb/v021/schema.go
@@ -1,0 +1,12 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package v021
+
+import _ "embed"
+
+//go:embed init.sql
+var schemaSQL string
+
+func SchemaSQL() string { return schemaSQL }

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -846,7 +846,7 @@ func (s *Service) TerminateInteraction(ctx context.Context, command TerminateInt
 		interaction.TerminalAt = &now
 		tx.SaveInteraction(interaction)
 		if s.enableHistoricalProvenance {
-			if err := s.appendHistoricalProvenanceBuildRequest(tx, conversation.Owner, interaction); err != nil {
+			if err := s.appendHistoricalProvenanceBuildRequest(tx, interaction); err != nil {
 				return err
 			}
 		}
@@ -1931,11 +1931,10 @@ func (s *Service) appendProjection(tx isessionstore.Transaction, aggregateType, 
 
 func (s *Service) appendHistoricalProvenanceBuildRequest(
 	tx isessionstore.Transaction,
-	owner sessionvo.Owner,
 	interaction sessionvo.Interaction,
 ) error {
 	request, err := sessionvo.NewHistoricalProvenanceBuildRequest(
-		interaction.ID, owner, tx.ListOperationCallFacts(interaction.ID),
+		interaction.ID, tx.ListOperationCallFacts(interaction.ID),
 	)
 	if err != nil {
 		return err

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
@@ -615,8 +615,8 @@ func TestTerminalInteractionEnqueuesImmutableHistoricalProvenanceBuildRequest(t 
 	if !found {
 		t.Fatalf("terminal interaction did not enqueue %q: %#v", sessionvo.HistoricalProvenanceBuildRequestedEventType, items)
 	}
-	if request.InteractionID != completed.ID || request.TenantID != owner.TenantID {
-		t.Fatalf("unexpected request scope: %#v", request)
+	if request.InteractionID != completed.ID {
+		t.Fatalf("unexpected request interaction: %#v", request)
 	}
 	if request.FactsHash == "" || len(request.Facts) != 1 || request.Facts[0].OperationID != operation.ID {
 		t.Fatalf("request does not contain sealed facts: %#v", request)

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
@@ -21,7 +21,6 @@ const HistoricalProvenanceBuildRequestedEventType = "historical_provenance.build
 // caller credentials or mutable session state.
 type HistoricalProvenanceBuildRequest struct {
 	InteractionID       string              `json:"interaction_id"`
-	TenantID            string              `json:"tenant_id"`
 	FactsHash           string              `json:"facts_hash"`
 	KnowledgeNetworkIDs []string            `json:"knowledge_network_ids"`
 	Facts               []OperationCallFact `json:"facts"`
@@ -29,11 +28,10 @@ type HistoricalProvenanceBuildRequest struct {
 
 func NewHistoricalProvenanceBuildRequest(
 	interactionID string,
-	owner Owner,
 	facts []OperationCallFact,
 ) (HistoricalProvenanceBuildRequest, error) {
-	if interactionID == "" || owner.TenantID == "" {
-		return HistoricalProvenanceBuildRequest{}, errors.New("historical provenance scope is required")
+	if interactionID == "" {
+		return HistoricalProvenanceBuildRequest{}, errors.New("historical provenance interaction ID is required")
 	}
 	canonicalFacts := append([]OperationCallFact(nil), facts...)
 	slices.SortFunc(canonicalFacts, func(left, right OperationCallFact) int {
@@ -55,7 +53,6 @@ func NewHistoricalProvenanceBuildRequest(
 	sum := sha256.Sum256(canonical)
 	return HistoricalProvenanceBuildRequest{
 		InteractionID:       interactionID,
-		TenantID:            owner.TenantID,
 		FactsHash:           hex.EncodeToString(sum[:]),
 		KnowledgeNetworkIDs: explicitKnowledgeNetworkIDs(canonicalFacts),
 		Facts:               canonicalFacts,

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance_test.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance_test.go
@@ -6,6 +6,8 @@
 package sessionvo
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 )
@@ -20,9 +22,7 @@ func TestHistoricalProvenanceBuildRequestCanonicalizesFactsAndExplicitNetworks(t
 		{OperationID: "op-no-network", Attempt: 1, StartedAt: startedAt, ToolName: "run_sql", Input: mustInlinePayload(t, `{"query":"select 1"}`)},
 	}
 
-	request, err := NewHistoricalProvenanceBuildRequest("interaction-1", Owner{
-		TenantID: "tenant-1",
-	}, facts)
+	request, err := NewHistoricalProvenanceBuildRequest("interaction-1", facts)
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
@@ -35,11 +35,16 @@ func TestHistoricalProvenanceBuildRequestCanonicalizesFactsAndExplicitNetworks(t
 	if request.FactsHash == "" {
 		t.Fatal("facts hash is required")
 	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if bytes.Contains(payload, []byte(`"tenant_id"`)) {
+		t.Fatalf("historical provenance request must not serialize tenant scope: %s", payload)
+	}
 
 	reversed := []OperationCallFact{facts[2], facts[0], facts[1]}
-	second, err := NewHistoricalProvenanceBuildRequest("interaction-1", Owner{
-		TenantID: "tenant-1",
-	}, reversed)
+	second, err := NewHistoricalProvenanceBuildRequest("interaction-1", reversed)
 	if err != nil {
 		t.Fatalf("build reversed request: %v", err)
 	}

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema.go
@@ -18,6 +18,7 @@ import (
 	v018 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v018"
 	v019 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v019"
 	v020 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v020"
+	v021 "github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/migrations/mariadb/v021"
 )
 
 // Migration is immutable once released. Every statement in SQL must be safe to
@@ -42,6 +43,7 @@ func Migrations() []Migration {
 		{version: "018", sql: v018.SchemaSQL()},
 		{version: "019", sql: v019.SchemaSQL()},
 		{version: "020", sql: v020.SchemaSQL()},
+		{version: "021", sql: v021.SchemaSQL()},
 	})
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/schema_test.go
@@ -66,6 +66,7 @@ func TestMigrationsAreOrderedAndChecksumProtected(t *testing.T) {
 		"018": "9fd4c45b568a2a5c395ee09a4214a240d9e865239e1024f443559f45a97b89b8",
 		"019": "4bdaffbf5877ae560a8aaf13dbcb69b88c7dfe6fd642e06be1da54827f9134a8",
 		"020": "4e8e5084b1e913ede10b98f90718cd52f53931d65b11e2cff3b8e84719633d9f",
+		"021": "64c0d52ae3905b89091b57f3a38eccdfcb5d97929c6a5f7faab192af5a67de12",
 	}
 	migrations := sessionstore.Migrations()
 	if len(migrations) != len(expectedChecksums) {

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store_test.go
@@ -62,10 +62,24 @@ func TestMigrationPlanUpgradesExistingCoreSchemaWithoutBusinessDomain(t *testing
 	if err != nil {
 		t.Fatalf("plan tenant-only schema migration: %v", err)
 	}
-	if len(plan) != 4 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") ||
+	if len(plan) != 5 || plan[0].Version != "017" || !strings.Contains(plan[0].SQL, "bkn_trace_ee_provenance_analyses") ||
 		plan[2].Version != "019" || !strings.Contains(plan[2].SQL, "bkn_trace_ee_historical_provenance_projections") ||
-		plan[3].Version != "020" || !strings.Contains(plan[3].SQL, "DROP COLUMN IF EXISTS business_domain_id") {
+		plan[3].Version != "020" || !strings.Contains(plan[3].SQL, "DROP COLUMN IF EXISTS business_domain_id") ||
+		plan[4].Version != "021" || !strings.Contains(plan[4].SQL, "DROP COLUMN IF EXISTS tenant_id") {
 		t.Fatalf("unexpected tenant-only schema plan: %#v", plan)
+	}
+}
+
+func TestMigrationPlanRemovesTenantScopeFromHistoricalProvenanceProjection(t *testing.T) {
+	migrations := Migrations()
+	if len(migrations) == 0 {
+		t.Fatal("migration manifest is empty")
+	}
+	last := migrations[len(migrations)-1]
+	if last.Version != "021" ||
+		!strings.Contains(last.SQL, "bkn_trace_ee_historical_provenance_projections") ||
+		!strings.Contains(last.SQL, "DROP COLUMN IF EXISTS tenant_id") {
+		t.Fatalf("expected v021 to remove projection tenant scope, got %#v", last)
 	}
 }
 
@@ -79,11 +93,12 @@ func TestMigrationPlanAddsLocaleToExistingProvenanceHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan provenance locale migration: %v", err)
 	}
-	if len(plan) != 3 || plan[0].Version != "018" ||
+	if len(plan) != 4 || plan[0].Version != "018" ||
 		!strings.Contains(plan[0].SQL, "ADD COLUMN IF NOT EXISTS locale") ||
 		!strings.Contains(plan[0].SQL, "DEFAULT 'zh-CN'") ||
 		plan[1].Version != "019" || !strings.Contains(plan[1].SQL, "bkn_trace_ee_historical_provenance_tombstones") ||
-		plan[2].Version != "020" || !strings.Contains(plan[2].SQL, "DROP COLUMN IF EXISTS business_domain_id") {
+		plan[2].Version != "020" || !strings.Contains(plan[2].SQL, "DROP COLUMN IF EXISTS business_domain_id") ||
+		plan[3].Version != "021" || !strings.Contains(plan[3].SQL, "DROP COLUMN IF EXISTS tenant_id") {
 		t.Fatalf("unexpected provenance locale migration plan: %#v", plan)
 	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Remove `tenant_id` from the historical-provenance build event.
- [x] Add immutable Core-owned MariaDB v021 to remove the corresponding projection-table column and obsolete index.
- [x] Keep the projection identity constrained to `interaction_id` and sealed `facts_hash`.

---

## Why

- Related Issue: [openbkn-ee#31](https://github.com/openbkn-ai/openbkn-ee/issues/31)
- Related Feature: [Historical provenance projection design](https://github.com/openbkn-ai/bkn-docs/pull/86)
- Background: business-domain has been removed; tenant has no approved architecture for historical-projection scope. Retaining it in a new historical read model would create an invented authorization boundary.

---

## How

- Key implementation points: omit tenant from the Core outbox value object and append v021 rather than changing released migrations.
- Breaking changes (API, config, database, etc.): MariaDB v021 drops only the unused historical-projection `tenant_id` column and its scope index. It does not alter Core lifecycle tables that still use tenant.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: no live MariaDB required for the unit suite)
- [ ] Verified in test environment (requires controlled migration deployment)

Test notes: `GOCACHE=/tmp/openbkn-go-build-cache GOMODCACHE=/tmp/openbkn-go-mod-cache go test ./... -count=1`

---

## Risk & Rollback

- Potential risks: deployments with v019/v020 apply one additive version that drops only projection-scope data already prohibited by the final model.
- Rollback plan: roll back the application image before applying v021. After v021 is applied, do not downgrade a live database; forward repair is a new migration restoring a nullable compatibility column only if an approved architecture later requires it.

---

## Additional Notes

- This is the first implementation PR. The signed restricted BKN read contract and EE builder follow in separate PRs after this baseline is reviewed.