### PR TITLE
feat(trace): add signed projection read grant

### DIFF
--- a/comm-go/projectiongrant/grant.go
+++ b/comm-go/projectiongrant/grant.go
@@ -79,6 +79,9 @@ func Sign(claims Claims, privateKey ed25519.PrivateKey) (string, error) {
 }
 
 func Verify(token string, keys map[string]ed25519.PublicKey, options VerifyOptions) (Claims, error) {
+	if strings.TrimSpace(options.ExpectedIssuer) == "" || strings.TrimSpace(options.ExpectedAudience) == "" {
+		return Claims{}, errors.New("projection grant verification requires issuer and audience")
+	}
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return Claims{}, errors.New("projection grant has invalid compact encoding")
@@ -109,10 +112,10 @@ func Verify(token string, keys map[string]ed25519.PublicKey, options VerifyOptio
 	if claims.KeyID != head.KeyID {
 		return Claims{}, errors.New("projection grant key ID does not match header")
 	}
-	if options.ExpectedIssuer != "" && claims.Issuer != options.ExpectedIssuer {
+	if claims.Issuer != options.ExpectedIssuer {
 		return Claims{}, errors.New("projection grant issuer is invalid")
 	}
-	if options.ExpectedAudience != "" && claims.Audience != options.ExpectedAudience {
+	if claims.Audience != options.ExpectedAudience {
 		return Claims{}, errors.New("projection grant audience is invalid")
 	}
 	now := options.Now

--- a/comm-go/projectiongrant/grant.go
+++ b/comm-go/projectiongrant/grant.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+// Package projectiongrant signs and verifies the narrow capability used by a
+// Trace historical-provenance builder to read one of its recorded networks.
+package projectiongrant
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+const algorithm = "EdDSA"
+
+type Claims struct {
+	Version             int
+	Issuer              string
+	KeyID               string
+	Audience            string
+	EventID             string
+	InteractionID       string
+	FactsHash           string
+	KnowledgeNetworkIDs []string
+	IssuedAt            time.Time
+	ExpiresAt           time.Time
+}
+
+type VerifyOptions struct {
+	Now              time.Time
+	ExpectedIssuer   string
+	ExpectedAudience string
+}
+
+type header struct {
+	Algorithm string `json:"alg"`
+	KeyID     string `json:"kid"`
+	Type      string `json:"typ"`
+}
+
+type wireClaims struct {
+	Version             int      `json:"v"`
+	Issuer              string   `json:"iss"`
+	KeyID               string   `json:"kid"`
+	Audience            string   `json:"aud"`
+	EventID             string   `json:"event_id"`
+	InteractionID       string   `json:"interaction_id"`
+	FactsHash           string   `json:"facts_hash"`
+	KnowledgeNetworkIDs []string `json:"knowledge_network_ids"`
+	IssuedAt            int64    `json:"iat"`
+	ExpiresAt           int64    `json:"exp"`
+}
+
+func Sign(claims Claims, privateKey ed25519.PrivateKey) (string, error) {
+	canonical, err := canonicalClaims(claims)
+	if err != nil {
+		return "", err
+	}
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return "", errors.New("projection grant signing key is invalid")
+	}
+	head, err := json.Marshal(header{Algorithm: algorithm, KeyID: canonical.KeyID, Type: "JWT"})
+	if err != nil {
+		return "", err
+	}
+	body, err := json.Marshal(toWire(canonical))
+	if err != nil {
+		return "", err
+	}
+	input := base64.RawURLEncoding.EncodeToString(head) + "." + base64.RawURLEncoding.EncodeToString(body)
+	signature := ed25519.Sign(privateKey, []byte(input))
+	return input + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func Verify(token string, keys map[string]ed25519.PublicKey, options VerifyOptions) (Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return Claims{}, errors.New("projection grant has invalid compact encoding")
+	}
+	var head header
+	if err := decode(parts[0], &head); err != nil {
+		return Claims{}, errors.New("projection grant has invalid header")
+	}
+	if head.Algorithm != algorithm || head.Type != "JWT" || strings.TrimSpace(head.KeyID) == "" {
+		return Claims{}, errors.New("projection grant uses an unsupported header")
+	}
+	key, found := keys[head.KeyID]
+	if !found || len(key) != ed25519.PublicKeySize {
+		return Claims{}, errors.New("projection grant signing key is unknown")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || !ed25519.Verify(key, []byte(parts[0]+"."+parts[1]), signature) {
+		return Claims{}, errors.New("projection grant signature is invalid")
+	}
+	var wire wireClaims
+	if err := decode(parts[1], &wire); err != nil {
+		return Claims{}, errors.New("projection grant has invalid claims")
+	}
+	claims, err := canonicalClaims(fromWire(wire))
+	if err != nil {
+		return Claims{}, err
+	}
+	if claims.KeyID != head.KeyID {
+		return Claims{}, errors.New("projection grant key ID does not match header")
+	}
+	if options.ExpectedIssuer != "" && claims.Issuer != options.ExpectedIssuer {
+		return Claims{}, errors.New("projection grant issuer is invalid")
+	}
+	if options.ExpectedAudience != "" && claims.Audience != options.ExpectedAudience {
+		return Claims{}, errors.New("projection grant audience is invalid")
+	}
+	now := options.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if !claims.ExpiresAt.After(now) {
+		return Claims{}, errors.New("projection grant is expired")
+	}
+	if claims.IssuedAt.After(now) {
+		return Claims{}, errors.New("projection grant is not yet valid")
+	}
+	return claims, nil
+}
+
+func (claims Claims) AllowsKnowledgeNetwork(networkID string) bool {
+	networkID = strings.TrimSpace(networkID)
+	index := sort.SearchStrings(claims.KnowledgeNetworkIDs, networkID)
+	return index < len(claims.KnowledgeNetworkIDs) && claims.KnowledgeNetworkIDs[index] == networkID
+}
+
+func canonicalClaims(claims Claims) (Claims, error) {
+	claims.Issuer = strings.TrimSpace(claims.Issuer)
+	claims.KeyID = strings.TrimSpace(claims.KeyID)
+	claims.Audience = strings.TrimSpace(claims.Audience)
+	claims.EventID = strings.TrimSpace(claims.EventID)
+	claims.InteractionID = strings.TrimSpace(claims.InteractionID)
+	claims.FactsHash = strings.TrimSpace(claims.FactsHash)
+	claims.KnowledgeNetworkIDs = canonicalNetworkIDs(claims.KnowledgeNetworkIDs)
+	if claims.Version != 1 || claims.Issuer == "" || claims.KeyID == "" || claims.Audience == "" || claims.EventID == "" || claims.InteractionID == "" || claims.FactsHash == "" || claims.IssuedAt.IsZero() || claims.ExpiresAt.IsZero() || !claims.ExpiresAt.After(claims.IssuedAt) {
+		return Claims{}, errors.New("projection grant claims are invalid")
+	}
+	return claims, nil
+}
+
+func canonicalNetworkIDs(ids []string) []string {
+	unique := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for id := range unique {
+		result = append(result, id)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func toWire(claims Claims) wireClaims {
+	return wireClaims{Version: claims.Version, Issuer: claims.Issuer, KeyID: claims.KeyID, Audience: claims.Audience, EventID: claims.EventID, InteractionID: claims.InteractionID, FactsHash: claims.FactsHash, KnowledgeNetworkIDs: claims.KnowledgeNetworkIDs, IssuedAt: claims.IssuedAt.Unix(), ExpiresAt: claims.ExpiresAt.Unix()}
+}
+
+func fromWire(claims wireClaims) Claims {
+	return Claims{Version: claims.Version, Issuer: claims.Issuer, KeyID: claims.KeyID, Audience: claims.Audience, EventID: claims.EventID, InteractionID: claims.InteractionID, FactsHash: claims.FactsHash, KnowledgeNetworkIDs: claims.KnowledgeNetworkIDs, IssuedAt: time.Unix(claims.IssuedAt, 0).UTC(), ExpiresAt: time.Unix(claims.ExpiresAt, 0).UTC()}
+}
+
+func decode(part string, value any) error {
+	raw, err := base64.RawURLEncoding.DecodeString(part)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(raw, value)
+}

--- a/comm-go/projectiongrant/grant_test.go
+++ b/comm-go/projectiongrant/grant_test.go
@@ -8,6 +8,9 @@ package projectiongrant
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -68,9 +71,81 @@ func TestVerifyRejectsExpiredOrWrongAudienceGrant(t *testing.T) {
 	}); err == nil {
 		t.Fatal("expired grant was accepted")
 	}
-	if _, err = Verify(token, map[string]ed25519.PublicKey{"key-1": publicKey}, VerifyOptions{
-		Now: now.Add(-2 * time.Hour), ExpectedIssuer: "trace-core-projection", ExpectedAudience: "another-service",
+	validToken, err := Sign(validClaims(now), privateKey)
+	if err != nil {
+		t.Fatalf("sign valid grant: %v", err)
+	}
+	if _, err = Verify(validToken, map[string]ed25519.PublicKey{"key-1": publicKey}, VerifyOptions{
+		Now: now.Add(time.Minute), ExpectedIssuer: "trace-core-projection", ExpectedAudience: "another-service",
 	}); err == nil {
 		t.Fatal("wrong audience grant was accepted")
 	}
+}
+
+func TestVerifyRequiresExplicitIssuerAndAudience(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	now := time.Date(2026, 8, 31, 1, 0, 0, 0, time.UTC)
+	token, err := Sign(validClaims(now), privateKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err = Verify(token, map[string]ed25519.PublicKey{"key-1": publicKey}, VerifyOptions{Now: now.Add(time.Minute)}); err == nil {
+		t.Fatal("verification without an expected issuer and audience was accepted")
+	}
+}
+
+func TestVerifyRejectsTamperedGrantAndInconsistentHeader(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	now := time.Date(2026, 8, 31, 1, 0, 0, 0, time.UTC)
+	token, err := Sign(validClaims(now), privateKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	options := VerifyOptions{Now: now.Add(time.Minute), ExpectedIssuer: "trace-core-projection", ExpectedAudience: "bkn-projection-read"}
+	for _, malformed := range []string{
+		token[:len(token)-1] + "x",
+		replaceHeaderField(t, token, "alg", "none"),
+		replaceHeaderField(t, token, "kid", "unknown"),
+	} {
+		if _, err = Verify(malformed, map[string]ed25519.PublicKey{"key-1": publicKey}, options); err == nil {
+			t.Fatalf("malformed grant was accepted: %q", malformed)
+		}
+	}
+}
+
+func validClaims(now time.Time) Claims {
+	return Claims{
+		Version: 1, Issuer: "trace-core-projection", KeyID: "key-1", Audience: "bkn-projection-read",
+		EventID: "event-1", InteractionID: "interaction-1", FactsHash: "hash", KnowledgeNetworkIDs: []string{"kn-1"},
+		IssuedAt: now, ExpiresAt: now.Add(time.Hour),
+	}
+}
+
+func replaceHeaderField(t *testing.T, token, field, value string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatal("invalid test token")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	var header map[string]string
+	if err = json.Unmarshal(raw, &header); err != nil {
+		t.Fatalf("unmarshal header: %v", err)
+	}
+	header[field] = value
+	raw, err = json.Marshal(header)
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	parts[0] = base64.RawURLEncoding.EncodeToString(raw)
+	return strings.Join(parts, ".")
 }

--- a/comm-go/projectiongrant/grant_test.go
+++ b/comm-go/projectiongrant/grant_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 OpenBKN
+// SPDX-License-Identifier: LicenseRef-OpenBKN
+// Licensed under the OpenBKN License, a modified Apache 2.0 with Additional
+// Conditions. See LICENSE-OPENBKN.txt in the repository root for the full text.
+
+package projectiongrant
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyBindsGrantToExactProjectionNetworks(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	now := time.Date(2026, 8, 31, 1, 0, 0, 0, time.UTC)
+	grant := Claims{
+		Version:             1,
+		Issuer:              "trace-core-projection",
+		KeyID:               "key-2026-08",
+		Audience:            "bkn-projection-read",
+		EventID:             "event-1",
+		InteractionID:       "interaction-1",
+		FactsHash:           "f3e5b2db0dc9b053f80d6be8fdbbc21df6d5232263ed2eef2eb5a2f4183b31ce",
+		KnowledgeNetworkIDs: []string{"kn-b", "kn-a", "kn-a"},
+		IssuedAt:            now,
+		ExpiresAt:           now.Add(time.Hour),
+	}
+
+	token, err := Sign(grant, privateKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	verified, err := Verify(token, map[string]ed25519.PublicKey{"key-2026-08": publicKey}, VerifyOptions{
+		Now: now.Add(time.Minute), ExpectedIssuer: "trace-core-projection", ExpectedAudience: "bkn-projection-read",
+	})
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !verified.AllowsKnowledgeNetwork("kn-a") || !verified.AllowsKnowledgeNetwork("kn-b") || verified.AllowsKnowledgeNetwork("kn-c") {
+		t.Fatalf("grant widened or lost its network scope: %#v", verified)
+	}
+	if len(verified.KnowledgeNetworkIDs) != 2 || verified.KnowledgeNetworkIDs[0] != "kn-a" || verified.KnowledgeNetworkIDs[1] != "kn-b" {
+		t.Fatalf("grant networks were not canonicalized: %#v", verified.KnowledgeNetworkIDs)
+	}
+}
+
+func TestVerifyRejectsExpiredOrWrongAudienceGrant(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	now := time.Date(2026, 8, 31, 1, 0, 0, 0, time.UTC)
+	token, err := Sign(Claims{
+		Version: 1, Issuer: "trace-core-projection", KeyID: "key-1", Audience: "bkn-projection-read",
+		EventID: "event-1", InteractionID: "interaction-1", FactsHash: "hash", KnowledgeNetworkIDs: []string{"kn-1"},
+		IssuedAt: now.Add(-time.Hour), ExpiresAt: now.Add(-time.Minute),
+	}, privateKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err = Verify(token, map[string]ed25519.PublicKey{"key-1": publicKey}, VerifyOptions{
+		Now: now, ExpectedIssuer: "trace-core-projection", ExpectedAudience: "bkn-projection-read",
+	}); err == nil {
+		t.Fatal("expired grant was accepted")
+	}
+	if _, err = Verify(token, map[string]ed25519.PublicKey{"key-1": publicKey}, VerifyOptions{
+		Now: now.Add(-2 * time.Hour), ExpectedIssuer: "trace-core-projection", ExpectedAudience: "another-service",
+	}); err == nil {
+		t.Fatal("wrong audience grant was accepted")
+	}
+}


### PR DESCRIPTION
## What Changed

- [x] Add a shared `projectiongrant` package for compact Ed25519 (`EdDSA`) projection-read capabilities.
- [x] Bind a grant to version, issuer, `kid`, audience, event, Interaction, facts hash, expiry, and a sorted/deduplicated explicit `kn_id` allow-list.
- [x] Add signing and verification tests, including expiry, issuer/audience validation, signature/key selection, and allow-list enforcement.

---

## Why

- Related Issue: [openbkn-ee#31](https://github.com/openbkn-ai/openbkn-ee/issues/31)
- Related Feature: [Historical provenance projection design](https://github.com/openbkn-ai/bkn-docs/blob/main/docs/foundry/bkn-trace/design/issue-31-historical-provenance-projection-design.md)
- Background: historical provenance builders require a task-bound BKN read capability without inventing tenant/business-domain scope or forwarding user credentials.

---

## How

- Key implementation points: the package emits and verifies a compact JWT-shaped EdDSA token with strict header, claim, issuer, audience, expiry and `kid` checks. No user identity, tenant, business domain, SQL, or raw facts are represented.
- Breaking changes (API, config, database, etc.): none. This additive shared package is not wired into a runtime path in this PR; Core signer configuration and BKN verifier wiring follow in separate PRs.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: no external dependencies)
- [ ] Verified in test environment (not applicable: no runtime wiring yet)

Test notes:

- Passed: `GOCACHE=/tmp/openbkn-go-build-cache go test ./projectiongrant -count=1`
- Passed: `GOCACHE=/tmp/openbkn-go-build-cache go vet ./projectiongrant`
- `comm-go` full suite reaches existing DB-driver tests that require `MYSQL_TEST_PORT`, `DM_TEST_PORT`, and `KDB_TEST_PORT`; the projectiongrant package itself passes.

---

## Risk & Rollback

- Potential risks: later signers/verifiers must use the documented issuer/audience and preserve public keys until the final grant expiry plus clock skew.
- Rollback plan: this PR adds no runtime call site, configuration, migration, or external endpoint; reverting the commit removes the unused package.

---

## Additional Notes

- This is the first small PR in the Core/BKN capability batch. The subsequent wiring PR will include runtime configuration, event signing, BKN single-network verification, and end-to-end contract tests.