### PR TITLE
feat(bkn): grant creator policies on resource creation

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/permission_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_access.go
@@ -55,6 +55,16 @@ var (
 		OPERATION_TYPE_AUTHORIZE,
 		OPERATION_TYPE_TASK_MANAGE,
 	}
+	// KN_CREATOR_OPERATIONS is the fixed instance-level grant installed for a
+	// newly created knowledge network. Create remains a type-level capability.
+	KN_CREATOR_OPERATIONS = []string{
+		OPERATION_TYPE_VIEW_DETAIL,
+		OPERATION_TYPE_MODIFY,
+		OPERATION_TYPE_DELETE,
+		OPERATION_TYPE_QUERY_DATA,
+		OPERATION_TYPE_AUTHORIZE,
+		OPERATION_TYPE_TASK_MANAGE,
+	}
 )
 
 // PermissionCheck describes a permission check.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -176,6 +176,12 @@ func (ats *actionTypeService) CreateActionTypes(ctx context.Context, tx *sql.Tx,
 			_ = parentTracker.Cleanup(ctx, ats.ps)
 		}
 	}()
+	ctx, policyTracker, policyTrackerOwner := permission.WithCreatedPolicyTracker(ctx)
+	defer func() {
+		if policyTrackerOwner && err != nil {
+			_ = policyTracker.Cleanup(ctx, ats.ps)
+		}
+	}()
 
 	if !permission.KNImportPermissionPrechecked(ctx) && !permission.KNChildResourcePEPEnabled() {
 		err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
@@ -328,6 +334,25 @@ func (ats *actionTypeService) CreateActionTypes(ctx context.Context, tx *sql.Tx,
 		return []string{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_ActionType_InternalError_InsertOpenSearchDataFailed).
 			WithErrorDetails(err.Error())
+	}
+
+	if len(createActionTypes) > 0 {
+		resources := make([]interfaces.PermissionResource, 0, len(createActionTypes))
+		for _, actionType := range createActionTypes {
+			resources = append(resources, interfaces.PermissionResource{
+				ID:   interfaces.KNChildResourceID(actionType.KNID, actionType.ATID),
+				Type: interfaces.RESOURCE_TYPE_ACTION_TYPE,
+				Name: actionType.ATName,
+			})
+		}
+		permission.TrackCreatedPolicies(ctx, resources)
+		if err = ats.ps.CreateResources(ctx, resources, []string{interfaces.OPERATION_TYPE_EXECUTE}); err != nil {
+			logger.Errorf("Create action type policies error: %s", err.Error())
+			span.SetStatus(codes.Error, "创建行动类权限失败")
+			return []string{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_ActionType_InternalError).
+				WithErrorDetails(err.Error())
+		}
 	}
 
 	span.SetStatus(codes.Ok, "")

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -1216,10 +1216,63 @@ func Test_actionTypeService_CreateActionTypes(t *testing.T) {
 			ata.EXPECT().CheckActionTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			ata.EXPECT().CreateActionType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), []interfaces.PermissionResource{{
+				ID: "kn1/at1", Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, Name: "at1",
+			}}, []string{interfaces.OPERATION_TYPE_EXECUTE}).Return(nil)
 			smock.ExpectCommit()
 			atIDs, err := service.CreateActionTypes(ctx, nil, actionTypes, mode, false)
 			So(err, ShouldBeNil)
 			So(len(atIDs), ShouldEqual, 1)
+		})
+
+		Convey("Safe failure rolls back and compensates partial action type policies\n", func() {
+			actionTypes := []*interfaces.ActionType{{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at1", ATName: "at1"},
+				KNID:                   "kn1",
+				Branch:                 interfaces.MAIN_BRANCH,
+			}}
+
+			smock.ExpectBegin()
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ata.EXPECT().CheckActionTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ata.EXPECT().CheckActionTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ata.EXPECT().CreateActionType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), []interfaces.PermissionResource{{
+				ID: "kn1/at1", Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, Name: "at1",
+			}}, []string{interfaces.OPERATION_TYPE_EXECUTE}).Return(errors.New("safe write failed"))
+			smock.ExpectRollback()
+			ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_ACTION_TYPE,
+				[]string{"kn1/at1"}).Return(nil)
+
+			atIDs, err := service.CreateActionTypes(ctx, nil, actionTypes, interfaces.ImportMode_Normal, false)
+			So(err, ShouldNotBeNil)
+			So(atIDs, ShouldBeEmpty)
+		})
+
+		Convey("Commit failure compensates created action type policies\n", func() {
+			actionTypes := []*interfaces.ActionType{{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at1", ATName: "at1"},
+				KNID:                   "kn1",
+				Branch:                 interfaces.MAIN_BRANCH,
+			}}
+
+			smock.ExpectBegin()
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ata.EXPECT().CheckActionTypeExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ata.EXPECT().CheckActionTypeExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
+			ata.EXPECT().CreateActionType(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), []interfaces.PermissionResource{{
+				ID: "kn1/at1", Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, Name: "at1",
+			}}, []string{interfaces.OPERATION_TYPE_EXECUTE}).Return(nil)
+			smock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+			ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_ACTION_TYPE,
+				[]string{"kn1/at1"}).Return(nil)
+
+			atIDs, err := service.CreateActionTypes(ctx, nil, actionTypes, interfaces.ImportMode_Normal, false)
+			So(err, ShouldNotBeNil)
+			So(atIDs, ShouldResemble, []string{"at1"})
 		})
 
 		Convey("Failed when permission check fails\n", func() {
@@ -1289,6 +1342,13 @@ func Test_actionTypeService_CreateActionTypes(t *testing.T) {
 				So(atType.ATID, ShouldNotBeEmpty)
 			}).Return(nil)
 			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), gomock.Any(), []string{interfaces.OPERATION_TYPE_EXECUTE}).
+				DoAndReturn(func(_ context.Context, resources []interfaces.PermissionResource, _ []string) error {
+					So(len(resources), ShouldEqual, 1)
+					So(resources[0].Type, ShouldEqual, interfaces.RESOURCE_TYPE_ACTION_TYPE)
+					So(resources[0].ID, ShouldStartWith, "kn1/")
+					return nil
+				})
 			smock.ExpectCommit()
 			atIDs, err := service.CreateActionTypes(ctx, nil, actionTypes, mode, false)
 			So(err, ShouldBeNil)

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -126,6 +126,12 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			_ = parentTracker.Cleanup(ctx, cgs.ps)
 		}
 	}()
+	ctx, policyTracker, policyTrackerOwner := permission.WithCreatedPolicyTracker(ctx)
+	defer func() {
+		if policyTrackerOwner && err != nil {
+			_ = policyTracker.Cleanup(ctx, cgs.ps)
+		}
+	}()
 
 	if !permission.KNImportPermissionPrechecked(ctx) {
 		err = cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -134,20 +134,19 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			_ = parentTracker.Cleanup(ctx, kns.ps)
 		}
 	}()
+	ctx, policyTracker, policyTrackerOwner := permission.WithCreatedPolicyTracker(ctx)
+	defer func() {
+		if policyTrackerOwner && err != nil {
+			_ = policyTracker.Cleanup(ctx, kns.ps)
+		}
+	}()
 	var createdNewKN bool
 	var datasetWritten bool
-	var rootPolicyMayExist bool
 	defer func() {
 		if err == nil || !createdNewKN {
 			return
 		}
 		cleanupCtx := context.WithoutCancel(ctx)
-		if rootPolicyMayExist {
-			if cleanupErr := kns.ps.DeleteResources(cleanupCtx,
-				interfaces.RESOURCE_TYPE_KN, []string{kn.KNID}); cleanupErr != nil {
-				otellog.LogError(cleanupCtx, "CreateKN authorization compensation failed", cleanupErr)
-			}
-		}
 		if datasetWritten {
 			filterCondition := map[string]any{
 				"operation": "and",
@@ -436,13 +435,13 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 
 	// Register resource policies last and only during creation.
 	if isCreate {
-		// Register resource policies.
-		rootPolicyMayExist = true
-		err = kns.ps.CreateResources(ctx, []interfaces.PermissionResource{{
+		resources := []interfaces.PermissionResource{{
 			ID:   kn.KNID,
 			Type: interfaces.RESOURCE_TYPE_KN,
 			Name: kn.KNName,
-		}}, interfaces.COMMON_OPERATIONS)
+		}}
+		permission.TrackCreatedPolicies(ctx, resources)
+		err = kns.ps.CreateResources(ctx, resources, interfaces.KN_CREATOR_OPERATIONS)
 		if err != nil {
 			logger.Errorf("CreateResources error: %s", err.Error())
 			span.SetStatus(codes.Error, "创建业务知识网络资源失败")

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -1683,7 +1683,9 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			kna.EXPECT().CheckKNExistByName(gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			kna.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			vbs.EXPECT().WriteDatasetDocuments(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any()).Return(nil)
-			ps.EXPECT().CreateResources(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			ps.EXPECT().CreateResources(gomock.Any(), []interfaces.PermissionResource{{
+				ID: "kn1", Type: interfaces.RESOURCE_TYPE_KN, Name: "kn1",
+			}}, interfaces.KN_CREATOR_OPERATIONS).Return(nil)
 			smock.ExpectCommit()
 
 			knID, err := service.CreateKN(ctx, kn, mode, true)

--- a/adp/bkn/bkn-backend/server/logics/permission/resource_parent_lifecycle.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/resource_parent_lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 
@@ -24,6 +25,7 @@ const authorizationCleanupTimeout = 5 * time.Second
 
 type resourceParentTrackerKey struct{}
 type authorizationCleanupTrackerKey struct{}
+type createdPolicyTrackerKey struct{}
 
 type trackedResourceParent struct {
 	resourceType string
@@ -50,6 +52,18 @@ type trackedAuthorizationCleanup struct {
 type AuthorizationCleanupTracker struct {
 	mu      sync.Mutex
 	entries map[string]trackedAuthorizationCleanup
+}
+
+type trackedCreatedPolicy struct {
+	resourceType string
+	resourceID   string
+}
+
+// CreatedPolicyTracker records Safe policies created inside a business transaction.
+// The transaction owner removes them if any nested operation or the commit fails.
+type CreatedPolicyTracker struct {
+	mu      sync.Mutex
+	entries map[string]trackedCreatedPolicy
 }
 
 // WithResourceParentTracker returns the existing transaction tracker or installs a new one.
@@ -101,6 +115,69 @@ func (tracker *ResourceParentTracker) Cleanup(ctx context.Context, ps interfaces
 		if err := ps.DeleteResourceParents(cleanupCtx, entry.resourceType, []string{entry.resourceID}); err != nil {
 			logAuthorizationCleanupFailure("resource_parent", entry.resourceType, entry.resourceID,
 				entry.parentType, entry.parentID, err)
+			cleanupErrs = append(cleanupErrs, err)
+		}
+	}
+	return errors.Join(cleanupErrs...)
+}
+
+// WithCreatedPolicyTracker returns the existing transaction tracker or installs a new one.
+// The owner flag identifies the caller responsible for cleanup on transaction failure.
+func WithCreatedPolicyTracker(ctx context.Context) (context.Context, *CreatedPolicyTracker, bool) {
+	if tracker, ok := ctx.Value(createdPolicyTrackerKey{}).(*CreatedPolicyTracker); ok {
+		return ctx, tracker, false
+	}
+	tracker := &CreatedPolicyTracker{entries: map[string]trackedCreatedPolicy{}}
+	return context.WithValue(ctx, createdPolicyTrackerKey{}, tracker), tracker, true
+}
+
+// TrackCreatedPolicies adds resources that may have been written by Safe to the
+// active transaction tracker. Callers track before the write so partial remote
+// success is compensated when the write returns an error.
+func TrackCreatedPolicies(ctx context.Context, resources []interfaces.PermissionResource) {
+	tracker, ok := ctx.Value(createdPolicyTrackerKey{}).(*CreatedPolicyTracker)
+	if !ok || len(resources) == 0 {
+		return
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	for _, resource := range resources {
+		key := resource.Type + "\x00" + resource.ID
+		tracker.entries[key] = trackedCreatedPolicy{
+			resourceType: resource.Type,
+			resourceID:   resource.ID,
+		}
+	}
+}
+
+// Cleanup removes all tracked policies in deterministic type batches. It is
+// safe to call more than once.
+func (tracker *CreatedPolicyTracker) Cleanup(ctx context.Context, ps interfaces.PermissionService) error {
+	tracker.mu.Lock()
+	byType := make(map[string][]string)
+	for _, entry := range tracker.entries {
+		byType[entry.resourceType] = append(byType[entry.resourceType], entry.resourceID)
+	}
+	tracker.entries = map[string]trackedCreatedPolicy{}
+	tracker.mu.Unlock()
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), authorizationCleanupTimeout)
+	defer cancel()
+
+	resourceTypes := make([]string, 0, len(byType))
+	for resourceType := range byType {
+		resourceTypes = append(resourceTypes, resourceType)
+	}
+	sort.Strings(resourceTypes)
+
+	var cleanupErrs []error
+	for _, resourceType := range resourceTypes {
+		resourceIDs := byType[resourceType]
+		sort.Strings(resourceIDs)
+		if err := ps.DeleteResources(cleanupCtx, resourceType, resourceIDs); err != nil {
+			for _, resourceID := range resourceIDs {
+				logAuthorizationCleanupFailure("policy", resourceType, resourceID, "", "", err)
+			}
 			cleanupErrs = append(cleanupErrs, err)
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/permission/resource_parent_lifecycle_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/resource_parent_lifecycle_test.go
@@ -63,6 +63,37 @@ func TestResourceParentTrackerCompensatesNestedWrites(t *testing.T) {
 	}
 }
 
+func TestCreatedPolicyTrackerCompensatesNestedWritesInTypeBatches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := bmock.NewMockPermissionService(ctrl)
+	ctx, tracker, owner := WithCreatedPolicyTracker(context.Background())
+	if !owner {
+		t.Fatal("new tracker must have an owner")
+	}
+	childCtx, childTracker, childOwner := WithCreatedPolicyTracker(ctx)
+	if childOwner || childTracker != tracker {
+		t.Fatal("nested calls must share the outer transaction tracker")
+	}
+	TrackCreatedPolicies(childCtx, []interfaces.PermissionResource{
+		{Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, ID: "kn-1/at-2"},
+		{Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1"},
+		{Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, ID: "kn-1/at-1"},
+		{Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, ID: "kn-1/at-1"},
+	})
+	gomock.InOrder(
+		ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_ACTION_TYPE,
+			[]string{"kn-1/at-1", "kn-1/at-2"}).Return(nil),
+		ps.EXPECT().DeleteResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN,
+			[]string{"kn-1"}).Return(nil),
+	)
+	if err := tracker.Cleanup(ctx, ps); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if err := tracker.Cleanup(ctx, ps); err != nil {
+		t.Fatalf("second Cleanup() error = %v", err)
+	}
+}
+
 func TestCleanupKNChildAuthorizationAttemptsPolicyAndParent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ps := bmock.NewMockPermissionService(ctrl)

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -340,21 +340,25 @@ func ownerGrantFixture(t *testing.T) (*gin.Engine, *authz.Enforcer) {
 	t.Helper()
 	r, e, db, users := newAdminServer(t)
 	ctx := t.Context()
-	for _, u := range []struct{ id, account string }{
-		{"u-owner", "builder"},
-		{"u-mate", "teammate"},
-		{"u-stranger", "stranger"},
+	for _, u := range []struct {
+		id, account string
+		enabled     bool
+	}{
+		{"u-owner", "builder", true},
+		{"u-mate", "teammate", true},
+		{"u-stranger", "stranger", true},
+		{"u-disabled", "disabled", false},
 	} {
-		if err := users.CreateLocalUser(ctx, &model.User{ID: u.id, Account: u.account, Name: u.account, Enabled: true}, "pw-init0"); err != nil {
+		if err := users.CreateLocalUser(ctx, &model.User{ID: u.id, Account: u.account, Name: u.account, Enabled: u.enabled}, "pw-init0"); err != nil {
 			t.Fatal(err)
 		}
 	}
-	// task_manage is registered for the type but deliberately NOT granted below,
-	// so a test can ask for an operation that is valid yet unheld.
+	// Create is registered for the type but deliberately not granted on the
+	// instance, so a test can ask for an operation that is valid yet unheld.
 	seedCatalogOps(t, db, "knowledge_network",
-		"view_detail", "modify", "delete", "query_data", "authorize", "task_manage")
-	// Exactly what bkn-backend writes on create (COMMON_OPERATIONS).
-	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize"} {
+		"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage")
+	// Exactly what bkn-backend writes to a newly created KN instance.
+	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize", "task_manage"} {
 		if err := e.GrantObjectPermission("u-owner", "knowledge_network", "kn-mine", op); err != nil {
 			t.Fatal(err)
 		}
@@ -380,6 +384,19 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 		t.Error("shared grant did not take effect at enforce time")
 	}
 
+	// POST is replacement, not merge.
+	w = tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-owner")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("owner replacement share: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "query_data"); ok {
+		t.Error("replacement share retained an omitted operation")
+	}
+
 	// And can take it back.
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
 		"accessor_id": "u-mate",
@@ -390,6 +407,14 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 	}
 	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
 		t.Error("owner revoke did not remove the grant")
+	}
+	// DELETE is idempotent when the direct grant is already absent.
+	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-owner")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("idempotent owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
 }
 
@@ -415,13 +440,13 @@ func TestObjectGrantsOwnerLimits(t *testing.T) {
 			},
 		},
 		{
-			// task_manage is registered for the type but the owner does not hold
+			// create is registered for the type but the owner does not hold
 			// it, so it cannot be handed out.
 			"cannot grant an op it does not hold",
 			map[string]any{
 				"accessor_id": "u-mate",
 				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
-				"operations":  []string{"view_detail", "task_manage"},
+				"operations":  []string{"view_detail", "create"},
 			},
 		},
 		{
@@ -445,6 +470,18 @@ func TestObjectGrantsOwnerLimits(t *testing.T) {
 		t.Error("a rejected request must not write a partial grant")
 	}
 
+	// Disabled accounts are not valid grant targets and no policy is written.
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-disabled",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-owner"); w.Code != http.StatusBadRequest {
+		t.Fatalf("disabled grantee: want 400, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-disabled", "knowledge_network", "kn-mine", "view_detail"); ok {
+		t.Error("a disabled grantee received a policy")
+	}
+
 	// Someone with no stake in the object gets nothing.
 	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
 		"accessor_id": "u-mate",
@@ -455,9 +492,24 @@ func TestObjectGrantsOwnerLimits(t *testing.T) {
 	}
 }
 
-// A role holding type-wide authorize (network_builder does, on
-// knowledge_network) may delegate any instance of that type — the seeded policy
-// already says so. It is still a delegate: the same two limits apply.
+func TestObjectGrantsAuthorizeRevocationRemovesSharingAuthority(t *testing.T) {
+	r, e := ownerGrantFixture(t)
+	if _, err := e.RemoveAccessorResourcePolicies("u-owner", "knowledge_network", "kn-mine"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-owner")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("sharing after authorize revocation: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+// A role holding type-wide authorize may delegate any instance of that type.
+// This existing non-creator path remains restricted by the same two limits.
 func TestObjectGrantsTypeWideAuthorize(t *testing.T) {
 	r, e := ownerGrantFixture(t)
 	if err := e.GrantRolePermission("role-builder", "knowledge_network", "*", "authorize"); err != nil {
@@ -579,7 +631,7 @@ func TestObjectGrantsOwnerDirectoryLookups(t *testing.T) {
 // rule anyone trusted with one object could take it from the person who made it.
 func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	r, e := ownerGrantFixture(t)
-	// u-stranger is a network_builder: type-wide authorize on the whole type, no
+	// u-stranger holds type-wide authorize on the whole type, with no direct
 	// stake in this particular network.
 	mustGrantRole(t, e, "role-builder", "knowledge_network", "authorize")
 	mustGrantRole(t, e, "role-builder", "knowledge_network", "view_detail")


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Grant each newly created knowledge network a fixed set of creator permissions, excluding the type-level `create` operation.
- [x] Grant `execute` on newly created action types using the canonical `{kn_id}/{action_type_id}` resource ID.
- [x] Add transaction-scoped authorization compensation and focused bkn-safe object-grant regression coverage.

---

## Why

- Related Issue: Closes #520
- Related Feature: Creator authorization for knowledge resources
- Background: Newly created knowledge networks and action types need deterministic creator policies without introducing a separate creator identity model or changing bkn-safe's existing Resource Owner business semantics.

---

## How

- Key implementation points:
  - Define the fixed instance-level knowledge-network creator operations as `view_detail`, `modify`, `delete`, `query_data`, `authorize`, and `task_manage`.
  - Register newly created action types with an `execute` creator policy only for actual create paths, not ignore or overwrite paths.
  - Track Safe policy writes across nested creation flows and delete them in deterministic resource-type batches if the business transaction or commit fails.
  - Expand object-grant contract tests for replacement semantics, idempotent revocation, disabled grantees, and loss of sharing authority after `authorize` is revoked.
- Breaking changes (API, config, database, etc.): None. No API, configuration, or schema changes. Existing bkn-safe Owner behavior is preserved.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; focused service and HTTP contract tests were used)
- [ ] Verified in test environment (not run)

Test notes:

- `I18N_MODE_UT=true go test ./logics/permission ./logics/action_type ./logics/knowledge_network ./logics/concept_group -count=1`
- `I18N_MODE_UT=true go vet ./interfaces ./logics/permission ./logics/action_type ./logics/knowledge_network ./logics/concept_group`
- `go test ./internal/httpapi -run 'TestObjectGrants' -count=1`
- `go vet ./internal/httpapi`
- `go test ./internal/seed -count=1`

---

## Risk & Rollback

- Potential risks: Action-type creation now depends on a Safe policy write. Compensation is best-effort if Safe itself is unavailable during cleanup.
- Rollback plan: Revert commit `388b3fbf9`; no data or schema migration is required.

---

## Additional Notes

- This PR does not remove, deprecate, or redefine bkn-safe's existing Resource Owner model.
- No bkn-safe production code is changed; only its object-grant tests are extended.
