### PR TITLE
feat(trace): add signed BKN projection reader

### DIFF
--- a/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
@@ -87,6 +87,17 @@ spec:
             value: {{ .Values.bknSafe.url | quote }}
           - name: BKN_SAFE_BASE_URL
             value: {{ .Values.bknSafe.url | quote }}
+          {{- if .Values.bknTrace.projectionRead.enabled }}
+          - name: BKN_TRACE_PROJECTION_GRANT_ISSUER
+            value: {{ required "bknTrace.projectionRead.issuer is required when projection reads are enabled" .Values.bknTrace.projectionRead.issuer | quote }}
+          - name: BKN_TRACE_PROJECTION_GRANT_AUDIENCE
+            value: {{ required "bknTrace.projectionRead.audience is required when projection reads are enabled" .Values.bknTrace.projectionRead.audience | quote }}
+          - name: BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS
+            valueFrom:
+              secretKeyRef:
+                name: {{ required "bknTrace.projectionRead.publicKeysSecretName is required when projection reads are enabled" .Values.bknTrace.projectionRead.publicKeysSecretName | quote }}
+                key: {{ .Values.bknTrace.projectionRead.publicKeysSecretKey | quote }}
+          {{- end }}
           {{- if .Values.bknTrace.evidence.ingestUrl }}
           - name: BKN_TRACE_EVIDENCE_INGEST_URL
             value: {{ .Values.bknTrace.evidence.ingestUrl | quote }}

--- a/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
@@ -88,6 +88,8 @@ spec:
           - name: BKN_SAFE_BASE_URL
             value: {{ .Values.bknSafe.url | quote }}
           {{- if .Values.bknTrace.projectionRead.enabled }}
+          - name: BKN_TRACE_PROJECTION_GRANT_ENABLED
+            value: "true"
           - name: BKN_TRACE_PROJECTION_GRANT_ISSUER
             value: {{ required "bknTrace.projectionRead.issuer is required when projection reads are enabled" .Values.bknTrace.projectionRead.issuer | quote }}
           - name: BKN_TRACE_PROJECTION_GRANT_AUDIENCE

--- a/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
@@ -148,6 +148,14 @@ resources:
     memory: 4Gi
 
 bknTrace:
+  # Enables the narrow historical-projection reader. Core signs each request;
+  # BKN only receives the rotating Ed25519 public-key set from this secret.
+  projectionRead:
+    enabled: false
+    issuer: ""
+    audience: ""
+    publicKeysSecretName: ""
+    publicKeysSecretKey: "projection-grant-public-keys"
   evidence:
     ingestUrl: ""
     timeoutMs: "2000"

--- a/adp/bkn/bkn-backend/server/common/bkntrace/projection_grant.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/projection_grant.go
@@ -1,0 +1,87 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
+)
+
+// projectionGrantVerifier validates the narrow capability that permits an EE
+// projection builder to read one explicitly recorded knowledge network.
+type ProjectionGrantVerifier struct {
+	keys     map[string]ed25519.PublicKey
+	issuer   string
+	audience string
+	now      func() time.Time
+}
+
+func newProjectionGrantVerifier(
+	keys map[string]ed25519.PublicKey,
+	issuer string,
+	audience string,
+	now func() time.Time,
+) ProjectionGrantVerifier {
+	return ProjectionGrantVerifier{keys: keys, issuer: issuer, audience: audience, now: now}
+}
+
+// NewProjectionGrantVerifierFromEnv loads BKN's verification-only key table.
+// The comma-separated value is kid=base64-ed25519-public-key. It intentionally
+// has no private-key input.
+func NewProjectionGrantVerifierFromEnv() (ProjectionGrantVerifier, error) {
+	issuer := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ISSUER"))
+	audience := strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE"))
+	if issuer == "" || audience == "" {
+		return ProjectionGrantVerifier{}, errors.New("projection grant issuer and audience are required")
+	}
+	keys := make(map[string]ed25519.PublicKey)
+	for _, entry := range strings.Split(os.Getenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS"), ",") {
+		kid, encoded, found := strings.Cut(strings.TrimSpace(entry), "=")
+		kid, encoded = strings.TrimSpace(kid), strings.TrimSpace(encoded)
+		if !found || kid == "" || encoded == "" {
+			return ProjectionGrantVerifier{}, errors.New("projection grant public keys must use kid=base64 format")
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil || len(decoded) != ed25519.PublicKeySize {
+			return ProjectionGrantVerifier{}, fmt.Errorf("projection grant public key %q is invalid", kid)
+		}
+		if _, duplicate := keys[kid]; duplicate {
+			return ProjectionGrantVerifier{}, fmt.Errorf("projection grant public key %q is duplicated", kid)
+		}
+		keys[kid] = ed25519.PublicKey(decoded)
+	}
+	if len(keys) == 0 {
+		return ProjectionGrantVerifier{}, errors.New("projection grant public keys are required")
+	}
+	return newProjectionGrantVerifier(keys, issuer, audience, time.Now), nil
+}
+
+func (v ProjectionGrantVerifier) Authorize(token string, knowledgeNetworkID string) (projectiongrant.Claims, error) {
+	if strings.TrimSpace(token) == "" {
+		return projectiongrant.Claims{}, errors.New("projection grant is required")
+	}
+	if v.now == nil {
+		v.now = time.Now
+	}
+	claims, err := projectiongrant.Verify(token, v.keys, projectiongrant.VerifyOptions{
+		Now: v.now(), ExpectedIssuer: v.issuer, ExpectedAudience: v.audience,
+	})
+	if err != nil {
+		return projectiongrant.Claims{}, err
+	}
+	if !claims.AllowsKnowledgeNetwork(knowledgeNetworkID) {
+		return projectiongrant.Claims{}, errors.New("projection grant does not allow this knowledge network")
+	}
+	return claims, nil
+}

--- a/adp/bkn/bkn-backend/server/common/bkntrace/projection_grant_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/projection_grant_test.go
@@ -1,0 +1,59 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkntrace
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
+)
+
+func TestProjectionGrantVerifierAllowsOnlyClaimedNetwork(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	token, err := projectiongrant.Sign(projectiongrant.Claims{
+		Version: 1, Issuer: "trace-core-projection", KeyID: "key-1", Audience: "bkn-projection-read",
+		EventID: "event-1", InteractionID: "interaction-1", FactsHash: "facts-1",
+		KnowledgeNetworkIDs: []string{"kn-allowed"}, IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Hour),
+	}, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifier := newProjectionGrantVerifier(map[string]ed25519.PublicKey{"key-1": publicKey}, "trace-core-projection", "bkn-projection-read", func() time.Time { return now })
+	if _, err := verifier.Authorize(token, "kn-allowed"); err != nil {
+		t.Fatalf("claimed network was rejected: %v", err)
+	}
+	if _, err := verifier.Authorize(token, "kn-other"); err == nil {
+		t.Fatal("network outside the grant must be rejected")
+	}
+}
+
+func TestProjectionGrantVerifierFromEnvRejectsMissingOrMalformedKeys(t *testing.T) {
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", "trace-core-projection")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", "bkn-projection-read")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", "key-1=not-base64")
+	if _, err := NewProjectionGrantVerifierFromEnv(); err == nil {
+		t.Fatal("malformed public keys must be rejected")
+	}
+
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", "key-1="+base64.StdEncoding.EncodeToString(publicKey))
+	if _, err := NewProjectionGrantVerifierFromEnv(); err != nil {
+		t.Fatalf("complete public-key configuration was rejected: %v", err)
+	}
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -27,6 +27,32 @@ import (
 	"bkn-backend/interfaces"
 )
 
+const projectionGrantHeader = "X-BKN-Projection-Grant"
+
+// GetKNByProjectionGrant exports one current network for a sealed historical
+// projection build. It has no caller, tenant, or business-domain fallback.
+func (r *restHandler) GetKNByProjectionGrant(c *gin.Context) {
+	if r.projectionGrantVerifier == nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	knID := c.Param("kn_id")
+	if _, err := r.projectionGrantVerifier.Authorize(c.GetHeader(projectionGrantHeader), knID); err != nil {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	kn, err := r.kns.GetKNByID(c.Request.Context(), knID, interfaces.MAIN_BRANCH, interfaces.Mode_Export)
+	if err != nil {
+		if httpErr, ok := err.(*rest.HTTPError); ok {
+			rest.ReplyError(c, httpErr)
+			return
+		}
+		c.Status(http.StatusInternalServerError)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, kn)
+}
+
 // Create knowledge networks (internal).
 func (r *restHandler) CreateKNByIn(c *gin.Context) {
 	logger.Debug("Handler CreateKNByIn Start")

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -41,13 +41,9 @@ func (r *restHandler) GetKNByProjectionGrant(c *gin.Context) {
 		c.Status(http.StatusNotFound)
 		return
 	}
-	kn, err := r.kns.GetKNByID(c.Request.Context(), knID, interfaces.MAIN_BRANCH, interfaces.Mode_Export)
+	kn, err := r.kns.ExportKNForProjection(c.Request.Context(), knID)
 	if err != nil {
-		if httpErr, ok := err.(*rest.HTTPError); ok {
-			rest.ReplyError(c, httpErr)
-			return
-		}
-		c.Status(http.StatusInternalServerError)
+		c.Status(http.StatusNotFound)
 		return
 	}
 	rest.ReplyOK(c, http.StatusOK, kn)

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -8,19 +8,25 @@ package driveradapters
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/projectiongrant"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
+	"bkn-backend/common/bkntrace"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
@@ -36,6 +42,70 @@ func MockNewKnowledgeNetworkRestHandler(appSetting *common.AppSetting,
 		kns:        kns,
 	}
 	return r
+}
+
+func TestKnowledgeNetworkProjectionReadRequiresGrantForClaimedNetwork(t *testing.T) {
+	test := setGinMode()
+	defer test()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", "trace-core-projection")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", "bkn-projection-read")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", "key-1="+base64.StdEncoding.EncodeToString(publicKey))
+	verifier, err := bkntrace.NewProjectionGrantVerifierFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	token, err := projectiongrant.Sign(projectiongrant.Claims{
+		Version: 1, Issuer: "trace-core-projection", KeyID: "key-1", Audience: "bkn-projection-read",
+		EventID: "event-1", InteractionID: "interaction-1", FactsHash: "facts-1",
+		KnowledgeNetworkIDs: []string{"kn-allowed"}, IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Hour),
+	}, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	kns := bmock.NewMockKNService(ctrl)
+	handler := &restHandler{kns: kns, projectionGrantVerifier: &verifier}
+	engine := gin.New()
+	engine.GET("/api/bkn-backend/in/v1/trace/projection/knowledge-networks/:kn_id", handler.GetKNByProjectionGrant)
+
+	kns.EXPECT().GetKNByID(gomock.Any(), "kn-allowed", interfaces.MAIN_BRANCH, interfaces.Mode_Export).Return(&interfaces.KN{KNID: "kn-allowed", KNName: "Allowed"}, nil)
+	request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/in/v1/trace/projection/knowledge-networks/kn-allowed", nil)
+	request.Header.Set(projectionGrantHeader, token)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("claimed network response = %d, want 200", response.Code)
+	}
+
+	for _, request := range []*http.Request{
+		httptest.NewRequest(http.MethodGet, "/api/bkn-backend/in/v1/trace/projection/knowledge-networks/kn-allowed", nil),
+		func() *http.Request {
+			r := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/in/v1/trace/projection/knowledge-networks/kn-other", nil)
+			r.Header.Set(projectionGrantHeader, token)
+			return r
+		}(),
+	} {
+		response = httptest.NewRecorder()
+		engine.ServeHTTP(response, request)
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("ungranted projection read response = %d, want 404", response.Code)
+		}
+	}
+
+	// The ontology-manager compatibility alias must not expose this internal route.
+	response = httptest.NewRecorder()
+	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/ontology-manager/in/v1/trace/projection/knowledge-networks/kn-allowed", nil))
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("ontology-manager projection alias response = %d, want 404", response.Code)
+	}
 }
 
 func Test_KnowledgeNetworkRestHandler_CreateKN(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -76,7 +76,7 @@ func TestKnowledgeNetworkProjectionReadRequiresGrantForClaimedNetwork(t *testing
 	engine := gin.New()
 	engine.GET("/api/bkn-backend/in/v1/trace/projection/knowledge-networks/:kn_id", handler.GetKNByProjectionGrant)
 
-	kns.EXPECT().GetKNByID(gomock.Any(), "kn-allowed", interfaces.MAIN_BRANCH, interfaces.Mode_Export).Return(&interfaces.KN{KNID: "kn-allowed", KNName: "Allowed"}, nil)
+	kns.EXPECT().ExportKNForProjection(gomock.Any(), "kn-allowed").Return(&interfaces.KN{KNID: "kn-allowed", KNName: "Allowed"}, nil)
 	request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/in/v1/trace/projection/knowledge-networks/kn-allowed", nil)
 	request.Header.Set(projectionGrantHeader, token)
 	response := httptest.NewRecorder()
@@ -105,6 +105,51 @@ func TestKnowledgeNetworkProjectionReadRequiresGrantForClaimedNetwork(t *testing
 	engine.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/api/ontology-manager/in/v1/trace/projection/knowledge-networks/kn-allowed", nil))
 	if response.Code != http.StatusNotFound {
 		t.Fatalf("ontology-manager projection alias response = %d, want 404", response.Code)
+	}
+}
+
+func TestKnowledgeNetworkProjectionReadHidesSourceFailures(t *testing.T) {
+	test := setGinMode()
+	defer test()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", "trace-core-projection")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", "bkn-projection-read")
+	t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", "key-1="+base64.StdEncoding.EncodeToString(publicKey))
+	verifier, err := bkntrace.NewProjectionGrantVerifierFromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := projectiongrant.Sign(projectiongrant.Claims{
+		Version: 1, Issuer: "trace-core-projection", KeyID: "key-1", Audience: "bkn-projection-read",
+		EventID: "event-1", InteractionID: "interaction-1", FactsHash: "facts-1",
+		KnowledgeNetworkIDs: []string{"kn-allowed"}, IssuedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Hour),
+	}, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	kns := bmock.NewMockKNService(ctrl)
+	kns.EXPECT().ExportKNForProjection(gomock.Any(), "kn-allowed").Return(nil, errors.New("database unavailable"))
+	handler := &restHandler{kns: kns, projectionGrantVerifier: &verifier}
+	engine := gin.New()
+	engine.GET("/api/bkn-backend/in/v1/trace/projection/knowledge-networks/:kn_id", handler.GetKNByProjectionGrant)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/in/v1/trace/projection/knowledge-networks/kn-allowed", nil)
+	request.Header.Set(projectionGrantHeader, token)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("source failure response = %d, want 404", response.Code)
+	}
+	if response.Body.Len() != 0 {
+		t.Fatalf("source failure body = %q, want empty", response.Body.String())
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -64,7 +64,7 @@ type restHandler struct {
 
 func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.Store) RestHandler {
 	var projectionVerifier *bkntrace.ProjectionGrantVerifier
-	if projectionGrantVerifierConfigured() {
+	if projectionGrantVerifierEnabled() {
 		verifier, err := bkntrace.NewProjectionGrantVerifierFromEnv()
 		if err != nil {
 			panic(fmt.Sprintf("invalid projection grant verifier configuration: %v", err))
@@ -99,10 +99,8 @@ func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.St
 	return r
 }
 
-func projectionGrantVerifierConfigured() bool {
-	return strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ISSUER")) != "" ||
-		strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE")) != "" ||
-		strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS")) != ""
+func projectionGrantVerifierEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ENABLED")), "true")
 }
 
 func (r *restHandler) RegisterPublic(c *gin.Engine) {

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -8,7 +8,10 @@ package driveradapters
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -41,24 +44,33 @@ type RestHandler interface {
 }
 
 type restHandler struct {
-	appSetting            *common.AppSetting
-	auditRecorder         operationAuditRecorder
-	auditQueryStore       operationAuditQueryStore
-	auditIdentityResolver func(context.Context, string, hydra.Visitor) operationAuditActor
-	auditAccessResolver   func(context.Context, string, string) (bkntrace.OperationAuditProfile, error)
-	as                    interfaces.AuthService
-	ass                   interfaces.ActionScheduleService
-	ats                   interfaces.ActionTypeService
-	cgs                   interfaces.ConceptGroupService
-	kns                   interfaces.KNService
-	ots                   interfaces.ObjectTypeService
-	rts                   interfaces.RelationTypeService
-	rtsRisk               interfaces.RiskTypeService
-	ms                    interfaces.MetricService
-	bs                    interfaces.BKNService
+	appSetting              *common.AppSetting
+	auditRecorder           operationAuditRecorder
+	auditQueryStore         operationAuditQueryStore
+	auditIdentityResolver   func(context.Context, string, hydra.Visitor) operationAuditActor
+	auditAccessResolver     func(context.Context, string, string) (bkntrace.OperationAuditProfile, error)
+	as                      interfaces.AuthService
+	ass                     interfaces.ActionScheduleService
+	ats                     interfaces.ActionTypeService
+	cgs                     interfaces.ConceptGroupService
+	kns                     interfaces.KNService
+	ots                     interfaces.ObjectTypeService
+	rts                     interfaces.RelationTypeService
+	rtsRisk                 interfaces.RiskTypeService
+	ms                      interfaces.MetricService
+	bs                      interfaces.BKNService
+	projectionGrantVerifier *bkntrace.ProjectionGrantVerifier
 }
 
 func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.Store) RestHandler {
+	var projectionVerifier *bkntrace.ProjectionGrantVerifier
+	if projectionGrantVerifierConfigured() {
+		verifier, err := bkntrace.NewProjectionGrantVerifierFromEnv()
+		if err != nil {
+			panic(fmt.Sprintf("invalid projection grant verifier configuration: %v", err))
+		}
+		projectionVerifier = &verifier
+	}
 	r := &restHandler{
 		appSetting:          appSetting,
 		auditRecorder:       auditStore,
@@ -72,18 +84,25 @@ func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.St
 			}
 			return actor
 		},
-		as:      auth.NewAuthService(appSetting),
-		ass:     action_schedule.NewActionScheduleService(appSetting),
-		ats:     action_type.NewActionTypeService(appSetting),
-		cgs:     concept_group.NewConceptGroupService(appSetting),
-		kns:     knowledge_network.NewKNService(appSetting),
-		ots:     object_type.NewObjectTypeService(appSetting),
-		rts:     relation_type.NewRelationTypeService(appSetting),
-		rtsRisk: risk_type.NewRiskTypeService(appSetting),
-		ms:      metriclogics.NewMetricService(appSetting),
-		bs:      bkn.NewBKNService(appSetting),
+		as:                      auth.NewAuthService(appSetting),
+		ass:                     action_schedule.NewActionScheduleService(appSetting),
+		ats:                     action_type.NewActionTypeService(appSetting),
+		cgs:                     concept_group.NewConceptGroupService(appSetting),
+		kns:                     knowledge_network.NewKNService(appSetting),
+		ots:                     object_type.NewObjectTypeService(appSetting),
+		rts:                     relation_type.NewRelationTypeService(appSetting),
+		rtsRisk:                 risk_type.NewRiskTypeService(appSetting),
+		ms:                      metriclogics.NewMetricService(appSetting),
+		bs:                      bkn.NewBKNService(appSetting),
+		projectionGrantVerifier: projectionVerifier,
 	}
 	return r
+}
+
+func projectionGrantVerifierConfigured() bool {
+	return strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_ISSUER")) != "" ||
+		strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE")) != "" ||
+		strings.TrimSpace(os.Getenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS")) != ""
 }
 
 func (r *restHandler) RegisterPublic(c *gin.Engine) {
@@ -190,6 +209,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	otlApiInV1 := c.Group("/api/ontology-manager/in/v1")
 	bknApiInV1.Use(rest.PrivateNoCacheMiddleware())
 	otlApiInV1.Use(rest.PrivateNoCacheMiddleware())
+	bknApiInV1.GET("/trace/projection/knowledge-networks/:kn_id", r.GetKNByProjectionGrant)
 
 	for _, apiInV1 := range []*gin.RouterGroup{bknApiInV1, otlApiInV1} {
 		// Knowledge networks.

--- a/adp/bkn/bkn-backend/server/driveradapters/routers_projection_grant_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers_projection_grant_test.go
@@ -6,28 +6,45 @@
 
 package driveradapters
 
-import "testing"
+import (
+	"testing"
 
-func TestProjectionGrantVerifierConfigured(t *testing.T) {
+	"github.com/gin-gonic/gin"
+)
+
+func TestProjectionGrantVerifierEnabled(t *testing.T) {
 	for _, test := range []struct {
-		name   string
-		issuer string
-		aud    string
-		keys   string
-		want   bool
+		name    string
+		enabled string
+		issuer  string
+		aud     string
+		keys    string
+		want    bool
 	}{
 		{name: "all unset", want: false},
-		{name: "issuer set", issuer: "trace-core-projection", want: true},
-		{name: "audience set", aud: "bkn-projection-read", want: true},
-		{name: "keys set", keys: "key-1=base64", want: true},
+		{name: "unrelated projection config", issuer: "trace-core-projection", aud: "bkn-projection-read", keys: "key-1=base64", want: false},
+		{name: "explicitly enabled", enabled: "true", want: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BKN_TRACE_PROJECTION_GRANT_ENABLED", test.enabled)
 			t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", test.issuer)
 			t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", test.aud)
 			t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", test.keys)
-			if got := projectionGrantVerifierConfigured(); got != test.want {
-				t.Fatalf("projectionGrantVerifierConfigured() = %t, want %t", got, test.want)
+			if got := projectionGrantVerifierEnabled(); got != test.want {
+				t.Fatalf("projectionGrantVerifierEnabled() = %t, want %t", got, test.want)
 			}
 		})
+	}
+}
+
+func TestProjectionReadRouteHasNoOntologyManagerAlias(t *testing.T) {
+	test := setGinMode()
+	defer test()
+	engine := gin.New()
+	(&restHandler{}).RegisterPublic(engine)
+	for _, route := range engine.Routes() {
+		if route.Path == "/api/ontology-manager/in/v1/trace/projection/knowledge-networks/:kn_id" {
+			t.Fatal("projection reader must not have an ontology-manager alias")
+		}
 	}
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/routers_projection_grant_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers_projection_grant_test.go
@@ -1,0 +1,33 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package driveradapters
+
+import "testing"
+
+func TestProjectionGrantVerifierConfigured(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		issuer string
+		aud    string
+		keys   string
+		want   bool
+	}{
+		{name: "all unset", want: false},
+		{name: "issuer set", issuer: "trace-core-projection", want: true},
+		{name: "audience set", aud: "bkn-projection-read", want: true},
+		{name: "keys set", keys: "key-1=base64", want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("BKN_TRACE_PROJECTION_GRANT_ISSUER", test.issuer)
+			t.Setenv("BKN_TRACE_PROJECTION_GRANT_AUDIENCE", test.aud)
+			t.Setenv("BKN_TRACE_PROJECTION_GRANT_PUBLIC_KEYS", test.keys)
+			if got := projectionGrantVerifierConfigured(); got != test.want {
+				t.Fatalf("projectionGrantVerifierConfigured() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}

--- a/adp/bkn/bkn-backend/server/go.mod
+++ b/adp/bkn/bkn-backend/server/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/uuid v1.6.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4
+	github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/smartystreets/goconvey v1.8.1

--- a/adp/bkn/bkn-backend/server/go.sum
+++ b/adp/bkn/bkn-backend/server/go.sum
@@ -154,8 +154,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nsqio/go-nsq v1.1.0 h1:PQg+xxiUjA7V+TLdXw7nVrJ5Jbl3sN86EhGCQj4+FYE=
 github.com/nsqio/go-nsq v1.1.0/go.mod h1:vKq36oyeVXgsS5Q8YEO7WghqidAVXQlcFxzQbQTuDEY=
-github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4 h1:gzR1lRYnjyyMSWAZak9YnQjc5RGYuFk6cF9ziespAoU=
-github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d h1:l61dZgJYzyaUcgVue1Dfs9IKRHVw5Z4318NF/hSC/Nw=
+github.com/openbkn-ai/bkn-foundry/comm-go v0.1.4-0.20260831021942-4643567ee25d/go.mod h1:D0d+xRVJAk7DutF2g8I/TsXceE/1Iv3EmNNj8yxu2pA=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0 h1:nQIEMr+A92CkhHrZgUhcfsrZjibvB3APXf2a1VwCmMQ=
 github.com/opensearch-project/opensearch-go/v2 v2.3.0/go.mod h1:8LDr9FCgUTVoT+5ESjc2+iaZuldqE+23Iq0r1XeNue8=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
@@ -18,6 +18,9 @@ type KNService interface {
 	CreateKN(ctx context.Context, kn *KN, mode string, strictMode bool) (string, error)
 	ListKNs(ctx context.Context, query KNsQueryParams) ([]*KN, int, error)
 	GetKNByID(ctx context.Context, knID string, branch string, mode string) (*KN, error)
+	// ExportKNForProjection reads exactly one current main-branch network after
+	// the HTTP boundary has verified a ProjectionReadGrant.
+	ExportKNForProjection(ctx context.Context, knID string) (*KN, error)
 	UpdateKN(ctx context.Context, tx *sql.Tx, kn *KN, strictMode bool) error
 	UpdateKNDetail(ctx context.Context, knID string, branch string, detail string) error
 	DeleteKN(ctx context.Context, kn *KN) error

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
@@ -103,6 +103,21 @@ func (mr *MockKNServiceMockRecorder) DeleteKN(ctx, kn any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKN", reflect.TypeOf((*MockKNService)(nil).DeleteKN), ctx, kn)
 }
 
+// ExportKNForProjection mocks base method.
+func (m *MockKNService) ExportKNForProjection(ctx context.Context, knID string) (*interfaces.KN, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExportKNForProjection", ctx, knID)
+	ret0, _ := ret[0].(*interfaces.KN)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExportKNForProjection indicates an expected call of ExportKNForProjection.
+func (mr *MockKNServiceMockRecorder) ExportKNForProjection(ctx, knID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportKNForProjection", reflect.TypeOf((*MockKNService)(nil).ExportKNForProjection), ctx, knID)
+}
+
 // GetKNByID mocks base method.
 func (m *MockKNService) GetKNByID(ctx context.Context, knID, branch, mode string) (*interfaces.KN, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -669,7 +669,39 @@ func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, 
 // caller has already been authorized for this exact network by a signed grant,
 // so it must not enter account-based resource filtering or identity enrichment.
 func (kns *knowledgeNetworkService) ExportKNForProjection(ctx context.Context, knID string) (*interfaces.KN, error) {
-	return kns.getKNByID(ctx, knID, interfaces.MAIN_BRANCH, interfaces.Mode_Export, false)
+	kn, err := kns.getKNByID(ctx, knID, interfaces.MAIN_BRANCH, "", false)
+	if err != nil {
+		return nil, err
+	}
+	query := interfaces.PaginationQueryParameters{Limit: -1}
+	kn.ConceptGroups, err = kns.cga.ListConceptGroups(ctx, interfaces.ConceptGroupsQueryParams{PaginationQueryParameters: query, KNID: kn.KNID, Branch: kn.Branch})
+	if err != nil {
+		return nil, err
+	}
+	kn.ObjectTypes, err = kns.ota.ListObjectTypes(ctx, nil, interfaces.ObjectTypesQueryParams{PaginationQueryParameters: query, KNID: kn.KNID, Branch: kn.Branch})
+	if err != nil {
+		return nil, err
+	}
+	kn.RelationTypes, err = kns.rta.ListRelationTypes(ctx, interfaces.RelationTypesQueryParams{PaginationQueryParameters: query, KNID: kn.KNID, Branch: kn.Branch})
+	if err != nil {
+		return nil, err
+	}
+	kn.ActionTypes, err = kns.ata.ListActionTypes(ctx, interfaces.ActionTypesQueryParams{PaginationQueryParameters: query, KNID: kn.KNID, Branch: kn.Branch})
+	if err != nil {
+		return nil, err
+	}
+	metrics, err := kns.ma.ListMetrics(ctx, interfaces.MetricsListQueryParams{PaginationQueryParameters: query, KNID: kn.KNID, Branch: kn.Branch})
+	if err != nil {
+		return nil, err
+	}
+	kn.Metrics = metrics
+	if kns.riskTypeA != nil {
+		kn.RiskTypes, err = kns.riskTypeA.GetAllRiskTypesByKnID(ctx, kn.KNID, kn.Branch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return kn, nil
 }
 
 func (kns *knowledgeNetworkService) getKNByID(ctx context.Context, knID string, branch string, mode string, enforceUserPermission bool) (*interfaces.KN, error) {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -662,6 +662,17 @@ func (kns *knowledgeNetworkService) GetKNNamesByIDs(ctx context.Context, ids []s
 }
 
 func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, branch string, mode string) (*interfaces.KN, error) {
+	return kns.getKNByID(ctx, knID, branch, mode, true)
+}
+
+// ExportKNForProjection is deliberately separate from user-facing reads. The
+// caller has already been authorized for this exact network by a signed grant,
+// so it must not enter account-based resource filtering or identity enrichment.
+func (kns *knowledgeNetworkService) ExportKNForProjection(ctx context.Context, knID string) (*interfaces.KN, error) {
+	return kns.getKNByID(ctx, knID, interfaces.MAIN_BRANCH, interfaces.Mode_Export, false)
+}
+
+func (kns *knowledgeNetworkService) getKNByID(ctx context.Context, knID string, branch string, mode string, enforceUserPermission bool) (*interfaces.KN, error) {
 
 	// Get business knowledge networks.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, fmt.Sprintf("查询业务知识网络[%s]信息", knID))
@@ -688,27 +699,29 @@ func (kns *knowledgeNetworkService) GetKNByID(ctx context.Context, knID string, 
 			WithErrorDetails(errStr)
 	}
 
-	// Filter objects by view permission. The filtered length is the total, so no separate total query is needed.
-	matchResoucesMap, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, []string{kn.KNID},
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
-	if err != nil {
-		span.SetStatus(codes.Error, "Filter resources error")
-		return nil, err
-	}
+	if enforceUserPermission {
+		// Filter objects by view permission. The filtered length is the total, so no separate total query is needed.
+		matchResoucesMap, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, []string{kn.KNID},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		if err != nil {
+			span.SetStatus(codes.Error, "Filter resources error")
+			return nil, err
+		}
 
-	if resrc, exist := matchResoucesMap[kn.KNID]; exist {
-		kn.Operations = resrc.Operations // Operations currently allowed for the user
-	} else {
-		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
-	}
+		if resrc, exist := matchResoucesMap[kn.KNID]; exist {
+			kn.Operations = resrc.Operations // Operations currently allowed for the user
+		} else {
+			return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
+		}
 
-	accountInfos := []*interfaces.AccountInfo{&kn.Creator, &kn.Updater}
-	err = kns.ums.GetAccountNames(ctx, accountInfos)
-	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
+		accountInfos := []*interfaces.AccountInfo{&kn.Creator, &kn.Updater}
+		err = kns.ums.GetAccountNames(ctx, accountInfos)
+		if err != nil {
+			span.SetStatus(codes.Error, "GetAccountNames error")
 
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 
 	if mode == interfaces.Mode_Export {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -783,22 +783,22 @@ func Test_knowledgeNetworkService_ExportKNForProjectionDoesNotUseUserServices(t 
 		defer mockCtrl.Finish()
 
 		kna := bmock.NewMockKNAccess(mockCtrl)
-		cgs := bmock.NewMockConceptGroupService(mockCtrl)
-		ots := bmock.NewMockObjectTypeService(mockCtrl)
-		rts := bmock.NewMockRelationTypeService(mockCtrl)
-		ats := bmock.NewMockActionTypeService(mockCtrl)
-		ms := bmock.NewMockMetricService(mockCtrl)
+		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
+		ota := bmock.NewMockObjectTypeAccess(mockCtrl)
+		rta := bmock.NewMockRelationTypeAccess(mockCtrl)
+		ata := bmock.NewMockActionTypeAccess(mockCtrl)
+		ma := bmock.NewMockMetricAccess(mockCtrl)
 		service := &knowledgeNetworkService{
-			kna: kna, cgs: cgs, ots: ots, rts: rts, ats: ats, ms: ms,
+			kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma,
 		}
 
 		kn := &interfaces.KN{KNID: "kn-allowed", KNName: "Allowed", Branch: interfaces.MAIN_BRANCH}
 		kna.EXPECT().GetKNByID(gomock.Any(), "kn-allowed", interfaces.MAIN_BRANCH).Return(kn, nil)
-		cgs.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, 0, nil)
-		ots.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, 0, nil)
-		rts.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, 0, nil)
-		ats.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, 0, nil)
-		ms.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(&interfaces.MetricsList{}, nil)
+		cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
+		ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
+		rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
+		ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
+		ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return([]*interfaces.MetricDefinition{}, nil)
 
 		result, err := service.ExportKNForProjection(ctx, "kn-allowed")
 		So(err, ShouldBeNil)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -776,6 +776,36 @@ func Test_knowledgeNetworkService_GetKNByID(t *testing.T) {
 	})
 }
 
+func Test_knowledgeNetworkService_ExportKNForProjectionDoesNotUseUserServices(t *testing.T) {
+	Convey("Test projection export bypasses user authorization and enrichment\n", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		cgs := bmock.NewMockConceptGroupService(mockCtrl)
+		ots := bmock.NewMockObjectTypeService(mockCtrl)
+		rts := bmock.NewMockRelationTypeService(mockCtrl)
+		ats := bmock.NewMockActionTypeService(mockCtrl)
+		ms := bmock.NewMockMetricService(mockCtrl)
+		service := &knowledgeNetworkService{
+			kna: kna, cgs: cgs, ots: ots, rts: rts, ats: ats, ms: ms,
+		}
+
+		kn := &interfaces.KN{KNID: "kn-allowed", KNName: "Allowed", Branch: interfaces.MAIN_BRANCH}
+		kna.EXPECT().GetKNByID(gomock.Any(), "kn-allowed", interfaces.MAIN_BRANCH).Return(kn, nil)
+		cgs.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, 0, nil)
+		ots.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, 0, nil)
+		rts.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, 0, nil)
+		ats.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, 0, nil)
+		ms.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(&interfaces.MetricsList{}, nil)
+
+		result, err := service.ExportKNForProjection(ctx, "kn-allowed")
+		So(err, ShouldBeNil)
+		So(result, ShouldEqual, kn)
+	})
+}
+
 func Test_knowledgeNetworkService_InsertDatasetData(t *testing.T) {
 	Convey("Test InsertDatasetData\n", t, func() {
 		ctx := context.Background()

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -235,6 +235,38 @@ paths:
           type: string
         in: path
         required: true
+  /api/bkn-backend/in/v1/trace/projection/knowledge-networks/{kn_id}:
+    get:
+      summary: Export one knowledge network for a sealed Trace projection
+      description: |
+        Internal Trace-only capability. The caller supplies a signed Ed25519
+        ProjectionReadGrant in X-BKN-Projection-Grant; it is not a user bearer
+        token. BKN verifies issuer, audience, key ID, expiry, signature and that
+        the exact path kn_id is in the grant. It never resolves user identity,
+        tenant, business domain, a list, or a reverse lookup. A missing, invalid,
+        expired, or non-matching grant returns 404.
+      parameters:
+        - name: kn_id
+          description: The single knowledge network explicitly authorized by the grant.
+          schema:
+            type: string
+          in: path
+          required: true
+        - name: X-BKN-Projection-Grant
+          description: Signed ProjectionReadGrant. Do not send an Authorization bearer token.
+          schema:
+            type: string
+          in: header
+          required: true
+      responses:
+        "200":
+          description: Current export of the authorized knowledge network.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KnowledgeNetworkDetail"
+        "404":
+          description: Projection reads are disabled, the grant is invalid or does not authorize this network, or the network does not exist.
   /api/bkn-backend/v1/knowledge-networks/{kn_id}/validation:
     post:
       summary: Validate a business knowledge network


### PR DESCRIPTION
## Why
Implements the BKN prerequisite for Issue #31 historical projections: Trace can export only the explicitly recorded current knowledge network with a sealed, signed grant.

## Scope
- Adds one internal projection-read endpoint at /api/bkn-backend/in/v1/trace/projection/knowledge-networks/{kn_id}; no ontology-manager alias, list, batch, scan, or reverse lookup.
- Verifies Ed25519 ProjectionReadGrant issuer, audience, key ID, expiry, signature, and exact kn_id scope.
- Fails closed with 404 when disabled, missing, invalid, expired, or out of scope.
- Adds explicit Helm opt-in that injects rotating public keys only; BKN never receives a signing private key.
- Documents the internal contract.

## Verification
- go test ./... -count=1
- go vet ./...
- helm lint and template with default and enabled projection-read configuration
- make api-docs-lint

Related: openbkn-ai/openbkn-ee#31