### PR TITLE
fix(context-loader): report "no skills" instead of ObjectTypeNotFound (#1224)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/infra/localize/locales/en-US.json
+++ b/adp/context-loader/agent-retrieval/server/infra/localize/locales/en-US.json
@@ -128,6 +128,7 @@
     "LogicPropertyGenerationFailed": "Unable to generate dynamic parameters."
   },
   "find_skills": {
+    "skills_not_modeled": "This knowledge network has no skills object type modeled, so there are no skills to recall. To enable skill recall, create the skills object type in this network and bind skill data to it.",
     "network_scope_too_wide": "Skills in this knowledge network are not globally effective, and no results were found at the network level. Please provide object_type_id; if you can identify the instance, also provide instance_identities and retry.",
     "network_no_skills": "No recallable skills found in the current knowledge network. Please confirm that skills have been created and are visible in this knowledge network.",
     "object_type_no_binding": "No skill binding configured for this object type, unable to recall skills in this scope. Please confirm that skills are bound to this object type.",

--- a/adp/context-loader/agent-retrieval/server/infra/localize/locales/zh-Hans.json
+++ b/adp/context-loader/agent-retrieval/server/infra/localize/locales/zh-Hans.json
@@ -128,6 +128,7 @@
     "LogicPropertyGenerationFailed": "生成动态参数失败。"
   },
   "find_skills": {
+    "skills_not_modeled": "当前知识网络未建模技能对象类（skills），因此没有可召回的 Skill。如需启用技能召回，请先在该网络中创建 skills 对象类并绑定技能数据。",
     "network_scope_too_wide": "当前知识网络中的 Skill 不是全局生效，网络级范围未返回结果。请补充 object_type_id；如已定位到实例，再补充 instance_identities 后重试。",
     "network_no_skills": "当前知识网络下未找到可召回的 Skill。请确认 Skill 是否已创建并在当前知识网络中可见。",
     "object_type_no_binding": "当前对象类未配置 Skill 绑定关系，无法在该范围内召回 Skill。请确认该对象类是否已绑定 Skill。",

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/find_skills_service_test.go
@@ -179,26 +179,84 @@ func TestFindSkills_ObjectTypeNotFound(t *testing.T) {
 	}
 }
 
-func TestFindSkills_SkillsObjectTypeNotFound(t *testing.T) {
-	bkn := &testBknBackend{
-		getObjectTypeDetailFunc: func(_ context.Context, _ string, otIDs []string, includeDetail bool) ([]*interfaces.ObjectType, error) {
-			if len(otIDs) != 1 {
-				t.Fatalf("expected a single object type lookup, got %v", otIDs)
+// A network that models no skills object type has no skills to recall. The caller
+// asked what skills exist; "none" is the answer, not a failure. Reporting
+// bkn-backend's ObjectTypeNotFound here pointed triage at the caller's
+// object_type_id, which does exist. See #1224.
+func TestFindSkills_SkillsObjectTypeNotModeledReturnsEmptyResult(t *testing.T) {
+	skillsLookup := func(result []*interfaces.ObjectType, lookupErr error) *testBknBackend {
+		return &testBknBackend{
+			getObjectTypeDetailFunc: func(_ context.Context, _ string, otIDs []string, includeDetail bool) ([]*interfaces.ObjectType, error) {
+				if len(otIDs) != 1 {
+					t.Fatalf("expected a single object type lookup, got %v", otIDs)
+				}
+				switch otIDs[0] {
+				case "contract":
+					if includeDetail {
+						t.Fatal("expected includeDetail=false for business object type existence check")
+					}
+					return []*interfaces.ObjectType{{ID: "contract", Name: "contract"}}, nil
+				case "skills":
+					if !includeDetail {
+						t.Fatal("expected includeDetail=true for skills contract check")
+					}
+					return result, lookupErr
+				default:
+					t.Fatalf("unexpected object type lookup: %v", otIDs)
+					return nil, nil
+				}
+			},
+		}
+	}
+
+	cases := []struct {
+		name string
+		bkn  *testBknBackend
+	}{
+		// What bkn-backend actually answers: its batch lookup fails the whole call
+		// when any requested id is missing, so the absent skills object type arrives
+		// as a 404 carrying BknBackend.ObjectType.ObjectTypeNotFound.
+		{"downstream reports the object type as not found", skillsLookup(nil, &infraErr.HTTPError{
+			HTTPCode: 404,
+			Code:     bknBackendObjectTypeNotFoundCode,
+		})},
+		{"downstream returns no entries", skillsLookup([]*interfaces.ObjectType{}, nil)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewFindSkillsServiceWith(&testLogger{}, newTestConfig(), &testOntologyQuery{}, tc.bkn)
+
+			resp, err := svc.FindSkills(zhCtx(), &interfaces.FindSkillsReq{
+				KnID: "kn1", ObjectTypeID: "contract", TopK: 10,
+			})
+			if err != nil {
+				t.Fatalf("a network without skills is an empty result, not an error: %v", err)
 			}
-			switch otIDs[0] {
-			case "contract":
-				if includeDetail {
-					t.Fatal("expected includeDetail=false for business object type existence check")
-				}
+			if resp == nil {
+				t.Fatal("expected a response")
+			}
+			if len(resp.Entries) != 0 {
+				t.Fatalf("expected no entries, got %d", len(resp.Entries))
+			}
+			if resp.Message == "" || resp.Message == "find_skills.skills_not_modeled" {
+				t.Fatalf("expected a translated explanation, got %q", resp.Message)
+			}
+		})
+	}
+}
+
+// Only bkn-backend's ObjectTypeNotFound means "no skills modeled". Any other 404 —
+// an unknown kn_id, a routing miss — is a real failure and must keep surfacing.
+func TestFindSkills_UnrelatedNotFoundStillFails(t *testing.T) {
+	bkn := &testBknBackend{
+		getObjectTypeDetailFunc: func(_ context.Context, _ string, otIDs []string, _ bool) ([]*interfaces.ObjectType, error) {
+			if otIDs[0] == "contract" {
 				return []*interfaces.ObjectType{{ID: "contract", Name: "contract"}}, nil
-			case "skills":
-				if !includeDetail {
-					t.Fatal("expected includeDetail=true for skills contract check")
-				}
-				return []*interfaces.ObjectType{}, nil
-			default:
-				t.Fatalf("unexpected object type lookup: %v", otIDs)
-				return nil, nil
+			}
+			return nil, &infraErr.HTTPError{
+				HTTPCode: 404,
+				Code:     "BknBackend.KnowledgeNetwork.NotFound",
 			}
 		},
 	}
@@ -208,18 +266,14 @@ func TestFindSkills_SkillsObjectTypeNotFound(t *testing.T) {
 		KnID: "kn1", ObjectTypeID: "contract", TopK: 10,
 	})
 	if err == nil {
-		t.Fatal("expected error when skills object type is missing")
+		t.Fatalf("an unknown knowledge network must stay an error, got %#v", resp)
 	}
-	if resp != nil {
-		t.Fatalf("expected nil response on error, got %#v", resp)
-	}
-
 	httpErr := &infraErr.HTTPError{}
 	if !errors.As(err, &httpErr) {
 		t.Fatalf("expected HTTPError, got %T", err)
 	}
-	if httpErr.HTTPCode != 404 {
-		t.Fatalf("expected HTTP 404, got %d", httpErr.HTTPCode)
+	if httpErr.Code != "BknBackend.KnowledgeNetwork.NotFound" {
+		t.Fatalf("expected the downstream code to survive, got %q", httpErr.Code)
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knfindskills/index.go
@@ -9,6 +9,7 @@ package knfindskills
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -26,6 +27,26 @@ import (
 )
 
 var requiredSkillsDataProperties = []string{"skill_id", "name"}
+
+// bknBackendObjectTypeNotFoundCode is the error code bkn-backend returns when a
+// requested object type id is absent from the knowledge network. Its batch lookup
+// fails the whole call as soon as one id is missing, so this is exactly what a
+// network with no skills object type looks like from here.
+const bknBackendObjectTypeNotFoundCode = "BknBackend.ObjectType.ObjectTypeNotFound"
+
+// errSkillsNotModeled marks "this knowledge network has no skills object type",
+// which is a property of the network rather than a failure of the call.
+var errSkillsNotModeled = errors.New("skills object type is not modeled in this knowledge network")
+
+// isObjectTypeNotFound reports whether err is bkn-backend saying the object type
+// does not exist. It matches the downstream error code rather than the bare 404,
+// because an unknown kn_id is also a 404 and must keep surfacing as one.
+func isObjectTypeNotFound(err error) bool {
+	var he *infraErr.HTTPError
+	return errors.As(err, &he) &&
+		he.HTTPCode == http.StatusNotFound &&
+		he.Code == bknBackendObjectTypeNotFoundCode
+}
 
 type findSkillsServiceImpl struct {
 	logger        interfaces.Logger
@@ -97,15 +118,32 @@ func (s *findSkillsServiceImpl) FindSkills(ctx context.Context, req *interfaces.
 		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error())
 	}
 
-	skillsObjType, err := s.loadAndValidateSkillsContract(ctx, req.KnID, fsCfg.SkillsObjectTypeID)
-	if err != nil {
-		return nil, err
-	}
-
+	// Validate the caller-supplied object type FIRST. A wrong object_type_id is the
+	// caller's error and must keep reporting ObjectTypeNotFound; a missing skills
+	// object type is a property of the network and is answered with an empty result
+	// just below. Running the skills contract first made the two indistinguishable.
 	if req.ObjectTypeID != fsCfg.SkillsObjectTypeID {
 		if err := s.validateObjectTypeExists(ctx, req.KnID, req.ObjectTypeID); err != nil {
 			return nil, err
 		}
+	}
+
+	skillsObjType, err := s.loadAndValidateSkillsContract(ctx, req.KnID, fsCfg.SkillsObjectTypeID)
+	if err != nil {
+		// A network that binds no skills has nothing to recall. The caller asked
+		// "what skills does this object type have"; the answer is "none", not a
+		// failure — and reporting bkn-backend's ObjectTypeNotFound sent triage
+		// after the caller's object_type_id, which does exist. See #1224.
+		if errors.Is(err, errSkillsNotModeled) {
+			s.logger.WithContext(ctx).Infof(
+				"[FindSkills] kn_id=%s has no skills object type %q; returning an empty result",
+				req.KnID, fsCfg.SkillsObjectTypeID)
+			return &interfaces.FindSkillsResp{
+				Entries: []*interfaces.SkillItem{},
+				Message: translateMessage(ctx, "find_skills.skills_not_modeled"),
+			}, nil
+		}
+		return nil, err
 	}
 
 	s.logger.WithContext(ctx).Infof("[FindSkills] kn_id=%s, mode=%d, object_type_id=%s, instance_count=%d, has_skill_query=%v",
@@ -160,14 +198,13 @@ func (s *findSkillsServiceImpl) FindSkills(ctx context.Context, req *interfaces.
 func (s *findSkillsServiceImpl) loadAndValidateSkillsContract(ctx context.Context, knID, skillsObjectTypeID string) (*interfaces.ObjectType, error) {
 	objectTypes, err := s.bknBackend.GetObjectTypeDetail(ctx, knID, []string{skillsObjectTypeID}, true)
 	if err != nil {
+		if isObjectTypeNotFound(err) {
+			return nil, errSkillsNotModeled
+		}
 		return nil, err
 	}
 	if len(objectTypes) == 0 {
-		return nil, infraErr.DefaultHTTPError(ctx, http.StatusNotFound, map[string]interface{}{
-			"kn_id":                 knID,
-			"skills_object_type_id": skillsObjectTypeID,
-			"reason":                "skills object type not found in current knowledge network",
-		})
+		return nil, errSkillsNotModeled
 	}
 
 	skillsObjType := objectTypes[0]


### PR DESCRIPTION
## Problem

`find_skills` on a knowledge network that models no skills object type returned:

```json
{"code": "BknBackend.ObjectType.ObjectTypeNotFound", "description": "对象类不存在"}
```

The object type the caller passed exists — `get_object_types` on the same `kn_id` + `object_type_id` returns it. The missing object type is the *skills contract* one (`find_skills.skills_object_type_id`, default `skills`), which `FindSkills` loads before it validates the caller's `object_type_id`. bkn-backend's batch lookup fails the whole call as soon as one id is missing ([`object_type_service.go:557-563`](https://github.com/openbkn-ai/bkn-foundry/blob/main/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go#L557-L563)), and the adapter carries the downstream error code through verbatim, so the error reads as a verdict on the caller's input.

## Change

- Validate the caller-supplied `object_type_id` **first**, so a genuinely wrong id keeps reporting `ObjectTypeNotFound`.
- Treat an absent skills object type as an **empty result plus a message**, not a failure. The caller asked what skills an object type has; "none" is an answer. Both shapes are handled: the downstream 404 carrying `BknBackend.ObjectType.ObjectTypeNotFound`, and an empty entries list.
- Match on the downstream **error code**, not the bare 404 — an unknown `kn_id` is also a 404 and must keep surfacing as one. Covered by a test.

An incomplete skills contract (missing `skill_id` / `name`) still returns 400: that is a modelling defect and should stay visible.

New i18n key `find_skills.skills_not_modeled` in both locales.

## Evidence

On `14.103.77.23`, `get_object_types(ecommerce_ops_bkn_public, ["skills", "brand"])` returns `entries: [brand]`, `missing: ["skills"]` — which is exactly why every `object_type_id` in that network 404'd, while the same four ids in `ecommerce_ops_bkn_zh_attrs` (which does model skills) returned normally.

## Test

`go test ./...` green for agent-retrieval. `TestFindSkills_SkillsObjectTypeNotModeledReturnsEmptyResult` replaces the test that encoded the old contract; `TestFindSkills_UnrelatedNotFoundStillFails` pins the kn-not-found case.

Closes #1224

🤖 Generated with [Claude Code](https://claude.com/claude-code)