### PR TITLE
fix(deploy): use supply sample hotfix chart versions

### DIFF
--- a/deploy/release-manifests/0.1.4/bkn-foundry.yaml
+++ b/deploy/release-manifests/0.1.4/bkn-foundry.yaml
@@ -34,16 +34,16 @@ releases:
     version: 0.1.4
   agent-operator-integration:
     chart: agent-operator-integration
-    version: 0.1.4
+    version: 0.1.4-hotfix-supply-sample-p1
   oss-gateway-backend:
     chart: oss-gateway-backend
     version: 0.1.4
   sandbox:
     chart: sandbox
-    version: 0.1.4
+    version: 0.1.4-hotfix-supply-sample-p1
   agent-retrieval:
     chart: agent-retrieval
-    version: 0.1.4
+    version: 0.1.4-hotfix-supply-sample-p1
   bkn-agent:
     chart: bkn-agent
     version: 0.1.4


### PR DESCRIPTION
Update the 0.1.4 release manifest to use
v0.1.4-hotfix-supply-sample-p1 for the supply sample compatibility versions of agent-operator-integration, sandbox, and agent-retrieval.

# Pull Request

## What Changed

- [x] Feature/module 1: deploy release manifest
- [ ] Feature/module 2
- [ ] Docs/doc 1

更新 `deploy/release-manifests/0.1.4/bkn-foundry.yaml`，将以下组件切换到
`0.1.4-hotfix-supply-sample-p1`：

- agent-operator-integration
- sandbox
- agent-retrieval

---

## Why

- Related Issue: N/A
- Background:

Supply sample 需要使用对应的 hotfix chart 版本，以确保组件版本兼容。

---

## How

- Key implementation points:
  - 更新 0.1.4 release manifest 中的组件版本。
- Breaking changes:
  - 无 API 或数据库变更。
  - 发布清单将拉取 hotfix chart 版本。

---

## Testing

- [ ] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

已检查 YAML 修改内容，确认三个组件版本均更新为
`0.1.4-hotfix-supply-sample-p1`。

---

## Risk & Rollback

- Potential risks:
  - 部分组件将使用 hotfix chart，需确保对应 chart 已发布到 chart 仓库。
- Rollback plan:
  - 将三个组件版本恢复为 `0.1.4`，或回滚本次提交。

---

## Additional Notes

- Related tag: `v0.1.4-hotfix-supply-sample-p1`
- Changed file: `deploy/release-manifests/0.1.4/bkn-foundry.yaml`