### PR TITLE
feat(deploy): add customer deployment skill

### DIFF
--- a/deploy/openbkn-deploy/SKILL.md
+++ b/deploy/openbkn-deploy/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: openbkn-deploy
+description: Deploy or upgrade OpenBKN on a customer-authorized Linux server through the repository's deploy scripts, with preflight checks, explicit confirmation, secret handling, and post-deployment verification.
+metadata:
+  short-description: Safely deploy OpenBKN for an authorized customer
+---
+
+# OpenBKN deployment
+
+Use this skill when a customer asks to install, upgrade, verify, or diagnose an OpenBKN deployment using this repository's `deploy/` directory.
+
+## Scope and authorization
+
+- Act only on a server the customer explicitly identifies and authorizes.
+- Before any remote mutation, show the target host, SSH user, selected version, deployment mode, components, and expected impact; require explicit confirmation.
+- Never assume that providing credentials authorizes an upgrade, data cleanup, reset, uninstall, or production change.
+- Never put passwords, private keys, tokens, or generated credentials in this skill, Git, command arguments, shell history, or normal logs. Prefer an SSH key or a temporary credential supplied through a secure secret mechanism.
+- Never run `k8s reset`, delete PVCs, uninstall data services, run trace cleanup, or perform a database/schema migration without a separate confirmation that states what changes, blast radius, and rollback/backup plan.
+
+## Standard workflow
+
+1. Collect only the required deployment inputs: target host, SSH method, sudo/root access, access address, Kubernetes distribution (`k8s` or `k3s`), requested version, registry, whether this is a new install or upgrade, the delivery source (release package or repository URL), and the deployment directory if it already exists.
+2. Inspect the target without changing it: OS, CPU, memory, disk, hostname, time sync, open ports, container runtime, Kubernetes context, `kubectl`, and `helm` availability.
+3. Locate and verify the deployment directory. Prefer the directory supplied by the customer. If absent, do a limited read-only search for a directory containing `deploy/deploy.sh`; if there are zero or multiple candidates, stop and ask the customer to identify the intended directory. Verify the selected directory's source and version before using it.
+   - Establish one canonical deployment root for the entire operation. Once selected or created, reuse it for every preflight, manifest, download, and deploy command.
+   - Never create a parallel directory such as `/opt/bkn-foundry-<version>` to resolve a version mismatch. If the selected root's source, commit/tag, `VERSION`, or release manifest does not match the requested release, stop and report the mismatch; replace it only with explicit customer approval or use an explicitly supplied release package in the same approved root.
+   - The deployment script, `VERSION`, release manifest, and charts must come from the same verified source/tag. Record the canonical root, source URL, commit/tag, script version, and manifest path before mutation.
+4. If no verified deployment directory exists, obtain the customer-approved release package or clone the approved repository at the requested tag/commit. If Git is unavailable, use the release package; do not install Git or download an unapproved package without confirmation. Work from the resulting `deploy/` directory.
+5. Run the repository preflight in check-only mode first. When the customer confirms host preparation, the default deployment policy is to disable the host firewall; state this explicitly in the confirmation, identify the detected firewall implementation, and report the change after it is made. Do not change cloud security groups or external network firewalls without separate authorization.
+6. For a new install, use the pinned release manifest when one is requested or available. Prefer the repository's documented version entrypoint (for example, `--version=<version>`) when it resolves the same verified manifest; use `--version_file` only when needed and record why. Do not use `--latest` in production unless explicitly authorized. Do not mix a script from one source/tag with a manifest or charts from another.
+   - If the target has less than 8 GiB total memory or fewer than 8 logical CPU cores, append both `--set resources.requests.cpu=0m` and `--set resources.requests.memory=0Mi` to the `openbkn install` command, unless the customer explicitly supplied different resource overrides. Report this low-resource override as a lab-only warning; it does not make the host meet the recommended production capacity.
+   - Default/latest mode is distinct: when the customer explicitly chooses the default or omits both `version` and `version_file`, the repository's documented behavior is to use the official `main` branch and let the script resolve/install the newest available release. Omit both version flags, state that this is a moving-target latest install, and record the resolved version after installation. This is allowed only with explicit customer authorization; never silently substitute it for a requested pinned release.
+7. For an upgrade, verify backups, current Helm releases, PVCs, runtime configuration, current version, and release notes. Read the applicable upgrade instructions before running any migration or cleanup script.
+8. Execute the existing deployment scripts rather than reimplementing Helm commands. Do not run `onboard.sh` as part of the default installation; leave post-install business initialization to the customer as a separate, explicitly requested operation:
+
+   ```bash
+   sudo bash ./preflight.sh --check-only
+   sudo bash ./deploy.sh openbkn install \
+     --registry=swr \
+     --access_address=https://HOST \
+     --api_server_address=API_IP
+   sudo bash ./deploy.sh openbkn status
+   ```
+
+9. Verify Kubernetes nodes, Pods, Helm releases, Ingress, service health, access URL, and the recorded runtime configuration. Report failures with the exact component and next safe diagnostic command.
+
+## Upgrade rules
+
+- Treat `git pull` as a code/config change: inspect the diff and identify the target version before installing.
+- Use `--version_file=./release-manifests/<version>/bkn-foundry.yaml` for reproducible production upgrades.
+- Do not run legacy Trace cleanup merely because the document mentions it; confirm that the target upgrade requires it, take a backup, quiesce writes, and obtain explicit confirmation.
+- Do not assume changing a ConfigMap or `OPENSEARCH_INITIAL_ADMIN_PASSWORD` changes an already-initialized OpenSearch password on an existing PVC. Distinguish application connection settings from the OpenSearch internal admin credential.
+- Do not run `onboard.sh` unless the customer separately requests post-install initialization such as model registration, business-user provisioning, or CLI login setup.
+- Use `--force-upgrade` only when a deliberate configuration or access-address change requires it, and explain the expected rollout.
+
+## Failure handling
+
+- Stop on authentication, target mismatch, backup failure, ambiguous version, or unexpected destructive prompt.
+- Diagnose with read-only commands first (`kubectl get`, `kubectl describe`, `kubectl logs`, `helm list`, `helm status`).
+- Do not “fix” failures by deleting Pods, PVCs, namespaces, or the cluster unless the customer separately confirms the exact action.
+- At completion, provide the deployed version, access URL, admin credential delivery location (never print the secret), health summary, commands run, and remaining warnings.
+
+For detailed command selection and confirmation wording, read [references/operations.md](references/operations.md).

--- a/deploy/openbkn-deploy/references/operations.md
+++ b/deploy/openbkn-deploy/references/operations.md
@@ -1,0 +1,147 @@
+# OpenBKN deployment operations
+
+## Inputs to confirm
+
+```text
+Target host:
+SSH user / authentication method:
+Authorized scope: new install or upgrade
+Existing deployment directory (if any):
+Delivery source: customer-provided release package or approved repository URL
+Kubernetes distribution: k8s or k3s
+OpenBKN version or release manifest:
+Access address:
+API server address:
+Image registry:
+Data backup completed: yes/no/not applicable
+```
+
+Do not request a password in ordinary chat. Use the platform's secret input, an SSH agent, or a temporary credential. Never echo it or include it in a command line.
+
+## Locate or obtain deployment files
+
+The customer should provide the deployment directory when it exists. Verify it before use:
+
+```bash
+test -x <customer-directory>/deploy/deploy.sh
+test -f <customer-directory>/AGENTS.md
+```
+
+If no directory is supplied, only inspect the current working directory and conventional locations such as `/opt/openbkn`, `/opt/bkn-foundry`, `/srv/bkn-foundry`, and `/root/bkn-foundry`. A candidate must contain `deploy/deploy.sh`. If discovery finds more than one candidate, report their paths and wait for the customer to choose; never select one based on name or modification time alone.
+
+After selecting a candidate, declare it the canonical deployment root and use that exact path for the rest of the operation. Do not create a second version-suffixed root (for example, `/opt/bkn-foundry-0.1.4`) to work around a mismatch. Verify, in the same root, all of the following before any remote mutation:
+
+```bash
+test -x <root>/deploy/deploy.sh
+test -f <root>/VERSION
+test -f <root>/deploy/release-manifests/<version>/bkn-foundry.yaml
+git -C <root> describe --tags --always --dirty  # when Git metadata exists
+cat <root>/VERSION
+```
+
+The deployment script, `VERSION`, release manifest, and any local charts must be from the same approved package or Git tag. If they disagree, stop and report the exact paths and versions. Only change the canonical root after explicit approval; never silently create a parallel root.
+
+If Git metadata is present, record the current commit and remote URL before an upgrade:
+
+```bash
+git -C <candidate-directory> rev-parse HEAD
+git -C <candidate-directory> remote -v
+```
+
+First prefer a customer-provided, versioned release package. If the approved delivery method is Git, clone the approved repository and check out the requested tag or commit before running any deploy script:
+
+```bash
+git clone https://github.com/openbkn-ai/bkn-foundry.git
+cd bkn-foundry
+git checkout <approved-tag-or-commit>
+cd deploy
+```
+
+For a production installation, report the resolved commit and the selected `release-manifests/<version>/bkn-foundry.yaml` before continuing. Do not run `git pull` blindly on a customer server; it can silently change the deployment version.
+
+Prefer the repository's documented version entrypoint, such as `deploy.sh openbkn install --version=<version>`, when it resolves the verified manifest in the canonical root. If using `--version_file`, confirm it points inside that same root and record the reason. Never mix a script from one checkout/tag with a manifest or charts from another checkout/tag.
+
+### Default/latest mode
+
+When the customer explicitly says to use defaults, or supplies no `version` and no `version_file`, follow the repository's default behavior: obtain/use the official repository `main` branch and invoke `openbkn install` without `--version` or `--version_file`. The script then resolves the newest available release according to its own logic. Before mutation, state that the result is not pinned and may change as `main` or the registry changes; after installation, record the resolved product/chart versions. Keep the selected canonical root; never create a version-suffixed directory for this mode. If an existing checkout would need `git pull`, inspect the diff and get the required confirmation before changing it.
+
+### Low-resource install override
+
+After the read-only CPU and memory check, if either condition is true—total memory `< 8 GiB` or logical CPU cores `< 8`—add these flags to the `openbkn install` invocation:
+
+```bash
+--set resources.requests.cpu=0m \
+--set resources.requests.memory=0Mi
+```
+
+Treat this as a lab-only scheduling override and report it in the confirmation and final result. It does not waive other preflight failures and does not change the host's recommended-capacity warning. If the customer explicitly provides resource settings, preserve those settings and report that the automatic override was not applied.
+
+If Git is unavailable, do not install it automatically. Ask the customer to provide the approved release package or explicitly authorize installing Git. Extract a customer-provided package only into a customer-approved directory, then verify that it contains `deploy/deploy.sh` before continuing.
+
+## Read-only checks
+
+```bash
+hostname -f
+uname -a
+nproc
+free -h
+df -h
+kubectl config current-context
+kubectl get nodes -o wide
+kubectl get pods -A
+helm list -A
+```
+
+On a fresh Linux host, run:
+
+```bash
+sudo bash ./preflight.sh --check-only
+```
+
+Use `--distro=k3s` consistently if the target uses k3s.
+
+## Firewall policy
+
+The default host-preparation policy is to disable the operating-system firewall after the customer confirms the host changes. Include this in the confirmation because it exposes services according to the surrounding network policy. Do not modify cloud security groups, hardware firewalls, or other external network controls unless the customer separately authorizes them.
+
+Detect the active implementation first. After confirmation, use the matching command:
+
+```bash
+# firewalld
+sudo systemctl stop firewalld
+sudo systemctl disable firewalld
+
+# UFW
+sudo ufw disable
+```
+
+If neither implementation is detected, do not guess; report the finding and continue with the rest of the preflight results.
+
+## Confirmation gate
+
+Before installation or upgrade, present:
+
+```text
+将对 <host> 执行 OpenBKN <version> 的 <新装/升级>。
+范围：Kubernetes/Ingress、MariaDB、Redis、Kafka、OpenSearch、OpenBKN 应用。
+主机变更：<将停用 firewalld/UFW；不会修改云安全组或外部防火墙>。
+数据影响：<无数据删除 / 包含数据库迁移 / 包含指定数据清理>。
+回滚：<备份、旧版本 manifest、人工恢复方案>。
+确认继续执行？
+```
+
+If the answer is not explicit, stop.
+
+## Verification
+
+```bash
+sudo bash ./deploy.sh openbkn status
+kubectl get nodes
+kubectl get pods -A
+helm list -n openbkn
+kubectl get ingress -A
+```
+
+`onboard.sh` is not part of the default deployment workflow. Run it only after a separate customer request for model registration, business-user provisioning, or CLI login initialization.
+
+Check the configured URL from the runtime config, not only the repository template. Do not print passwords in the final report.


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 新增 `deploy/openbkn-deploy` 客户部署 Skill
- [x] 新增部署操作参考文档 `references/operations.md`
- [x] 定义新装、升级、目录发现、无 Git、发布包交付与版本固定流程
- [x] 增加客户授权、凭据保护、防火墙处理、危险操作确认与部署后验证规则

---

## Why

- Related Issue: N/A
- Related Feature: 客户侧 AI 辅助部署 OpenBKN
- Background:

客户不希望手动执行 OpenBKN 部署流程。现有 `deploy.sh`、`preflight.sh` 和状态检查脚本已具备自动化基础，需要通过 Skill 统一部署步骤、参数收集、风险确认和故障处理边界。

---

## How

- Key implementation points:
  - 新增 `deploy/openbkn-deploy/SKILL.md`，定义 AI 部署工作流和安全边界。
  - 新增 `deploy/openbkn-deploy/references/operations.md`，提供部署输入、目录/版本校验、无 Git 场景、低资源测试环境、防火墙、确认模板和验收命令。
  - 默认不执行 `onboard.sh`；仅在客户单独要求模型注册、用户初始化或 CLI 登录时执行。
  - 对 Kubernetes 重置、PVC 删除、数据清理、数据库迁移等高风险操作要求单独确认。
  - 不在 Skill、命令参数或日志中保存客户密码、私钥或 Token。

- Breaking changes (API, config, database, etc.):

  无。新增部署辅助 Skill，不修改现有部署脚本、Chart、API 或数据库结构。

---

## Testing

- [x] Unit tests passed locally — N/A，纯 Skill/文档新增，无可执行单元测试
- [x] Integration tests passed locally — N/A，未连接真实客户服务器
- [x] Verified in test environment — 已进行本地文件结构与 Git diff 检查

Test notes:

- 已检查新增文件路径和 YAML frontmatter 格式。
- 已执行 `git diff --check`，无空白错误。
- Skill 官方校验脚本依赖 `PyYAML`，当前环境未安装该依赖，未执行该校验。

---

## Risk & Rollback

- Potential risks:
  - Skill 可能在客户授权的远程服务器上执行系统和部署操作。
  - 默认主机准备策略包含停用本机防火墙，需在客户确认后执行。
  - 若客户选择升级，可能涉及数据迁移或版本兼容性风险。

- Rollback plan:
  - 删除 `deploy/openbkn-deploy/` 即可完全回滚本 PR。
  - Skill 本身不修改现有部署脚本和运行中服务。
  - 实际部署发生异常时，按客户备份、固定版本 manifest 和既有 Helm 回滚流程处理。

---

## Additional Notes

- Skill 交付给客户时需要安装到其 Codex Skills 目录，或通过插件方式分发。
- PR 不包含临时 SSH 凭据文件或其他未跟踪工作树内容。