### PR TITLE
fix(bkn-trace): prevent ontology evidence event ID collisions

### DIFF
--- a/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
@@ -305,7 +305,12 @@ func (r *Repository) loadExistingEvent(ctx context.Context, eventID string) (Eve
 
 func isDuplicateKeyError(err error) bool {
 	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "duplicate") || strings.Contains(message, "unique constraint")
+	return strings.Contains(message, "duplicate") ||
+		strings.Contains(message, "unique constraint") ||
+		strings.Contains(message, "唯一性约束") ||
+		strings.Contains(message, "error -6602") ||
+		strings.Contains(message, "error -6612") ||
+		strings.Contains(message, "error -6625")
 }
 
 // ClaimHeadOfLine atomically leases only the oldest incomplete event in this

--- a/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
@@ -41,7 +41,10 @@ const (
 	tableAudit  = "ontology_query_trace_outbox_action_audit"
 )
 
-var ErrDisabled = errors.New("bkn trace producer outbox is disabled")
+var (
+	ErrDisabled        = errors.New("bkn trace producer outbox is disabled")
+	ErrEventIDConflict = errors.New("evidence event id conflicts with existing outbox record")
+)
 
 // Owner is the trusted lifecycle identity that Core requires when ingesting an
 // immutable event. It is persisted inside the sanitized envelope so a retry
@@ -197,6 +200,35 @@ func (r *Repository) Enqueue(ctx context.Context, event Event, owner Owner) (Eve
 	if event.EventID == "" || event.EventType == "" || len(event.Envelope) == 0 {
 		return Event{}, errors.New("evidence event is incomplete")
 	}
+	event.SchemaVersion = "3.0.0"
+	event.ProducerID = r.config.ProducerID
+	event.ProducerStreamID = r.config.ProducerStreamID
+	if event.EmittedAt.IsZero() {
+		event.EmittedAt = time.Now().UTC()
+	}
+	if event.StartedAt.IsZero() {
+		event.StartedAt = event.ObservedAt
+	}
+	if event.ObservedAt.IsZero() || event.EmittedAt.Before(event.ObservedAt) {
+		return Event{}, errors.New("invalid evidence timestamps")
+	}
+	coreEnvelope, err := sonic.ConfigStd.Marshal(struct {
+		Event json.RawMessage `json:"event"`
+		Owner Owner           `json:"owner"`
+	}{Event: event.Envelope, Owner: owner})
+	if err != nil {
+		return Event{}, err
+	}
+	event.Envelope = coreEnvelope
+	event.PayloadHash = CanonicalHash(event.Envelope)
+	if existing, found, err := r.loadExistingEvent(ctx, event.EventID); err != nil {
+		return Event{}, err
+	} else if found {
+		if existing.PayloadHash == event.PayloadHash {
+			return existing, nil
+		}
+		return Event{}, ErrEventIDConflict
+	}
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
 		return Event{}, err
@@ -212,30 +244,7 @@ func (r *Repository) Enqueue(ctx context.Context, event Event, owner Owner) (Eve
 	if _, err := tx.ExecContext(ctx, fmt.Sprintf("UPDATE %s SET next_sequence = ?, updated_at = ? WHERE producer_id = ? AND producer_stream_id = ?", tableStream), next+1, time.Now().UTC(), r.config.ProducerID, r.config.ProducerStreamID); err != nil {
 		return Event{}, err
 	}
-	event.SchemaVersion = "3.0.0"
-	event.ProducerID = r.config.ProducerID
-	event.ProducerStreamID = r.config.ProducerStreamID
-	event.ProducerEpoch = epoch
-	event.ProducerSequence = next
-	if event.EmittedAt.IsZero() {
-		event.EmittedAt = time.Now().UTC()
-	}
-	if event.StartedAt.IsZero() {
-		event.StartedAt = event.ObservedAt
-	}
-	if event.ObservedAt.IsZero() || event.EmittedAt.Before(event.ObservedAt) {
-		return Event{}, errors.New("invalid evidence timestamps")
-	}
-	event.PayloadHash = CanonicalHash(event.Envelope)
-	coreEnvelope, err := sonic.ConfigStd.Marshal(struct {
-		Event json.RawMessage `json:"event"`
-		Owner Owner           `json:"owner"`
-	}{Event: event.Envelope, Owner: owner})
-	if err != nil {
-		return Event{}, err
-	}
-	event.Envelope = coreEnvelope
-	event.PayloadHash = CanonicalHash(event.Envelope)
+	event.ProducerEpoch, event.ProducerSequence = epoch, next
 	stored, err := sonic.ConfigStd.Marshal(struct {
 		Event Event `json:"event"`
 		Owner Owner `json:"owner"`
@@ -251,12 +260,52 @@ func (r *Repository) Enqueue(ctx context.Context, event Event, owner Owner) (Eve
 		event.EventID, event.PayloadHash, event.EventType, event.SchemaVersion, event.ProducerID, event.ProducerStreamID, event.ProducerEpoch, event.ProducerSequence,
 		string(stored), StatusPending, now, now, now)
 	if err != nil {
+		if isDuplicateKeyError(err) {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+				return Event{}, rollbackErr
+			}
+			existing, found, loadErr := r.loadExistingEvent(ctx, event.EventID)
+			if loadErr != nil {
+				return Event{}, loadErr
+			}
+			if found && existing.PayloadHash == event.PayloadHash {
+				return existing, nil
+			}
+			if found {
+				return Event{}, ErrEventIDConflict
+			}
+		}
 		return Event{}, err
 	}
 	if err := tx.Commit(); err != nil {
 		return Event{}, err
 	}
 	return event, nil
+}
+
+func (r *Repository) loadExistingEvent(ctx context.Context, eventID string) (Event, bool, error) {
+	var payloadHash, stored string
+	err := r.db.QueryRowContext(ctx, fmt.Sprintf("SELECT payload_hash, envelope FROM %s WHERE event_id = ?", tableOutbox), eventID).Scan(&payloadHash, &stored)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Event{}, false, nil
+	}
+	if err != nil {
+		return Event{}, false, err
+	}
+	var row struct {
+		Event Event `json:"event"`
+		Owner Owner `json:"owner"`
+	}
+	if err := sonic.ConfigStd.Unmarshal([]byte(stored), &row); err != nil {
+		return Event{}, false, err
+	}
+	row.Event.PayloadHash = payloadHash
+	return row.Event, true, nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "duplicate") || strings.Contains(message, "unique constraint")
 }
 
 // ClaimHeadOfLine atomically leases only the oldest incomplete event in this

--- a/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/outbox/outbox.go
@@ -307,7 +307,6 @@ func isDuplicateKeyError(err error) bool {
 	message := strings.ToLower(err.Error())
 	return strings.Contains(message, "duplicate") ||
 		strings.Contains(message, "unique constraint") ||
-		strings.Contains(message, "唯一性约束") ||
 		strings.Contains(message, "error -6602") ||
 		strings.Contains(message, "error -6612") ||
 		strings.Contains(message, "error -6625")

--- a/adp/bkn/ontology-query/server/common/bkntrace/outbox/repository_test.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/outbox/repository_test.go
@@ -7,12 +7,88 @@ package outbox
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestEnqueueReplaysIdenticalEvidenceAndRejectsConflict(t *testing.T) {
+	owner := Owner{ApplicationPrincipalID: "ontology-query", EffectiveSubjectType: "service", EffectiveSubjectID: "svc-1"}
+	now := time.Now().UTC()
+	event := Event{EventID: "evt-replay", EventType: "data.query.observed", ObservedAt: now, EmittedAt: now, Envelope: []byte(`{"payload":{}}`)}
+	core, _ := json.Marshal(struct {
+		Event json.RawMessage `json:"event"`
+		Owner Owner           `json:"owner"`
+	}{event.Envelope, owner})
+	hash := CanonicalHash(core)
+	existing := event
+	existing.Envelope, existing.PayloadHash, existing.ProducerSequence = core, hash, 7
+	stored, _ := json.Marshal(struct {
+		Event Event `json:"event"`
+		Owner Owner `json:"owner"`
+	}{existing, owner})
+
+	for _, tc := range []struct {
+		name, storedHash string
+		wantConflict     bool
+	}{{"replay", hash, false}, {"conflict", "different", true}} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, _ := sqlmock.New()
+			defer db.Close()
+			repository := &Repository{db: db, config: Config{ProducerID: "bkn-ontology", ProducerStreamID: "ontology-query"}, dialect: dialectMariaDB}
+			mock.ExpectQuery(regexp.QuoteMeta("SELECT payload_hash, envelope FROM " + tableOutbox + " WHERE event_id = ?")).WithArgs(event.EventID).WillReturnRows(sqlmock.NewRows([]string{"payload_hash", "envelope"}).AddRow(tc.storedHash, string(stored)))
+			got, err := repository.Enqueue(context.Background(), event, owner)
+			if tc.wantConflict && !errors.Is(err, ErrEventIDConflict) {
+				t.Fatalf("error = %v, want conflict", err)
+			}
+			if !tc.wantConflict && (err != nil || got.ProducerSequence != 7) {
+				t.Fatalf("replay = %#v, %v", got, err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEnqueueReReadsAfterDuplicateKeyRace(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+	defer db.Close()
+	repository := &Repository{db: db, config: Config{ProducerID: "bkn-ontology", ProducerStreamID: "ontology-query"}, dialect: dialectMariaDB}
+	owner := Owner{ApplicationPrincipalID: "ontology-query", EffectiveSubjectType: "service", EffectiveSubjectID: "svc-1"}
+	now := time.Now().UTC()
+	event := Event{EventID: "evt-race", EventType: "data.query.observed", ObservedAt: now, EmittedAt: now, Envelope: []byte(`{"payload":{}}`)}
+	core, _ := json.Marshal(struct {
+		Event json.RawMessage `json:"event"`
+		Owner Owner           `json:"owner"`
+	}{event.Envelope, owner})
+	hash := CanonicalHash(core)
+	existing := event
+	existing.Envelope, existing.PayloadHash, existing.ProducerSequence = core, hash, 1
+	stored, _ := json.Marshal(struct {
+		Event Event `json:"event"`
+		Owner Owner `json:"owner"`
+	}{existing, owner})
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT payload_hash, envelope FROM " + tableOutbox + " WHERE event_id = ?")).WithArgs("evt-race").WillReturnError(sql.ErrNoRows)
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT current_epoch, next_sequence FROM "+tableStream+" WHERE producer_id = ? AND producer_stream_id = ? FOR UPDATE")).WithArgs("bkn-ontology", "ontology-query").WillReturnRows(sqlmock.NewRows([]string{"current_epoch", "next_sequence"}).AddRow(uint64(1), uint64(1)))
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE "+tableStream+" SET next_sequence = ?, updated_at = ? WHERE producer_id = ? AND producer_stream_id = ?")).WithArgs(uint64(2), sqlmock.AnyArg(), "bkn-ontology", "ontology-query").WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO " + tableOutbox)).WillReturnError(errors.New("Error 1062: Duplicate entry"))
+	mock.ExpectRollback()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT payload_hash, envelope FROM " + tableOutbox + " WHERE event_id = ?")).WithArgs("evt-race").WillReturnRows(sqlmock.NewRows([]string{"payload_hash", "envelope"}).AddRow(hash, string(stored)))
+	got, err := repository.Enqueue(context.Background(), event, owner)
+	if err != nil || got.ProducerSequence != 1 {
+		t.Fatalf("duplicate-key replay = %#v, %v", got, err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestEnqueueUsesCurrentEpochFromStreamState(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -40,6 +116,7 @@ func TestEnqueueUsesCurrentEpochFromStreamState(t *testing.T) {
 		StartedAt: now, ObservedAt: now, EmittedAt: now, Envelope: []byte(`{"payload":{}}`),
 	}
 
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT payload_hash, envelope FROM " + tableOutbox + " WHERE event_id = ?")).WithArgs("evt-1").WillReturnError(sql.ErrNoRows)
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT current_epoch, next_sequence FROM "+tableStream+" WHERE producer_id = ? AND producer_stream_id = ? FOR UPDATE")).
 		WithArgs("bkn-ontology", "ontology-query").
@@ -79,6 +156,7 @@ func TestEnqueueRejectsZeroEpoch(t *testing.T) {
 		dialect: dialectMariaDB,
 	}
 	now := time.Now().UTC()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT payload_hash, envelope FROM " + tableOutbox + " WHERE event_id = ?")).WithArgs("evt-zero").WillReturnError(sql.ErrNoRows)
 	mock.ExpectBegin()
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT current_epoch, next_sequence FROM "+tableStream+" WHERE producer_id = ? AND producer_stream_id = ? FOR UPDATE")).
 		WithArgs("bkn-ontology", "ontology-query").

--- a/adp/bkn/ontology-query/server/common/bkntrace/outbox/repository_test.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/outbox/repository_test.go
@@ -90,6 +90,24 @@ func TestEnqueueReReadsAfterDuplicateKeyRace(t *testing.T) {
 	}
 }
 
+func TestIsDuplicateKeyErrorSupportsMariaDBAndDM8(t *testing.T) {
+	tests := []struct {
+		message string
+		want    bool
+	}{
+		{"Error 1062 (23000): Duplicate entry", true},
+		{"UNIQUE constraint failed", true},
+		{"Error -6602: 违反唯一性约束", true},
+		{"Error -6625: 违反表[T]唯一性约束[UQ_T]", true},
+		{"connection reset", false},
+	}
+	for _, tc := range tests {
+		if got := isDuplicateKeyError(errors.New(tc.message)); got != tc.want {
+			t.Fatalf("isDuplicateKeyError(%q) = %v, want %v", tc.message, got, tc.want)
+		}
+	}
+}
+
 func TestEnqueueUsesCurrentEpochFromStreamState(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -8,6 +8,7 @@ package drivenadapters
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"net/http"
@@ -154,7 +155,7 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	}
 	target := fmt.Sprintf("%s%s?%s", o.baseURL, uri, query.Encode())
 
-	header := common.GetHeaderForChildOperation(ctx, "ontology.object.query", 1)
+	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", objectQueryIdentity(uri+"?"+query.Encode(), req))
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
@@ -172,6 +173,17 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	}
 	resolveTotalCount(req, resp)
 	return
+}
+
+func objectQueryIdentity(target string, req *interfaces.QueryObjectInstancesReq) string {
+	encoded, err := sonic.ConfigStd.Marshal(struct {
+		Target string                              `json:"target"`
+		Body   *interfaces.QueryObjectInstancesReq `json:"body"`
+	}{Target: target, Body: req})
+	if err != nil {
+		return "marshal-error"
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256(encoded))
 }
 
 // resolveTotalCount recovers the "zero hits" case that the wire format cannot carry.

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -155,7 +155,7 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	}
 	target := fmt.Sprintf("%s%s?%s", o.baseURL, uri, query.Encode())
 
-	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", objectQueryIdentity(uri+"?"+query.Encode(), req))
+	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", ontologyQueryIdentity(uri+"?"+query.Encode(), req))
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
@@ -175,13 +175,13 @@ func (o *ontologyQueryClient) QueryObjectInstances(ctx context.Context, req *int
 	return
 }
 
-func objectQueryIdentity(target string, req *interfaces.QueryObjectInstancesReq) string {
+func ontologyQueryIdentity(target string, body any) string {
 	encoded, err := sonic.ConfigStd.Marshal(struct {
-		Target string                              `json:"target"`
-		Body   *interfaces.QueryObjectInstancesReq `json:"body"`
-	}{Target: target, Body: req})
+		Target string `json:"target"`
+		Body   any    `json:"body"`
+	}{Target: target, Body: body})
 	if err != nil {
-		return "marshal-error"
+		return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(target)))
 	}
 	return fmt.Sprintf("sha256:%x", sha256.Sum256(encoded))
 }
@@ -495,7 +495,7 @@ func (o *ontologyQueryClient) ExploreSubgraph(ctx context.Context, req *interfac
 	}
 	target := fmt.Sprintf("%s%s?%s", o.baseURL, uri, query.Encode())
 
-	header := common.GetHeaderForChildOperation(ctx, "ontology.subgraph.explore", 1)
+	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.subgraph.explore", ontologyQueryIdentity(uri+"?"+query.Encode(), req))
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 
@@ -552,7 +552,7 @@ func (o *ontologyQueryClient) QueryInstanceSubgraph(ctx context.Context, req *in
 	o.logger.WithContext(ctx).Debugf("[OntologyQuery#QueryInstanceSubgraph] Request Body: %s", string(bodyJSON))
 
 	// Build request headers.
-	header := common.GetHeaderForChildOperation(ctx, "ontology.subgraph.query", 1)
+	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.subgraph.query", ontologyQueryIdentity(uri, body))
 	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	header["x-http-method-override"] = "GET"
 
@@ -591,12 +591,11 @@ func (o *ontologyQueryClient) QueryMetricData(ctx context.Context, knID, metricI
 	query.Set("fill_null", strconv.FormatBool(fillNull))
 	target := fmt.Sprintf("%s%s?%s", o.baseURL, uri, query.Encode())
 
-	header := common.GetHeaderForChildOperation(ctx, "ontology.metric.query", 1)
-	header[rest.ContentTypeKey] = rest.ContentTypeJSON
-
 	if req == nil {
 		req = &interfaces.MetricQueryDownstreamReq{}
 	}
+	header := common.GetHeaderForChildOperationIdentity(ctx, "ontology.metric.query", ontologyQueryIdentity(uri+"?"+query.Encode(), req))
+	header[rest.ContentTypeKey] = rest.ContentTypeJSON
 	_, respBody, err := o.httpClient.PostBytes(ctx, target, header, req)
 	if err != nil {
 		o.logger.WithContext(ctx).Warnf("[OntologyQuery#QueryMetricData] kn=%s metric=%s failed: %v", knID, metricID, err)

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -59,6 +59,22 @@ func TestQueryObjectInstances_Success(t *testing.T) {
 	})
 }
 
+func TestObjectQueryIdentityIsStablePerConcreteQuery(t *testing.T) {
+	first := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "customer", Limit: 10}
+	replay := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "customer", Limit: 10}
+	different := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "order", Limit: 10}
+	const target = "/api/bkn-backend/v1/knowledge-networks/kn-1/object-types/customer/objects?include_type_info=false"
+	if objectQueryIdentity(target, first) != objectQueryIdentity(target, replay) {
+		t.Fatal("equivalent queries must have a stable identity")
+	}
+	if objectQueryIdentity(target, first) == objectQueryIdentity(target, different) {
+		t.Fatal("different queries must not share an identity")
+	}
+	if objectQueryIdentity(target, first) == objectQueryIdentity(target+"&ignoring_store_cache=true", first) {
+		t.Fatal("different query parameters must not share an identity")
+	}
+}
+
 // TestQueryObjectInstances_HTTPError test QueryObjectInstances HTTP error.
 func TestQueryObjectInstances_HTTPError(t *testing.T) {
 	convey.Convey("TestQueryObjectInstances_HTTPError", t, func() {

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_test.go
@@ -59,19 +59,27 @@ func TestQueryObjectInstances_Success(t *testing.T) {
 	})
 }
 
-func TestObjectQueryIdentityIsStablePerConcreteQuery(t *testing.T) {
+func TestOntologyQueryIdentityIsStablePerConcreteQuery(t *testing.T) {
 	first := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "customer", Limit: 10}
 	replay := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "customer", Limit: 10}
 	different := &interfaces.QueryObjectInstancesReq{KnID: "kn-1", OtID: "order", Limit: 10}
 	const target = "/api/bkn-backend/v1/knowledge-networks/kn-1/object-types/customer/objects?include_type_info=false"
-	if objectQueryIdentity(target, first) != objectQueryIdentity(target, replay) {
+	if ontologyQueryIdentity(target, first) != ontologyQueryIdentity(target, replay) {
 		t.Fatal("equivalent queries must have a stable identity")
 	}
-	if objectQueryIdentity(target, first) == objectQueryIdentity(target, different) {
+	if ontologyQueryIdentity(target, first) == ontologyQueryIdentity(target, different) {
 		t.Fatal("different queries must not share an identity")
 	}
-	if objectQueryIdentity(target, first) == objectQueryIdentity(target+"&ignoring_store_cache=true", first) {
+	if ontologyQueryIdentity(target, first) == ontologyQueryIdentity(target+"&ignoring_store_cache=true", first) {
 		t.Fatal("different query parameters must not share an identity")
+	}
+}
+
+func TestOntologyQueryIdentityFallbackDistinguishesTargets(t *testing.T) {
+	first := ontologyQueryIdentity("/query/object-a", func() {})
+	second := ontologyQueryIdentity("/query/object-b", func() {})
+	if first == second {
+		t.Fatal("marshal failures for different targets must not collapse to one identity")
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -344,6 +344,18 @@ func GetHeaderForChildOperation(ctx context.Context, operationName string, callO
 	return GetHeaderFromCtx(SetTraceContextToCtx(ctx, traceContext))
 }
 
+// GetHeaderForChildOperationIdentity derives a stable child operation for one
+// concrete downstream operation. identity must remain stable across retries.
+func GetHeaderForChildOperationIdentity(ctx context.Context, operationName, identity string) map[string]string {
+	traceContext, ok := GetTraceContextFromCtx(ctx)
+	if !ok {
+		return GetHeaderFromCtx(ctx)
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s|%s|%d|%s", traceContext.OperationID, strings.TrimSpace(operationName), traceContext.Attempt, strings.TrimSpace(identity))))
+	traceContext.OperationID = "op_" + hex.EncodeToString(sum[:])
+	return GetHeaderFromCtx(SetTraceContextToCtx(ctx, traceContext))
+}
+
 func childOperationID(parentOperationID, operationName string, attempt, callOrdinal int) string {
 	if callOrdinal < 1 {
 		callOrdinal = 1

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage_test.go
@@ -182,6 +182,15 @@ func TestBusinessCausalityHeadersAreValidatedAndPropagated(t *testing.T) {
 		convey.So(first[HeaderBKNAttempt], convey.ShouldEqual, "2")
 	})
 
+	convey.Convey("child operation identity distinguishes concrete queries and replays the same query", t, func() {
+		ctx := SetTraceContextToCtx(context.Background(), TraceContext{OperationID: "parent-operation", Attempt: 2})
+		first := GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", "sha256:query-a")
+		replay := GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", "sha256:query-a")
+		second := GetHeaderForChildOperationIdentity(ctx, "ontology.object.query", "sha256:query-b")
+		convey.So(first[HeaderBKNOperationID], convey.ShouldEqual, replay[HeaderBKNOperationID])
+		convey.So(first[HeaderBKNOperationID], convey.ShouldNotEqual, second[HeaderBKNOperationID])
+	})
+
 	convey.Convey("invalid inbound business causality is removed at the boundary", t, func() {
 		headers := map[string]string{
 			HeaderBKNRequestID:        "req_01JZVALIDREQUESTID000000006",


### PR DESCRIPTION
## What Changed

- [x] Context Loader 按规范化的下游查询路径、查询参数和请求 body 派生稳定且唯一的 child operation ID
- [x] Evidence Outbox 将同 event_id、同 payload 作为幂等重放返回既有记录
- [x] Evidence Outbox 将同 event_id、不同 payload 返回显式冲突，并覆盖并发 1062 竞态

---

## Why

- Related Issue: Closes #1236
- Related Feature: BKN Trace evidence chain
- Background: 同一父 Operation/attempt 内的多个 ontology.object.query 曾固定使用 callOrdinal=1，导致不同查询复用 child operation_id；Evidence event_id 又由 trace_id、operation_id、event_type、attempt 派生，最终触发 Outbox 唯一索引冲突。

---

## How

- Key implementation points:
  - 以 parent operation、attempt、operation name 和具体请求身份派生 child operation_id；相同请求重试保持稳定，不同请求相互区分。
  - 写入 Outbox 前先按 event_id 检查；payload hash 相同直接返回已存事件，不消耗 producer sequence。
  - payload hash 不同返回 ErrEventIDConflict。
  - 并发 INSERT 遇到 duplicate/unique key 时先回滚事务，再重读记录并执行相同幂等/冲突裁决。
- Breaking changes (API, config, database, etc.): 无 API、配置或数据库 schema 变更。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- context-loader: go test ./...
- ontology-query: go test ./common/...
- race: go test -race ./server/drivenadapters ./server/infra/common
- race: go test -race ./common/bkntrace/outbox
- git diff --check

---

## Risk & Rollback

- Potential risks: child operation_id 的派生规则变化会使新版本产生新的查询操作标识；同一规范化请求的重试仍保持稳定。
- Rollback plan: 回滚本 PR 的单个提交即可；不涉及数据库迁移。紧急情况下仍可关闭 BKN Trace Outbox producer/worker，不影响正常查询业务。

---

## Additional Notes

- 0.1.4 现场可继续使用 BKN_TRACE_OUTBOX_ENABLED=false 与 BKN_TRACE_OUTBOX_WORKER_ENABLED=false 作为临时止损；主线采用本 PR 的源头唯一性与 Outbox 幂等双层修复。