### PR TITLE
fix(execution-factory): disable business domain integration

### DIFF
--- a/adp/execution-factory/operator-integration/Makefile
+++ b/adp/execution-factory/operator-integration/Makefile
@@ -11,7 +11,7 @@ DEV_CONFIG_PROFILE ?= $(shell d="$(CURDIR)"; \
 	done; \
 	printf "%s/.env/execution-factory" "$(CURDIR)")
 AUTH_ENABLED ?= true
-BUSINESS_DOMAIN_ENABLED ?= true
+BUSINESS_DOMAIN_ENABLED ?= false
 
 help:
 	@echo "operator-integration - available commands:"

--- a/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
+++ b/adp/execution-factory/operator-integration/helm/agent-operator-integration/values.yaml
@@ -103,7 +103,7 @@ auth:
 
 # Business domain switch.
 businessDomain:
-  enabled: true
+  enabled: false
 
 depServices:
   class-443:

--- a/adp/execution-factory/operator-integration/project.sh
+++ b/adp/execution-factory/operator-integration/project.sh
@@ -57,7 +57,7 @@ do
         echo "$BUSINESS_DOMAIN_ENABLED"
 
         export AUTH_ENABLED=true
-        export BUSINESS_DOMAIN_ENABLED=true
+        export BUSINESS_DOMAIN_ENABLED=false
 
         go run ./server/main.go;;
     "h")


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Feature/module 1: operator-integration
- [ ] Feature/module 2
- [ ] Docs/doc 1

将 `operator-integration` 中的 `BUSINESS_DOMAIN_ENABLED` 默认值及 Helm 配置改为 `false`：

- Makefile 默认值改为 `false`
- 本地启动脚本设置为 `false`
- Helm `businessDomain.enabled` 改为 `false`

---

## Why

- Related Issue: N/A
- Background:

Supply sample hotfix 不需要启用 Business Domain 集成，避免启动和运行时依赖相关能力。

---

## How

- Key implementation points:
  - 更新 `Makefile`
  - 更新 `project.sh`
  - 更新 Helm `values.yaml`
- Breaking changes:
  - 关闭 `operator-integration` 的 Business Domain 集成开关。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

本次仅修改配置开关，尚未运行完整测试。

---

## Risk & Rollback

- Potential risks:
  - 依赖 Business Domain 能力的功能将不可用。
- Rollback plan:
  - 将上述配置恢复为 `true`，或回滚提交 `4014813b8`。

---

## Additional Notes

- Base version: `v0.1.4-hotfix-supply-sample-p1`
- Commit: `4014813b8`