### PR TITLE
feat(trace): sign historical projection grants

### DIFF
--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -83,6 +83,21 @@ spec:
             - name: BKN_TRACE_PROJECTION_REBUILD_VERSION
               value: {{ . | quote }}
             {{- end }}
+            {{- if and .Values.core.projection.enabled .Values.enterpriseBusinessProvenance.enabled }}
+            - name: BKN_TRACE_PROJECTION_GRANT_ISSUER
+              value: {{ required "core.projection.grant.issuer is required for enterprise provenance projection" .Values.core.projection.grant.issuer | quote }}
+            - name: BKN_TRACE_PROJECTION_GRANT_KEY_ID
+              value: {{ required "core.projection.grant.keyID is required for enterprise provenance projection" .Values.core.projection.grant.keyID | quote }}
+            - name: BKN_TRACE_PROJECTION_GRANT_AUDIENCE
+              value: {{ required "core.projection.grant.audience is required for enterprise provenance projection" .Values.core.projection.grant.audience | quote }}
+            - name: BKN_TRACE_PROJECTION_GRANT_TTL
+              value: {{ required "core.projection.grant.ttl is required for enterprise provenance projection" .Values.core.projection.grant.ttl | quote }}
+            - name: BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "core.projection.grant.existingSecret is required for enterprise provenance projection" .Values.core.projection.grant.existingSecret | quote }}
+                  key: {{ .Values.core.projection.grant.privateKeyKey | quote }}
+            {{- end }}
             {{- if eq .Values.core.store "mariadb" }}
             - name: BKN_TRACE_CORE_MARIADB_DSN
               valueFrom:

--- a/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               value: {{ .Values.core.evidenceCollectionState | quote }}
             - name: BKN_TRACE_PROJECTION_ENABLED
               value: {{ ternary "true" "false" .Values.core.projection.enabled | quote }}
+            - name: BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED
+              value: {{ ternary "true" "false" .Values.core.projection.historicalProvenance.enabled | quote }}
             - name: BKN_TRACE_PROJECTION_INDEX
               value: {{ .Values.core.projection.index | quote }}
             - name: BKN_TRACE_PROJECTION_INTERVAL
@@ -83,7 +85,7 @@ spec:
             - name: BKN_TRACE_PROJECTION_REBUILD_VERSION
               value: {{ . | quote }}
             {{- end }}
-            {{- if and .Values.core.projection.enabled .Values.enterpriseBusinessProvenance.enabled }}
+            {{- if .Values.core.projection.historicalProvenance.enabled }}
             - name: BKN_TRACE_PROJECTION_GRANT_ISSUER
               value: {{ required "core.projection.grant.issuer is required for enterprise provenance projection" .Values.core.projection.grant.issuer | quote }}
             - name: BKN_TRACE_PROJECTION_GRANT_KEY_ID

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -145,13 +145,17 @@ core:
   evidenceCollectionState: enabled
   projection:
     enabled: false
+    # Single runtime authority for signed historical-provenance projection.
+    # The EE image must register its handler when this is enabled.
+    historicalProvenance:
+      enabled: false
     index: bkn-trace-core
     interval: 1s
     # Rebuilding projections is an explicit maintenance operation. Leave empty
     # during normal startup so a rollout does not continuously rebuild indexes.
     rebuildVersion: ""
-    # Required only when both Core projection and the EE provenance handler are
-    # enabled. The private key remains in an externally managed Secret.
+    # Required only when historicalProvenance.enabled is true. The private key
+    # remains in an externally managed Secret.
     grant:
       issuer: trace-core-projection
       keyID: trace-projection-key

--- a/bkn-trace/agent-observability/charts/agent-observability/values.yaml
+++ b/bkn-trace/agent-observability/charts/agent-observability/values.yaml
@@ -150,6 +150,17 @@ core:
     # Rebuilding projections is an explicit maintenance operation. Leave empty
     # during normal startup so a rollout does not continuously rebuild indexes.
     rebuildVersion: ""
+    # Required only when both Core projection and the EE provenance handler are
+    # enabled. The private key remains in an externally managed Secret.
+    grant:
+      issuer: trace-core-projection
+      keyID: trace-projection-key
+      audience: bkn-projection-read
+      # Covers the 24-hour automatic outbox retry window plus delivery margin.
+      # DLQ replay is intentionally not a grant-renewal path.
+      ttl: 24h5m
+      existingSecret: ""
+      privateKeyKey: private-key
   mariadb:
     existingSecret: bkn-trace-core-mariadb
     dsnKey: dsn

--- a/bkn-trace/agent-observability/go.mod
+++ b/bkn-trace/agent-observability/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.3
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d
 	github.com/swaggo/http-swagger/v2 v2.0.2
 	github.com/swaggo/swag v1.8.12
 	gopkg.in/yaml.v2 v2.4.0

--- a/bkn-trace/agent-observability/go.sum
+++ b/bkn-trace/agent-observability/go.sum
@@ -108,6 +108,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.3 h1:0NgGsZnHge2H849S9oBix6G8I+bhvPXjjxz0x2E/4LA=
 github.com/openbkn-ai/bkn-foundry/comm-go v0.1.3/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d h1:l61dZgJYzyaUcgVue1Dfs9IKRHVw5Z4318NF/hSC/Nw=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
+++ b/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
@@ -20,6 +20,7 @@ enabled="$(helm template agent-observability "${chart_dir}" \
     --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
     --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer \
     --set core.projection.enabled=true \
+    --set core.projection.historicalProvenance.enabled=true \
     --set core.projection.grant.existingSecret=trace-projection-grant)"
 
 for required in \
@@ -43,6 +44,22 @@ for required in \
     'key: "private-key"'; do
     grep -q "${required}" <<<"${enabled}" || {
         echo "rendered bootstrap Job missing: ${required}" >&2
+        exit 1
+    }
+done
+
+historical_only="$(helm template agent-observability "${chart_dir}" \
+    --set core.projection.enabled=true \
+    --set core.projection.historicalProvenance.enabled=true \
+    --set core.projection.grant.existingSecret=trace-projection-grant \
+    --show-only templates/deployment.yaml)"
+for required in \
+    'name: BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED' \
+    'value: "true"' \
+    'name: BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY' \
+    'name: "trace-projection-grant"'; do
+    grep -q "${required}" <<<"${historical_only}" || {
+        echo "historical provenance configuration must not depend on bootstrap selection: ${required}" >&2
         exit 1
     }
 done

--- a/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
+++ b/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
@@ -18,7 +18,9 @@ enabled="$(helm template agent-observability "${chart_dir}" \
     --set enterpriseBusinessProvenance.enabled=true \
     --set enterpriseBusinessProvenance.agentURL=http://bkn-agent:30800 \
     --set enterpriseBusinessProvenance.agentID=business_provenance_optimizer \
-    --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer)"
+    --set enterpriseBusinessProvenance.agentName=BusinessProvenanceOptimizer \
+    --set core.projection.enabled=true \
+    --set core.projection.grant.existingSecret=trace-projection-grant)"
 
 for required in \
     'name: agent-observability-business-provenance-bootstrap' \
@@ -28,7 +30,17 @@ for required in \
     'value: "http://bkn-safe:3000/api/safe/v1"' \
     'value: "http://bkn-agent:30800/api/bkn-agent/v1"' \
     'name: "bkn-agent-provenance-bootstrap"' \
-    'app.bootstrap.business_provenance'; do
+    'app.bootstrap.business_provenance' \
+    'name: BKN_TRACE_PROJECTION_GRANT_ISSUER' \
+    'value: "trace-core-projection"' \
+    'name: BKN_TRACE_PROJECTION_GRANT_KEY_ID' \
+    'value: "trace-projection-key"' \
+    'name: BKN_TRACE_PROJECTION_GRANT_AUDIENCE' \
+    'value: "bkn-projection-read"' \
+    'name: BKN_TRACE_PROJECTION_GRANT_TTL' \
+    'value: "24h5m"' \
+    'name: "trace-projection-grant"' \
+    'key: "private-key"'; do
     grep -q "${required}" <<<"${enabled}" || {
         echo "rendered bootstrap Job missing: ${required}" >&2
         exit 1

--- a/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
+++ b/bkn-trace/agent-observability/scripts/test_business_provenance_bootstrap.sh
@@ -55,7 +55,6 @@ historical_only="$(helm template agent-observability "${chart_dir}" \
     --show-only templates/deployment.yaml)"
 for required in \
     'name: BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED' \
-    'value: "true"' \
     'name: BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY' \
     'name: "trace-projection-grant"'; do
     grep -q "${required}" <<<"${historical_only}" || {
@@ -63,6 +62,10 @@ for required in \
         exit 1
     }
 done
+grep -A1 'name: BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED' <<<"${historical_only}" | grep -q 'value: "true"' || {
+    echo "historical provenance enablement must render true next to its environment variable" >&2
+    exit 1
+}
 
 private_registry="$(helm template agent-observability "${chart_dir}" \
     --set image.registry=registry.internal/openbkn \

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -66,6 +66,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isourcecoveragestore"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
 	httpSwagger "github.com/swaggo/http-swagger/v2"
 )
 
@@ -189,8 +190,9 @@ func NewApp() (*App, error) {
 	}
 	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions(logSources, logOptions), evidenceHandler)
 	provenanceHandler := enterpriseroute.HistoricalProvenanceHandler()
-	sessionService := sessionsvc.New(sessionStore, sessionsvc.Options{
-		EnableHistoricalProvenance: provenanceHandler != nil && coreConfig.ProjectionEnabled,
+	historicalProvenanceEnabled := provenanceHandler != nil && coreConfig.ProjectionEnabled
+	sessionOptions := sessionsvc.Options{
+		EnableHistoricalProvenance: historicalProvenanceEnabled,
 		Capacity: sessionsvc.CapacityLimits{
 			MaxOperationsPerInteraction:   coreConfig.MaxOperationsPerInteraction,
 			MaxClaimsPerInteraction:       coreConfig.MaxClaimsPerInteraction,
@@ -203,7 +205,20 @@ func NewApp() (*App, error) {
 			return coreConfig.EvidenceCollectionState
 		},
 		Metrics: metrics,
-	})
+	}
+	if historicalProvenanceEnabled {
+		if len(coreConfig.ProjectionGrantPrivateKey) == 0 {
+			return nil, errors.New("historical provenance projection requires BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY")
+		}
+		sessionOptions.ProjectionGrantIssuer = coreConfig.ProjectionGrantIssuer
+		sessionOptions.ProjectionGrantKeyID = coreConfig.ProjectionGrantKeyID
+		sessionOptions.ProjectionGrantAudience = coreConfig.ProjectionGrantAudience
+		sessionOptions.ProjectionGrantTTL = coreConfig.ProjectionGrantTTL
+		sessionOptions.ProjectionGrantSigner = func(claims projectiongrant.Claims) (string, error) {
+			return projectiongrant.Sign(claims, coreConfig.ProjectionGrantPrivateKey)
+		}
+	}
+	sessionService := sessionsvc.New(sessionStore, sessionOptions)
 	archiveStore := archivesvc.NewMemoryStore()
 	if databaseStore, ok := sessionStore.(interface{ Database() *sql.DB }); ok {
 		archiveStore = archivestore.New(databaseStore.Database())

--- a/bkn-trace/agent-observability/src/boot/bootstrap.go
+++ b/bkn-trace/agent-observability/src/boot/bootstrap.go
@@ -190,7 +190,10 @@ func NewApp() (*App, error) {
 	}
 	logHandler := httphandler.NewLogHandler(logsvc.NewWithOptions(logSources, logOptions), evidenceHandler)
 	provenanceHandler := enterpriseroute.HistoricalProvenanceHandler()
-	historicalProvenanceEnabled := provenanceHandler != nil && coreConfig.ProjectionEnabled
+	if coreConfig.HistoricalProvenanceEnabled && provenanceHandler == nil {
+		return nil, errors.New("historical provenance projection requires a registered enterprise handler")
+	}
+	historicalProvenanceEnabled := coreConfig.HistoricalProvenanceEnabled
 	sessionOptions := sessionsvc.Options{
 		EnableHistoricalProvenance: historicalProvenanceEnabled,
 		Capacity: sessionsvc.CapacityLimits{

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const minimumProjectionGrantTTL = 24*time.Hour + 5*time.Minute
+
 type CoreConfig struct {
 	Store                         string
 	MariaDBDSN                    string
@@ -77,11 +79,11 @@ func NewCoreConfig() (CoreConfig, error) {
 	projectionGrantIssuer := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ISSUER"))
 	projectionGrantKeyID := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_KEY_ID"))
 	projectionGrantAudience := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE"))
-	projectionGrantTTL := 5 * time.Minute
+	projectionGrantTTL := minimumProjectionGrantTTL
 	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_TTL")); configured != "" {
 		parsed, err := time.ParseDuration(configured)
-		if err != nil || parsed <= 0 {
-			return CoreConfig{}, fmt.Errorf("BKN_TRACE_PROJECTION_GRANT_TTL must be a positive duration")
+		if err != nil || parsed < minimumProjectionGrantTTL {
+			return CoreConfig{}, fmt.Errorf("BKN_TRACE_PROJECTION_GRANT_TTL must be at least %s", minimumProjectionGrantTTL)
 		}
 		projectionGrantTTL = parsed
 	}

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -24,6 +24,7 @@ type CoreConfig struct {
 	AbandonInterval               time.Duration
 	OneShotIdleTTL                time.Duration
 	ProjectionEnabled             bool
+	HistoricalProvenanceEnabled   bool
 	ProjectionIndex               string
 	ProjectionInterval            time.Duration
 	ProjectionBootstrapVersion    string
@@ -65,6 +66,13 @@ func NewCoreConfig() (CoreConfig, error) {
 		autoMigrate = parsed
 	}
 	projectionEnabled, _ := strconv.ParseBool(strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_ENABLED")))
+	historicalProvenanceEnabled, err := optionalBoolEnv("BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED")
+	if err != nil {
+		return CoreConfig{}, err
+	}
+	if historicalProvenanceEnabled && !projectionEnabled {
+		return CoreConfig{}, fmt.Errorf("BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED requires BKN_TRACE_PROJECTION_ENABLED")
+	}
 	projectionInterval := time.Second
 	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_INTERVAL")); configured != "" {
 		if parsed, err := time.ParseDuration(configured); err == nil && parsed > 0 {
@@ -119,7 +127,7 @@ func NewCoreConfig() (CoreConfig, error) {
 	return CoreConfig{
 		Store: store, MariaDBDSN: strings.TrimSpace(os.Getenv("BKN_TRACE_CORE_MARIADB_DSN")),
 		AutoMigrate: autoMigrate, AbandonInterval: interval, OneShotIdleTTL: oneShotIdleTTL,
-		ProjectionEnabled: projectionEnabled, ProjectionIndex: projectionIndex,
+		ProjectionEnabled: projectionEnabled, HistoricalProvenanceEnabled: historicalProvenanceEnabled, ProjectionIndex: projectionIndex,
 		ProjectionInterval:            projectionInterval,
 		ProjectionBootstrapVersion:    projectionBootstrapVersion,
 		ProjectionRebuildVersion:      projectionRebuildVersion,
@@ -133,6 +141,18 @@ func NewCoreConfig() (CoreConfig, error) {
 		MaxClaimsPerInteraction:       maxClaimsPerInteraction,
 		MaxEvidenceRefsPerInteraction: maxEvidenceRefsPerInteraction,
 	}, nil
+}
+
+func optionalBoolEnv(name string) (bool, error) {
+	configured := strings.TrimSpace(os.Getenv(name))
+	if configured == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(configured)
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", name, err)
+	}
+	return parsed, nil
 }
 
 func projectionGrantPrivateKeyFromEnv() (ed25519.PrivateKey, error) {

--- a/bkn-trace/agent-observability/src/conf/core.go
+++ b/bkn-trace/agent-observability/src/conf/core.go
@@ -6,6 +6,8 @@
 package conf
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"strconv"
@@ -24,6 +26,11 @@ type CoreConfig struct {
 	ProjectionInterval            time.Duration
 	ProjectionBootstrapVersion    string
 	ProjectionRebuildVersion      string
+	ProjectionGrantIssuer         string
+	ProjectionGrantKeyID          string
+	ProjectionGrantAudience       string
+	ProjectionGrantPrivateKey     ed25519.PrivateKey
+	ProjectionGrantTTL            time.Duration
 	EvidenceCollectionState       string
 	MaxOperationsPerInteraction   int
 	MaxClaimsPerInteraction       int
@@ -67,6 +74,24 @@ func NewCoreConfig() (CoreConfig, error) {
 		projectionIndex = "bkn-trace-core"
 	}
 	projectionRebuildVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_REBUILD_VERSION"))
+	projectionGrantIssuer := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ISSUER"))
+	projectionGrantKeyID := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_KEY_ID"))
+	projectionGrantAudience := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE"))
+	projectionGrantTTL := 5 * time.Minute
+	if configured := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_TTL")); configured != "" {
+		parsed, err := time.ParseDuration(configured)
+		if err != nil || parsed <= 0 {
+			return CoreConfig{}, fmt.Errorf("BKN_TRACE_PROJECTION_GRANT_TTL must be a positive duration")
+		}
+		projectionGrantTTL = parsed
+	}
+	projectionGrantPrivateKey, err := projectionGrantPrivateKeyFromEnv()
+	if err != nil {
+		return CoreConfig{}, err
+	}
+	if len(projectionGrantPrivateKey) > 0 && (projectionGrantIssuer == "" || projectionGrantKeyID == "" || projectionGrantAudience == "") {
+		return CoreConfig{}, fmt.Errorf("projection grant issuer, key ID, and audience are required when a private key is configured")
+	}
 	projectionBootstrapVersion := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_BOOTSTRAP_VERSION"))
 	if projectionBootstrapVersion == "" {
 		projectionBootstrapVersion = projectionIndex + "-v015-r1"
@@ -96,11 +121,31 @@ func NewCoreConfig() (CoreConfig, error) {
 		ProjectionInterval:            projectionInterval,
 		ProjectionBootstrapVersion:    projectionBootstrapVersion,
 		ProjectionRebuildVersion:      projectionRebuildVersion,
+		ProjectionGrantIssuer:         projectionGrantIssuer,
+		ProjectionGrantKeyID:          projectionGrantKeyID,
+		ProjectionGrantAudience:       projectionGrantAudience,
+		ProjectionGrantPrivateKey:     projectionGrantPrivateKey,
+		ProjectionGrantTTL:            projectionGrantTTL,
 		EvidenceCollectionState:       strings.TrimSpace(os.Getenv("BKN_TRACE_EVIDENCE_COLLECTION_STATE")),
 		MaxOperationsPerInteraction:   maxOperationsPerInteraction,
 		MaxClaimsPerInteraction:       maxClaimsPerInteraction,
 		MaxEvidenceRefsPerInteraction: maxEvidenceRefsPerInteraction,
 	}, nil
+}
+
+func projectionGrantPrivateKeyFromEnv() (ed25519.PrivateKey, error) {
+	configured := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY"))
+	if configured == "" {
+		return nil, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(configured)
+	if err != nil {
+		return nil, fmt.Errorf("decode BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY: %w", err)
+	}
+	if len(decoded) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY must be an Ed25519 private key")
+	}
+	return ed25519.PrivateKey(decoded), nil
 }
 
 func positiveIntEnv(name string, fallback int) (int, error) {

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -10,6 +10,14 @@ import (
 	"time"
 )
 
+func TestCoreConfigRejectsMalformedProjectionGrantPrivateKey(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY", "not-base64")
+
+	if _, err := NewCoreConfig(); err == nil {
+		t.Fatal("malformed projection grant private key must be rejected")
+	}
+}
+
 func TestCoreConfigRequiresExplicitMariaDBDSN(t *testing.T) {
 	t.Setenv("BKN_TRACE_CORE_STORE", "mariadb")
 	t.Setenv("BKN_TRACE_CORE_MARIADB_DSN", "trace:secret@tcp(mariadb:3306)/trace?parseTime=true")

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -20,6 +20,23 @@ func TestCoreConfigRejectsMalformedProjectionGrantPrivateKey(t *testing.T) {
 	}
 }
 
+func TestCoreConfigRejectsInvalidHistoricalProvenanceEnablement(t *testing.T) {
+	t.Setenv("BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED", "sometimes")
+
+	if _, err := NewCoreConfig(); err == nil {
+		t.Fatal("invalid historical provenance enablement must be rejected")
+	}
+}
+
+func TestCoreConfigRequiresProjectionForHistoricalProvenance(t *testing.T) {
+	t.Setenv("BKN_TRACE_HISTORICAL_PROVENANCE_ENABLED", "true")
+	t.Setenv("BKN_TRACE_PROJECTION_ENABLED", "false")
+
+	if _, err := NewCoreConfig(); err == nil {
+		t.Fatal("historical provenance must require Core projection")
+	}
+}
+
 func TestCoreConfigRejectsProjectionGrantTTLShorterThanAutomaticRetryWindow(t *testing.T) {
 	t.Setenv("BKN_TRACE_PROJECTION_GRANT_TTL", "1m")
 

--- a/bkn-trace/agent-observability/src/conf/core_test.go
+++ b/bkn-trace/agent-observability/src/conf/core_test.go
@@ -6,6 +6,8 @@
 package conf
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"testing"
 	"time"
 )
@@ -16,6 +18,46 @@ func TestCoreConfigRejectsMalformedProjectionGrantPrivateKey(t *testing.T) {
 	if _, err := NewCoreConfig(); err == nil {
 		t.Fatal("malformed projection grant private key must be rejected")
 	}
+}
+
+func TestCoreConfigRejectsProjectionGrantTTLShorterThanAutomaticRetryWindow(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_TTL", "1m")
+
+	if _, err := NewCoreConfig(); err == nil {
+		t.Fatal("projection grant TTL shorter than the automatic retry window must be rejected")
+	}
+}
+
+func TestCoreConfigRejectsProjectionGrantPrivateKeyWithoutGrantIdentity(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY", validProjectionGrantPrivateKey())
+
+	if _, err := NewCoreConfig(); err == nil {
+		t.Fatal("projection grant private key without issuer, key ID, and audience must be rejected")
+	}
+}
+
+func TestCoreConfigParsesProjectionGrantTTLAndIdentity(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PRIVATE_KEY", validProjectionGrantPrivateKey())
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", "trace-core")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_KEY_ID", "trace-key-2026-09")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", "bkn-projection-read")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_TTL", "24h5m")
+
+	config, err := NewCoreConfig()
+	if err != nil {
+		t.Fatalf("new core config: %v", err)
+	}
+	if config.ProjectionGrantTTL != 24*time.Hour+5*time.Minute ||
+		config.ProjectionGrantIssuer != "trace-core" ||
+		config.ProjectionGrantKeyID != "trace-key-2026-09" ||
+		config.ProjectionGrantAudience != "bkn-projection-read" {
+		t.Fatalf("unexpected projection grant config: %#v", config)
+	}
+}
+
+func validProjectionGrantPrivateKey() string {
+	privateKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	return base64.StdEncoding.EncodeToString(privateKey)
 }
 
 func TestCoreConfigRequiresExplicitMariaDBDSN(t *testing.T) {

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -29,8 +29,11 @@ import (
 var ErrInvalidOwner = errors.New("trusted conversation owner is incomplete")
 
 const (
-	defaultAssemblyTimeout    = 5 * time.Minute
-	defaultProjectionGrantTTL = 5 * time.Minute
+	defaultAssemblyTimeout = 5 * time.Minute
+	// The grant travels in an at-least-once outbox payload. It must remain
+	// usable throughout the worker's 24-hour automatic retry window, plus a
+	// small delivery margin. DLQ replay is deliberately not a grant renewal path.
+	defaultProjectionGrantTTL = 24*time.Hour + 5*time.Minute
 )
 
 type CapacityLimits struct {

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"time"
@@ -22,11 +23,15 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/sessionvo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
 )
 
 var ErrInvalidOwner = errors.New("trusted conversation owner is incomplete")
 
-const defaultAssemblyTimeout = 5 * time.Minute
+const (
+	defaultAssemblyTimeout    = 5 * time.Minute
+	defaultProjectionGrantTTL = 5 * time.Minute
+)
 
 type CapacityLimits struct {
 	MaxOperationsPerInteraction   int
@@ -45,6 +50,11 @@ type Options struct {
 	NewID                      func(prefix string) string
 	EvidenceCollectionState    func() string
 	EnableHistoricalProvenance bool
+	ProjectionGrantIssuer      string
+	ProjectionGrantKeyID       string
+	ProjectionGrantAudience    string
+	ProjectionGrantTTL         time.Duration
+	ProjectionGrantSigner      func(projectiongrant.Claims) (string, error)
 	AssemblyTimeout            time.Duration
 	Capacity                   CapacityLimits
 	Metrics                    icoremetrics.Recorder
@@ -56,6 +66,11 @@ type Service struct {
 	newID                      func(string) string
 	evidenceCollectionState    func() string
 	enableHistoricalProvenance bool
+	projectionGrantIssuer      string
+	projectionGrantKeyID       string
+	projectionGrantAudience    string
+	projectionGrantTTL         time.Duration
+	projectionGrantSigner      func(projectiongrant.Claims) (string, error)
 	assemblyTimeout            time.Duration
 	capacity                   CapacityLimits
 	metrics                    icoremetrics.Recorder
@@ -82,6 +97,10 @@ func New(store isessionstore.Store, options Options) *Service {
 	if assemblyTimeout <= 0 {
 		assemblyTimeout = defaultAssemblyTimeout
 	}
+	projectionGrantTTL := options.ProjectionGrantTTL
+	if projectionGrantTTL <= 0 {
+		projectionGrantTTL = defaultProjectionGrantTTL
+	}
 	capacity := options.Capacity
 	if capacity.MaxOperationsPerInteraction <= 0 {
 		capacity.MaxOperationsPerInteraction = defaultCapacityLimits.MaxOperationsPerInteraction
@@ -96,6 +115,11 @@ func New(store isessionstore.Store, options Options) *Service {
 		store: store, now: now, newID: newID,
 		evidenceCollectionState:    evidenceCollectionState,
 		enableHistoricalProvenance: options.EnableHistoricalProvenance,
+		projectionGrantIssuer:      strings.TrimSpace(options.ProjectionGrantIssuer),
+		projectionGrantKeyID:       strings.TrimSpace(options.ProjectionGrantKeyID),
+		projectionGrantAudience:    strings.TrimSpace(options.ProjectionGrantAudience),
+		projectionGrantTTL:         projectionGrantTTL,
+		projectionGrantSigner:      options.ProjectionGrantSigner,
 		assemblyTimeout:            assemblyTimeout,
 		capacity:                   capacity,
 		metrics:                    metrics,
@@ -1923,18 +1947,42 @@ func (s *Service) appendHistoricalProvenanceBuildRequest(
 	tx isessionstore.Transaction,
 	interaction sessionvo.Interaction,
 ) error {
+	if s.projectionGrantSigner == nil || s.projectionGrantIssuer == "" || s.projectionGrantKeyID == "" || s.projectionGrantAudience == "" {
+		return errors.New("historical provenance projection grant signer is not configured")
+	}
 	request, err := sessionvo.NewHistoricalProvenanceBuildRequest(
 		interaction.ID, tx.ListOperationCallFacts(interaction.ID),
 	)
 	if err != nil {
 		return err
 	}
+	eventID := s.newID("evt")
+	issuedAt := tx.Now().UTC()
+	grant, err := s.projectionGrantSigner(projectiongrant.Claims{
+		Version:             1,
+		Issuer:              s.projectionGrantIssuer,
+		KeyID:               s.projectionGrantKeyID,
+		Audience:            s.projectionGrantAudience,
+		EventID:             eventID,
+		InteractionID:       request.InteractionID,
+		FactsHash:           request.FactsHash,
+		KnowledgeNetworkIDs: request.KnowledgeNetworkIDs,
+		IssuedAt:            issuedAt,
+		ExpiresAt:           issuedAt.Add(s.projectionGrantTTL),
+	})
+	if err != nil {
+		return fmt.Errorf("sign historical provenance projection grant: %w", err)
+	}
+	if strings.TrimSpace(grant) == "" {
+		return errors.New("historical provenance projection grant signer returned an empty grant")
+	}
+	request.ProjectionReadGrant = grant
 	payload, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
 	tx.AppendProjection(sessionvo.ProjectionMutation{
-		EventID:          s.newID("evt"),
+		EventID:          eventID,
 		AggregateType:    "interaction",
 		AggregateID:      interaction.ID,
 		AggregateVersion: interaction.RowVersion,

--- a/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/sessionsvc/service_test.go
@@ -8,6 +8,7 @@ package sessionsvc_test
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -22,6 +23,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/icoremetrics"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionoutbox"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/isessionstore"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
 )
 
 const (
@@ -601,6 +603,7 @@ func TestTerminalInteractionEnqueuesImmutableHistoricalProvenanceBuildRequest(t 
 		t.Fatalf("lease outbox: %v", err)
 	}
 	var request sessionvo.HistoricalProvenanceBuildRequest
+	var eventID string
 	found := false
 	for _, item := range items {
 		if item.EventType != sessionvo.HistoricalProvenanceBuildRequestedEventType {
@@ -609,6 +612,7 @@ func TestTerminalInteractionEnqueuesImmutableHistoricalProvenanceBuildRequest(t 
 		if err := json.Unmarshal(item.Payload, &request); err != nil {
 			t.Fatalf("decode provenance request: %v", err)
 		}
+		eventID = item.EventID
 		found = true
 	}
 	if !found {
@@ -620,8 +624,48 @@ func TestTerminalInteractionEnqueuesImmutableHistoricalProvenanceBuildRequest(t 
 	if request.FactsHash == "" || len(request.Facts) != 1 || request.Facts[0].OperationID != operation.ID {
 		t.Fatalf("request does not contain sealed facts: %#v", request)
 	}
+	claims, err := projectiongrant.Verify(request.ProjectionReadGrant, map[string]ed25519.PublicKey{
+		"test-key": testHistoricalProvenanceGrantPrivateKey().Public().(ed25519.PublicKey),
+	}, projectiongrant.VerifyOptions{
+		Now: time.Now(), ExpectedIssuer: "trace-core", ExpectedAudience: "bkn-projection-read",
+	})
+	if err != nil {
+		t.Fatalf("verify projection read grant: %v", err)
+	}
+	if claims.EventID != eventID || claims.InteractionID != completed.ID || claims.FactsHash != request.FactsHash {
+		t.Fatalf("grant does not bind the terminal event facts: %#v", claims)
+	}
 	if bytes.Contains(itemPayloadForEvent(items, sessionvo.HistoricalProvenanceBuildRequestedEventType), []byte("Bearer")) {
 		t.Fatal("historical provenance request must not serialize a user bearer token")
+	}
+}
+
+func TestTerminalInteractionFailsClosedWithoutHistoricalProvenanceGrantSigner(t *testing.T) {
+	t.Parallel()
+
+	store := sessionstore.New()
+	service := sessionsvc.New(store, sessionsvc.Options{EnableHistoricalProvenance: true})
+	_, _, owner, _, interaction, operation, receipt := mustCreateOperationForService(t, store, service)
+	if _, _, err := service.CompleteOperationAttempt(context.Background(), sessionsvc.FinishAttemptCommand{
+		Owner: owner, OperationID: operation.ID, Attempt: operation.Attempt, ReceiptID: receipt.ID,
+		Output: operationOutput("ok"), EvidenceDurability: sessionvo.DurabilityDurable,
+		RequestID: "req-provenance-without-grant", TraceID: validTraceIDOne,
+	}); err != nil {
+		t.Fatalf("complete operation: %v", err)
+	}
+	if _, err := service.TerminateInteraction(context.Background(), sessionsvc.TerminateInteractionCommand{
+		Owner: owner, InteractionID: interaction.ID, Status: sessionvo.InteractionCompleted,
+		TerminalIdempotencyKey: "terminal-provenance-without-grant", LeaseToken: interaction.LeaseToken, LeaseEpoch: interaction.LeaseEpoch,
+		Manifest: sessionvo.ClosureManifest{Version: "1", CompletionReason: "answer_returned", ExpectedOperations: []sessionvo.ExpectedOperation{{OperationID: operation.ID, Required: true}}, ExpectedReceipts: []sessionvo.ExpectedReceipt{{ReceiptID: receipt.ID, Required: true}}},
+	}); err == nil {
+		t.Fatal("terminal interaction must fail closed when historical provenance has no projection grant signer")
+	}
+	items, err := store.Lease(context.Background(), 20, time.Minute)
+	if err != nil {
+		t.Fatalf("lease outbox: %v", err)
+	}
+	if payload := itemPayloadForEvent(items, sessionvo.HistoricalProvenanceBuildRequestedEventType); payload != nil {
+		t.Fatalf("unsigned historical provenance event must not be enqueued: %s", payload)
 	}
 }
 
@@ -2439,8 +2483,20 @@ func mustCreateOperationWithStore(t *testing.T) (*sessionstore.Store, *sessionsv
 func mustCreateOperationWithHistoricalProvenance(t *testing.T) (*sessionstore.Store, *sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {
 	t.Helper()
 	store := sessionstore.New()
-	service := sessionsvc.New(store, sessionsvc.Options{EnableHistoricalProvenance: true})
+	service := sessionsvc.New(store, sessionsvc.Options{
+		EnableHistoricalProvenance: true,
+		ProjectionGrantIssuer:      "trace-core",
+		ProjectionGrantKeyID:       "test-key",
+		ProjectionGrantAudience:    "bkn-projection-read",
+		ProjectionGrantSigner: func(claims projectiongrant.Claims) (string, error) {
+			return projectiongrant.Sign(claims, testHistoricalProvenanceGrantPrivateKey())
+		},
+	})
 	return mustCreateOperationForService(t, store, service)
+}
+
+func testHistoricalProvenanceGrantPrivateKey() ed25519.PrivateKey {
+	return ed25519.NewKeyFromSeed(bytes.Repeat([]byte{1}, ed25519.SeedSize))
 }
 
 func mustCreateOperationForService(t *testing.T, store *sessionstore.Store, service *sessionsvc.Service) (*sessionstore.Store, *sessionsvc.Service, sessionvo.Owner, sessionvo.Conversation, sessionvo.Interaction, sessionvo.Operation, sessionvo.Receipt) {

--- a/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
+++ b/bkn-trace/agent-observability/src/domain/valueobject/sessionvo/historical_provenance.go
@@ -24,6 +24,7 @@ type HistoricalProvenanceBuildRequest struct {
 	FactsHash           string              `json:"facts_hash"`
 	KnowledgeNetworkIDs []string            `json:"knowledge_network_ids"`
 	Facts               []OperationCallFact `json:"facts"`
+	ProjectionReadGrant string              `json:"projection_read_grant"`
 }
 
 func NewHistoricalProvenanceBuildRequest(


### PR DESCRIPTION
## What Changed

- Seal each historical-provenance build event with an Ed25519 projection-read grant bound to the outbox event, terminal interaction, facts hash, and explicit `kn_id` list.
- Fail closed before outbox append if signing configuration is absent or invalid.
- Load signer settings from Core configuration only when the enterprise provenance handler is active.

## Why

Part of #31. This implements the Core half of the signed, narrow capability needed for historical BKN Trace projection without tenant, business-domain, user identity, or bearer-token propagation.

## Testing

- `GOCACHE=/tmp/go-build make test`

## Risk & Rollback

- Risk: enabling the enterprise provenance handler without a configured signing key now fails safely instead of emitting an unsigned event.
- Rollback: revert commit `914498b6c`; no schema, data, or deployment operation is included.

## Follow-up

- The BKN-side grant-verification endpoint and EE projection consumer remain separate #31 work items; this PR deliberately does not close the issue.