### PR TITLE
fix(vega): normalize JSON payloads before batch indexing

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -79,6 +79,58 @@ func extractKeyValues(fields []string, document map[string]any) ([]interfaces.Ke
 	return values, nil
 }
 
+// normalizeJSONDocumentFields 将数据库 JSON 值转换为托管 OpenSearch 索引 mapping 所需的对象形态。
+func normalizeJSONDocumentFields(document map[string]any, properties []*interfaces.Property) error {
+	for _, property := range properties {
+		if property == nil || property.Type != interfaces.DataType_Json {
+			continue
+		}
+		value, exists := document[property.Name]
+		if !exists || value == nil {
+			continue
+		}
+
+		object, err := normalizeJSONObject(value)
+		if err != nil {
+			return fmt.Errorf("JSON field %q: %w", property.Name, err)
+		}
+		document[property.Name] = object
+	}
+	return nil
+}
+
+func normalizeJSONObject(value any) (map[string]any, error) {
+	if object, ok := value.(map[string]any); ok {
+		return object, nil
+	}
+
+	var text string
+	switch typed := value.(type) {
+	case string:
+		text = typed
+	case []byte:
+		text = string(typed)
+	default:
+		return nil, fmt.Errorf("expected object, JSON text, or null; got %T", value)
+	}
+	if strings.TrimSpace(text) == "" {
+		return nil, nil
+	}
+
+	var parsed any
+	if err := sonic.Unmarshal([]byte(text), &parsed); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	if parsed == nil {
+		return nil, nil
+	}
+	object, ok := parsed.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected JSON object or null; got %T", parsed)
+	}
+	return object, nil
+}
+
 // updateResourceIndexName updates the index name of a resource
 func updateResourceIndexName(ctx context.Context, resource *interfaces.Resource, rs interfaces.ResourceService, indexName string) error {
 	if resource.LocalIndexName == indexName {

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -105,6 +105,55 @@ func TestGenerateDocumentID(t *testing.T) {
 	require.ErrorContains(t, err, `build key field "id" is missing`)
 }
 
+func TestNormalizeJSONDocumentFields(t *testing.T) {
+	schema := []*interfaces.Property{
+		{Name: "payload", Type: interfaces.DataType_Json},
+		{Name: "name", Type: interfaces.DataType_String},
+	}
+
+	t.Run("normalizes objects JSON text bytes null and empty values", func(t *testing.T) {
+		document := map[string]any{
+			"object":  map[string]any{"region": "cn"},
+			"payload": `{"region":"cn"}`,
+			"name":    "unchanged",
+		}
+		schemaWithValues := append([]*interfaces.Property{}, schema...)
+		schemaWithValues = append(schemaWithValues,
+			&interfaces.Property{Name: "object", Type: interfaces.DataType_Json},
+			&interfaces.Property{Name: "bytes", Type: interfaces.DataType_Json},
+			&interfaces.Property{Name: "null_value", Type: interfaces.DataType_Json},
+			&interfaces.Property{Name: "empty_value", Type: interfaces.DataType_Json},
+		)
+		document["bytes"] = []byte(`{"tier":2}`)
+		document["null_value"] = "null"
+		document["empty_value"] = "  "
+
+		require.NoError(t, normalizeJSONDocumentFields(document, schemaWithValues))
+		assert.Equal(t, map[string]any{"region": "cn"}, document["object"])
+		assert.Equal(t, map[string]any{"region": "cn"}, document["payload"])
+		assert.Equal(t, map[string]any{"tier": float64(2)}, document["bytes"])
+		assert.Nil(t, document["null_value"])
+		assert.Nil(t, document["empty_value"])
+		assert.Equal(t, "unchanged", document["name"])
+	})
+
+	for name, value := range map[string]any{
+		"invalid JSON":        `{`,
+		"JSON scalar":         `"value"`,
+		"JSON array":          `[]`,
+		"unexpected Go value": 42,
+	} {
+		t.Run(name, func(t *testing.T) {
+			document := map[string]any{"payload": value}
+
+			err := normalizeJSONDocumentFields(document, schema)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, `JSON field "payload"`)
+		})
+	}
+}
+
 func TestPrepareFullBuildIndex(t *testing.T) {
 	t.Run("empty mark rebuild deletes existing task index", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -421,6 +421,9 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 				if err != nil {
 					return err
 				}
+				if err := normalizeJSONDocumentFields(doc, resource.SchemaDefinition); err != nil {
+					return fmt.Errorf("normalize document for local index: %w", err)
+				}
 				docID, err := generateDocumentID(keyValues)
 				if err != nil {
 					return err

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -155,6 +155,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		cf := vmock.NewMockConnectorFactory(ctrl)
 		connector := vmock.NewMockTableConnector(ctrl)
 		resource := workerTestResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{Name: "payload", Type: interfaces.DataType_Json})
 		resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
 		resource.LocalIndexName = "current-index"
 		resource.SyncMark = `{"mode":"batch","cursor":[]}`
@@ -177,13 +178,20 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
 				assert.Nil(t, params.FilterCondCfg)
-				return &interfaces.QueryResult{Total: 1, Entries: []map[string]any{{"id": int64(1)}}}, nil
+				return &interfaces.QueryResult{Total: 1, Entries: []map[string]any{{
+					"id":      int64(1),
+					"payload": []byte(`{"region":"cn"}`),
+				}}}, nil
 			})
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
 		indexed := false
 		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).DoAndReturn(
-			func(context.Context, string, map[string]map[string]any) ([]string, error) {
+			func(_ context.Context, _ string, documents map[string]map[string]any) ([]string, error) {
+				require.Len(t, documents, 1)
+				for _, document := range documents {
+					assert.Equal(t, map[string]any{"region": "cn"}, document["payload"])
+				}
 				indexed = true
 				return nil, nil
 			})

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -180,7 +180,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 				assert.Nil(t, params.FilterCondCfg)
 				return &interfaces.QueryResult{Total: 1, Entries: []map[string]any{{
 					"id":      int64(1),
-					"payload": []byte(`{"region":"cn"}`),
+					"payload": `{"region":"cn"}`,
 				}}}, nil
 			})
 		connector.EXPECT().Close(gomock.Any()).Return(nil)


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Vega batch-build JSON payload normalization
- [x] Focused regression tests
- [x] Docs: N/A (no public API or user-facing behavior contract changed)

---

## Why

- Related Issue: Closes #1183
- Related Feature: N/A
- Background: MariaDB JSON values are read as bytes and serialized as JSON strings, while the managed OpenSearch mapping requires an object.

---

## How

- Key implementation points: Normalize schema-declared JSON fields before batch indexing. Accept native objects, JSON text, and byte payloads; map empty values and JSON null to null; reject malformed or non-object JSON before the OpenSearch bulk request.
- Breaking changes (API, config, database, etc.): None. Existing invalid JSON values now fail with a field-level build error instead of an OpenSearch mapper error.

---

## Testing

- [x] Unit tests passed locally (`make test`)
- [ ] Integration tests passed locally (not applicable; change is fully mocked/unit-tested)
- [ ] Verified in test environment (not run; requires deployed Vega and source data)

Test notes:

- `make ci` passed: lint, unit tests, coverage artifacts (35.9%).
- Regression coverage includes native object, JSON string, byte value, null, empty input, malformed JSON, scalar JSON, array JSON, and a batch-worker handoff assertion.

---

## Risk & Rollback

- Potential risks: Previously tolerated malformed or non-object JSON now fails the affected batch task before index writes.
- Rollback plan: Revert commit `a087a8b70`.

---

## Additional Notes

- The change is limited to batch-build document preparation; no schema migration, production data modification, or API change.