### PR TITLE
fix(bkn): validate bkn-safe configuration at startup

### DIFF
--- a/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/values.yaml
@@ -6,7 +6,7 @@ env:
   timezone: Asia/Shanghai
   language: en_US.UTF-8
 
-# bkn-safe service base URL.
+# bkn-safe service base URL. Authentication requires an absolute HTTP(S) URL with a host.
 bknSafe:
   url: "http://bkn-safe:3000"
 

--- a/adp/bkn/bkn-backend/server/common/bkn_safe_url.go
+++ b/adp/bkn/bkn-backend/server/common/bkn_safe_url.go
@@ -1,0 +1,42 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package common
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+var (
+	errBknSafeURLRequired = errors.New("BKN_SAFE_URL is required when authentication is enabled")
+	errBknSafeURLInvalid  = errors.New("BKN_SAFE_URL must be an absolute HTTP or HTTPS URL with a host and without credentials, query, or fragment")
+)
+
+// NormalizeBknSafeURL validates and normalizes the bkn-safe service base URL.
+// Error messages deliberately omit the configured value because URLs may carry
+// sensitive data in misconfigured environments.
+func NormalizeBknSafeURL(rawURL string) (string, error) {
+	normalized := strings.TrimRight(strings.TrimSpace(rawURL), "/")
+	if normalized == "" {
+		return "", errBknSafeURLRequired
+	}
+
+	parsed, err := url.Parse(normalized)
+	if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" {
+		return "", errBknSafeURLInvalid
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return "", errBknSafeURLInvalid
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.ForceQuery || parsed.Fragment != "" {
+		return "", errBknSafeURLInvalid
+	}
+
+	parsed.Scheme = scheme
+	return strings.TrimRight(parsed.String(), "/"), nil
+}

--- a/adp/bkn/bkn-backend/server/common/bkn_safe_url_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkn_safe_url_test.go
@@ -1,0 +1,68 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeBknSafeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "HTTP", raw: "http://bkn-safe:3000", want: "http://bkn-safe:3000"},
+		{name: "HTTPS and whitespace", raw: "  https://safe.example.com/base/  ", want: "https://safe.example.com/base"},
+		{name: "case-insensitive scheme", raw: "HTTP://bkn-safe:3000/", want: "http://bkn-safe:3000"},
+		{name: "IPv6 host", raw: "http://[::1]:3000/", want: "http://[::1]:3000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBknSafeURL(tt.raw)
+			if err != nil {
+				t.Fatalf("NormalizeBknSafeURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeBknSafeURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeBknSafeURLRejectsInvalidValuesWithoutEchoingThem(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "empty", raw: ""},
+		{name: "whitespace", raw: "   "},
+		{name: "relative", raw: "bkn-safe:3000"},
+		{name: "scheme relative", raw: "//bkn-safe:3000"},
+		{name: "missing host", raw: "http:///api"},
+		{name: "unsupported scheme", raw: "ftp://bkn-safe:3000"},
+		{name: "credentials", raw: "http://user:secret@bkn-safe:3000"},
+		{name: "query", raw: "http://bkn-safe:3000?token=secret"},
+		{name: "empty query", raw: "http://bkn-safe:3000?"},
+		{name: "fragment", raw: "http://bkn-safe:3000#secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeBknSafeURL(tt.raw)
+			if err == nil {
+				t.Fatalf("NormalizeBknSafeURL(%q) error = nil", tt.raw)
+			}
+			if got != "" {
+				t.Fatalf("NormalizeBknSafeURL(%q) = %q, want empty", tt.raw, got)
+			}
+			if tt.raw != "" && strings.Contains(err.Error(), tt.raw) {
+				t.Fatalf("error exposes configured URL: %v", err)
+			}
+		})
+	}
+}

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access.go
@@ -32,14 +32,20 @@ func newSafeClient(baseURL string) *safeClient {
 
 func (c *safeClient) checkOne(ctx context.Context, accessorID, rtype, rid, op string) (bool, error) {
 	var out struct {
-		Allowed bool `json:"allowed"`
+		Allowed *bool `json:"allowed"`
 	}
 	err := c.do(ctx, http.MethodPost, "/api/safe/v1/authz/check", map[string]any{
 		"accessor_id": accessorID,
 		"resource":    map[string]string{"type": rtype, "id": rid},
 		"operation":   op,
 	}, &out)
-	return out.Allowed, err
+	if err != nil {
+		return false, err
+	}
+	if out.Allowed == nil {
+		return false, fmt.Errorf("invalid bkn-safe check response")
+	}
+	return *out.Allowed, nil
 }
 
 // safeResource is one { type, id } pair in the batch filter request.
@@ -60,7 +66,7 @@ func (c *safeClient) filterResources(ctx context.Context, accessorID string,
 		return out, nil
 	}
 	var resp struct {
-		Resources []struct {
+		Resources *[]struct {
 			ResourceID string   `json:"resource_id"`
 			Operations []string `json:"operations"`
 		} `json:"resources"`
@@ -73,7 +79,10 @@ func (c *safeClient) filterResources(ctx context.Context, accessorID string,
 	}, &resp); err != nil {
 		return nil, err
 	}
-	for _, r := range resp.Resources {
+	if resp.Resources == nil {
+		return nil, fmt.Errorf("invalid bkn-safe resource-filter response")
+	}
+	for _, r := range *resp.Resources {
 		out[r.ResourceID] = r.Operations
 	}
 	return out, nil
@@ -128,7 +137,7 @@ func (c *safeClient) do(ctx context.Context, method, path string, body, out any)
 	defer resp.Body.Close()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("bkn-safe %s %s: %d: %s", method, path, resp.StatusCode, data)
+		return fmt.Errorf("bkn-safe %s %s returned status %d", method, path, resp.StatusCode)
 	}
 	if out != nil && len(data) > 0 {
 		return json.Unmarshal(data, out)

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access_test.go
@@ -11,7 +11,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"bkn-backend/interfaces"
 )
@@ -282,5 +284,84 @@ func TestSafeFilterResourcesPropagatesError(t *testing.T) {
 	if _, err := access.FilterResources(context.Background(),
 		knFilter([]string{"kn-1"}, []string{"view_detail"}, []string{"view_detail"})); err == nil {
 		t.Fatal("want error from a failing bkn-safe, got nil")
+	}
+}
+
+func TestSafePermissionErrorsDoNotExposeResponseBodies(t *testing.T) {
+	const sensitiveBody = "token=do-not-log"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, sensitiveBody, http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	access := NewPermissionAccess(srv.URL)
+
+	_, err := access.CheckPermission(context.Background(), interfaces.PermissionCheck{
+		Accessor:   interfaces.PermissionAccessor{ID: "u-1", Type: "user"},
+		Resource:   interfaces.PermissionResource{Type: "knowledge_network", ID: "kn-1"},
+		Operations: []string{"view_detail"},
+	})
+	if err == nil {
+		t.Fatal("CheckPermission() error = nil, want server error")
+	}
+	if strings.Contains(err.Error(), sensitiveBody) {
+		t.Fatalf("CheckPermission() error exposes response body: %v", err)
+	}
+}
+
+func TestSafePermissionResponsesRejectInvalidPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "malformed JSON", body: "{"},
+		{name: "missing required field", body: "{}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(srv.Close)
+			access := NewPermissionAccess(srv.URL)
+
+			_, err := access.CheckPermission(context.Background(), interfaces.PermissionCheck{
+				Accessor:   interfaces.PermissionAccessor{ID: "u-1", Type: "user"},
+				Resource:   interfaces.PermissionResource{Type: "knowledge_network", ID: "kn-1"},
+				Operations: []string{"view_detail"},
+			})
+			if err == nil {
+				t.Fatal("CheckPermission() error = nil, want invalid-response error")
+			}
+
+			_, err = access.FilterResources(context.Background(),
+				knFilter([]string{"kn-1"}, []string{"view_detail"}, []string{"view_detail"}))
+			if err == nil {
+				t.Fatal("FilterResources() error = nil, want invalid-response error")
+			}
+		})
+	}
+}
+
+func TestSafePermissionTimeoutPropagates(t *testing.T) {
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+	t.Cleanup(func() {
+		close(release)
+		srv.Close()
+	})
+	client := newSafeClient(srv.URL)
+	client.http.Timeout = 20 * time.Millisecond
+	access := &safePermissionAccess{safe: client}
+
+	_, err := access.CheckPermission(context.Background(), interfaces.PermissionCheck{
+		Accessor:   interfaces.PermissionAccessor{ID: "u-1", Type: "user"},
+		Resource:   interfaces.PermissionResource{Type: "knowledge_network", ID: "kn-1"},
+		Operations: []string{"view_detail"},
+	})
+	if err == nil {
+		t.Fatal("CheckPermission() error = nil, want timeout error")
 	}
 }

--- a/adp/bkn/bkn-backend/server/main.go
+++ b/adp/bkn/bkn-backend/server/main.go
@@ -15,7 +15,6 @@ import (
 	// _ "net/http/pprof"
 	"os/signal"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 	_ "unicode/utf8"
@@ -188,9 +187,9 @@ func main() {
 
 	// Sort Set entries in ascending alphabetical order.
 	if common.GetAuthEnabled() {
-		bknSafeURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_URL")), "/")
-		if bknSafeURL == "" {
-			logger.Fatalf("BKN_SAFE_URL is required when authentication is enabled")
+		bknSafeURL, err := common.NormalizeBknSafeURL(os.Getenv("BKN_SAFE_URL"))
+		if err != nil {
+			logger.Fatalf("Invalid bkn-safe configuration: %v", err)
 		}
 		logics.SetAuthAccess(auth.NewHydraAuthAccess(appSetting))
 		logics.SetPermissionAccess(permission.NewPermissionAccess(bknSafeURL))


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Validate and normalize **BKN_SAFE_URL** before constructing authorization and directory clients.
- [x] Reject malformed or structurally incomplete bkn-safe authorization responses and keep dependency failures fail-closed.
- [x] Document the required bkn-safe URL format in the Helm values file.

---

## Why

- Related Issue: Closes #1246
- Related Feature: #1241
- Background: BKN already uses bkn-safe as its only authorization backend, but a non-empty malformed URL could still pass startup and fail on the first permission request. Error propagation also exposed upstream response bodies and did not distinguish missing required response fields from valid denials.

---

## How

- Key implementation points:
  - Add a focused URL normalizer that accepts absolute HTTP/HTTPS URLs with a host and rejects credentials, queries, fragments, unsupported schemes, and relative URLs.
  - Avoid including the configured URL in validation errors.
  - Validate configuration only when authentication is enabled, preserving the explicit authentication-disabled Noop mode.
  - Treat missing **allowed** or **resources** response fields as invalid bkn-safe responses.
  - Remove upstream response bodies from non-success authorization errors to avoid leaking sensitive content.
- Breaking changes (API, config, database, etc.): Invalid **BKN_SAFE_URL** values now stop BKN during startup when authentication is enabled. There are no API or database changes. **AUTH_ENABLED=false** and **KN_CHILD_RESOURCE_PEP_ENABLED** behavior is unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; no integration environment is required for this configuration boundary.
- [ ] Verified in test environment — not run; deployment is outside this Issue.

Test notes:

- **I18N_MODE_UT=true go test ./common ./drivenadapters/permission ./logics/permission -count=1 -timeout=120s**
- **I18N_MODE_UT=true go test . -count=1 -timeout=120s**
- **I18N_MODE_UT=true go vet ./common ./drivenadapters/permission ./logics/permission**
- ontology-query common package tests and vet passed after rebasing onto the latest main.
- **python3 tools/check_hardcoded_chinese.py** passed with zero new violations.
- **git diff --check origin/main...HEAD** passed.

---

## Risk & Rollback

- Potential risks: Environments using a malformed, credential-bearing, query-bearing, fragment-bearing, or unsupported-scheme bkn-safe URL will fail startup instead of failing on the first authorization request.
- Rollback plan: Revert commit 2818fe529 or deploy the previous bkn-backend image. No data rollback is required.

---

## Additional Notes

- The branch was rebased onto main after #1254. That merge already removed the remaining ontology-query ISF log wording, so this PR does not duplicate that change.
- No API documentation or CHANGELOG update is required because no public API contract or user-facing feature changed.
