### PR TITLE
fix(context-loader): surface ontology-query 4xx on the action endpoints (#1225)

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query.go
@@ -247,6 +247,26 @@ func classifyQueryError(ctx context.Context, err error) error {
 	return err
 }
 
+// classifyActionError maps a downstream ontology-query failure on the action
+// endpoints, which carry an operation-specific "dependency unavailable" detail.
+//
+// A 4xx is the caller's or the model's fault, so classifyQueryError surfaces it
+// verbatim; only a 5xx or a transport error is a real dependency fault and keeps
+// the localized fallback detail.
+//
+// Without the split, a modelling error reached the caller as an outage: an action
+// type bound to an object type with no data source makes ontology-query answer 400
+// "对象类 X 未绑定数据源", and get_action_info reported that as 502 "依赖服务不可用",
+// pointing triage at pod health instead of at the knowledge network. See #1225.
+func classifyActionError(ctx context.Context, err error, fallbackDetailKey string) error {
+	var he *infraErr.HTTPError
+	if errors.As(err, &he) && he.HTTPCode >= http.StatusBadRequest && he.HTTPCode < http.StatusInternalServerError {
+		return classifyQueryError(ctx, err)
+	}
+	return infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
+		infraErr.LocalizedDetail(ctx, fallbackDetailKey))
+}
+
 // QueryLogicProperties queries logical property values.
 func (o *ontologyQueryClient) QueryLogicProperties(ctx context.Context, req *interfaces.QueryLogicPropertiesReq) (resp *interfaces.QueryLogicPropertiesResp, err error) {
 	uri := fmt.Sprintf(queryLogicPropertiesURI, req.KnID, req.OtID)
@@ -310,8 +330,7 @@ func (o *ontologyQueryClient) QueryActions(ctx context.Context, req *interfaces.
 	_, respBody, err := o.httpClient.PostBytes(ctx, url, header, body)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#QueryActions] Request failed, err: %v", err)
-		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
-			infraErr.LocalizedDetail(ctx, "ActionQueryRequestFailed"))
+		return nil, classifyActionError(ctx, err, "ActionQueryRequestFailed")
 	}
 
 	resp = &interfaces.QueryActionsResponse{}
@@ -392,8 +411,7 @@ func (o *ontologyQueryClient) GetActionExecution(ctx context.Context, req *inter
 	_, respBody, err := o.httpClient.GetBytes(ctx, reqURL, nil, header)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#GetActionExecution] Request failed, err: %v", err)
-		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
-			infraErr.LocalizedDetail(ctx, "ActionExecutionLookupFailed"))
+		return nil, classifyActionError(ctx, err, "ActionExecutionLookupFailed")
 	}
 
 	result := map[string]any{}
@@ -453,8 +471,7 @@ func (o *ontologyQueryClient) ListActionExecutions(ctx context.Context, req *int
 	_, respBody, err := o.httpClient.GetBytes(ctx, reqURL, query, header)
 	if err != nil {
 		o.logger.WithContext(ctx).Errorf("[OntologyQuery#ListActionExecutions] Request failed, err: %v", err)
-		return nil, infraErr.DefaultHTTPError(ctx, http.StatusBadGateway,
-			infraErr.LocalizedDetail(ctx, "ActionExecutionHistoryRequestFailed"))
+		return nil, classifyActionError(ctx, err, "ActionExecutionHistoryRequestFailed")
 	}
 
 	result := map[string]any{}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_action_error_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/ontology_query_action_error_test.go
@@ -1,0 +1,177 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package drivenadapters
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/mocks"
+)
+
+// downstreamErrorForStatus reproduces what the shared HTTP client hands back for a
+// non-2xx ontology-query response: the downstream status code, the generic
+// external-server code, and the raw response body inside the details string.
+func downstreamErrorForStatus(status int, body string) error {
+	return infraErr.NewHTTPError(context.Background(), status, infraErr.ErrExtCommonExternalServerError,
+		fmt.Sprintf("Exception(http do error, method: POST, url: %s,  http status: %d, error: %s)",
+			"http://ontology-query/api", status, body))
+}
+
+func newActionErrorClient(t *testing.T) (*ontologyQueryClient, *mocks.MockHTTPClient, *gomock.Controller) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mockLogger := mocks.NewMockLogger(ctrl)
+	mockLogger.EXPECT().WithContext(gomock.Any()).Return(mockLogger).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any()).AnyTimes()
+	mockHTTPClient := mocks.NewMockHTTPClient(ctrl)
+	return &ontologyQueryClient{
+		logger:     mockLogger,
+		baseURL:    "http://ontology-query/api/ontology-query",
+		httpClient: mockHTTPClient,
+	}, mockHTTPClient, ctrl
+}
+
+func asHTTPError(t *testing.T, err error) *infraErr.HTTPError {
+	t.Helper()
+	var he *infraErr.HTTPError
+	if !errors.As(err, &he) {
+		t.Fatalf("expected *infraErr.HTTPError, got %T: %v", err, err)
+	}
+	return he
+}
+
+// A modelling error downstream is the caller's problem, not an outage: an action type
+// whose object type has no data source makes ontology-query answer 400, and reporting
+// that as 502 "dependency unavailable" sent triage to pod health instead of to the
+// knowledge network. See #1225.
+func TestQueryActions_DownstreamClientErrorIsNotReportedAsBadGateway(t *testing.T) {
+	client, mockHTTPClient, ctrl := newActionErrorClient(t)
+	defer ctrl.Finish()
+
+	const body = `{"error_code":"OntologyQuery.ObjectType.InvalidParameter",` +
+		`"description":"请求参数不合法","error_details":"对象类 contract 未绑定数据源。"}`
+	mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(http.StatusBadRequest, nil, downstreamErrorForStatus(http.StatusBadRequest, body))
+
+	_, err := client.QueryActions(context.Background(), &interfaces.QueryActionsRequest{
+		KnID: "crm-management",
+		AtID: "contract_to_order",
+	})
+
+	he := asHTTPError(t, err)
+	if he.HTTPCode != http.StatusBadRequest {
+		t.Fatalf("downstream 400 must stay a 400, got %d", he.HTTPCode)
+	}
+	details := fmt.Sprintf("%v", he.ErrorDetails)
+	if !strings.Contains(details, "对象类 contract 未绑定数据源。") {
+		t.Fatalf("downstream cause must reach the caller, got details: %s", details)
+	}
+}
+
+// A downstream 404 (unknown kn_id/at_id) must keep its own status rather than
+// collapsing into 400, so the caller can tell "no such action type" from
+// "this request is malformed".
+func TestQueryActions_DownstreamNotFoundKeepsItsStatus(t *testing.T) {
+	client, mockHTTPClient, ctrl := newActionErrorClient(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(http.StatusNotFound, nil, downstreamErrorForStatus(http.StatusNotFound,
+			`{"error_code":"OntologyQuery.ObjectType.ObjectTypeNotFound"}`))
+
+	_, err := client.QueryActions(context.Background(), &interfaces.QueryActionsRequest{
+		KnID: "kn-1", AtID: "missing_action",
+	})
+
+	if code := asHTTPError(t, err).HTTPCode; code != http.StatusNotFound {
+		t.Fatalf("downstream 404 must stay a 404, got %d", code)
+	}
+}
+
+// A 5xx really is a dependency fault, so it keeps the operation-specific 502 detail.
+func TestQueryActions_DownstreamServerErrorStaysBadGateway(t *testing.T) {
+	client, mockHTTPClient, ctrl := newActionErrorClient(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(http.StatusInternalServerError, nil,
+			downstreamErrorForStatus(http.StatusInternalServerError, `{"error_code":"OntologyQuery.InternalError"}`))
+
+	_, err := client.QueryActions(context.Background(), &interfaces.QueryActionsRequest{
+		KnID: "kn-1", AtID: "at-1",
+	})
+
+	if code := asHTTPError(t, err).HTTPCode; code != http.StatusBadGateway {
+		t.Fatalf("downstream 500 must stay a 502, got %d", code)
+	}
+}
+
+// A transport error carries no HTTP code at all and must also stay a 502.
+func TestQueryActions_TransportErrorStaysBadGateway(t *testing.T) {
+	client, mockHTTPClient, ctrl := newActionErrorClient(t)
+	defer ctrl.Finish()
+
+	mockHTTPClient.EXPECT().PostBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(0, nil, errors.New("dial tcp: connection refused"))
+
+	_, err := client.QueryActions(context.Background(), &interfaces.QueryActionsRequest{
+		KnID: "kn-1", AtID: "at-1",
+	})
+
+	if code := asHTTPError(t, err).HTTPCode; code != http.StatusBadGateway {
+		t.Fatalf("transport failure must stay a 502, got %d", code)
+	}
+}
+
+// get_action_execution and list_action_executions call the same downstream family and
+// had the same blanket mapping, so they are held to the same contract.
+func TestActionExecutionLookups_PreserveDownstreamClientError(t *testing.T) {
+	t.Run("GetActionExecution", func(t *testing.T) {
+		client, mockHTTPClient, ctrl := newActionErrorClient(t)
+		defer ctrl.Finish()
+
+		mockHTTPClient.EXPECT().GetBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusNotFound, nil, downstreamErrorForStatus(http.StatusNotFound,
+				`{"error_code":"OntologyQuery.ActionExecution.NotFound"}`))
+
+		_, err := client.GetActionExecution(context.Background(), &interfaces.GetActionExecutionRequest{
+			KnID: "kn-1", ExecutionID: "exec-1",
+		})
+
+		if code := asHTTPError(t, err).HTTPCode; code != http.StatusNotFound {
+			t.Fatalf("downstream 404 must stay a 404, got %d", code)
+		}
+	})
+
+	t.Run("ListActionExecutions", func(t *testing.T) {
+		client, mockHTTPClient, ctrl := newActionErrorClient(t)
+		defer ctrl.Finish()
+
+		mockHTTPClient.EXPECT().GetBytes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(http.StatusBadRequest, nil, downstreamErrorForStatus(http.StatusBadRequest,
+				`{"error_code":"OntologyQuery.InvalidParameter"}`))
+
+		_, err := client.ListActionExecutions(context.Background(), &interfaces.ListActionExecutionsRequest{
+			KnID: "kn-1",
+		})
+
+		if code := asHTTPError(t, err).HTTPCode; code != http.StatusBadRequest {
+			t.Fatalf("downstream 400 must stay a 400, got %d", code)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`get_action_info` on `crm-management` returned a stable 502:

```json
{"code": "Public.BadGateway", "description": "依赖服务不可用", "details": "获取行动信息失败。"}
```

Nothing was down. ontology-query's answer on the same trace (`7ea0ebd497ba30b42b632f02eabbb890`) was a **400**:

```
请求参数不合法. 对象类 contract 未绑定数据源。
error_code: OntologyQuery.ObjectType.InvalidParameter
```

`QueryActions` mapped every downstream failure — transport error, 4xx, 5xx alike — to `502 BadGateway`, so a modelling error arrived as a dependency outage and sent triage to pod health and cluster logs, where nothing was wrong.

## Change

`classifyQueryError` already draws this line for the object and subgraph queries: a 4xx keeps its downstream status and detail, a 5xx or transport failure stays a dependency fault. The action endpoints predate it.

`classifyActionError` applies the same rule while keeping each endpoint's localized 502 detail for the genuine dependency case. `QueryActions`, `GetActionExecution` and `ListActionExecutions` now use it — all three back agent-facing tools (`get_action_info`, `get_action_execution`, `list_action_executions`) and all three had the same blanket mapping.

## Evidence

`crm-management`'s `contract` object type has `data_source: null` and every `mapped_field` set to `"-"`, so its action types cannot resolve instances. After this change that is what the caller is told, instead of "dependency unavailable".

## Test

Five new cases pin the contract: downstream 400 preserved with its cause reaching the caller, downstream 404 keeping its own status rather than collapsing to 400, downstream 500 and transport failure both staying 502, and the two execution-lookup endpoints held to the same rule. `go test ./...` green for agent-retrieval.

Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)