### PR TITLE
feat(bkn): enforce child permission entrypoints

### DIFF
--- a/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
@@ -137,6 +137,8 @@ spec:
             value: {{ .Values.auth.enabled | quote }}
           - name: KN_CHILD_RESOURCE_PEP_ENABLED
             value: {{ .Values.auth.knChildResourcePepEnabled | quote }}
+          - name: KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE
+            value: {{ .Values.auth.knChildResourceFilterChunkSize | quote }}
         resources: {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
           - name: {{ .Values.moduleName }}-cm

--- a/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
@@ -43,6 +43,8 @@ auth:
   enabled: true
   # Enable only after existing KN child policies and ResourceParent data are migrated.
   knChildResourcePepEnabled: false
+  # Zero sends one request; set a positive runtime value to split resource-filter calls without imposing a request cap.
+  knChildResourceFilterChunkSize: 0
 
 # Microservice communication dependency configuration.
 depServices:

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -177,13 +177,14 @@ func (ats *actionTypeService) CreateActionTypes(ctx context.Context, tx *sql.Tx,
 		}
 	}()
 
-	// Check whether the user ID can modify the business knowledge network.
-	err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   actionTypes[0].KNID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return []string{}, err
+	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
+		err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   actionTypes[0].KNID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return []string{}, err
+		}
 	}
 
 	// 0. Begin the transaction.
@@ -268,6 +269,25 @@ func (ats *actionTypeService) CreateActionTypes(ctx context.Context, tx *sql.Tx,
 	createActionTypes, updateActionTypes, err := ats.handleActionTypeImportMode(ctx, mode, actionTypes)
 	if err != nil {
 		return []string{}, err
+	}
+	if !permission.KNImportPermissionPrechecked(ctx) && permission.KNChildResourcePEPEnabled() {
+		if len(createActionTypes) > 0 {
+			if err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   actionTypes[0].KNID,
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+				return []string{}, err
+			}
+		}
+		updateIDs := make([]string, 0, len(updateActionTypes))
+		for _, actionType := range updateActionTypes {
+			updateIDs = append(updateIDs, actionType.ATID)
+		}
+		if err = permission.CheckKNChildBatchPermission(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, actionTypes[0].KNID, updateIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_MODIFY); err != nil {
+			return []string{}, err
+		}
 	}
 
 	// Create.
@@ -376,18 +396,19 @@ func (ats *actionTypeService) ValidateActionTypes(ctx context.Context, knID stri
 func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfaces.ActionTypesQueryParams) ([]*interfaces.ActionType, int, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListActionTypes")
 	defer span.End()
-
-	// Check whether the user ID can view the business knowledge network.
-	err := ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return []*interfaces.ActionType{}, 0, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return []*interfaces.ActionType{}, 0, err
+		}
 	}
 
-	// Get the action type list.
-	actionTypes, err := ats.ata.ListActionTypes(ctx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	actionTypes, err := ats.ata.ListActionTypes(ctx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListActionTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List action types error")
@@ -395,12 +416,16 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 			berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total, err := ats.ata.GetActionTypesTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetActionTypesTotal error: %s", err.Error())
-		span.SetStatus(codes.Error, "Get action types total error")
-		return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
+	total := len(actionTypes)
+	if permission.KNChildResourcePEPEnabled() {
+		actionTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, query.KNID, actionTypes,
+			func(actionType *interfaces.ActionType) string { return actionType.ATID }, query.Offset, query.Limit)
+		if err != nil {
+			return []*interfaces.ActionType{}, 0, err
+		}
+	} else {
+		actionTypes = permission.PaginateKNChildCandidates(actionTypes, query.Offset, query.Limit)
 	}
 	if len(actionTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -651,8 +676,6 @@ func (ats *actionTypeService) DeleteActionTypesByIDs(ctx context.Context, tx *sq
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, atIDs); err != nil {
 		return err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_MODIFY
 	if len(atIDs) == 1 {
 		_, exists, err := ats.CheckActionTypeExistByID(ctx, knID, branch, atIDs[0])
 		if err != nil {
@@ -661,11 +684,28 @@ func (ats *actionTypeService) DeleteActionTypesByIDs(ctx context.Context, tx *sq
 		if !exists {
 			return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ActionType_ActionTypeNotFound)
 		}
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_ACTION_TYPE,
+		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_ACTION_TYPE,
 			knID, atIDs[0], interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
-	}
-	if err := ats.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return err
+		if err := ats.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
+			return err
+		}
+	} else {
+		if permission.KNChildResourcePEPEnabled() {
+			for _, atID := range atIDs {
+				_, exists, err := ats.CheckActionTypeExistByID(ctx, knID, branch, atID)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ActionType_ActionTypeNotFound)
+				}
+			}
+		}
+		if err := permission.CheckKNChildBatchPermission(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, knID, atIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE); err != nil {
+			return err
+		}
 	}
 	if tx == nil {
 		// 0. Begin the transaction.
@@ -965,13 +1005,29 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 	response := interfaces.ActionTypes{}
 	var err error
 
-	// Check whether the user ID can view the business knowledge network.
-	err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return response, err
+	var visibleIDs []string
+	if !permission.KNChildResourcePEPEnabled() {
+		err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		if err != nil {
+			return response, err
+		}
+	} else {
+		candidateIDs, err := ats.GetActionTypeIDsByKnID(ctx, query.KNID, query.Branch)
+		if err != nil {
+			return response, err
+		}
+		visibleIDs, err = permission.FilterKNChildIDs(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, query.KNID, candidateIDs,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		if err != nil {
+			return response, err
+		}
+		if len(visibleIDs) == 0 {
+			return response, nil
+		}
 	}
 
 	// Convert conditions to dataset filter conditions.
@@ -1011,6 +1067,9 @@ func (ats *actionTypeService) SearchActionTypes(ctx context.Context, query *inte
 				berrors.BknBackend_ActionType_InvalidParameter_ConceptCondition).
 				WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.ConditionDecodeFailed", nil))
 		}
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		filterCondition = permission.RestrictDatasetFilterToIDs(filterCondition, visibleIDs)
 	}
 
 	// 1. Get relation types in the groups.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -396,7 +396,8 @@ func (ats *actionTypeService) ValidateActionTypes(ctx context.Context, knID stri
 func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfaces.ActionTypesQueryParams) ([]*interfaces.ActionType, int, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListActionTypes")
 	defer span.End()
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -405,10 +406,12 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 		}
 	}
 
-	candidateQuery := query
-	candidateQuery.Offset = 0
-	candidateQuery.Limit = -1
-	actionTypes, err := ats.ata.ListActionTypes(ctx, candidateQuery)
+	listQuery := query
+	if pepEnabled {
+		listQuery.Offset = 0
+		listQuery.Limit = -1
+	}
+	actionTypes, err := ats.ata.ListActionTypes(ctx, listQuery)
 	if err != nil {
 		logger.Errorf("ListActionTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List action types error")
@@ -416,8 +419,8 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 			berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total := len(actionTypes)
-	if permission.KNChildResourcePEPEnabled() {
+	var total int
+	if pepEnabled {
 		actionTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ats.ps,
 			interfaces.RESOURCE_TYPE_ACTION_TYPE, query.KNID, actionTypes,
 			func(actionType *interfaces.ActionType) string { return actionType.ATID }, query.Offset, query.Limit)
@@ -425,7 +428,13 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 			return []*interfaces.ActionType{}, 0, err
 		}
 	} else {
-		actionTypes = permission.PaginateKNChildCandidates(actionTypes, query.Offset, query.Limit)
+		total, err = ats.ata.GetActionTypesTotal(ctx, query)
+		if err != nil {
+			logger.Errorf("GetActionTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get action types total error")
+			return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 	if len(actionTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -691,14 +700,13 @@ func (ats *actionTypeService) DeleteActionTypesByIDs(ctx context.Context, tx *sq
 		}
 	} else {
 		if permission.KNChildResourcePEPEnabled() {
-			for _, atID := range atIDs {
-				_, exists, err := ats.CheckActionTypeExistByID(ctx, knID, branch, atID)
-				if err != nil {
-					return err
-				}
-				if !exists {
-					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ActionType_ActionTypeNotFound)
-				}
+			actionTypes, err := ats.ata.GetActionTypesByIDs(ctx, knID, branch, atIDs)
+			if err != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_ActionType_InternalError_GetActionTypesByIDsFailed).WithErrorDetails(err.Error())
+			}
+			if len(actionTypes) != len(atIDs) {
+				return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ActionType_ActionTypeNotFound)
 			}
 		}
 		if err := permission.CheckKNChildBatchPermission(ctx, ats.ps,

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -406,7 +406,8 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), query).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -428,6 +429,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -481,6 +483,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
 			ats, total, err := service.ListActionTypes(ctx, query)
@@ -510,6 +513,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
@@ -540,6 +544,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -559,9 +564,8 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 				},
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{{
-				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at1"},
-			}}, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -603,7 +607,8 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr[1:], nil)
+			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
 				[]string{"ot1"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -407,7 +407,6 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -429,7 +428,6 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -483,7 +481,6 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
 			ats, total, err := service.ListActionTypes(ctx, query)
@@ -513,7 +510,6 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ActionType_InternalError))
 
@@ -544,7 +540,6 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -564,8 +559,9 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 				},
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{}, nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.ActionType{{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at1"},
+			}}, nil)
 
 			ats, total, err := service.ListActionTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -607,8 +603,7 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr[1:], nil)
-			ata.EXPECT().GetActionTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(atArr, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
 				[]string{"ot1"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -414,7 +414,8 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询概念分组列表")
 	defer span.End()
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -423,10 +424,12 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 		}
 	}
 
-	candidateQuery := query
-	candidateQuery.Offset = 0
-	candidateQuery.Limit = -1
-	conceptGroups, err := cgs.cga.ListConceptGroups(ctx, candidateQuery)
+	listQuery := query
+	if pepEnabled {
+		listQuery.Offset = 0
+		listQuery.Limit = -1
+	}
+	conceptGroups, err := cgs.cga.ListConceptGroups(ctx, listQuery)
 	if err != nil {
 		logger.Errorf("ListConceptGroups error: %s", err.Error())
 		span.SetStatus(codes.Error, "List concept groups error")
@@ -435,8 +438,8 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 			berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total := len(conceptGroups)
-	if permission.KNChildResourcePEPEnabled() {
+	var total int
+	if pepEnabled {
 		conceptGroups, total, err = permission.FilterAndPaginateKNChildren(ctx, cgs.ps,
 			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, query.KNID, conceptGroups,
 			func(group *interfaces.ConceptGroup) string { return group.CGID }, query.Offset, query.Limit)
@@ -444,7 +447,13 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 			return []*interfaces.ConceptGroup{}, 0, err
 		}
 	} else {
-		conceptGroups = permission.PaginateKNChildCandidates(conceptGroups, query.Offset, query.Limit)
+		total, err = cgs.cga.GetConceptGroupsTotal(ctx, query)
+		if err != nil {
+			logger.Errorf("GetConceptGroupsTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get concept groups total error")
+			return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 	if len(conceptGroups) == 0 {
 		span.SetStatus(codes.Ok, "")

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -127,13 +127,14 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 		}
 	}()
 
-	// Check whether the user ID can create concept groups through policy evaluation.
-	err = cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   conceptGroup.KNID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return "", err
+	if !permission.KNImportPermissionPrechecked(ctx) {
+		err = cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   conceptGroup.KNID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return "", err
+		}
 	}
 
 	currentTime := time.Now().UnixMilli()
@@ -413,18 +414,19 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询概念分组列表")
 	defer span.End()
-
-	// Check whether the user ID can view the business knowledge network.
-	err := cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return []*interfaces.ConceptGroup{}, 0, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return []*interfaces.ConceptGroup{}, 0, err
+		}
 	}
 
-	// Get the concept group list.
-	conceptGroups, err := cgs.cga.ListConceptGroups(ctx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	conceptGroups, err := cgs.cga.ListConceptGroups(ctx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListConceptGroups error: %s", err.Error())
 		span.SetStatus(codes.Error, "List concept groups error")
@@ -433,13 +435,16 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 			berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total, err := cgs.cga.GetConceptGroupsTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetConceptGroupsTotal error: %s", err.Error())
-		span.SetStatus(codes.Error, "Get concept groups total error")
-
-		return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
+	total := len(conceptGroups)
+	if permission.KNChildResourcePEPEnabled() {
+		conceptGroups, total, err = permission.FilterAndPaginateKNChildren(ctx, cgs.ps,
+			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, query.KNID, conceptGroups,
+			func(group *interfaces.ConceptGroup) string { return group.CGID }, query.Offset, query.Limit)
+		if err != nil {
+			return []*interfaces.ConceptGroup{}, 0, err
+		}
+	} else {
+		conceptGroups = permission.PaginateKNChildCandidates(conceptGroups, query.Offset, query.Limit)
 	}
 	if len(conceptGroups) == 0 {
 		span.SetStatus(codes.Ok, "")

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -324,7 +324,8 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), query).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 
@@ -346,6 +347,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -400,6 +402,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
@@ -437,6 +440,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
@@ -464,6 +468,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil)
 
@@ -483,7 +488,8 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 				},
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{{CGID: "cg1"}}, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -507,7 +513,8 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr[1:], nil)
+			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(3, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
 

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -325,7 +325,6 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil)
 
@@ -347,7 +346,6 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -402,7 +400,6 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
@@ -440,7 +437,6 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
 
@@ -468,7 +464,6 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return([]string{}, nil)
 
@@ -488,8 +483,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 				},
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{}, nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return([]*interfaces.ConceptGroup{{CGID: "cg1"}}, nil)
 
 			cgs, total, err := service.ListConceptGroups(ctx, query)
 			So(err, ShouldBeNil)
@@ -513,8 +507,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr[1:], nil)
-			cga.EXPECT().GetConceptGroupsTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(cgArr, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			cga.EXPECT().GetConceptIDsByConceptGroupIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{}, nil).AnyTimes()
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -134,6 +134,38 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			_ = parentTracker.Cleanup(ctx, kns.ps)
 		}
 	}()
+	var createdNewKN bool
+	var datasetWritten bool
+	var rootPolicyMayExist bool
+	defer func() {
+		if err == nil || !createdNewKN {
+			return
+		}
+		cleanupCtx := context.WithoutCancel(ctx)
+		if rootPolicyMayExist {
+			if cleanupErr := kns.ps.DeleteResources(cleanupCtx,
+				interfaces.RESOURCE_TYPE_KN, []string{kn.KNID}); cleanupErr != nil {
+				otellog.LogError(cleanupCtx, "CreateKN authorization compensation failed", cleanupErr)
+			}
+		}
+		if datasetWritten {
+			filterCondition := map[string]any{
+				"operation": "and",
+				"sub_conditions": []map[string]any{
+					{
+						"field": "kn_id", "operation": "==", "value": kn.KNID, "value_from": "const",
+					},
+					{
+						"field": "branch", "operation": "==", "value": kn.Branch, "value_from": "const",
+					},
+				},
+			}
+			if cleanupErr := kns.vbs.DeleteDatasetDocumentsByQuery(cleanupCtx,
+				interfaces.BKN_DATASET_ID, filterCondition); cleanupErr != nil {
+				otellog.LogError(cleanupCtx, "CreateKN dataset compensation failed", cleanupErr)
+			}
+		}
+	}()
 
 	// Check whether the user ID can create business knowledge networks through policy evaluation.
 	err = kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
@@ -143,6 +175,7 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 	if err != nil {
 		return "", err
 	}
+	ctx = permission.WithKNImportPermissionPrechecked(ctx)
 
 	currentTime := time.Now().UnixMilli()
 	// Generate a distributed ID when the submitted model ID is empty.
@@ -223,6 +256,7 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 	if err != nil {
 		return "", err
 	}
+	createdNewKN = isCreate
 
 	// Process creation.
 	if isCreate {
@@ -393,11 +427,15 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 				berrors.BknBackend_KnowledgeNetwork_InternalError_InsertOpenSearchDataFailed).
 				WithErrorDetails(err.Error())
 		}
+		if isCreate {
+			datasetWritten = true
+		}
 	}
 
 	// Register resource policies last and only during creation.
 	if isCreate {
 		// Register resource policies.
+		rootPolicyMayExist = true
 		err = kns.ps.CreateResources(ctx, []interfaces.PermissionResource{{
 			ID:   kn.KNID,
 			Type: interfaces.RESOURCE_TYPE_KN,

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -175,7 +175,6 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 	if err != nil {
 		return "", err
 	}
-	ctx = permission.WithKNImportPermissionPrechecked(ctx)
 
 	currentTime := time.Now().UnixMilli()
 	// Generate a distributed ID when the submitted model ID is empty.
@@ -257,6 +256,9 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 		return "", err
 	}
 	createdNewKN = isCreate
+	if isCreate {
+		ctx = permission.WithKNImportPermissionPrechecked(ctx)
+	}
 
 	// Process creation.
 	if isCreate {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -8,6 +8,8 @@ package knowledge_network
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -22,6 +24,7 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
+	"bkn-backend/logics/permission"
 )
 
 func Test_knowledgeNetworkService_CheckKNExistByID(t *testing.T) {
@@ -1688,6 +1691,29 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			So(knID, ShouldNotBeEmpty)
 		})
 
+		Convey("Commit failure compensates root authorization and dataset documents\n", func() {
+			kn := &interfaces.KN{
+				KNID:   "kn1",
+				KNName: "kn1",
+				Branch: interfaces.MAIN_BRANCH,
+			}
+
+			smock.ExpectBegin()
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			kna.EXPECT().CheckKNExistByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH).Return("", false, nil)
+			kna.EXPECT().CheckKNExistByName(gomock.Any(), "kn1", interfaces.MAIN_BRANCH).Return("", false, nil)
+			kna.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			smock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+			ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"}).Return(nil)
+			vbs.EXPECT().DeleteDatasetDocumentsByQuery(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil)
+
+			knID, err := service.CreateKN(ctx, kn, interfaces.ImportMode_Normal, true)
+			So(err, ShouldNotBeNil)
+			So(knID, ShouldEqual, "kn1")
+		})
+
 		Convey("Failed when permission check fails\n", func() {
 			kn := &interfaces.KN{
 				KNID:   "kn1",
@@ -1880,7 +1906,12 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			kna.EXPECT().CheckKNExistByID(gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			kna.EXPECT().CheckKNExistByName(gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			kna.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			cgs.EXPECT().CreateConceptGroup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
+			cgs.EXPECT().CreateConceptGroup(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(childCtx context.Context, _ *sql.Tx, _ *interfaces.ConceptGroup,
+					_ string, _ bool) (string, error) {
+					So(permission.KNImportPermissionPrechecked(childCtx), ShouldBeTrue)
+					return "", rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError)
+				})
 			smock.ExpectRollback()
 
 			knID, err := service3.CreateKN(ctx, kn, mode, true)
@@ -2042,6 +2073,8 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil)
 			ps.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
 			smock.ExpectRollback()
+			ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"}).Return(nil)
+			vbs.EXPECT().DeleteDatasetDocumentsByQuery(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil)
 
 			knID, err := service.CreateKN(ctx, kn, mode, true)
 			So(err, ShouldNotBeNil)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -1798,6 +1798,9 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 				KNID:   "kn1",
 				KNName: "kn1",
 				Branch: interfaces.MAIN_BRANCH,
+				ConceptGroups: []*interfaces.ConceptGroup{{
+					CGID: "cg1", KNID: "kn1", Branch: interfaces.MAIN_BRANCH,
+				}},
 			}
 			mode := interfaces.ImportMode_Overwrite
 			kna2 := bmock.NewMockKNAccess(mockCtrl)
@@ -1823,7 +1826,15 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			// CreateKN handleKNImportMode + UpdateKN(strict) → ValidateKN(..., Overwrite) → handleKNImportMode again
 			kna2.EXPECT().CheckKNExistByID(gomock.Any(), gomock.Any(), gomock.Any()).Return("kn1", true, nil).AnyTimes()
 			kna2.EXPECT().CheckKNExistByName(gomock.Any(), gomock.Any(), gomock.Any()).Return("kn1", true, nil).AnyTimes()
+			cgs.EXPECT().ValidateConceptGroups(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
+				kn.ConceptGroups, true, gomock.Any(), interfaces.ImportMode_Overwrite).Return(nil)
 			kna2.EXPECT().UpdateKN(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			cgs.EXPECT().CreateConceptGroup(gomock.Any(), gomock.Any(), kn.ConceptGroups[0], interfaces.ImportMode_Overwrite, true).
+				DoAndReturn(func(childCtx context.Context, _ *sql.Tx, _ *interfaces.ConceptGroup,
+					_ string, _ bool) (string, error) {
+					So(permission.KNImportPermissionPrechecked(childCtx), ShouldBeFalse)
+					return "cg1", nil
+				})
 			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil).AnyTimes()
 			smock.ExpectCommit()
 

--- a/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
@@ -7,8 +7,11 @@ package metric
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/interfaces"
@@ -56,5 +59,109 @@ func TestMetricSingleResourcePEP(t *testing.T) {
 				t.Fatalf("operation error = %v, want %v", err, denied)
 			}
 		})
+	}
+}
+
+func TestMetricListPEPFiltersBeforeTotalAndPagination(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	query := interfaces.MetricsListQueryParams{
+		KNID: "kn-1",
+		PaginationQueryParameters: interfaces.PaginationQueryParameters{
+			Offset: 1,
+			Limit:  1,
+		},
+	}
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.AssignableToTypeOf(query)).DoAndReturn(
+		func(_ context.Context, candidateQuery interfaces.MetricsListQueryParams) ([]*interfaces.MetricDefinition, error) {
+			if candidateQuery.Offset != 0 || candidateQuery.Limit != -1 {
+				t.Fatalf("candidate query offset/limit = %d/%d", candidateQuery.Offset, candidateQuery.Limit)
+			}
+			return []*interfaces.MetricDefinition{
+				{ID: "metric-1", KnID: "kn-1"},
+				{ID: "metric-2", KnID: "kn-1"},
+				{ID: "metric-3", KnID: "kn-1"},
+			}, nil
+		})
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/metric-1", "kn-1/metric-2", "kn-1/metric-3"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/metric-1": {ResourceID: "kn-1/metric-1"},
+		"kn-1/metric-3": {ResourceID: "kn-1/metric-3"},
+	}, nil)
+
+	result, err := (&metricService{ma: ma, ps: ps}).ListMetrics(context.Background(), query)
+	if err != nil {
+		t.Fatalf("ListMetrics() error = %v", err)
+	}
+	if result.TotalCount != 2 || len(result.Entries) != 1 || result.Entries[0].ID != "metric-3" {
+		t.Fatalf("ListMetrics() = %#v", result)
+	}
+}
+
+func TestMetricBatchDeletePEPRejectsBeforeBusinessWrites(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	for _, metricID := range []string{"metric-1", "metric-2"} {
+		ma.EXPECT().CheckMetricExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, metricID).
+			Return(metricID, true, nil)
+	}
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/metric-1", "kn-1/metric-2"}, []string{interfaces.OPERATION_TYPE_DELETE}, true,
+		[]string{interfaces.OPERATION_TYPE_DELETE}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/metric-1": {ResourceID: "kn-1/metric-1", Operations: []string{interfaces.OPERATION_TYPE_DELETE}},
+	}, nil)
+
+	service := &metricService{ma: ma, ps: ps}
+	err := service.DeleteMetricsByIDs(context.Background(), nil, "kn-1", interfaces.MAIN_BRANCH,
+		[]string{"metric-1", "metric-2"})
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.HTTPCode != http.StatusForbidden {
+		t.Fatalf("DeleteMetricsByIDs() error = %v, want HTTP 403", err)
+	}
+}
+
+func TestMetricBatchOverwritePEPRejectsAndRollsBackBeforeBusinessWrites(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	db, dbMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	entries := []*interfaces.MetricDefinition{
+		{ID: "metric-1", Name: "Metric 1", KnID: "kn-1", Branch: interfaces.MAIN_BRANCH},
+		{ID: "metric-2", Name: "Metric 2", KnID: "kn-1", Branch: interfaces.MAIN_BRANCH},
+	}
+
+	dbMock.ExpectBegin()
+	for _, entry := range entries {
+		ma.EXPECT().CheckMetricExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, entry.ID).
+			Return(entry.Name, true, nil)
+		ma.EXPECT().CheckMetricExistByName(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, entry.Name).
+			Return(entry.ID, true, nil)
+	}
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/metric-1", "kn-1/metric-2"}, []string{interfaces.OPERATION_TYPE_MODIFY}, true,
+		[]string{interfaces.OPERATION_TYPE_MODIFY}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/metric-1": {ResourceID: "kn-1/metric-1", Operations: []string{interfaces.OPERATION_TYPE_MODIFY}},
+	}, nil)
+	dbMock.ExpectRollback()
+
+	service := &metricService{db: db, ma: ma, ps: ps}
+	_, err = service.CreateMetrics(context.Background(), nil, entries, false, interfaces.ImportMode_Overwrite)
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.HTTPCode != http.StatusForbidden {
+		t.Fatalf("CreateMetrics() error = %v, want HTTP 403", err)
+	}
+	if err := dbMock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("database expectations were not met: %v", err)
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
@@ -107,10 +107,10 @@ func TestMetricBatchDeletePEPRejectsBeforeBusinessWrites(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ma := bmock.NewMockMetricAccess(ctrl)
 	ps := bmock.NewMockPermissionService(ctrl)
-	for _, metricID := range []string{"metric-1", "metric-2"} {
-		ma.EXPECT().CheckMetricExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, metricID).
-			Return(metricID, true, nil)
-	}
+	ma.EXPECT().GetMetricsByIDs(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH,
+		[]string{"metric-1", "metric-2"}).Return([]*interfaces.MetricDefinition{
+		{ID: "metric-1"}, {ID: "metric-2"},
+	}, nil)
 	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
 		[]string{"kn-1/metric-1", "kn-1/metric-2"}, []string{interfaces.OPERATION_TYPE_DELETE}, true,
 		[]string{interfaces.OPERATION_TYPE_DELETE}).Return(map[string]interfaces.PermissionResourceOps{

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -161,12 +161,14 @@ func (ms *metricService) CreateMetrics(ctx context.Context, tx *sql.Tx, entries 
 			WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.EntriesRequired", nil))
 	}
 
-	err = ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   entries[0].KnID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return nil, err
+	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
+		err = ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   entries[0].KnID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// 0. Begin the transaction.
@@ -236,6 +238,25 @@ func (ms *metricService) CreateMetrics(ctx context.Context, tx *sql.Tx, entries 
 	creates, updates, err = ms.handleMetricImportMode(ctx, importMode, entries)
 	if err != nil {
 		return nil, err
+	}
+	if !permission.KNImportPermissionPrechecked(ctx) && permission.KNChildResourcePEPEnabled() {
+		if len(creates) > 0 {
+			if err = ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   entries[0].KnID,
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+				return nil, err
+			}
+		}
+		updateIDs := make([]string, 0, len(updates))
+		for _, metric := range updates {
+			updateIDs = append(updateIDs, metric.ID)
+		}
+		if err = permission.CheckKNChildBatchPermission(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, entries[0].KnID, updateIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_MODIFY); err != nil {
+			return nil, err
+		}
 	}
 
 	ids = make([]string, 0, len(creates)+len(updates))
@@ -354,33 +375,32 @@ func (ms *metricService) handleMetricImportMode(ctx context.Context, mode string
 func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.MetricsListQueryParams) (*interfaces.MetricsList, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListMetrics")
 	defer span.End()
-
-	err := ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return nil, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return nil, err
+		}
 	}
 
-	list, err := ms.ma.ListMetrics(ctx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	list, err := ms.ma.ListMetrics(ctx, candidateQuery)
 	if err != nil {
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
 	}
-	total, err := ms.ma.GetMetricsTotal(ctx, query)
-	if err != nil {
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
-	}
-
-	if query.Limit != -1 {
-		if query.Offset < 0 || int(query.Offset) >= len(list) {
-			return &interfaces.MetricsList{Entries: []*interfaces.MetricDefinition{}, TotalCount: int64(total)}, nil
+	total := len(list)
+	if permission.KNChildResourcePEPEnabled() {
+		list, total, err = permission.FilterAndPaginateKNChildren(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, query.KNID, list,
+			func(metric *interfaces.MetricDefinition) string { return metric.ID }, query.Offset, query.Limit)
+		if err != nil {
+			return nil, err
 		}
-		end := int(query.Offset) + query.Limit
-		if end > len(list) {
-			end = len(list)
-		}
-		list = list[query.Offset:end]
+	} else {
+		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
 	}
 
 	if len(list) > 0 && ms.uma != nil {
@@ -601,8 +621,6 @@ func (ms *metricService) DeleteMetricsByIDs(ctx context.Context, tx *sql.Tx, knI
 	if err = permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, metricIDs); err != nil {
 		return err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_MODIFY
 	if len(metricIDs) == 1 {
 		_, exists, checkErr := ms.CheckMetricExistByID(ctx, knID, branch, metricIDs[0])
 		if checkErr != nil {
@@ -611,11 +629,28 @@ func (ms *metricService) DeleteMetricsByIDs(ctx context.Context, tx *sql.Tx, knI
 		if !exists {
 			return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_Metric_NotFound)
 		}
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_METRIC,
+		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_METRIC,
 			knID, metricIDs[0], interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
-	}
-	if err := ms.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return err
+		if err := ms.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
+			return err
+		}
+	} else {
+		if permission.KNChildResourcePEPEnabled() {
+			for _, metricID := range metricIDs {
+				_, exists, checkErr := ms.CheckMetricExistByID(ctx, knID, branch, metricID)
+				if checkErr != nil {
+					return checkErr
+				}
+				if !exists {
+					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_Metric_NotFound)
+				}
+			}
+		}
+		if err := permission.CheckKNChildBatchPermission(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, knID, metricIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE); err != nil {
+			return err
+		}
 	}
 
 	if tx == nil {
@@ -707,12 +742,31 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 		Groups: []any{},
 	}
 
-	err := ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return response, err
+	var err error
+	var visibleIDs []string
+	if !permission.KNChildResourcePEPEnabled() {
+		err = ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		if err != nil {
+			return response, err
+		}
+	} else {
+		candidateIDs, candidateErr := ms.ma.GetMetricIDsByKnID(ctx, query.KNID, query.Branch)
+		if candidateErr != nil {
+			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_Metric_InternalError).WithErrorDetails(candidateErr.Error())
+		}
+		visibleIDs, err = permission.FilterKNChildIDs(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, query.KNID, candidateIDs,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		if err != nil {
+			return response, err
+		}
+		if len(visibleIDs) == 0 {
+			return response, nil
+		}
 	}
 
 	var filterCondition map[string]any
@@ -749,6 +803,9 @@ func (ms *metricService) SearchMetrics(ctx context.Context, query *interfaces.Co
 				berrors.BknBackend_InvalidParameter_Condition).
 				WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.ConditionDecodeFailed", nil))
 		}
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		filterCondition = permission.RestrictDatasetFilterToIDs(filterCondition, visibleIDs)
 	}
 
 	otIDMap := map[string]bool{}

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -636,14 +636,13 @@ func (ms *metricService) DeleteMetricsByIDs(ctx context.Context, tx *sql.Tx, knI
 		}
 	} else {
 		if permission.KNChildResourcePEPEnabled() {
-			for _, metricID := range metricIDs {
-				_, exists, checkErr := ms.CheckMetricExistByID(ctx, knID, branch, metricID)
-				if checkErr != nil {
-					return checkErr
-				}
-				if !exists {
-					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_Metric_NotFound)
-				}
+			metrics, queryErr := ms.ma.GetMetricsByIDs(ctx, knID, branch, metricIDs)
+			if queryErr != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_Metric_InternalError_GetMetricsByIDsFailed).WithErrorDetails(queryErr.Error())
+			}
+			if len(metrics) != len(metricIDs) {
+				return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_Metric_NotFound)
 			}
 		}
 		if err := permission.CheckKNChildBatchPermission(ctx, ms.ps,

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -228,8 +228,7 @@ func Test_metricService_ListMetrics(t *testing.T) {
 			}
 			entries := []*interfaces.MetricDefinition{{ID: "m1", KnID: "kn1", Name: "n1"}}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ma.EXPECT().ListMetrics(gomock.Any(), q).Return(entries, nil)
-			ma.EXPECT().GetMetricsTotal(gomock.Any(), q).Return(1, nil)
+			ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(entries, nil)
 
 			out, err := service.ListMetrics(ctx, q)
 			So(err, ShouldBeNil)
@@ -250,13 +249,12 @@ func Test_metricService_ListMetrics(t *testing.T) {
 				{ID: "m2", KnID: "kn1"},
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ma.EXPECT().ListMetrics(gomock.Any(), q).Return(entries, nil)
-			ma.EXPECT().GetMetricsTotal(gomock.Any(), q).Return(99, nil)
+			ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(entries, nil)
 
 			out, err := service.ListMetrics(ctx, q)
 			So(err, ShouldBeNil)
 			So(len(out.Entries), ShouldEqual, 0)
-			So(out.TotalCount, ShouldEqual, 99)
+			So(out.TotalCount, ShouldEqual, 2)
 		})
 
 		Convey("Failed when permission denied\n", func() {

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -408,7 +408,8 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询对象类列表")
 	defer span.End()
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -447,10 +448,12 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 		}()
 	}
 
-	candidateQuery := query
-	candidateQuery.Offset = 0
-	candidateQuery.Limit = -1
-	objectTypes, err := ots.ota.ListObjectTypes(ctx, tx, candidateQuery)
+	listQuery := query
+	if pepEnabled {
+		listQuery.Offset = 0
+		listQuery.Limit = -1
+	}
+	objectTypes, err := ots.ota.ListObjectTypes(ctx, tx, listQuery)
 	if err != nil {
 		logger.Errorf("ListObjectTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List object types error")
@@ -459,8 +462,8 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 			berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total := len(objectTypes)
-	if permission.KNChildResourcePEPEnabled() {
+	var total int
+	if pepEnabled {
 		objectTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ots.ps,
 			interfaces.RESOURCE_TYPE_OBJECT_TYPE, query.KNID, objectTypes,
 			func(objectType *interfaces.ObjectType) string { return objectType.OTID }, query.Offset, query.Limit)
@@ -468,7 +471,13 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 			return []*interfaces.ObjectType{}, 0, err
 		}
 	} else {
-		objectTypes = permission.PaginateKNChildCandidates(objectTypes, query.Offset, query.Limit)
+		total, err = ots.ota.GetObjectTypesTotal(ctx, query)
+		if err != nil {
+			logger.Errorf("GetObjectTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get object types total error")
+			return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 	if len(objectTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -985,14 +994,13 @@ func (ots *objectTypeService) DeleteObjectTypesByIDs(ctx context.Context, tx *sq
 		}
 	} else {
 		if permission.KNChildResourcePEPEnabled() {
-			for _, otID := range otIDs {
-				_, exists, err := ots.CheckObjectTypeExistByID(ctx, knID, branch, otID)
-				if err != nil {
-					return err
-				}
-				if !exists {
-					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ObjectType_ObjectTypeNotFound)
-				}
+			objectTypes, err := ots.ota.GetObjectTypesByIDs(ctx, tx, knID, branch, otIDs)
+			if err != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_ObjectType_InternalError_GetObjectTypesByIDsFailed).WithErrorDetails(err.Error())
+			}
+			if len(objectTypes) != len(otIDs) {
+				return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ObjectType_ObjectTypeNotFound)
 			}
 		}
 		if err := permission.CheckKNChildBatchPermission(ctx, ots.ps,

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -164,13 +164,14 @@ func (ots *objectTypeService) CreateObjectTypes(ctx context.Context, tx *sql.Tx,
 		}
 	}()
 
-	// Check whether the user ID can modify the business knowledge network.
-	err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   objectTypes[0].KNID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return []string{}, err
+	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
+		err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   objectTypes[0].KNID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return []string{}, err
+		}
 	}
 
 	currentTime := time.Now().UnixMilli()
@@ -235,6 +236,25 @@ func (ots *objectTypeService) CreateObjectTypes(ctx context.Context, tx *sql.Tx,
 	createObjectTypes, updateObjectTypes, err := ots.handleObjectTypeImportMode(ctx, mode, objectTypes)
 	if err != nil {
 		return []string{}, err
+	}
+	if !permission.KNImportPermissionPrechecked(ctx) && permission.KNChildResourcePEPEnabled() {
+		if len(createObjectTypes) > 0 {
+			if err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   objectTypes[0].KNID,
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+				return []string{}, err
+			}
+		}
+		updateIDs := make([]string, 0, len(updateObjectTypes))
+		for _, objectType := range updateObjectTypes {
+			updateIDs = append(updateIDs, objectType.OTID)
+		}
+		if err = permission.CheckKNChildBatchPermission(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, objectTypes[0].KNID, updateIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_MODIFY); err != nil {
+			return []string{}, err
+		}
 	}
 
 	// Create.
@@ -388,17 +408,17 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询对象类列表")
 	defer span.End()
-
-	// Check whether the user ID can view the business knowledge network.
-	err := ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return []*interfaces.ObjectType{}, 0, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return []*interfaces.ObjectType{}, 0, err
+		}
 	}
 
 	// 0. Begin the transaction.
+	var err error
 	if tx == nil {
 		tx, err = ots.db.Begin()
 		if err != nil {
@@ -427,8 +447,10 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 		}()
 	}
 
-	// Get the object type list.
-	objectTypes, err := ots.ota.ListObjectTypes(ctx, tx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	objectTypes, err := ots.ota.ListObjectTypes(ctx, tx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListObjectTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List object types error")
@@ -437,13 +459,16 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 			berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total, err := ots.ota.GetObjectTypesTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetObjectTypesTotal error: %s", err.Error())
-		span.SetStatus(codes.Error, "Get object types total error")
-
-		return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
+	total := len(objectTypes)
+	if permission.KNChildResourcePEPEnabled() {
+		objectTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, query.KNID, objectTypes,
+			func(objectType *interfaces.ObjectType) string { return objectType.OTID }, query.Offset, query.Limit)
+		if err != nil {
+			return []*interfaces.ObjectType{}, 0, err
+		}
+	} else {
+		objectTypes = permission.PaginateKNChildCandidates(objectTypes, query.Offset, query.Limit)
 	}
 	if len(objectTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -945,8 +970,6 @@ func (ots *objectTypeService) DeleteObjectTypesByIDs(ctx context.Context, tx *sq
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, otIDs); err != nil {
 		return err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_MODIFY
 	if len(otIDs) == 1 {
 		_, exists, err := ots.CheckObjectTypeExistByID(ctx, knID, branch, otIDs[0])
 		if err != nil {
@@ -955,11 +978,28 @@ func (ots *objectTypeService) DeleteObjectTypesByIDs(ctx context.Context, tx *sq
 		if !exists {
 			return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ObjectType_ObjectTypeNotFound)
 		}
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_OBJECT_TYPE,
 			knID, otIDs[0], interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
-	}
-	if err := ots.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return err
+		if err := ots.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
+			return err
+		}
+	} else {
+		if permission.KNChildResourcePEPEnabled() {
+			for _, otID := range otIDs {
+				_, exists, err := ots.CheckObjectTypeExistByID(ctx, knID, branch, otID)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ObjectType_ObjectTypeNotFound)
+				}
+			}
+		}
+		if err := permission.CheckKNChildBatchPermission(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, knID, otIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE); err != nil {
+			return err
+		}
 	}
 	if tx == nil {
 		// 0. Begin the transaction.
@@ -1355,13 +1395,29 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 	response := interfaces.ObjectTypes{}
 	var err error
 
-	// Check whether the user ID can view the business knowledge network.
-	err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return response, err
+	var visibleIDs []string
+	if !permission.KNChildResourcePEPEnabled() {
+		err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		if err != nil {
+			return response, err
+		}
+	} else {
+		candidateIDs, err := ots.GetObjectTypeIDsByKnID(ctx, query.KNID, query.Branch)
+		if err != nil {
+			return response, err
+		}
+		visibleIDs, err = permission.FilterKNChildIDs(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, query.KNID, candidateIDs,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		if err != nil {
+			return response, err
+		}
+		if len(visibleIDs) == 0 {
+			return response, nil
+		}
 	}
 
 	// Convert conditions to dataset filter conditions.
@@ -1401,6 +1457,9 @@ func (ots *objectTypeService) SearchObjectTypes(ctx context.Context,
 				berrors.BknBackend_ObjectType_InvalidParameter_ConceptCondition).
 				WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.ConditionDecodeFailed", nil))
 		}
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		filterCondition = permission.RestrictDatasetFilterToIDs(filterCondition, visibleIDs)
 	}
 
 	// 1. Get object types in the groups.

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1220,7 +1220,8 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), query).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1243,6 +1244,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)
@@ -1305,6 +1307,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ObjectType_InternalError))
 			smock.ExpectRollback()
 
@@ -1337,6 +1340,7 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1357,9 +1361,8 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			}
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{{
-				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot1"},
-			}}, nil)
+			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
+			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1221,7 +1221,6 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
-			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1244,7 +1243,6 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
-			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)
@@ -1307,7 +1305,6 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
-			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_ObjectType_InternalError))
 			smock.ExpectRollback()
 
@@ -1340,7 +1337,6 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return(objectTypes, nil)
-			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 			smock.ExpectCommit()
 
@@ -1361,8 +1357,9 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 			}
 			smock.ExpectBegin()
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{}, nil)
-			ota.EXPECT().GetObjectTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			ota.EXPECT().ListObjectTypes(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*interfaces.ObjectType{{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot1"},
+			}}, nil)
 			smock.ExpectCommit()
 
 			result, total, err := service.ListObjectTypes(ctx, nil, query)

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
@@ -6,17 +6,37 @@ package permission
 
 import (
 	"context"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
 	"bkn-backend/interfaces"
 )
 
 const knChildResourcePEPEnabledEnv = "KN_CHILD_RESOURCE_PEP_ENABLED"
+const knChildResourceFilterChunkSizeEnv = "KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE"
 
-// KNChildResourcePEPEnabled reports whether single-resource KN child PEPs use
-// canonical child resources. It defaults to false until existing authorization
-// data has been migrated.
+type knImportPermissionPrecheckedKey struct{}
+
+// WithKNImportPermissionPrechecked marks child creates invoked by an already
+// authorized whole-KN create or overwrite operation.
+func WithKNImportPermissionPrechecked(ctx context.Context) context.Context {
+	return context.WithValue(ctx, knImportPermissionPrecheckedKey{}, true)
+}
+
+// KNImportPermissionPrechecked reports whether the parent KN operation already
+// authorized the complete import transaction.
+func KNImportPermissionPrechecked(ctx context.Context) bool {
+	prechecked, _ := ctx.Value(knImportPermissionPrecheckedKey{}).(bool)
+	return prechecked
+}
+
+// KNChildResourcePEPEnabled reports whether KN child PEPs use canonical child
+// resources. It defaults to false until existing authorization data has been
+// migrated.
 func KNChildResourcePEPEnabled() bool {
 	value := strings.ToLower(strings.TrimSpace(os.Getenv(knChildResourcePEPEnabledEnv)))
 	return value == "true" || value == "1"
@@ -41,4 +61,194 @@ func ResolveKNChildPermissionTarget(resourceType, knID, childID, legacyOperation
 		return interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}, legacyOperation
 	}
 	return interfaces.KNChildPermissionResource(resourceType, knID, childID), childOperation
+}
+
+// CheckKNChildBatchPermission authorizes every child before business writes.
+// Callers that already opened a transaction must roll it back when this check
+// fails.
+func CheckKNChildBatchPermission(ctx context.Context, ps interfaces.PermissionService,
+	resourceType, knID string, childIDs []string, legacyOperation, childOperation string) error {
+
+	if !KNChildResourcePEPEnabled() {
+		return ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   knID,
+		}, []string{legacyOperation})
+	}
+	if len(childIDs) == 0 {
+		return nil
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
+		return err
+	}
+
+	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
+	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, childOperation)
+	if err != nil {
+		return err
+	}
+	for _, resourceID := range resourceIDs {
+		if _, ok := matched[resourceID]; !ok {
+			return rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails(localizedPermissionDetail(ctx, "PermissionDenied"))
+		}
+	}
+	return nil
+}
+
+// FilterKNChildIDs returns the authorized subset of trusted business IDs in
+// candidate order. Callers must only pass IDs loaded from the business store.
+func FilterKNChildIDs(ctx context.Context, ps interfaces.PermissionService,
+	resourceType, knID string, childIDs []string, operation string) ([]string, error) {
+
+	if len(childIDs) == 0 {
+		return []string{}, nil
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
+		return nil, err
+	}
+
+	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
+	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, operation)
+	if err != nil {
+		return nil, err
+	}
+
+	visibleIDs := make([]string, 0, len(matched))
+	for index, resourceID := range resourceIDs {
+		if _, ok := matched[resourceID]; ok {
+			visibleIDs = append(visibleIDs, childIDs[index])
+		}
+	}
+	return visibleIDs, nil
+}
+
+// RestrictDatasetFilterToIDs combines a concept-search condition with the
+// authorized business candidate IDs so the dataset owns total and cursor
+// pagination over the already-authorized result set.
+func RestrictDatasetFilterToIDs(filterCondition map[string]any, childIDs []string) map[string]any {
+	idCondition := map[string]any{
+		"field":      "id",
+		"operation":  "in",
+		"value":      childIDs,
+		"value_from": "const",
+	}
+	if filterCondition == nil {
+		return idCondition
+	}
+	return map[string]any{
+		"operation": "and",
+		"sub_conditions": []map[string]any{
+			filterCondition,
+			idCondition,
+		},
+	}
+}
+
+// FilterAndPaginateKNChildren filters a trusted, ordered business candidate set
+// before applying pagination. Disabled deployments retain the legacy parent-KN
+// visibility check; enabled deployments filter canonical child resources.
+func FilterAndPaginateKNChildren[T any](ctx context.Context, ps interfaces.PermissionService,
+	resourceType, knID string, candidates []T, childID func(T) string,
+	offset, limit int) ([]T, int, error) {
+
+	if !KNChildResourcePEPEnabled() {
+		if err := ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   knID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return nil, 0, err
+		}
+		return PaginateKNChildCandidates(candidates, offset, limit), len(candidates), nil
+	}
+
+	if len(candidates) == 0 {
+		return []T{}, 0, nil
+	}
+	childIDs := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		childIDs = append(childIDs, childID(candidate))
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
+		return nil, 0, err
+	}
+
+	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
+	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType,
+		resourceIDs, interfaces.OPERATION_TYPE_VIEW_DETAIL)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	visible := make([]T, 0, len(matched))
+	for _, candidate := range candidates {
+		canonicalID := interfaces.KNChildResourceID(knID, childID(candidate))
+		if _, ok := matched[canonicalID]; ok {
+			visible = append(visible, candidate)
+		}
+	}
+
+	return PaginateKNChildCandidates(visible, offset, limit), len(visible), nil
+}
+
+func filterKNChildResourceIDs(ctx context.Context, ps interfaces.PermissionService,
+	resourceType string, resourceIDs []string, operation string) (map[string]interfaces.PermissionResourceOps, error) {
+
+	chunkSize := len(resourceIDs)
+	if configured, err := strconv.Atoi(strings.TrimSpace(os.Getenv(knChildResourceFilterChunkSizeEnv))); err == nil && configured > 0 && configured < chunkSize {
+		chunkSize = configured
+	}
+	matched := make(map[string]interfaces.PermissionResourceOps, len(resourceIDs))
+	for start := 0; start < len(resourceIDs); start += chunkSize {
+		end := start + chunkSize
+		if end > len(resourceIDs) {
+			end = len(resourceIDs)
+		}
+		blockIDs := resourceIDs[start:end]
+		block, err := ps.FilterResources(ctx, resourceType, blockIDs,
+			[]string{operation}, true, []string{operation})
+		if err != nil {
+			return nil, err
+		}
+		if err := validateFilterResponse(ctx, blockIDs, block); err != nil {
+			return nil, err
+		}
+		for resourceID, resourceOps := range block {
+			matched[resourceID] = resourceOps
+		}
+	}
+	return matched, nil
+}
+
+func validateFilterResponse(ctx context.Context, requestedIDs []string,
+	matched map[string]interfaces.PermissionResourceOps) error {
+
+	requested := make(map[string]struct{}, len(requestedIDs))
+	for _, resourceID := range requestedIDs {
+		requested[resourceID] = struct{}{}
+	}
+	for key, resourceOps := range matched {
+		if _, ok := requested[key]; !ok || resourceOps.ResourceID != key {
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				rest.PublicError_InternalServerError).
+				WithErrorDetails("invalid resource-filter response")
+		}
+	}
+	return nil
+}
+
+// PaginateKNChildCandidates applies list pagination to an already authorized
+// ordered candidate set.
+func PaginateKNChildCandidates[T any](candidates []T, offset, limit int) []T {
+	if limit == -1 || limit == 0 {
+		return candidates
+	}
+	if limit < -1 || offset < 0 || offset >= len(candidates) {
+		return []T{}
+	}
+	end := offset + limit
+	if end > len(candidates) {
+		end = len(candidates)
+	}
+	return candidates[offset:end]
 }

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
@@ -104,11 +104,20 @@ func FilterKNChildIDs(ctx context.Context, ps interfaces.PermissionService,
 	if len(childIDs) == 0 {
 		return []string{}, nil
 	}
-	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
+	validChildIDs := make([]string, 0, len(childIDs))
+	for _, childID := range childIDs {
+		if interfaces.IsValidAuthorizationID(childID) {
+			validChildIDs = append(validChildIDs, childID)
+		}
+	}
+	if len(validChildIDs) == 0 {
+		return []string{}, nil
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, validChildIDs); err != nil {
 		return nil, err
 	}
 
-	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
+	resourceIDs := interfaces.KNChildResourceIDs(knID, validChildIDs)
 	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, operation)
 	if err != nil {
 		return nil, err
@@ -117,7 +126,7 @@ func FilterKNChildIDs(ctx context.Context, ps interfaces.PermissionService,
 	visibleIDs := make([]string, 0, len(matched))
 	for index, resourceID := range resourceIDs {
 		if _, ok := matched[resourceID]; ok {
-			visibleIDs = append(visibleIDs, childIDs[index])
+			visibleIDs = append(visibleIDs, validChildIDs[index])
 		}
 	}
 	return visibleIDs, nil
@@ -165,9 +174,17 @@ func FilterAndPaginateKNChildren[T any](ctx context.Context, ps interfaces.Permi
 	if len(candidates) == 0 {
 		return []T{}, 0, nil
 	}
+	validCandidates := make([]T, 0, len(candidates))
 	childIDs := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {
-		childIDs = append(childIDs, childID(candidate))
+		id := childID(candidate)
+		if interfaces.IsValidAuthorizationID(id) {
+			validCandidates = append(validCandidates, candidate)
+			childIDs = append(childIDs, id)
+		}
+	}
+	if len(validCandidates) == 0 {
+		return []T{}, 0, nil
 	}
 	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
 		return nil, 0, err
@@ -181,7 +198,7 @@ func FilterAndPaginateKNChildren[T any](ctx context.Context, ps interfaces.Permi
 	}
 
 	visible := make([]T, 0, len(matched))
-	for _, candidate := range candidates {
+	for _, candidate := range validCandidates {
 		canonicalID := interfaces.KNChildResourceID(knID, childID(candidate))
 		if _, ok := matched[canonicalID]; ok {
 			visible = append(visible, candidate)

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
@@ -134,6 +134,24 @@ func TestFilterAndPaginateKNChildrenPropagatesFilterFailure(t *testing.T) {
 	}
 }
 
+func TestFilterAndPaginateKNChildrenSkipsHistoricalInvalidIDs(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+		[]string{"kn-1/valid"}, gomock.Any(), true, gomock.Any()).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/valid": {ResourceID: "kn-1/valid"},
+	}, nil)
+
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1",
+		[]childCandidate{{id: "legacy/id"}, {id: "valid"}},
+		func(candidate childCandidate) string { return candidate.id }, 0, -1)
+	if err != nil || total != 1 || !reflect.DeepEqual(got, []childCandidate{{id: "valid"}}) {
+		t.Fatalf("result = %#v, total = %d, error = %v", got, total, err)
+	}
+}
+
 func TestFilterAndPaginateKNChildrenSupportsEveryChildResourceType(t *testing.T) {
 	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
 	resourceTypes := []string{
@@ -243,6 +261,23 @@ func TestFilterKNChildIDsKeepsEqualChildIDsIsolatedByKN(t *testing.T) {
 		interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	if err != nil || len(second) != 0 {
 		t.Fatalf("second KN result = %#v, error = %v", second, err)
+	}
+}
+
+func TestFilterKNChildIDsSkipsHistoricalInvalidIDs(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/valid"}, gomock.Any(), true, gomock.Any()).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/valid": {ResourceID: "kn-1/valid"},
+	}, nil)
+
+	got, err := FilterKNChildIDs(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_METRIC, "kn-1", []string{"bad*id", "valid", " spaced "},
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+	if err != nil || !reflect.DeepEqual(got, []string{"valid"}) {
+		t.Fatalf("result = %#v, error = %v", got, err)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
@@ -6,9 +6,16 @@ package permission
 
 import (
 	"context"
+	"errors"
+	"net/http"
+	"reflect"
 	"testing"
 
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"go.uber.org/mock/gomock"
+
 	"bkn-backend/interfaces"
+	interfacemock "bkn-backend/interfaces/mock"
 )
 
 func TestKNChildResourcePEPDefaultsToDisabled(t *testing.T) {
@@ -29,6 +36,21 @@ func TestKNChildResourcePEPDefaultsToDisabled(t *testing.T) {
 	}
 }
 
+func TestKNImportPermissionPrecheckedIsScopedToMarkedContext(t *testing.T) {
+	ctx := context.Background()
+	if KNImportPermissionPrechecked(ctx) {
+		t.Fatal("plain context must not skip child authorization")
+	}
+
+	marked := WithKNImportPermissionPrechecked(ctx)
+	if !KNImportPermissionPrechecked(marked) {
+		t.Fatal("marked whole-KN import context must skip duplicate child authorization")
+	}
+	if KNImportPermissionPrechecked(ctx) {
+		t.Fatal("marking a derived context must not mutate its parent")
+	}
+}
+
 func TestKNChildResourcePEPEnabledUsesCanonicalChild(t *testing.T) {
 	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
 	if !KNChildResourcePEPEnabled() {
@@ -44,5 +66,235 @@ func TestKNChildResourcePEPEnabledUsesCanonicalChild(t *testing.T) {
 	}
 	if err := ValidateKNChildPEPAuthorizationIDs(context.Background(), "kn-1", []string{"bad/id"}); err == nil {
 		t.Fatal("enabled PEP must reject ambiguous child IDs")
+	}
+}
+
+type childCandidate struct {
+	id string
+}
+
+func TestFilterAndPaginateKNChildrenUsesLegacyKNWhenDisabled(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "false")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(nil)
+
+	candidates := []childCandidate{{id: "one"}, {id: "two"}, {id: "three"}}
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1", candidates,
+		func(candidate childCandidate) string { return candidate.id }, 1, 1)
+	if err != nil {
+		t.Fatalf("FilterAndPaginateKNChildren() error = %v", err)
+	}
+	if total != 3 || !reflect.DeepEqual(got, []childCandidate{{id: "two"}}) {
+		t.Fatalf("result = %#v, total = %d", got, total)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenFiltersCanonicalIDsBeforePaging(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+		[]string{"kn-2/one", "kn-2/two", "kn-2/three"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-2/one":   {ResourceID: "kn-2/one", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+		"kn-2/three": {ResourceID: "kn-2/three", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+	}, nil)
+
+	candidates := []childCandidate{{id: "one"}, {id: "two"}, {id: "three"}}
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-2", candidates,
+		func(candidate childCandidate) string { return candidate.id }, 1, 1)
+	if err != nil {
+		t.Fatalf("FilterAndPaginateKNChildren() error = %v", err)
+	}
+	if total != 2 || !reflect.DeepEqual(got, []childCandidate{{id: "three"}}) {
+		t.Fatalf("result = %#v, total = %d", got, total)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenPropagatesFilterFailure(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "1")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	wantErr := errors.New("bkn-safe unavailable")
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RISK_TYPE,
+		[]string{"kn-1/risk-1"}, gomock.Any(), true, gomock.Any()).Return(nil, wantErr)
+
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_RISK_TYPE, "kn-1", []childCandidate{{id: "risk-1"}},
+		func(candidate childCandidate) string { return candidate.id }, 0, 10)
+	if !errors.Is(err, wantErr) || got != nil || total != 0 {
+		t.Fatalf("result = %#v, total = %d, error = %v", got, total, err)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenSupportsEveryChildResourceType(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	resourceTypes := []string{
+		interfaces.RESOURCE_TYPE_CONCEPT_GROUP,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+		interfaces.RESOURCE_TYPE_RELATION_TYPE,
+		interfaces.RESOURCE_TYPE_ACTION_TYPE,
+		interfaces.RESOURCE_TYPE_METRIC,
+		interfaces.RESOURCE_TYPE_RISK_TYPE,
+	}
+	for _, resourceType := range resourceTypes {
+		t.Run(resourceType, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			ps := interfacemock.NewMockPermissionService(ctrl)
+			ps.EXPECT().FilterResources(gomock.Any(), resourceType, []string{"kn-1/child-1"},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(map[string]interfaces.PermissionResourceOps{
+				"kn-1/child-1": {ResourceID: "kn-1/child-1"},
+			}, nil)
+
+			got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+				resourceType, "kn-1", []childCandidate{{id: "child-1"}},
+				func(candidate childCandidate) string { return candidate.id }, 0, -1)
+			if err != nil || total != 1 || len(got) != 1 {
+				t.Fatalf("result = %#v, total = %d, error = %v", got, total, err)
+			}
+		})
+	}
+}
+
+func TestFilterAndPaginateKNChildrenMergesRuntimeConfiguredBlocks(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	t.Setenv("KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE", "2")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	gomock.InOrder(
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+			[]string{"kn-1/one", "kn-1/two"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn-1/one": {ResourceID: "kn-1/one"},
+			}, nil),
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+			[]string{"kn-1/three"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn-1/three": {ResourceID: "kn-1/three"},
+			}, nil),
+	)
+
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1",
+		[]childCandidate{{id: "one"}, {id: "two"}, {id: "three"}},
+		func(candidate childCandidate) string { return candidate.id }, 0, -1)
+	if err != nil || total != 2 || !reflect.DeepEqual(got,
+		[]childCandidate{{id: "one"}, {id: "three"}}) {
+		t.Fatalf("result = %#v, total = %d, error = %v", got, total, err)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenDiscardsEarlierBlocksOnLaterFailure(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	t.Setenv("KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE", "1")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	wantErr := errors.New("second block timed out")
+	gomock.InOrder(
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+			[]string{"kn-1/one"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn-1/one": {ResourceID: "kn-1/one"},
+			}, nil),
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+			[]string{"kn-1/two"}, gomock.Any(), true, gomock.Any()).Return(nil, wantErr),
+	)
+
+	got, total, err := FilterAndPaginateKNChildren(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_METRIC, "kn-1",
+		[]childCandidate{{id: "one"}, {id: "two"}},
+		func(candidate childCandidate) string { return candidate.id }, 0, -1)
+	if !errors.Is(err, wantErr) || got != nil || total != 0 {
+		t.Fatalf("result = %#v, total = %d, error = %v", got, total, err)
+	}
+}
+
+func TestFilterKNChildIDsKeepsEqualChildIDsIsolatedByKN(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	gomock.InOrder(
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+			[]string{"kn-1/shared"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn-1/shared": {ResourceID: "kn-1/shared"},
+			}, nil),
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+			[]string{"kn-2/shared"}, gomock.Any(), true, gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{}, nil),
+	)
+
+	first, err := FilterKNChildIDs(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1", []string{"shared"},
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+	if err != nil || !reflect.DeepEqual(first, []string{"shared"}) {
+		t.Fatalf("first KN result = %#v, error = %v", first, err)
+	}
+	second, err := FilterKNChildIDs(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-2", []string{"shared"},
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+	if err != nil || len(second) != 0 {
+		t.Fatalf("second KN result = %#v, error = %v", second, err)
+	}
+}
+
+func TestCheckKNChildBatchPermissionUsesLegacyKNWhenDisabled(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "false")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(nil)
+
+	err := CheckKNChildBatchPermission(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1", []string{"one", "two"},
+		interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
+	if err != nil {
+		t.Fatalf("CheckKNChildBatchPermission() error = %v", err)
+	}
+}
+
+func TestCheckKNChildBatchPermissionRequiresEveryCanonicalChild(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/one", "kn-1/two"}, []string{interfaces.OPERATION_TYPE_DELETE}, true,
+		[]string{interfaces.OPERATION_TYPE_DELETE}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/one": {ResourceID: "kn-1/one", Operations: []string{interfaces.OPERATION_TYPE_DELETE}},
+	}, nil)
+
+	err := CheckKNChildBatchPermission(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_METRIC, "kn-1", []string{"one", "two"},
+		interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.HTTPCode != http.StatusForbidden {
+		t.Fatalf("CheckKNChildBatchPermission() error = %v, want HTTP 403", err)
+	}
+}
+
+func TestCheckKNChildBatchPermissionPropagatesFilterFailure(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	wantErr := errors.New("bkn-safe unavailable")
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RISK_TYPE,
+		[]string{"kn-1/one", "kn-1/two"}, []string{interfaces.OPERATION_TYPE_DELETE}, true,
+		[]string{interfaces.OPERATION_TYPE_DELETE}).Return(nil, wantErr)
+
+	err := CheckKNChildBatchPermission(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_RISK_TYPE, "kn-1", []string{"one", "two"},
+		interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CheckKNChildBatchPermission() error = %v, want %v", err, wantErr)
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
@@ -257,8 +257,19 @@ func (ps *PermissionServiceImpl) FilterResources(ctx context.Context, resourceTy
 	}
 
 	// Convert resource IDs to a lookup map.
-	idMap := map[string]interfaces.PermissionResourceOps{}
-	for _, resourceOps := range matchResouces {
+	requestedIDs := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		requestedIDs[id] = struct{}{}
+	}
+	idMap := make(map[string]interfaces.PermissionResourceOps, len(matchResouces))
+	for key, resourceOps := range matchResouces {
+		if _, ok := requestedIDs[key]; !ok || resourceOps.ResourceID != key {
+			httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_InternalError_FilterResourcesFailed).
+				WithErrorDetails("invalid resource-filter response")
+			otellog.LogError(ctx, "FilterResources returned an invalid resource", httpErr)
+			return nil, httpErr
+		}
 		idMap[resourceOps.ResourceID] = resourceOps
 	}
 

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_test.go
@@ -246,6 +246,17 @@ func Test_PermissionServiceImpl_FilterResources(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(result, ShouldBeNil)
 		})
+
+		Convey("Failed: response contains an unrequested resource\n", func() {
+			ctx := withAccountInfo(context.Background(), "u1", "user")
+			pa.EXPECT().FilterResources(gomock.Any(), gomock.Any()).Return(map[string]interfaces.PermissionResourceOps{
+				"kn2": {ResourceID: "kn2", Operations: []string{"read"}},
+			}, nil)
+
+			result, err := svc.FilterResources(ctx, "kn", []string{"kn1"}, []string{"read"}, true, []string{"read"})
+			So(err, ShouldNotBeNil)
+			So(result, ShouldBeNil)
+		})
 	})
 }
 

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -105,13 +105,14 @@ func (rts *relationTypeService) CreateRelationTypes(ctx context.Context, tx *sql
 		}
 	}()
 
-	// Check whether the user ID can modify the business knowledge network.
-	err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   relationTypes[0].KNID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return []string{}, err
+	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
+		err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   relationTypes[0].KNID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return []string{}, err
+		}
 	}
 
 	// 0. Begin the transaction.
@@ -176,6 +177,25 @@ func (rts *relationTypeService) CreateRelationTypes(ctx context.Context, tx *sql
 	createRelationTypes, updateRelationTypes, err := rts.handleRelationTypeImportMode(ctx, mode, relationTypes)
 	if err != nil {
 		return []string{}, err
+	}
+	if !permission.KNImportPermissionPrechecked(ctx) && permission.KNChildResourcePEPEnabled() {
+		if len(createRelationTypes) > 0 {
+			if err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   relationTypes[0].KNID,
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+				return []string{}, err
+			}
+		}
+		updateIDs := make([]string, 0, len(updateRelationTypes))
+		for _, relationType := range updateRelationTypes {
+			updateIDs = append(updateIDs, relationType.RTID)
+		}
+		if err = permission.CheckKNChildBatchPermission(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, relationTypes[0].KNID, updateIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_MODIFY); err != nil {
+			return []string{}, err
+		}
 	}
 
 	// 1. Create the model.
@@ -270,18 +290,19 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 	if query.Branch == "" {
 		query.Branch = interfaces.MAIN_BRANCH
 	}
-
-	// Check whether the user ID can view the business knowledge network.
-	err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return []*interfaces.RelationType{}, 0, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return []*interfaces.RelationType{}, 0, err
+		}
 	}
 
-	// Get the relation type list.
-	relationTypes, err := rts.rta.ListRelationTypes(ctx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	relationTypes, err := rts.rta.ListRelationTypes(ctx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListRelationTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List relation types error")
@@ -290,13 +311,16 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 			berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total, err := rts.rta.GetRelationTypesTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetRelationTypesTotal error: %s", err.Error())
-		span.SetStatus(codes.Error, "Get relation types total error")
-
-		return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
+	total := len(relationTypes)
+	if permission.KNChildResourcePEPEnabled() {
+		relationTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, query.KNID, relationTypes,
+			func(relationType *interfaces.RelationType) string { return relationType.RTID }, query.Offset, query.Limit)
+		if err != nil {
+			return []*interfaces.RelationType{}, 0, err
+		}
+	} else {
+		relationTypes = permission.PaginateKNChildCandidates(relationTypes, query.Offset, query.Limit)
 	}
 	if len(relationTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -592,8 +616,6 @@ func (rts *relationTypeService) DeleteRelationTypesByIDs(ctx context.Context, tx
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, rtIDs); err != nil {
 		return err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_MODIFY
 	if len(rtIDs) == 1 {
 		_, exists, err := rts.CheckRelationTypeExistByID(ctx, knID, branch, rtIDs[0])
 		if err != nil {
@@ -602,11 +624,28 @@ func (rts *relationTypeService) DeleteRelationTypesByIDs(ctx context.Context, tx
 		if !exists {
 			return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RelationType_RelationTypeNotFound)
 		}
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RELATION_TYPE,
+		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RELATION_TYPE,
 			knID, rtIDs[0], interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
-	}
-	if err := rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return err
+		if err := rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
+			return err
+		}
+	} else {
+		if permission.KNChildResourcePEPEnabled() {
+			for _, rtID := range rtIDs {
+				_, exists, err := rts.CheckRelationTypeExistByID(ctx, knID, branch, rtID)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RelationType_RelationTypeNotFound)
+				}
+			}
+		}
+		if err := permission.CheckKNChildBatchPermission(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, knID, rtIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE); err != nil {
+			return err
+		}
 	}
 	if tx == nil {
 		// 0. Begin the transaction.
@@ -834,13 +873,29 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 	response := interfaces.RelationTypes{}
 	var err error
 
-	// Check whether the user ID can view the business knowledge network.
-	err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return response, err
+	var visibleIDs []string
+	if !permission.KNChildResourcePEPEnabled() {
+		err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		if err != nil {
+			return response, err
+		}
+	} else {
+		candidateIDs, err := rts.GetRelationTypeIDsByKnID(ctx, query.KNID, query.Branch)
+		if err != nil {
+			return response, err
+		}
+		visibleIDs, err = permission.FilterKNChildIDs(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, query.KNID, candidateIDs,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		if err != nil {
+			return response, err
+		}
+		if len(visibleIDs) == 0 {
+			return response, nil
+		}
 	}
 
 	// Convert conditions to dataset filter conditions.
@@ -880,6 +935,9 @@ func (rts *relationTypeService) SearchRelationTypes(ctx context.Context,
 				berrors.BknBackend_RelationType_InvalidParameter_ConceptCondition).
 				WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.ConditionDecodeFailed", nil))
 		}
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		filterCondition = permission.RestrictDatasetFilterToIDs(filterCondition, visibleIDs)
 	}
 
 	// 1. Get relation types in the groups.

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -290,7 +290,8 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 	if query.Branch == "" {
 		query.Branch = interfaces.MAIN_BRANCH
 	}
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -299,10 +300,12 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 		}
 	}
 
-	candidateQuery := query
-	candidateQuery.Offset = 0
-	candidateQuery.Limit = -1
-	relationTypes, err := rts.rta.ListRelationTypes(ctx, candidateQuery)
+	listQuery := query
+	if pepEnabled {
+		listQuery.Offset = 0
+		listQuery.Limit = -1
+	}
+	relationTypes, err := rts.rta.ListRelationTypes(ctx, listQuery)
 	if err != nil {
 		logger.Errorf("ListRelationTypes error: %s", err.Error())
 		span.SetStatus(codes.Error, "List relation types error")
@@ -311,8 +314,8 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 			berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total := len(relationTypes)
-	if permission.KNChildResourcePEPEnabled() {
+	var total int
+	if pepEnabled {
 		relationTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, rts.ps,
 			interfaces.RESOURCE_TYPE_RELATION_TYPE, query.KNID, relationTypes,
 			func(relationType *interfaces.RelationType) string { return relationType.RTID }, query.Offset, query.Limit)
@@ -320,7 +323,13 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 			return []*interfaces.RelationType{}, 0, err
 		}
 	} else {
-		relationTypes = permission.PaginateKNChildCandidates(relationTypes, query.Offset, query.Limit)
+		total, err = rts.rta.GetRelationTypesTotal(ctx, query)
+		if err != nil {
+			logger.Errorf("GetRelationTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get relation types total error")
+			return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 	if len(relationTypes) == 0 {
 		span.SetStatus(codes.Ok, "")
@@ -631,14 +640,13 @@ func (rts *relationTypeService) DeleteRelationTypesByIDs(ctx context.Context, tx
 		}
 	} else {
 		if permission.KNChildResourcePEPEnabled() {
-			for _, rtID := range rtIDs {
-				_, exists, err := rts.CheckRelationTypeExistByID(ctx, knID, branch, rtID)
-				if err != nil {
-					return err
-				}
-				if !exists {
-					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RelationType_RelationTypeNotFound)
-				}
+			relationTypes, err := rts.rta.GetRelationTypesByIDs(ctx, knID, branch, rtIDs)
+			if err != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_RelationType_InternalError_GetRelationTypesByIDsFailed).WithErrorDetails(err.Error())
+			}
+			if len(relationTypes) != len(rtIDs) {
+				return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RelationType_RelationTypeNotFound)
 			}
 		}
 		if err := permission.CheckKNChildBatchPermission(ctx, rts.ps,

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -358,7 +358,8 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), query).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -393,6 +394,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 					So(q.Branch, ShouldEqual, interfaces.MAIN_BRANCH)
 					return rtArr, nil
 				})
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, knID string, branch string, otIDs []string, _ bool) (map[string]*interfaces.ObjectType, error) {
 					So(branch, ShouldEqual, interfaces.MAIN_BRANCH)
@@ -423,6 +425,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -481,6 +484,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
@@ -511,6 +515,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
@@ -542,6 +547,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -562,9 +568,8 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{{
-				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{RTID: "rt1"},
-			}}, nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -609,7 +614,8 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr[1:], nil)
+			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
 				[]string{"ot1", "ot2"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -359,7 +359,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -394,7 +393,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 					So(q.Branch, ShouldEqual, interfaces.MAIN_BRANCH)
 					return rtArr, nil
 				})
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ context.Context, knID string, branch string, otIDs []string, _ bool) (map[string]*interfaces.ObjectType, error) {
 					So(branch, ShouldEqual, interfaces.MAIN_BRANCH)
@@ -425,7 +423,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(0, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -484,7 +481,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
@@ -515,7 +511,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 500, berrors.BknBackend_RelationType_InternalError))
 
@@ -547,7 +542,6 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
@@ -568,8 +562,9 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{}, nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return([]*interfaces.RelationType{{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{RTID: "rt1"},
+			}}, nil)
 
 			rts, total, err := service.ListRelationTypes(ctx, query)
 			So(err, ShouldBeNil)
@@ -614,8 +609,7 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 			}
 
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr[1:], nil)
-			rta.EXPECT().GetRelationTypesTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+			rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(rtArr, nil)
 			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), "kn1", interfaces.MAIN_BRANCH,
 				[]string{"ot1", "ot2"}, false).Return(map[string]*interfaces.ObjectType{}, nil)
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -476,14 +476,13 @@ func (rts *riskTypeService) DeleteRiskTypesByIDs(ctx context.Context, tx *sql.Tx
 		}
 	} else {
 		if permission.KNChildResourcePEPEnabled() {
-			for _, rtID := range rtIDs {
-				_, exists, err := rts.CheckRiskTypeExistByID(ctx, knID, branch, rtID)
-				if err != nil {
-					return err
-				}
-				if !exists {
-					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RiskType_RiskTypeNotFound)
-				}
+			riskTypes, queryErr := rts.rta.GetRiskTypesByIDs(ctx, knID, branch, rtIDs)
+			if queryErr != nil {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_RiskType_InternalError_GetRiskTypesByIDsFailed).WithErrorDetails(queryErr.Error())
+			}
+			if len(riskTypes) != len(rtIDs) {
+				return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RiskType_RiskTypeNotFound)
 			}
 		}
 		if err := permission.CheckKNChildBatchPermission(ctx, rts.ps,

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -107,12 +107,14 @@ func (rts *riskTypeService) CreateRiskTypes(ctx context.Context, tx *sql.Tx, ris
 		}
 	}()
 
-	err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   riskTypes[0].KNID,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
-	if err != nil {
-		return nil, err
+	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
+		err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   riskTypes[0].KNID,
+		}, []string{interfaces.OPERATION_TYPE_MODIFY})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	currentTime := time.Now().UnixMilli()
@@ -160,6 +162,25 @@ func (rts *riskTypeService) CreateRiskTypes(ctx context.Context, tx *sql.Tx, ris
 	createList, updateList, err := rts.handleImportMode(ctx, mode, riskTypes)
 	if err != nil {
 		return nil, err
+	}
+	if !permission.KNImportPermissionPrechecked(ctx) && permission.KNChildResourcePEPEnabled() {
+		if len(createList) > 0 {
+			if err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   riskTypes[0].KNID,
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
+				return nil, err
+			}
+		}
+		updateIDs := make([]string, 0, len(updateList))
+		for _, riskType := range updateList {
+			updateIDs = append(updateIDs, riskType.RTID)
+		}
+		if err = permission.CheckKNChildBatchPermission(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RISK_TYPE, riskTypes[0].KNID, updateIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_MODIFY); err != nil {
+			return nil, err
+		}
 	}
 
 	rtIDs := []string{}
@@ -289,40 +310,35 @@ func (rts *riskTypeService) handleImportMode(ctx context.Context, mode string, r
 func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.RiskTypesQueryParams) ([]*interfaces.RiskType, int, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListRiskTypes")
 	defer span.End()
-
-	err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return nil, 0, err
+	if !permission.KNChildResourcePEPEnabled() {
+		if err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return nil, 0, err
+		}
 	}
 
-	list, err := rts.rta.ListRiskTypes(ctx, query)
+	candidateQuery := query
+	candidateQuery.Offset = 0
+	candidateQuery.Limit = -1
+	list, err := rts.rta.ListRiskTypes(ctx, candidateQuery)
 	if err != nil {
 		logger.Errorf("ListRiskTypes error: %s", err.Error())
 		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_RiskType_InternalError).WithErrorDetails(err.Error())
 	}
 
-	total, err := rts.rta.GetRiskTypesTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetRiskTypesTotal error: %s", err.Error())
-		return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_RiskType_InternalError).WithErrorDetails(err.Error())
-	}
-
-	// Return all results when limit is -1.
-	if query.Limit != -1 {
-		if query.Offset < 0 || query.Offset >= len(list) {
-			span.SetStatus(codes.Ok, "")
-			return []*interfaces.RiskType{}, total, nil
+	total := len(list)
+	if permission.KNChildResourcePEPEnabled() {
+		list, total, err = permission.FilterAndPaginateKNChildren(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RISK_TYPE, query.KNID, list,
+			func(riskType *interfaces.RiskType) string { return riskType.RTID }, query.Offset, query.Limit)
+		if err != nil {
+			return nil, 0, err
 		}
-		end := query.Offset + query.Limit
-		if end > len(list) {
-			end = len(list)
-		}
-		list = list[query.Offset:end]
+	} else {
+		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
 	}
 
 	if len(list) > 0 && rts.uma != nil {
@@ -445,8 +461,6 @@ func (rts *riskTypeService) DeleteRiskTypesByIDs(ctx context.Context, tx *sql.Tx
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, rtIDs); err != nil {
 		return err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_MODIFY
 	if len(rtIDs) == 1 {
 		_, exists, err := rts.CheckRiskTypeExistByID(ctx, knID, branch, rtIDs[0])
 		if err != nil {
@@ -455,11 +469,28 @@ func (rts *riskTypeService) DeleteRiskTypesByIDs(ctx context.Context, tx *sql.Tx
 		if !exists {
 			return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RiskType_RiskTypeNotFound)
 		}
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RISK_TYPE,
+		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RISK_TYPE,
 			knID, rtIDs[0], interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE)
-	}
-	if err := rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return err
+		if err := rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
+			return err
+		}
+	} else {
+		if permission.KNChildResourcePEPEnabled() {
+			for _, rtID := range rtIDs {
+				_, exists, err := rts.CheckRiskTypeExistByID(ctx, knID, branch, rtID)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					return rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RiskType_RiskTypeNotFound)
+				}
+			}
+		}
+		if err := permission.CheckKNChildBatchPermission(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RISK_TYPE, knID, rtIDs,
+			interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE); err != nil {
+			return err
+		}
 	}
 	if tx == nil {
 		tx, err = rts.db.Begin()
@@ -587,12 +618,34 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 	response := interfaces.RiskTypes{}
 	var err error
 
-	err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return response, err
+	var visibleIDs []string
+	if !permission.KNChildResourcePEPEnabled() {
+		err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   query.KNID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		if err != nil {
+			return response, err
+		}
+	} else {
+		candidates, candidateErr := rts.rta.GetAllRiskTypesByKnID(ctx, query.KNID, query.Branch)
+		if candidateErr != nil {
+			return response, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_RiskType_InternalError).WithErrorDetails(candidateErr.Error())
+		}
+		candidateIDs := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			candidateIDs = append(candidateIDs, candidate.RTID)
+		}
+		visibleIDs, err = permission.FilterKNChildIDs(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RISK_TYPE, query.KNID, candidateIDs,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+		if err != nil {
+			return response, err
+		}
+		if len(visibleIDs) == 0 {
+			return response, nil
+		}
 	}
 
 	var filterCondition map[string]any
@@ -631,6 +684,9 @@ func (rts *riskTypeService) SearchRiskTypes(ctx context.Context, query *interfac
 				berrors.BknBackend_RiskType_InvalidParameter).
 				WithErrorDetails(i18n.Translate(rest.GetLanguageByCtx(ctx), "BknBackend.Validation.Detail.ConditionDecodeFailed", nil))
 		}
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		filterCondition = permission.RestrictDatasetFilterToIDs(filterCondition, visibleIDs)
 	}
 
 	if query.NeedTotal {

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service_test.go
@@ -18,6 +18,7 @@ package risk_type
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -228,6 +229,60 @@ func TestRiskTypeServiceSearchRiskTypesContinuesDefaultCursorPaging(t *testing.T
 		So(len(result.Entries), ShouldEqual, interfaces.ConceptQueryLimit+1)
 		So(result.Entries[len(result.Entries)-1].RTID, ShouldEqual, "risk-last")
 	})
+}
+
+func TestRiskTypeServiceSearchRiskTypesFiltersTrustedCandidatesBeforeDatasetPaging(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	rta := bmock.NewMockRiskTypeAccess(ctrl)
+	vbs := bmock.NewMockVegaBackendService(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	service := &riskTypeService{appSetting: &common.AppSetting{}, rta: rta, vbs: vbs, ps: ps}
+
+	rta.EXPECT().GetAllRiskTypesByKnID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).
+		Return([]*interfaces.RiskType{{RTID: "risk-1"}, {RTID: "risk-2"}, {RTID: "risk-3"}}, nil)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RISK_TYPE,
+		[]string{"kn-1/risk-1", "kn-1/risk-2", "kn-1/risk-3"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/risk-1": {ResourceID: "kn-1/risk-1"},
+		"kn-1/risk-3": {ResourceID: "kn-1/risk-3"},
+	}, nil)
+
+	wantFilter := map[string]any{
+		"field": "id", "operation": "in", "value": []string{"risk-1", "risk-3"}, "value_from": "const",
+	}
+	nextCursor := "visible-cursor"
+	gomock.InOrder(
+		vbs.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+				if !reflect.DeepEqual(params.FilterCondition, wantFilter) || !params.NeedTotal {
+					t.Fatalf("total query params = %#v", params)
+				}
+				return &interfaces.DatasetQueryResponse{TotalCount: 2}, nil
+			}),
+		vbs.EXPECT().QueryResourceData(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
+				if !reflect.DeepEqual(params.FilterCondition, wantFilter) {
+					t.Fatalf("page query filter = %#v", params.FilterCondition)
+				}
+				return &interfaces.DatasetQueryResponse{
+					Entries: []map[string]any{{"id": "risk-1", "name": "Risk 1"}},
+					Paging:  &interfaces.ResourceDataPagingResult{NextCursor: &nextCursor},
+				}, nil
+			}),
+	)
+
+	result, err := service.SearchRiskTypes(context.Background(), &interfaces.ConceptsQuery{
+		KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, NeedTotal: true, Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchRiskTypes() error = %v", err)
+	}
+	if result.TotalCount != 2 || len(result.Entries) != 1 || result.Entries[0].RTID != "risk-1" ||
+		result.NextCursor == nil || *result.NextCursor != nextCursor {
+		t.Fatalf("SearchRiskTypes() = %#v", result)
+	}
 }
 
 func TestRiskTypeServiceHandleImportModeLocalizesInvalidMode(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Filter knowledge-network and six child-resource list/search candidates before total and pagination.
- [x] Enforce all-or-nothing authorization for batch updates and deletes.
- [x] Harden import authorization, ResourceParent lifecycle compensation, and runtime-configurable filter chunking.
- [x] Documentation changes are not applicable; the authorization design is tracked in openbkn-ai/bkn-docs#92 and #94.

---

## Why

- Related Issue: Closes #1247
- Related Feature: KN child-resource authorization introduced by #1250
- Background: The remaining list, search, batch, and import entrypoints could still rely on parent-KN authorization, calculate totals before filtering, or partially execute a denied batch.

---

## How

- Key implementation points:
  - Load trusted candidates from the business store and filter canonical KN child references through bkn-safe before pagination or dataset search.
  - Apply visible child IDs to Vega filters so totals, cursors, and pages are computed over the authorized set.
  - Preflight every batch target before business or index writes; any denial or filter failure aborts the whole operation.
  - Preserve valid client-provided child IDs and generate IDs only when omitted.
  - Mark already-authorized whole-KN imports to avoid duplicate child authorization before the root creator policy exists.
  - Compensate root authorization and dataset documents when a new-KN import or commit fails.
  - Support optional runtime filter chunking without fixed request-size caps or HTTP 413 behavior.
- Breaking changes (API, config, database, etc.):
  - No API or database schema change.
  - Adds optional KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE; zero keeps a single filter request.
  - KN_CHILD_RESOURCE_PEP_ENABLED remains disabled by default, so legacy behavior is preserved until rollout.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; no integration environment was used.
- [ ] Verified in test environment — pending CI and environment verification.

Test notes:

- KN_CHILD_RESOURCE_PEP_ENABLED=false I18N_MODE_UT=true go test -p 1 ./logics/permission ./logics/knowledge_network ./logics/concept_group ./logics/object_type ./logics/relation_type ./logics/action_type ./logics/metric ./logics/risk_type
- KN_CHILD_RESOURCE_PEP_ENABLED=false I18N_MODE_UT=true go vet ./logics/permission ./logics/knowledge_network ./logics/concept_group ./logics/object_type ./logics/relation_type ./logics/action_type ./logics/metric ./logics/risk_type
- git diff --check

---

## Risk & Rollback

- Potential risks: Enabling child-resource PEP changes visible totals and batch authorization outcomes for callers that previously relied on broad parent-KN access. Large candidate sets may increase business-store reads before filtering.
- Rollback plan: Keep the PEP disabled, or revert commit d24b08e4d and redeploy the previous image. No data migration is performed by this PR.

---

## Additional Notes

- Focused coverage includes filter-before-pagination, runtime chunking, whole-request failure, cross-KN child-ID isolation, batch rejection before writes, search restriction, and import compensation.
- Helm rendering was not run locally because Helm is not installed; CI should validate the chart.