### PR TITLE
fix(vega): split oversized OpenSearch bulk requests

### DIFF
--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -10,17 +10,32 @@ package opensearch
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/bytedance/sonic"
 	"github.com/mitchellh/mapstructure"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/opensearch-project/opensearch-go/v2/opensearchapi"
 
 	"vega-backend/interfaces"
 )
+
+const (
+	defaultBulkRequestMaxBytes = 32 * 1024 * 1024
+)
+
+type bulkRequestError struct {
+	statusCode int
+	detail     string
+}
+
+func (e *bulkRequestError) Error() string {
+	return fmt.Sprintf("OpenSearch bulk request returned HTTP %d: %s", e.statusCode, e.detail)
+}
 
 type opensearchConfig struct {
 	Host          string   `mapstructure:"host"`
@@ -35,6 +50,8 @@ type OpenSearchConnector struct {
 	enabled bool
 	Config  *opensearchConfig
 	client  *opensearch.Client
+
+	bulkRequestMaxBytes int
 }
 
 // ValidateAnalyzer verifies that a configured analyzer is available in the connected OpenSearch cluster.
@@ -353,29 +370,155 @@ func (c *OpenSearchConnector) CreateDocuments(ctx context.Context, indexName str
 		return nil, err
 	}
 
-	var bulkBody strings.Builder
-	for _, doc := range documents {
-		opMeta := map[string]map[string]string{
-			"index": {
-				"_index": indexName,
-			},
+	encodedDocuments := make([][]byte, 0, len(documents))
+	for _, document := range documents {
+		encoded, err := encodeBulkDocument(indexName, document, c.bulkMaxBytes())
+		if err != nil {
+			return nil, err
 		}
-		// if _id in doc, use it as document id
-		if docID, ok := doc["_id"].(string); ok {
-			opMeta["index"]["_id"] = docID
-			delete(doc, "_id")
-		}
+		encodedDocuments = append(encodedDocuments, encoded)
+	}
+	return c.indexBulkDocuments(ctx, encodedDocuments)
+}
 
-		if err := sonic.ConfigDefault.NewEncoder(&bulkBody).Encode(opMeta); err != nil {
+func (c *OpenSearchConnector) bulkMaxBytes() int {
+	if c.bulkRequestMaxBytes > 0 {
+		return c.bulkRequestMaxBytes
+	}
+	return defaultBulkRequestMaxBytes
+}
+
+func encodeBulkDocument(indexName string, document map[string]any, maxBytes int) ([]byte, error) {
+	if document == nil {
+		return nil, errors.New("bulk document is required")
+	}
+	opMeta := map[string]map[string]string{"index": {"_index": indexName}}
+	body := make(map[string]any, len(document))
+	for key, value := range document {
+		if key == "_id" {
+			if documentID, ok := value.(string); ok {
+				opMeta["index"]["_id"] = documentID
+				continue
+			}
+		}
+		body[key] = value
+	}
+	opBytes, err := sonic.Marshal(opMeta)
+	if err != nil {
+		return nil, fmt.Errorf("marshal bulk operation metadata: %w", err)
+	}
+	bodyBytes, err := sonic.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal bulk document: %w", err)
+	}
+	encoded := make([]byte, 0, len(opBytes)+len(bodyBytes)+2)
+	encoded = append(encoded, opBytes...)
+	encoded = append(encoded, '\n')
+	encoded = append(encoded, bodyBytes...)
+	encoded = append(encoded, '\n')
+	if len(encoded) > maxBytes {
+		return nil, fmt.Errorf("bulk document is %d bytes, exceeding the %d byte request limit", len(encoded), maxBytes)
+	}
+	return encoded, nil
+}
+
+func (c *OpenSearchConnector) indexBulkDocuments(ctx context.Context, documents [][]byte) ([]string, error) {
+	var documentIDs []string
+	maxBytes := c.bulkMaxBytes()
+	chunkDocuments := make([][]byte, 0)
+	chunkBytes := 0
+	for _, document := range documents {
+		if len(chunkDocuments) > 0 && chunkBytes+len(document) > maxBytes {
+			ids, err := c.indexBulkChunk(ctx, chunkDocuments)
+			if err != nil {
+				return nil, err
+			}
+			documentIDs = append(documentIDs, ids...)
+			chunkDocuments = chunkDocuments[:0]
+			chunkBytes = 0
+		}
+		chunkDocuments = append(chunkDocuments, document)
+		chunkBytes += len(document)
+	}
+	if len(chunkDocuments) > 0 {
+		ids, err := c.indexBulkChunk(ctx, chunkDocuments)
+		if err != nil {
 			return nil, err
 		}
-		if err := sonic.ConfigDefault.NewEncoder(&bulkBody).Encode(doc); err != nil {
-			return nil, err
-		}
+		documentIDs = append(documentIDs, ids...)
+	}
+	return documentIDs, nil
+}
+
+func (c *OpenSearchConnector) indexBulkChunk(ctx context.Context, documents [][]byte) ([]string, error) {
+	ids, err := c.sendBulkRequest(ctx, documents)
+	if err == nil {
+		return ids, nil
+	}
+	if !shouldSplitBulkRequest(err) || len(documents) == 1 {
+		return nil, err
 	}
 
+	splitAt := splitBulkDocumentsByBytes(documents)
+	leftDocuments := documents[:splitAt+1]
+	rightDocuments := documents[splitAt+1:]
+	logger.Warnf("OpenSearch bulk request rejected; splitting %d documents into %d and %d documents by serialized bytes: %v",
+		len(documents), len(leftDocuments), len(rightDocuments), err)
+	leftIDs, err := c.sendBulkRequest(ctx, leftDocuments)
+	if err != nil {
+		return nil, err
+	}
+	rightIDs, err := c.sendBulkRequest(ctx, rightDocuments)
+	if err != nil {
+		return nil, err
+	}
+	return append(leftIDs, rightIDs...), nil
+}
+
+// splitBulkDocumentsByBytes 返回左批最后一条文档的下标。
+// 该下标属于左批，右批从下一条文档开始；调用方必须传入至少两条文档。
+func splitBulkDocumentsByBytes(documents [][]byte) int {
+	totalBytes := 0
+	for _, document := range documents {
+		totalBytes += len(document)
+	}
+	targetBytes := totalBytes / 2
+	currentBytes := 0
+	for i, document := range documents {
+		if currentBytes+len(document) > targetBytes {
+			if i == len(documents)-1 {
+				return i - 1
+			}
+			return i
+		}
+		currentBytes += len(document)
+	}
+	return len(documents) - 1
+}
+
+func shouldSplitBulkRequest(err error) bool {
+	var requestErr *bulkRequestError
+	if !errors.As(err, &requestErr) {
+		return false
+	}
+	if requestErr.statusCode == http.StatusRequestEntityTooLarge {
+		return true
+	}
+	return requestErr.statusCode == http.StatusTooManyRequests &&
+		strings.Contains(strings.ToLower(requestErr.detail), "rejected_execution_exception")
+}
+
+func (c *OpenSearchConnector) sendBulkRequest(ctx context.Context, documents [][]byte) ([]string, error) {
+	size := 0
+	for _, document := range documents {
+		size += len(document)
+	}
+	body := make([]byte, 0, size)
+	for _, document := range documents {
+		body = append(body, document...)
+	}
 	req := opensearchapi.BulkRequest{
-		Body:    strings.NewReader(bulkBody.String()),
+		Body:    bytes.NewReader(body),
 		Refresh: "true",
 	}
 
@@ -386,43 +529,52 @@ func (c *OpenSearchConnector) CreateDocuments(ctx context.Context, indexName str
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.IsError() {
-		return nil, fmt.Errorf("failed to create documents: %s", resp.String())
+		return nil, &bulkRequestError{statusCode: resp.StatusCode, detail: resp.String()}
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
 	}
-	if errors, ok := result["errors"].(bool); ok && errors {
-		// Traverse all the operation results and check if there are any failures
-		if items, ok := result["items"].([]interface{}); ok {
-			for _, item := range items {
-				if itemMap, ok := item.(map[string]interface{}); ok {
-					if indexResult, ok := itemMap["index"].(map[string]interface{}); ok {
-						if errorObj, ok := indexResult["error"].(map[string]interface{}); ok {
-							// Find the failed document and return an error
-							return nil, fmt.Errorf("failed to create document, error type: %s, reason: %s", errorObj["type"].(string), errorObj["reason"].(string))
-						}
-					}
-				}
-			}
-		}
+	if hasErrors, ok := result["errors"].(bool); ok && hasErrors {
+		return nil, bulkResponseError(result)
 	}
-
-	var docIDs []string
-	if items, ok := result["items"].([]interface{}); ok {
+	var documentIDs []string
+	if items, ok := result["items"].([]any); ok {
 		for _, item := range items {
-			if itemMap, ok := item.(map[string]interface{}); ok {
-				if indexResult, ok := itemMap["index"].(map[string]interface{}); ok {
-					if docID, ok := indexResult["_id"].(string); ok {
-						docIDs = append(docIDs, docID)
+			if itemMap, ok := item.(map[string]any); ok {
+				if indexResult, ok := itemMap["index"].(map[string]any); ok {
+					if documentID, ok := indexResult["_id"].(string); ok {
+						documentIDs = append(documentIDs, documentID)
 					}
 				}
 			}
 		}
 	}
+	return documentIDs, nil
+}
 
-	return docIDs, nil
+func bulkResponseError(result map[string]any) error {
+	items, ok := result["items"].([]any)
+	if !ok {
+		return errors.New("bulk response contains failed operations")
+	}
+	for _, item := range items {
+		itemMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		indexResult, ok := itemMap["index"].(map[string]any)
+		if !ok {
+			continue
+		}
+		errorObject, ok := indexResult["error"].(map[string]any)
+		if !ok {
+			continue
+		}
+		return fmt.Errorf("failed to create document, error type: %v, reason: %v", errorObject["type"], errorObject["reason"])
+	}
+	return errors.New("bulk response contains failed operations")
 }
 
 // IndexDocuments replaces complete documents when their IDs already exist and

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -476,7 +476,8 @@ func (c *OpenSearchConnector) indexBulkChunk(ctx context.Context, documents [][]
 }
 
 // splitBulkDocumentsByBytes 返回左批最后一条文档的下标。
-// 该下标属于左批，右批从下一条文档开始；调用方必须传入至少两条文档。
+// 该下标属于左批，右批从下一条文档开始。优先选择字节数不超过总量一半的最大左批；
+// 首条文档本身超过一半时返回 0，以保证两批都非空。调用方必须传入至少两条文档。
 func splitBulkDocumentsByBytes(documents [][]byte) int {
 	totalBytes := 0
 	for _, document := range documents {
@@ -486,14 +487,14 @@ func splitBulkDocumentsByBytes(documents [][]byte) int {
 	currentBytes := 0
 	for i, document := range documents {
 		if currentBytes+len(document) > targetBytes {
-			if i == len(documents)-1 {
-				return i - 1
+			if i == 0 {
+				return 0
 			}
-			return i
+			return i - 1
 		}
 		currentBytes += len(document)
 	}
-	return len(documents) - 1
+	return len(documents) - 2
 }
 
 func shouldSplitBulkRequest(err error) bool {

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch.go
@@ -476,8 +476,9 @@ func (c *OpenSearchConnector) indexBulkChunk(ctx context.Context, documents [][]
 }
 
 // splitBulkDocumentsByBytes 返回左批最后一条文档的下标。
-// 该下标属于左批，右批从下一条文档开始。优先选择字节数不超过总量一半的最大左批；
-// 首条文档本身超过一半时返回 0，以保证两批都非空。调用方必须传入至少两条文档。
+// 该下标属于左批，右批从下一条文档开始。优先选择字节数最接近总量一半的切点；
+// 首条文档本身超过一半或最后一条文档导致右批为空时，选择能保证两批非空的切点。
+// 调用方必须传入至少两条文档。
 func splitBulkDocumentsByBytes(documents [][]byte) int {
 	totalBytes := 0
 	for _, document := range documents {
@@ -490,7 +491,15 @@ func splitBulkDocumentsByBytes(documents [][]byte) int {
 			if i == 0 {
 				return 0
 			}
-			return i - 1
+			if i == len(documents)-1 {
+				return i - 1
+			}
+			leftDistance := targetBytes - currentBytes
+			rightDistance := currentBytes + len(document) - targetBytes
+			if leftDistance <= rightDistance {
+				return i - 1
+			}
+			return i
 		}
 		currentBytes += len(document)
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
@@ -6,13 +6,173 @@ package opensearch
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/opensearch-project/opensearch-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"vega-backend/interfaces"
 )
+
+func TestCreateDocumentsSplitsBulkRequestsBySerializedSize(t *testing.T) {
+	var requestSizes []int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestSizes = append(requestSizes, len(body))
+		writeBulkSuccess(t, w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	document := map[string]any{"_id": "doc-1", "content": string(make([]byte, 128))}
+	encoded, err := encodeBulkDocument("index-1", document, defaultBulkRequestMaxBytes)
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{client: client, bulkRequestMaxBytes: len(encoded) + 1}
+
+	ids, err := connector.CreateDocuments(context.Background(), "index-1", []map[string]any{
+		document,
+		{"_id": "doc-2", "content": string(make([]byte, 128))},
+		{"_id": "doc-3", "content": string(make([]byte, 128))},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"doc-1", "doc-2", "doc-3"}, ids)
+	assert.Equal(t, []int{len(encoded), len(encoded), len(encoded)}, requestSizes)
+	assert.Equal(t, "doc-1", document["_id"], "bulk encoding must not mutate the caller's document")
+}
+
+func TestEncodeBulkDocumentRejectsSingleDocumentOverByteLimit(t *testing.T) {
+	document := map[string]any{"_id": "doc-1", "content": string(make([]byte, 128))}
+
+	_, err := encodeBulkDocument("index-1", document, 10)
+
+	require.ErrorContains(t, err, "exceeding the 10 byte request limit")
+}
+
+func TestSplitBulkDocumentsByBytes(t *testing.T) {
+	t.Run("keeps the first document when it already exceeds half", func(t *testing.T) {
+		assert.Equal(t, 0, splitBulkDocumentsByBytes([][]byte{
+			make([]byte, 14), make([]byte, 6), make([]byte, 6),
+		}))
+	})
+
+	t.Run("stops before the next document exceeds half", func(t *testing.T) {
+		assert.Equal(t, 1, splitBulkDocumentsByBytes([][]byte{
+			make([]byte, 4), make([]byte, 12), make([]byte, 12),
+		}))
+	})
+
+	t.Run("keeps the right chunk non-empty", func(t *testing.T) {
+		assert.Equal(t, 0, splitBulkDocumentsByBytes([][]byte{
+			make([]byte, 4), make([]byte, 12),
+		}))
+	})
+}
+
+func TestCreateDocumentsSplitsRejectedLargeRequests(t *testing.T) {
+	for _, statusCode := range []int{http.StatusRequestEntityTooLarge, http.StatusTooManyRequests} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			requestDocumentCounts := []int{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				count := len(splitBulkLines(t, body)) / 2
+				requestDocumentCounts = append(requestDocumentCounts, count)
+				if count > 3 {
+					w.WriteHeader(statusCode)
+					if statusCode == http.StatusTooManyRequests {
+						_, err = w.Write([]byte(`{"error":{"type":"rejected_execution_exception"}}`))
+					} else {
+						_, err = w.Write([]byte(`{"error":"request entity too large"}`))
+					}
+					require.NoError(t, err)
+					return
+				}
+				writeBulkSuccess(t, w, body)
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+			require.NoError(t, err)
+			connector := &OpenSearchConnector{client: client, bulkRequestMaxBytes: 1024 * 1024}
+
+			ids, err := connector.CreateDocuments(context.Background(), "index-1", []map[string]any{
+				{"_id": "doc-1", "content": "same"},
+				{"_id": "doc-2", "content": "same"},
+				{"_id": "doc-3", "content": "same"},
+				{"_id": "doc-4", "content": "same"},
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, []int{4, 3, 1}, requestDocumentCounts)
+			assert.ElementsMatch(t, []string{"doc-1", "doc-2", "doc-3", "doc-4"}, ids)
+		})
+	}
+}
+
+func TestCreateDocumentsStopsAfterOneRejectedSplit(t *testing.T) {
+	requestDocumentCounts := []int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requestDocumentCounts = append(requestDocumentCounts, len(splitBulkLines(t, body))/2)
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		_, err = w.Write([]byte(`{"error":"request entity too large"}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := opensearch.NewClient(opensearch.Config{Addresses: []string{server.URL}})
+	require.NoError(t, err)
+	connector := &OpenSearchConnector{client: client, bulkRequestMaxBytes: 1024 * 1024}
+
+	_, err = connector.CreateDocuments(context.Background(), "index-1", []map[string]any{
+		{"_id": "doc-1", "content": "same"},
+		{"_id": "doc-2", "content": "same"},
+		{"_id": "doc-3", "content": "same"},
+		{"_id": "doc-4", "content": "same"},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, []int{4, 3}, requestDocumentCounts)
+}
+
+func splitBulkLines(t *testing.T, body []byte) [][]byte {
+	lines := bytesSplit(body, '\n')
+	require.Empty(t, lines[len(lines)-1])
+	return lines[:len(lines)-1]
+}
+
+func writeBulkSuccess(t *testing.T, w http.ResponseWriter, body []byte) {
+	items := make([]map[string]map[string]string, 0)
+	lines := splitBulkLines(t, body)
+	for i := 0; i < len(lines); i += 2 {
+		var metadata map[string]map[string]string
+		require.NoError(t, json.Unmarshal(lines[i], &metadata))
+		items = append(items, map[string]map[string]string{"index": {"_id": metadata["index"]["_id"]}})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"errors": false, "items": items}))
+}
+
+func bytesSplit(value []byte, separator byte) [][]byte {
+	result := make([][]byte, 0)
+	start := 0
+	for index, current := range value {
+		if current == separator {
+			result = append(result, value[start:index])
+			start = index + 1
+		}
+	}
+	return append(result, value[start:])
+}
 
 func TestIndexDocumentsRequiresDocumentID(t *testing.T) {
 	c := &OpenSearchConnector{}

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
@@ -63,8 +63,8 @@ func TestSplitBulkDocumentsByBytes(t *testing.T) {
 		}))
 	})
 
-	t.Run("stops before the next document exceeds half", func(t *testing.T) {
-		assert.Equal(t, 1, splitBulkDocumentsByBytes([][]byte{
+	t.Run("keeps the next document in the right chunk when it exceeds half", func(t *testing.T) {
+		assert.Equal(t, 0, splitBulkDocumentsByBytes([][]byte{
 			make([]byte, 4), make([]byte, 12), make([]byte, 12),
 		}))
 	})
@@ -111,7 +111,7 @@ func TestCreateDocumentsSplitsRejectedLargeRequests(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			assert.Equal(t, []int{4, 3, 1}, requestDocumentCounts)
+			assert.Equal(t, []int{4, 2, 2}, requestDocumentCounts)
 			assert.ElementsMatch(t, []string{"doc-1", "doc-2", "doc-3", "doc-4"}, ids)
 		})
 	}
@@ -141,7 +141,7 @@ func TestCreateDocumentsStopsAfterOneRejectedSplit(t *testing.T) {
 	})
 
 	require.Error(t, err)
-	assert.Equal(t, []int{4, 3}, requestDocumentCounts)
+	assert.Equal(t, []int{4, 2}, requestDocumentCounts)
 }
 
 func splitBulkLines(t *testing.T, body []byte) [][]byte {

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_test.go
@@ -63,8 +63,8 @@ func TestSplitBulkDocumentsByBytes(t *testing.T) {
 		}))
 	})
 
-	t.Run("keeps the next document in the right chunk when it exceeds half", func(t *testing.T) {
-		assert.Equal(t, 0, splitBulkDocumentsByBytes([][]byte{
+	t.Run("chooses the cut point closest to half", func(t *testing.T) {
+		assert.Equal(t, 1, splitBulkDocumentsByBytes([][]byte{
 			make([]byte, 4), make([]byte, 12), make([]byte, 12),
 		}))
 	})

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -411,12 +411,14 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		totalRows := result.Total
 		readRows := len(result.Entries)
 		if firstQuery {
-			totalCount := int64(totalRows)
-			if _, err := bbw.bts.InternalSetProgress(ctx, nil, buildTaskInfo.ID,
-				interfaces.BuildTaskProgress{TotalCount: &totalCount}); err != nil {
-				return fmt.Errorf("set build task total count: %w", err)
-			}
 			firstQuery = false
+			if totalRows > 0 || readRows > 0 {
+				totalCount := int64(totalRows)
+				if _, err := bbw.bts.InternalSetProgress(ctx, nil, buildTaskInfo.ID,
+					interfaces.BuildTaskProgress{TotalCount: &totalCount}); err != nil {
+					return fmt.Errorf("set build task total count: %w", err)
+				}
+			}
 		}
 
 		if readRows > 0 {

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -11,6 +11,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync/atomic"
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
@@ -339,7 +341,8 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		}
 	}
 
-	hasEmbedding := buildTaskHasEmbedding(buildTaskInfo)
+	embeddingConfig := buildTaskEmbeddingConfig(buildTaskInfo)
+	hasEmbedding := len(embeddingConfig) > 0
 	pipeline := &embeddingPipeline{mfs: bbw.mfs}
 
 	syncedCount := buildTaskInfo.SyncedCount
@@ -407,6 +410,14 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 
 		totalRows := result.Total
 		readRows := len(result.Entries)
+		if firstQuery {
+			totalCount := int64(totalRows)
+			if _, err := bbw.bts.InternalSetProgress(ctx, nil, buildTaskInfo.ID,
+				interfaces.BuildTaskProgress{TotalCount: &totalCount}); err != nil {
+				return fmt.Errorf("set build task total count: %w", err)
+			}
+			firstQuery = false
+		}
 
 		if readRows > 0 {
 			// Update lastBatchKeyValues with the last values in this batch
@@ -435,23 +446,19 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 			}
 
 			if hasEmbedding {
-				if err := pipeline.enrich(ctx, indexDocuments, buildTaskEmbeddingConfig(buildTaskInfo)); err != nil {
+				if err := pipeline.enrich(ctx, indexDocuments, embeddingConfig); err != nil {
 					return fmt.Errorf("vectorize batch: %w", err)
 				}
 			}
+			logger.Infof("Indexing batch task %s: source rows=%d, vector fields=%s", buildTaskInfo.ID,
+				readRows, formatEmbeddingFields(embeddingConfig))
 			_, err = bbw.lim.IndexDocuments(ctx, indexName, indexDocuments)
 			if err != nil {
 				return fmt.Errorf("index documents failed: %w", err)
 			}
 
 			syncedCount += int64(readRows)
-			// Set firstQuery to false after the first query
 			progress := interfaces.BuildTaskProgress{SyncedCount: &syncedCount}
-			if firstQuery {
-				firstQuery = false
-				totalCount := int64(totalRows)
-				progress.TotalCount = &totalCount
-			}
 			syncedMarkStr, err := sync_checkpoint.EncodeBatch(lastBatchKeyValues)
 			if err != nil {
 				return fmt.Errorf("encode synced mark: %w", err)
@@ -501,4 +508,20 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		}
 	}
 	return nil
+}
+
+func formatEmbeddingFields(config map[string]*interfaces.SmallModel) string {
+	if len(config) == 0 {
+		return "none"
+	}
+	fields := make([]string, 0, len(config))
+	for field, model := range config {
+		dimension := 0
+		if model != nil {
+			dimension = model.EmbeddingDim
+		}
+		fields = append(fields, fmt.Sprintf("%s(%d)", field, dimension))
+	}
+	sort.Strings(fields)
+	return strings.Join(fields, ",")
 }

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -129,7 +129,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 					progressMarks = append(progressMarks, *progress.SyncedMark)
 				}
 				return true, nil
-			}).Times(3)
+			}).Times(2)
 		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
 		connector.EXPECT().Connect(gomock.Any()).Return(nil)
 		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Return(&interfaces.QueryResult{Total: 0}, nil)
@@ -146,7 +146,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ID: "c1", ConnectorType: "mysql"}, resource, task)
 
 		require.NoError(t, err)
-		assert.Equal(t, []int64{0, 0}, totalCounts)
+		assert.Equal(t, []int64{0}, totalCounts)
 		assert.Equal(t, []string{"", `{"mode":"batch","cursor":[]}`}, progressMarks)
 		assert.Equal(t, `{"mode":"batch","cursor":[]}`, resource.SyncMark)
 		require.NoError(t, mockDB.ExpectationsWereMet())
@@ -255,12 +255,6 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Return(&interfaces.QueryResult{}, nil)
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
-		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
-			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
-				require.NotNil(t, progress.TotalCount)
-				assert.EqualValues(t, 0, *progress.TotalCount)
-				return true, nil
-			})
 		bts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, task.ID).Return(true, nil)
 
 		err := bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -119,13 +119,17 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		lim.EXPECT().CheckIndexExist(gomock.Any(), indexName).Return(false, nil)
 		lim.EXPECT().CreateIndex(gomock.Any(), indexName, gomock.Any()).Return(nil)
 		var progressMarks []string
+		var totalCounts []int64
 		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+				if progress.TotalCount != nil {
+					totalCounts = append(totalCounts, *progress.TotalCount)
+				}
 				if progress.SyncedMark != nil {
 					progressMarks = append(progressMarks, *progress.SyncedMark)
 				}
 				return true, nil
-			}).Times(2)
+			}).Times(3)
 		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
 		connector.EXPECT().Connect(gomock.Any()).Return(nil)
 		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Return(&interfaces.QueryResult{Total: 0}, nil)
@@ -142,6 +146,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ID: "c1", ConnectorType: "mysql"}, resource, task)
 
 		require.NoError(t, err)
+		assert.Equal(t, []int64{0, 0}, totalCounts)
 		assert.Equal(t, []string{"", `{"mode":"batch","cursor":[]}`}, progressMarks)
 		assert.Equal(t, `{"mode":"batch","cursor":[]}`, resource.SyncMark)
 		require.NoError(t, mockDB.ExpectationsWereMet())
@@ -185,6 +190,12 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 			})
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
+		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+				require.NotNil(t, progress.TotalCount)
+				assert.EqualValues(t, 1, *progress.TotalCount)
+				return true, nil
+			})
 		indexed := false
 		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ string, documents map[string]map[string]any) ([]string, error) {
@@ -244,6 +255,12 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Return(&interfaces.QueryResult{}, nil)
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
+		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+				require.NotNil(t, progress.TotalCount)
+				assert.EqualValues(t, 0, *progress.TotalCount)
+				return true, nil
+			})
 		bts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, task.ID).Return(true, nil)
 
 		err := bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)


### PR DESCRIPTION
# Pull Request

## What Changed

- Split OpenSearch Bulk indexing requests by serialized NDJSON size, with a 32 MiB request limit.
- Reject an individual document that exceeds the request limit during encoding.
- Retry an OpenSearch 413 or indexing-pressure 429 once by splitting the failed batch by bytes.
- Persist batch totals before the first index write and add vector-field context to batch logs.

## Why

- Related Issue: Closes #1188
- Related Feature: N/A
- Background: high-dimensional vector fields can create Bulk requests that exceed OpenSearch indexing-pressure limits.

## How

- Encode each document once, then group the encoded NDJSON records under the byte limit.
- Build the complete Bulk request body immediately before sending it.
- On a size-related rejection, split the original request once at a byte-aware boundary and send both halves; do not recursively shrink requests.
- Breaking changes: None.

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests (if applicable)
- [ ] Verified in test environment

Test notes:

- `make -C adp/vega/vega-backend ci`

## Risk & Rollback

- Potential risks: a source batch can result in multiple OpenSearch Bulk requests; if a later request fails, earlier documents remain indexed and are safely overwritten when the deterministic-ID batch is retried.
- Rollback plan: revert commit 83d76096d; the existing index is preserved until the normal build publication step.

## Additional Notes

- The limit applies to serialized NDJSON bytes, including Bulk metadata, rather than source-row count.
