### PR TITLE
fix(deploy): disable legacy business domain by default

### DIFF
--- a/deploy/scripts/services/openbkn.sh
+++ b/deploy/scripts/services/openbkn.sh
@@ -1253,6 +1253,8 @@ _openbkn_config_sets_image_registry() {
 }
 
 # Inject default --set values for bkn-foundry if user did not override them.
+# Keep the legacy 0.1.4 charts from enabling the retired business-system dependency
+# when this script is used with a release manifest that still pins those charts.
 _openbkn_apply_default_set_values() {
     # image.registry precedence in ONLINE mode: explicit --set image.registry=… wins;
     # else an explicit --registry flag is applied; else if CONFIG_YAML_PATH already sets
@@ -1282,6 +1284,11 @@ _openbkn_apply_default_set_values() {
         _reg_resolved="$(_openbkn_resolve_registry "swr")"
         CORE_SET_VALUES+=("image.registry=${_reg_resolved}")
         log_info "Image registry default applied: --set image.registry=${_reg_resolved} (override with --registry=ghcr or --set image.registry=...)."
+    fi
+
+    if ! get_set_value "businessDomain.enabled" "${CORE_SET_VALUES[@]-}" >/dev/null 2>&1; then
+        CORE_SET_VALUES+=("businessDomain.enabled=false")
+        log_info "Default applied: --set businessDomain.enabled=false (override with --set businessDomain.enabled=true)"
     fi
 
     # Lightweight resource overrides for resource-constrained environments (mac kind / k3s).


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Restored the default `businessDomain.enabled=false` Helm override in the OpenBKN deployment script.
- [x] Added context explaining that the override protects legacy `0.1.4` charts from calling the retired `business-system` dependency.

---

## Why

- Related Issue: N/A
- Related Feature: N/A
- Background: The current deployment script can still resolve the legacy `0.1.4` release manifest. Its `bkn-backend` chart defaults `businessDomain.enabled` to `true`, while the retired `business-system` service is no longer available. Earlier deployment script versions injected `--set businessDomain.enabled=false`; restoring this default prevents new installations from re-enabling the legacy dependency.

---

## How

- Key implementation points:
  - Add `businessDomain.enabled=false` to default Helm set values when the caller has not explicitly supplied the key.
  - Preserve explicit operator overrides such as `--set businessDomain.enabled=true`.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally: Not applicable; deployment shell-script-only change.
- [x] Integration tests passed locally: Not applicable.
- [ ] Verified in test environment: Not performed.

Test notes:

- Ran `bash -n deploy/scripts/services/openbkn.sh`.
- Ran `git diff --check`.

---

## Risk & Rollback

- Potential risks:
  - Installations using legacy charts will disable business-domain integration by default.
  - Operators explicitly requiring the legacy integration must pass `--set businessDomain.enabled=true`.
- Rollback plan:
  - Revert commit `906098bce`, or explicitly install with `--set businessDomain.enabled=true`.

---

## Additional Notes

- Scope is limited to `deploy/scripts/services/openbkn.sh`.
- This keeps the current deployment script compatible with the still-pinned legacy `0.1.4` chart.