### PR TITLE
fix(vega): split index key fields

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/build_task/build_task_access_test.go
@@ -797,7 +797,10 @@ func sampleBuildTask() *interfaces.BuildTask {
 		FinishTime:       2000,
 		LastProgressTime: 1800,
 		IndexConfig: &interfaces.BuildTaskIndexConfig{
-			IndexConfigContract: interfaces.IndexConfigContract{BuildKeyFields: []string{"id"}},
+			IndexConfigContract: interfaces.IndexConfigContract{
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
+			},
 			Features: map[string]interfaces.BuildTaskFieldIndexFeature{
 				"title": {
 					Vector:   &interfaces.SmallModel{ModelID: "embedding", EmbeddingDim: 1024},

--- a/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/resource/resource_access_test.go
@@ -44,7 +44,7 @@ func TestResourceAccessCreate(t *testing.T) {
 				"public.orders",
 				`{"properties":{"row_count":42}}`,
 				`[{"name":"id","display_name":"","type":"integer","description":"","original_name":"","original_type":"","original_description":"","features":null,"attributes":null}]`,
-				`{"build_key_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
+				`{"primary_key_fields":["id"],"incremental_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
 				"",
 				"[]",
 				interfaces.ResourceLocalIndexStatusAvailable,
@@ -110,7 +110,8 @@ func TestResourceAccessGetByID(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, "resource-1", got.ID)
 		require.NotNil(t, got.IndexConfig)
-		assert.Equal(t, []string{"updated_at", "id"}, got.IndexConfig.BuildKeyFields)
+		assert.Equal(t, []string{"id"}, got.IndexConfig.PrimaryKeyFields)
+		assert.Equal(t, []string{"updated_at", "id"}, got.IndexConfig.IncrementalFields)
 		assert.Equal(t, interfaces.ResourceLocalIndexStatusAvailable, got.LocalIndexStatus)
 		assert.Equal(t, "vega-build-resource-1-task-1", got.LocalIndexName)
 		assert.Equal(t, `{"mode":"batch","cursor":[10,"a"]}`, got.SyncMark)
@@ -387,7 +388,7 @@ func TestResourceAccessUpdate(t *testing.T) {
 				`"pii","core"`,
 				res.Description,
 				`[{"name":"id","display_name":"","type":"integer","description":"","original_name":"","original_type":"","original_description":"","features":null,"attributes":null}]`,
-				`{"build_key_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
+				`{"primary_key_fields":["id"],"incremental_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
 				"",
 				"[]",
 				res.Updater.ID,
@@ -801,7 +802,8 @@ func sampleResource() *interfaces.Resource {
 		SourceMetadata:     map[string]any{"properties": map[string]any{"row_count": 42}},
 		SchemaDefinition:   []*interfaces.Property{{Name: "id", Type: "integer"}},
 		IndexConfig: &interfaces.ResourceIndexConfig{
-			BuildKeyFields:          []string{"updated_at", "id"},
+			PrimaryKeyFields:        []string{"id"},
+			IncrementalFields:       []string{"updated_at", "id"},
 			DefaultFulltextAnalyzer: "ik_max_word",
 			DefaultEmbeddingModel:   "embedding",
 		},
@@ -868,7 +870,7 @@ func resourceNameRowValues(resource *interfaces.Resource) []driver.Value {
 		resource.SourceIdentifier,
 		`{"properties":{"row_count":42}}`,
 		`[{"name":"id","type":"integer"}]`,
-		`{"build_key_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
+		`{"primary_key_fields":["id"],"incremental_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
 		resource.LocalIndexStatus,
 		resource.LocalIndexName,
 		resource.SyncMark,
@@ -959,7 +961,7 @@ func resourceRowValues(resource *interfaces.Resource) []driver.Value {
 		resource.SourceIdentifier,
 		`{"properties":{"row_count":42}}`,
 		`[{"name":"id","type":"integer"}]`,
-		`{"build_key_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
+		`{"primary_key_fields":["id"],"incremental_fields":["updated_at","id"],"default_fulltext_analyzer":"ik_max_word","default_embedding_model":"embedding"}`,
 		resource.LocalIndexStatus,
 		resource.LocalIndexName,
 		resource.SyncMark,

--- a/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/build_task_handler_test.go
@@ -67,7 +67,7 @@ func Test_BuildTaskRestHandler_CreateBuildTask(t *testing.T) {
 		assert.NotContains(t, w.Body.String(), `"status"`)
 	})
 
-	t.Run("ignores legacy index config fields", func(t *testing.T) {
+	t.Run("creates batch task without index config fields", func(t *testing.T) {
 		engine, bts, _ := setupBuildTaskHandlerTest(t)
 		bts.EXPECT().Create(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, req *interfaces.CreateBuildTaskRequest) (string, error) {
@@ -76,7 +76,7 @@ func Test_BuildTaskRestHandler_CreateBuildTask(t *testing.T) {
 				return "task-1", nil
 			})
 
-		body := `{"resource_id":"res-1","mode":"batch","build_key_fields":"id","embedding_fields":"title","embedding_model":"embedding","model_dimensions":1024,"fulltext_fields":"title","fulltext_analyzer":"ik_max_word"}`
+		body := `{"resource_id":"res-1","mode":"batch"}`
 		req := httptest.NewRequest(http.MethodPost, url, strings.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		w := httptest.NewRecorder()

--- a/adp/vega/vega-backend/server/errors/build_task.go
+++ b/adp/vega/vega-backend/server/errors/build_task.go
@@ -16,7 +16,9 @@ const (
 	VegaBackend_BuildTask_InvalidExecuteType                       = "VegaBackend.BuildTask.InvalidExecuteType"
 	VegaBackend_BuildTask_InvalidParameter_ResourceID              = "VegaBackend.BuildTask.InvalidParameter.ResourceID"
 	VegaBackend_BuildTask_InvalidParameter_Mode                    = "VegaBackend.BuildTask.InvalidParameter.Mode"
-	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields          = "VegaBackend.BuildTask.InvalidParameter.BuildKeyFields"
+	VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields        = "VegaBackend.BuildTask.InvalidParameter.PrimaryKeyFields"
+	VegaBackend_BuildTask_InvalidParameter_IncrementalFields       = "VegaBackend.BuildTask.InvalidParameter.IncrementalFields"
+	VegaBackend_BuildTask_StreamingUnsupported                     = "VegaBackend.BuildTask.StreamingUnsupported"
 	VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields = "VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields"
 	VegaBackend_BuildTask_InvalidParameter_Analyzer                = "VegaBackend.BuildTask.InvalidParameter.Analyzer"
 	VegaBackend_BuildTask_InvalidParameter_EmbeddingModel          = "VegaBackend.BuildTask.InvalidParameter.EmbeddingModel"
@@ -48,7 +50,9 @@ var BuildTaskErrCodeList = []string{
 	VegaBackend_BuildTask_InvalidExecuteType,
 	VegaBackend_BuildTask_InvalidParameter_ResourceID,
 	VegaBackend_BuildTask_InvalidParameter_Mode,
-	VegaBackend_BuildTask_InvalidParameter_BuildKeyFields,
+	VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields,
+	VegaBackend_BuildTask_InvalidParameter_IncrementalFields,
+	VegaBackend_BuildTask_StreamingUnsupported,
 	VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields,
 	VegaBackend_BuildTask_InvalidParameter_Analyzer,
 	VegaBackend_BuildTask_InvalidParameter_EmbeddingModel,

--- a/adp/vega/vega-backend/server/errors/resource.go
+++ b/adp/vega/vega-backend/server/errors/resource.go
@@ -10,20 +10,21 @@ package errors
 // Resource error codes.
 const (
 	// 400 Bad Request
-	VegaBackend_Resource_InvalidParameter                = "VegaBackend.Resource.InvalidParameter"
-	VegaBackend_Resource_InvalidParameter_Type           = "VegaBackend.Resource.InvalidParameter.Type"
-	VegaBackend_Resource_InvalidParameter_Name           = "VegaBackend.Resource.InvalidParameter.Name"
-	VegaBackend_Resource_InvalidParameter_CatalogID      = "VegaBackend.Resource.InvalidParameter.CatalogID"
-	VegaBackend_Resource_InvalidParameter_Analyzer       = "VegaBackend.Resource.InvalidParameter.Analyzer"
-	VegaBackend_Resource_InvalidParameter_BuildKeyFields = "VegaBackend.Resource.InvalidParameter.BuildKeyFields"
-	VegaBackend_Resource_LengthExceeded_Name             = "VegaBackend.Resource.LengthExceeded.Name"
-	VegaBackend_Resource_LengthExceeded_Description      = "VegaBackend.Resource.LengthExceeded.Description"
-	VegaBackend_Resource_CategoryNotCreatable            = "VegaBackend.Resource.CategoryNotCreatable"
-	VegaBackend_InvalidParameter_Aggregation             = "VegaBackend.InvalidParameter.Aggregation"
-	VegaBackend_InvalidParameter_GroupBy                 = "VegaBackend.InvalidParameter.GroupBy"
-	VegaBackend_InvalidParameter_OrderBy                 = "VegaBackend.InvalidParameter.OrderBy"
-	VegaBackend_InvalidParameter_Having                  = "VegaBackend.InvalidParameter.Having"
-	VegaBackend_InvalidParameter_CalendarInterval        = "VegaBackend.InvalidParameter.CalendarInterval"
+	VegaBackend_Resource_InvalidParameter                   = "VegaBackend.Resource.InvalidParameter"
+	VegaBackend_Resource_InvalidParameter_Type              = "VegaBackend.Resource.InvalidParameter.Type"
+	VegaBackend_Resource_InvalidParameter_Name              = "VegaBackend.Resource.InvalidParameter.Name"
+	VegaBackend_Resource_InvalidParameter_CatalogID         = "VegaBackend.Resource.InvalidParameter.CatalogID"
+	VegaBackend_Resource_InvalidParameter_Analyzer          = "VegaBackend.Resource.InvalidParameter.Analyzer"
+	VegaBackend_Resource_InvalidParameter_PrimaryKeyFields  = "VegaBackend.Resource.InvalidParameter.PrimaryKeyFields"
+	VegaBackend_Resource_InvalidParameter_IncrementalFields = "VegaBackend.Resource.InvalidParameter.IncrementalFields"
+	VegaBackend_Resource_LengthExceeded_Name                = "VegaBackend.Resource.LengthExceeded.Name"
+	VegaBackend_Resource_LengthExceeded_Description         = "VegaBackend.Resource.LengthExceeded.Description"
+	VegaBackend_Resource_CategoryNotCreatable               = "VegaBackend.Resource.CategoryNotCreatable"
+	VegaBackend_InvalidParameter_Aggregation                = "VegaBackend.InvalidParameter.Aggregation"
+	VegaBackend_InvalidParameter_GroupBy                    = "VegaBackend.InvalidParameter.GroupBy"
+	VegaBackend_InvalidParameter_OrderBy                    = "VegaBackend.InvalidParameter.OrderBy"
+	VegaBackend_InvalidParameter_Having                     = "VegaBackend.InvalidParameter.Having"
+	VegaBackend_InvalidParameter_CalendarInterval           = "VegaBackend.InvalidParameter.CalendarInterval"
 
 	// 404 Not Found
 	VegaBackend_Resource_NotFound        = "VegaBackend.Resource.NotFound"
@@ -58,7 +59,8 @@ var ResourceErrCodeList = []string{
 	VegaBackend_Resource_InvalidParameter_Name,
 	VegaBackend_Resource_InvalidParameter_CatalogID,
 	VegaBackend_Resource_InvalidParameter_Analyzer,
-	VegaBackend_Resource_InvalidParameter_BuildKeyFields,
+	VegaBackend_Resource_InvalidParameter_PrimaryKeyFields,
+	VegaBackend_Resource_InvalidParameter_IncrementalFields,
 	VegaBackend_Resource_LengthExceeded_Name,
 	VegaBackend_Resource_LengthExceeded_Description,
 	VegaBackend_Resource_CategoryNotCreatable,

--- a/adp/vega/vega-backend/server/interfaces/data_types.go
+++ b/adp/vega/vega-backend/server/interfaces/data_types.go
@@ -69,15 +69,6 @@ var (
 		DataType_Datetime:  {},
 		DataType_Timestamp: {},
 	}
-
-	BUILD_KEY_TYPES = map[string]struct{}{
-		DataType_Integer:         {},
-		DataType_UnsignedInteger: {},
-		DataType_String:          {},
-		DataType_Date:            {},
-		DataType_Datetime:        {},
-		DataType_Timestamp:       {},
-	}
 )
 
 func DataType_IsString(t string) bool {
@@ -92,11 +83,5 @@ func DataType_IsNumber(t string) bool {
 
 func DataType_IsDate(t string) bool {
 	_, ok := DATE_TYPES[t]
-	return ok
-}
-
-// The DataType_IsBuildKey determines whether the field type can be used as a stable build cursor.
-func DataType_IsBuildKey(t string) bool {
-	_, ok := BUILD_KEY_TYPES[t]
 	return ok
 }

--- a/adp/vega/vega-backend/server/interfaces/index_config.go
+++ b/adp/vega/vega-backend/server/interfaces/index_config.go
@@ -8,11 +8,42 @@ package interfaces
 
 import "encoding/json"
 
+// PRIMARY_KEY_TYPES are scalar types whose values have a stable document-ID
+// representation across the supported table connectors.
+var PRIMARY_KEY_TYPES = map[string]struct{}{
+	DataType_Integer:         {},
+	DataType_UnsignedInteger: {},
+	DataType_String:          {},
+}
+
+// INCREMENTAL_FIELD_TYPES are scalar types supported by batch keyset sorting,
+// cursor filtering, and checkpoint decoding.
+var INCREMENTAL_FIELD_TYPES = map[string]struct{}{
+	DataType_Integer:         {},
+	DataType_UnsignedInteger: {},
+	DataType_String:          {},
+	DataType_Date:            {},
+	DataType_Time:            {},
+	DataType_Datetime:        {},
+	DataType_Timestamp:       {},
+}
+
+func IndexConfig_IsPrimaryKeyType(dataType string) bool {
+	_, ok := PRIMARY_KEY_TYPES[dataType]
+	return ok
+}
+
+func IndexConfig_IsIncrementalFieldType(dataType string) bool {
+	_, ok := INCREMENTAL_FIELD_TYPES[dataType]
+	return ok
+}
+
 // IndexConfigContract contains only configuration that affects local index
 // mappings, generated documents, queries, document IDs, or batch cursors.
 type IndexConfigContract struct {
-	BuildKeyFields []string                   `json:"build_key_fields"`
-	Fields         []IndexConfigFieldContract `json:"fields"`
+	PrimaryKeyFields  []string                   `json:"primary_key_fields"`
+	IncrementalFields []string                   `json:"incremental_fields"`
+	Fields            []IndexConfigFieldContract `json:"fields"`
 }
 
 type IndexConfigFieldContract struct {

--- a/adp/vega/vega-backend/server/interfaces/resource.go
+++ b/adp/vega/vega-backend/server/interfaces/resource.go
@@ -158,7 +158,8 @@ type PropertyFeature struct {
 
 // ResourceIndexConfig carries resource-level defaults and cross-field build policy.
 type ResourceIndexConfig struct {
-	BuildKeyFields          []string `json:"build_key_fields,omitempty"`
+	PrimaryKeyFields        []string `json:"primary_key_fields,omitempty"`
+	IncrementalFields       []string `json:"incremental_fields,omitempty"`
 	DefaultFulltextAnalyzer string   `json:"default_fulltext_analyzer,omitempty"`
 	DefaultEmbeddingModel   string   `json:"default_embedding_model,omitempty"`
 }

--- a/adp/vega/vega-backend/server/locale/build_task.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.en-US.toml
@@ -13,9 +13,19 @@ Description = "Invalid build task mode"
 Solution = "Mode must be one of: streaming, batch"
 ErrorLink = ""
 
-[VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
-Description = "Invalid batch build key fields"
-Solution = "Configure at least one unique build_key_fields field that exists in the resource schema and has a supported type"
+[VegaBackend.BuildTask.InvalidParameter.PrimaryKeyFields]
+Description = "Invalid primary key fields"
+Solution = "Configure at least one unique primary_key_fields field that exists in the resource schema and has a supported type"
+ErrorLink = ""
+
+[VegaBackend.BuildTask.InvalidParameter.IncrementalFields]
+Description = "Invalid incremental fields"
+Solution = "Configure at least one unique incremental_fields field that exists in the resource schema and has a supported type"
+ErrorLink = ""
+
+[VegaBackend.BuildTask.StreamingUnsupported]
+Description = "Streaming build tasks are temporarily unsupported"
+Solution = "Create a batch build task instead"
 ErrorLink = ""
 
 [VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields]

--- a/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/build_task.zh-CN.toml
@@ -13,9 +13,19 @@ Description = "构建任务模式无效"
 Solution = "mode 必须为 streaming / batch 之一"
 ErrorLink = ""
 
-[VegaBackend.BuildTask.InvalidParameter.BuildKeyFields]
-Description = "批量构建键无效"
-Solution = "请在资源 index_config 中配置至少一个不重复、存在于 schema 且类型受支持的 build_key_fields 字段"
+[VegaBackend.BuildTask.InvalidParameter.PrimaryKeyFields]
+Description = "主键字段无效"
+Solution = "请在资源 index_config 中配置至少一个不重复、存在于 schema 且类型受支持的 primary_key_fields 字段"
+ErrorLink = ""
+
+[VegaBackend.BuildTask.InvalidParameter.IncrementalFields]
+Description = "增量字段无效"
+Solution = "请在资源 index_config 中配置至少一个不重复、存在于 schema 且类型受支持的 incremental_fields 字段"
+ErrorLink = ""
+
+[VegaBackend.BuildTask.StreamingUnsupported]
+Description = "暂不支持流式构建任务"
+Solution = "请改为创建批量构建任务"
 ErrorLink = ""
 
 [VegaBackend.BuildTask.InvalidParameter.UnsupportedSchemaFields]

--- a/adp/vega/vega-backend/server/locale/resource.en-US.toml
+++ b/adp/vega/vega-backend/server/locale/resource.en-US.toml
@@ -28,9 +28,14 @@ Description = "Configured full-text analyzer is unavailable"
 Solution = "Choose an analyzer supported by the current index capability snapshot"
 ErrorLink = ""
 
-[VegaBackend.Resource.InvalidParameter.BuildKeyFields]
-Description = "Invalid build key fields"
-Solution = "Build keys must be unique schema fields of type integer, unsigned integer, string, date, datetime, or timestamp"
+[VegaBackend.Resource.InvalidParameter.PrimaryKeyFields]
+Description = "Invalid primary key fields"
+Solution = "Primary keys must be unique schema fields of a supported type"
+ErrorLink = ""
+
+[VegaBackend.Resource.InvalidParameter.IncrementalFields]
+Description = "Invalid incremental fields"
+Solution = "Incremental fields must be unique schema fields of a supported type"
 ErrorLink = ""
 
 [VegaBackend.Resource.LengthExceeded.Name]

--- a/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
+++ b/adp/vega/vega-backend/server/locale/resource.zh-CN.toml
@@ -28,9 +28,14 @@ Description = "配置的全文分词器不可用"
 Solution = "请选择当前索引能力快照支持的分词器"
 ErrorLink = ""
 
-[VegaBackend.Resource.InvalidParameter.BuildKeyFields]
-Description = "构建键无效"
-Solution = "构建键必须不重复、存在于 schema，且类型为 integer、unsigned integer、string、date、datetime 或 timestamp"
+[VegaBackend.Resource.InvalidParameter.PrimaryKeyFields]
+Description = "主键字段无效"
+Solution = "主键必须是不重复、存在于 schema 且类型受支持的字段"
+ErrorLink = ""
+
+[VegaBackend.Resource.InvalidParameter.IncrementalFields]
+Description = "增量字段无效"
+Solution = "增量字段必须是不重复、存在于 schema 且类型受支持的字段"
 ErrorLink = ""
 
 [VegaBackend.Resource.LengthExceeded.Name]

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -122,13 +122,17 @@ func (bts *buildTaskService) Create(ctx context.Context, req *interfaces.CreateB
 		return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InternalError_InvalidCategory).
 			WithErrorDetails("Resource category must be table")
 	}
+	if req.Mode == interfaces.BuildTaskModeStreaming {
+		return "", rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_StreamingUnsupported).
+			WithErrorDetails("streaming build tasks are temporarily unsupported")
+	}
 	executeType, err := normalizeCreateBuildTaskExecuteType(ctx, req)
 	if err != nil {
 		span.SetStatus(codes.Error, "Invalid execute type")
 		return "", err
 	}
-	if err := validateBuildKeyFields(ctx, resource); err != nil {
-		span.SetStatus(codes.Error, "Invalid build key fields")
+	if err := validateBuildTaskKeyFields(ctx, resource); err != nil {
+		span.SetStatus(codes.Error, "Invalid primary or incremental key fields")
 		return "", err
 	}
 	if executeType == interfaces.BuildTaskExecuteTypeIncremental {
@@ -210,10 +214,12 @@ func validateBuildTaskAnalyzers(ctx context.Context, indexManager interfaces.Loc
 	return nil
 }
 
-func validateBuildKeyFields(ctx context.Context, resource *interfaces.Resource) error {
-	if resource.IndexConfig == nil || len(resource.IndexConfig.BuildKeyFields) == 0 {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
-			WithErrorDetails("build task requires at least one build_key_fields entry")
+func validateBuildTaskKeyFields(ctx context.Context, resource *interfaces.Resource) error {
+	if resource.IndexConfig == nil || len(resource.IndexConfig.PrimaryKeyFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields).WithErrorDetails("build task requires at least one primary_key_fields entry")
+	}
+	if len(resource.IndexConfig.IncrementalFields) == 0 {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_IncrementalFields).WithErrorDetails("build task requires at least one incremental_fields entry")
 	}
 
 	schemaFields := make(map[string]*interfaces.Property, len(resource.SchemaDefinition))
@@ -232,22 +238,34 @@ func validateBuildKeyFields(ctx context.Context, resource *interfaces.Resource) 
 			WithErrorDetails(fmt.Sprintf("resource schema contains unsupported fields: %s", strings.Join(unsupportedFields, ", ")))
 	}
 
-	seen := make(map[string]struct{}, len(resource.IndexConfig.BuildKeyFields))
-	for _, fieldName := range resource.IndexConfig.BuildKeyFields {
+	primaryKeys := make(map[string]struct{}, len(resource.IndexConfig.PrimaryKeyFields))
+	for _, fieldName := range resource.IndexConfig.PrimaryKeyFields {
 		prop, exists := schemaFields[fieldName]
 		if !exists {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields field %q is not in the resource schema", fieldName))
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields field %q is not in the resource schema", fieldName))
 		}
-		if _, duplicate := seen[fieldName]; duplicate {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields contains duplicate field %q", fieldName))
+		if _, duplicate := primaryKeys[fieldName]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields contains duplicate field %q", fieldName))
 		}
-		if !interfaces.DataType_IsBuildKey(prop.Type) {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields field %q has unsupported type %q", fieldName, prop.Type))
+		if !interfaces.IndexConfig_IsPrimaryKeyType(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields field %q has unsupported type %q", fieldName, prop.Type))
 		}
-		seen[fieldName] = struct{}{}
+		primaryKeys[fieldName] = struct{}{}
+	}
+
+	incrementalKeys := make(map[string]struct{}, len(resource.IndexConfig.IncrementalFields))
+	for _, fieldName := range resource.IndexConfig.IncrementalFields {
+		prop, exists := schemaFields[fieldName]
+		if !exists {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields field %q is not in the resource schema", fieldName))
+		}
+		if _, duplicate := incrementalKeys[fieldName]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields contains duplicate field %q", fieldName))
+		}
+		if !interfaces.IndexConfig_IsIncrementalFieldType(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields field %q has unsupported type %q", fieldName, prop.Type))
+		}
+		incrementalKeys[fieldName] = struct{}{}
 	}
 	return nil
 }
@@ -339,7 +357,8 @@ func (bts *buildTaskService) fillBuildTaskIndexSnapshot(ctx context.Context, res
 		Features: map[string]interfaces.BuildTaskFieldIndexFeature{},
 	}
 	if resource.IndexConfig != nil {
-		buildTask.IndexConfig.BuildKeyFields = append([]string(nil), resource.IndexConfig.BuildKeyFields...)
+		buildTask.IndexConfig.PrimaryKeyFields = resource.IndexConfig.PrimaryKeyFields
+		buildTask.IndexConfig.IncrementalFields = resource.IndexConfig.IncrementalFields
 		defaultEmbeddingModel = resource.IndexConfig.DefaultEmbeddingModel
 		defaultFulltextAnalyzer = resource.IndexConfig.DefaultFulltextAnalyzer
 	}
@@ -421,7 +440,7 @@ func validateIncrementalBaseline(ctx context.Context, resource *interfaces.Resou
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_IncrementalBaselineUnavailable).
 			WithErrorDetails(fmt.Sprintf("invalid incremental checkpoint: %v", err))
 	}
-	if err := sync_checkpoint.ValidateCursor(checkpoint, resource.IndexConfig.BuildKeyFields, resource.SchemaDefinition); err != nil {
+	if err := sync_checkpoint.ValidateCursor(checkpoint, resource.IndexConfig.IncrementalFields, resource.SchemaDefinition); err != nil {
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_IncrementalBaselineUnavailable).
 			WithErrorDetails(fmt.Sprintf("invalid incremental checkpoint: %v", err))
 	}
@@ -802,6 +821,10 @@ func (bts *buildTaskService) Start(ctx context.Context, taskID string, reset boo
 }
 
 func (bts *buildTaskService) validateStartBuildTaskStillCurrent(ctx context.Context, buildTask *interfaces.BuildTask) error {
+	if buildTask.Mode == interfaces.BuildTaskModeStreaming {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_StreamingUnsupported).
+			WithErrorDetails("streaming build tasks are temporarily unsupported")
+	}
 	resource, err := bts.rs.GetByID(ctx, buildTask.ResourceID)
 	if err != nil {
 		otellog.LogError(ctx, "Get resource failed", err)
@@ -811,7 +834,7 @@ func (bts *buildTaskService) validateStartBuildTaskStillCurrent(ctx context.Cont
 	if resource == nil {
 		return rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_NotFound)
 	}
-	if err := validateBuildKeyFields(ctx, resource); err != nil {
+	if err := validateBuildTaskKeyFields(ctx, resource); err != nil {
 		return err
 	}
 

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -356,7 +356,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			CatalogID: "catalog-1",
 			Category:  interfaces.ResourceCategoryTable,
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields:          []string{"id"},
+				PrimaryKeyFields:        []string{"id"},
+				IncrementalFields:       []string{"id"},
 				DefaultFulltextAnalyzer: "standard",
 			},
 			SchemaDefinition: []*interfaces.Property{
@@ -373,7 +374,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, "analyzer")
 		assert.Len(t, validator.captured, 1)
 	})
-	t.Run("rejects batch task without build key fields", func(t *testing.T) {
+	t.Run("rejects batch task without primary key fields", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockRS := mock_interfaces.NewMockResourceService(ctrl)
 		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
@@ -390,10 +391,10 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			ResourceID: "resource-1",
 			Mode:       interfaces.BuildTaskModeBatch,
 		})
-		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
-	t.Run("rejects streaming task without build key fields", func(t *testing.T) {
+	t.Run("rejects streaming task", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockRS := mock_interfaces.NewMockResourceService(ctrl)
 		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
@@ -410,7 +411,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			ResourceID: "resource-1",
 			Mode:       interfaces.BuildTaskModeStreaming,
 		})
-		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_StreamingUnsupported)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
 	t.Run("rejects resources containing unsupported fields before creating a task", func(t *testing.T) {
@@ -424,7 +425,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			ID:          "resource-1",
 			CatalogID:   "catalog-1",
 			Category:    interfaces.ResourceCategoryTable,
-			IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
 				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
@@ -448,12 +449,12 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			ID:               "resource-1",
 			CatalogID:        "catalog-1",
 			Category:         interfaces.ResourceCategoryTable,
-			IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"body"}},
+			IndexConfig:      &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"body"}, IncrementalFields: []string{"body"}},
 			SchemaDefinition: []*interfaces.Property{{Name: "body", Type: interfaces.DataType_Text}},
 		}, nil)
 
 		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
-		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_BuildKeyFields)
+		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_PrimaryKeyFields)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, `unsupported type "text"`)
 	})
@@ -470,7 +471,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				ID:               "resource-1",
 				CatalogID:        "catalog-1",
 				Category:         interfaces.ResourceCategoryTable,
-				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+				IndexConfig:      &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 				SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
@@ -492,7 +493,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				ID:               "resource-1",
 				CatalogID:        "catalog-1",
 				Category:         interfaces.ResourceCategoryTable,
-				IndexConfig:      &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+				IndexConfig:      &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 				SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_Integer}},
 			}, nil)
 		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
@@ -541,7 +542,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		assert.Equal(t, interfaces.BuildTaskExecuteTypeIncremental, captured.ExecuteType)
 		assert.Equal(t, mustBuildTaskIndexConfig(t, resource).Fields, captured.IndexConfig.Fields)
 	})
-	t.Run("allows streaming task with a build key and no physical primary key", func(t *testing.T) {
+	t.Run("rejects streaming task with configured keys", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
 		mockRS := mock_interfaces.NewMockResourceService(ctrl)
@@ -559,26 +560,17 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			CatalogID: "catalog-1",
 			Category:  interfaces.ResourceCategoryTable,
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields: []string{"supplier_id"},
+				PrimaryKeyFields:  []string{"supplier_id"},
+				IncrementalFields: []string{"supplier_id"},
 			},
 			SchemaDefinition: []*interfaces.Property{{Name: "supplier_id", Type: interfaces.DataType_Integer}},
 		}, nil)
-		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
-			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
-		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
-		mockBTA.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
-
 		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{
 			ResourceID: "resource-1",
 			Mode:       interfaces.BuildTaskModeStreaming,
 		})
 
-		require.NoError(t, err)
-		select {
-		case <-service.DispatchSignal():
-		default:
-			t.Fatal("expected a dispatch signal after the task was persisted")
-		}
+		requireHTTPError(t, err, verrors.VegaBackend_BuildTask_StreamingUnsupported)
 	})
 	t.Run("rejects execute type for streaming", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -600,7 +592,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			ExecuteType: interfaces.BuildTaskExecuteTypeFull,
 		})
 
-		requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidExecuteType)
+		requireHTTPError(t, err, verrors.VegaBackend_BuildTask_StreamingUnsupported)
 	})
 	t.Run("caches default embedding SmallModel by model ID", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -617,7 +609,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
-					BuildKeyFields:          []string{"id"},
+					PrimaryKeyFields:        []string{"id"},
+					IncrementalFields:       []string{"id"},
 					DefaultEmbeddingModel:   "2064382281006583808",
 					DefaultFulltextAnalyzer: "ik_max_word",
 				},
@@ -665,7 +658,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		require.NotNil(t, captured)
 		require.NotNil(t, captured.IndexConfig)
 		assert.Equal(t, interfaces.BuildTaskExecuteTypeFull, captured.ExecuteType)
-		assert.Equal(t, []string{"id"}, captured.IndexConfig.BuildKeyFields)
+		assert.Equal(t, []string{"id"}, captured.IndexConfig.PrimaryKeyFields)
 		expectedModel := &interfaces.SmallModel{ModelID: "2064382281006583808", ModelName: "text-embedding-v4", EmbeddingDim: 1024}
 		assert.Equal(t, expectedModel, captured.IndexConfig.Features["family_name"].Vector)
 		assert.Equal(t, expectedModel, captured.IndexConfig.Features["given_name"].Vector)
@@ -685,7 +678,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 			CatalogID: "catalog-1",
 			Category:  interfaces.ResourceCategoryTable,
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields:          []string{"id"},
+				PrimaryKeyFields:        []string{"id"},
+				IncrementalFields:       []string{"id"},
 				DefaultEmbeddingModel:   "2064382281006583808",
 				DefaultFulltextAnalyzer: "ik_max_word",
 			},
@@ -723,11 +717,10 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		require.NotNil(t, captured)
 		require.NotNil(t, captured.IndexConfig)
 
-		resource.IndexConfig.BuildKeyFields[0] = "changed"
 		resource.IndexConfig.DefaultEmbeddingModel = "changed-model"
 		resource.SchemaDefinition[0].Features = nil
 
-		assert.Equal(t, []string{"id"}, captured.IndexConfig.BuildKeyFields)
+		assert.Equal(t, []string{"id"}, captured.IndexConfig.PrimaryKeyFields)
 		assert.Equal(t, expectedFields, captured.IndexConfig.Fields)
 		assert.Equal(t, &interfaces.SmallModel{ModelID: "2064382281006583808", ModelName: "text-embedding-v4", EmbeddingDim: 1024}, captured.IndexConfig.Features["family_name"].Vector)
 		assert.Equal(t, &interfaces.BuildTaskFulltextConfig{Analyzer: "ik_max_word"}, captured.IndexConfig.Features["family_name"].Fulltext)
@@ -747,7 +740,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
-					BuildKeyFields:        []string{"id"},
+					PrimaryKeyFields:      []string{"id"},
+					IncrementalFields:     []string{"id"},
 					DefaultEmbeddingModel: "default-model-id",
 				},
 				SchemaDefinition: []*interfaces.Property{
@@ -807,7 +801,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
-					BuildKeyFields:          []string{"id"},
+					PrimaryKeyFields:        []string{"id"},
+					IncrementalFields:       []string{"id"},
 					DefaultEmbeddingModel:   "default-model",
 					DefaultFulltextAnalyzer: "default_analyzer",
 				},
@@ -864,7 +859,7 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, captured)
 		require.NotNil(t, captured.IndexConfig)
-		assert.Equal(t, []string{"id"}, captured.IndexConfig.BuildKeyFields)
+		assert.Equal(t, []string{"id"}, captured.IndexConfig.PrimaryKeyFields)
 		assert.Equal(t, &interfaces.SmallModel{ModelID: "model-a-id", ModelName: "model-a", EmbeddingDim: 768}, captured.IndexConfig.Features["title"].Vector)
 		assert.Equal(t, &interfaces.SmallModel{ModelID: "model-b-id", ModelName: "model-b", EmbeddingDim: 1024}, captured.IndexConfig.Features["body"].Vector)
 		assert.Equal(t, &interfaces.BuildTaskFulltextConfig{Analyzer: "ik_max_word"}, captured.IndexConfig.Features["title"].Fulltext)
@@ -885,7 +880,8 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 				CatalogID: "catalog-1",
 				Category:  interfaces.ResourceCategoryTable,
 				IndexConfig: &interfaces.ResourceIndexConfig{
-					BuildKeyFields:        []string{"id"},
+					PrimaryKeyFields:      []string{"id"},
+					IncrementalFields:     []string{"id"},
 					DefaultEmbeddingModel: "bogus-model-id",
 				},
 				SchemaDefinition: []*interfaces.Property{
@@ -1187,8 +1183,9 @@ func TestBuildTaskServiceStart(t *testing.T) {
 		currentResource := &interfaces.Resource{
 			ID:          "resource-1",
 			CatalogID:   "catalog-1",
-			IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"updated_at"}},
+			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"updated_at", "id"}},
 			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
 				{Name: "updated_at", Type: interfaces.DataType_Timestamp},
 			},
 		}
@@ -1248,7 +1245,7 @@ func TestBuildTaskServiceStart(t *testing.T) {
 			CatalogID:  "catalog-1",
 			Status:     interfaces.BuildTaskStatusStopped,
 			IndexConfig: &interfaces.BuildTaskIndexConfig{
-				IndexConfigContract: interfaces.IndexConfigContract{BuildKeyFields: []string{"id"}},
+				IndexConfigContract: interfaces.IndexConfigContract{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 				Features:            map[string]interfaces.BuildTaskFieldIndexFeature{},
 			},
 		}, nil)
@@ -1259,7 +1256,8 @@ func TestBuildTaskServiceStart(t *testing.T) {
 			ID:        "resource-1",
 			CatalogID: "catalog-1",
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields: []string{"id"},
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
 			},
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
@@ -1288,7 +1286,7 @@ func TestBuildTaskServiceStart(t *testing.T) {
 		resource := &interfaces.Resource{
 			ID:          "resource-1",
 			CatalogID:   "catalog-1",
-			IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
 				{
@@ -1347,7 +1345,7 @@ func buildTaskTestResource() *interfaces.Resource {
 		ID:          "resource-1",
 		CatalogID:   "catalog-1",
 		Category:    interfaces.ResourceCategoryTable,
-		IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+		IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 		SchemaDefinition: []*interfaces.Property{
 			{Name: "id", Type: interfaces.DataType_Integer},
 		},
@@ -1363,7 +1361,8 @@ func mustBuildTaskIndexConfig(t *testing.T, resource *interfaces.Resource) *inte
 		Features:            map[string]interfaces.BuildTaskFieldIndexFeature{},
 	}
 	if resource.IndexConfig != nil {
-		config.IndexConfigContract.BuildKeyFields = append([]string(nil), resource.IndexConfig.BuildKeyFields...)
+		config.IndexConfigContract.PrimaryKeyFields = append([]string(nil), resource.IndexConfig.PrimaryKeyFields...)
+		config.IndexConfigContract.IncrementalFields = append([]string(nil), resource.IndexConfig.IncrementalFields...)
 	}
 	return config
 }

--- a/adp/vega/vega-backend/server/logics/resource/index_config_fingerprint.go
+++ b/adp/vega/vega-backend/server/logics/resource/index_config_fingerprint.go
@@ -16,6 +16,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/bytedance/sonic"
+
 	"vega-backend/interfaces"
 )
 
@@ -28,13 +30,15 @@ func BuildIndexConfigContract(resource *interfaces.Resource) (interfaces.IndexCo
 	}
 
 	contract := interfaces.IndexConfigContract{
-		BuildKeyFields: make([]string, 0),
-		Fields:         make([]interfaces.IndexConfigFieldContract, 0, len(resource.SchemaDefinition)),
+		PrimaryKeyFields:  make([]string, 0),
+		IncrementalFields: make([]string, 0),
+		Fields:            make([]interfaces.IndexConfigFieldContract, 0, len(resource.SchemaDefinition)),
 	}
 	defaultEmbeddingModel := ""
 	defaultFulltextAnalyzer := ""
 	if resource.IndexConfig != nil {
-		contract.BuildKeyFields = append(contract.BuildKeyFields, resource.IndexConfig.BuildKeyFields...)
+		contract.PrimaryKeyFields = append(contract.PrimaryKeyFields, resource.IndexConfig.PrimaryKeyFields...)
+		contract.IncrementalFields = append(contract.IncrementalFields, resource.IndexConfig.IncrementalFields...)
 		defaultEmbeddingModel = strings.TrimSpace(resource.IndexConfig.DefaultEmbeddingModel)
 		defaultFulltextAnalyzer = strings.TrimSpace(resource.IndexConfig.DefaultFulltextAnalyzer)
 	}
@@ -186,8 +190,9 @@ func SnapshotBuildTaskIndexConfigFields(resource *interfaces.Resource) ([]interf
 
 func cloneIndexConfigContract(contract interfaces.IndexConfigContract) interfaces.IndexConfigContract {
 	cloned := interfaces.IndexConfigContract{
-		BuildKeyFields: append([]string(nil), contract.BuildKeyFields...),
-		Fields:         make([]interfaces.IndexConfigFieldContract, 0, len(contract.Fields)),
+		PrimaryKeyFields:  append([]string(nil), contract.PrimaryKeyFields...),
+		IncrementalFields: append([]string(nil), contract.IncrementalFields...),
+		Fields:            make([]interfaces.IndexConfigFieldContract, 0, len(contract.Fields)),
 	}
 	for _, field := range contract.Fields {
 		clonedField := interfaces.IndexConfigFieldContract{
@@ -236,7 +241,7 @@ func normalizeIndexConfigContract(contract interfaces.IndexConfigContract) (inte
 				feature.RefProperty = ""
 			}
 			if len(feature.Config) > 0 {
-				config, err := canonicalJSON(feature.Config)
+				config, err := sonic.ConfigStd.Marshal(feature.Config)
 				if err != nil {
 					return interfaces.IndexConfigContract{}, fmt.Errorf("index config contract field %q feature %q: %w", field.Name, feature.Type, err)
 				}
@@ -278,7 +283,7 @@ func normalizeIndexConfigContract(contract interfaces.IndexConfigContract) (inte
 
 // IndexConfigFingerprint hashes a normalized contract with canonical JSON.
 func IndexConfigFingerprint(config interfaces.IndexConfigContract) (string, error) {
-	data, err := json.Marshal(config)
+	data, err := sonic.ConfigStd.Marshal(config)
 	if err != nil {
 		return "", fmt.Errorf("fingerprint index config: %w", err)
 	}
@@ -328,7 +333,7 @@ func effectiveFeatureConfig(feature interfaces.PropertyFeature, defaultEmbedding
 	if len(config) == 0 {
 		return nil, nil
 	}
-	return canonicalJSON(config)
+	return sonic.ConfigStd.Marshal(config)
 }
 
 func stringConfigValueForFingerprint(config map[string]any, key string) string {
@@ -337,25 +342,4 @@ func stringConfigValueForFingerprint(config map[string]any, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
-}
-
-func canonicalJSON(value any) (json.RawMessage, error) {
-	data, err := json.Marshal(value)
-	if err != nil {
-		return nil, err
-	}
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	var normalized any
-	if err := decoder.Decode(&normalized); err != nil {
-		return nil, err
-	}
-	var extra any
-	if err := decoder.Decode(&extra); err != io.EOF {
-		if err == nil {
-			return nil, fmt.Errorf("multiple JSON values are not allowed")
-		}
-		return nil, err
-	}
-	return json.Marshal(normalized)
 }

--- a/adp/vega/vega-backend/server/logics/resource/index_config_fingerprint_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/index_config_fingerprint_test.go
@@ -49,8 +49,8 @@ func TestIndexConfigFingerprint(t *testing.T) {
 		}},
 		{"effective analyzer", func(resource *interfaces.Resource) { resource.IndexConfig.DefaultFulltextAnalyzer = "english" }},
 		{"effective model ID", func(resource *interfaces.Resource) { resource.IndexConfig.DefaultEmbeddingModel = "model-b" }},
-		{"build key order", func(resource *interfaces.Resource) {
-			resource.IndexConfig.BuildKeyFields = []string{"created_at", "id"}
+		{"incremental field order", func(resource *interfaces.Resource) {
+			resource.IndexConfig.IncrementalFields = []string{"id", "created_at"}
 		}},
 		{"field added", func(resource *interfaces.Resource) {
 			resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{Name: "extra", Type: interfaces.DataType_String})
@@ -116,8 +116,9 @@ func TestBuildTaskIndexConfigFingerprintMatchesResourceSnapshot(t *testing.T) {
 
 	taskFingerprint, err := BuildTaskIndexConfigFingerprint(&interfaces.BuildTaskIndexConfig{
 		IndexConfigContract: interfaces.IndexConfigContract{
-			BuildKeyFields: append([]string(nil), resource.IndexConfig.BuildKeyFields...),
-			Fields:         fields,
+			PrimaryKeyFields:  append([]string(nil), resource.IndexConfig.PrimaryKeyFields...),
+			IncrementalFields: append([]string(nil), resource.IndexConfig.IncrementalFields...),
+			Fields:            fields,
 		},
 	})
 	require.NoError(t, err)
@@ -140,8 +141,9 @@ func TestBuildTaskIndexConfigFingerprintSupportsUpgradedSnapshot(t *testing.T) {
 
 	taskFingerprint, err := BuildTaskIndexConfigFingerprint(&interfaces.BuildTaskIndexConfig{
 		IndexConfigContract: interfaces.IndexConfigContract{
-			BuildKeyFields: append([]string(nil), resource.IndexConfig.BuildKeyFields...),
-			Fields:         fields,
+			PrimaryKeyFields:  append([]string(nil), resource.IndexConfig.PrimaryKeyFields...),
+			IncrementalFields: append([]string(nil), resource.IndexConfig.IncrementalFields...),
+			Fields:            fields,
 		},
 		Features: map[string]interfaces.BuildTaskFieldIndexFeature{
 			"title": {
@@ -206,7 +208,8 @@ func fingerprintTestResource(reordered bool) *interfaces.Resource {
 		return &interfaces.Resource{
 			SchemaDefinition: []*interfaces.Property{title, createdAt, id},
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields:          []string{"id", "created_at"},
+				PrimaryKeyFields:        []string{"id"},
+				IncrementalFields:       []string{"created_at", "id"},
 				DefaultFulltextAnalyzer: "standard",
 				DefaultEmbeddingModel:   "model-a",
 			},
@@ -216,7 +219,8 @@ func fingerprintTestResource(reordered bool) *interfaces.Resource {
 	return &interfaces.Resource{
 		SchemaDefinition: []*interfaces.Property{id, title, createdAt},
 		IndexConfig: &interfaces.ResourceIndexConfig{
-			BuildKeyFields:          []string{"id", "created_at"},
+			PrimaryKeyFields:        []string{"id"},
+			IncrementalFields:       []string{"created_at", "id"},
 			DefaultFulltextAnalyzer: "standard",
 			DefaultEmbeddingModel:   "model-a",
 		},

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -948,6 +948,7 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 		}
 	}
 	previousFingerprint := ""
+	keyFieldsChanged := req.IndexConfig != nil && indexConfigKeyFieldsChanged(resource.IndexConfig, req.IndexConfig)
 	if buildRelevantChanged {
 		previousFingerprint, err = ResourceIndexConfigFingerprint(resource)
 		if err != nil {
@@ -1046,7 +1047,15 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 		span.SetStatus(codes.Error, "Resource update conflict")
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_UpdateConflict)
 	}
-	if buildRelevantChanged && previousFingerprint != currentFingerprint &&
+	if keyFieldsChanged {
+		updated, err := rs.ra.UpdateLocalIndexState(ctx, tx, resource.ID,
+			resource.LocalIndexStatus, resource.LocalIndexName, "")
+		if err != nil || !updated {
+			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_UpdateFailed).
+				WithErrorDetails("failed to clear resource incremental checkpoint")
+		}
+		resource.SyncMark = ""
+	} else if buildRelevantChanged && previousFingerprint != currentFingerprint &&
 		resource.LocalIndexStatus == interfaces.ResourceLocalIndexStatusAvailable {
 		updated, err := rs.ra.UpdateLocalIndexState(ctx, tx, resource.ID,
 			interfaces.ResourceLocalIndexStatusStale, resource.LocalIndexName, "")
@@ -1071,6 +1080,17 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 
 	span.SetStatus(codes.Ok, "")
 	return nil
+}
+
+func indexConfigKeyFieldsChanged(current, requested *interfaces.ResourceIndexConfig) bool {
+	if requested == nil {
+		return false
+	}
+	if current == nil {
+		return len(requested.PrimaryKeyFields) > 0 || len(requested.IncrementalFields) > 0
+	}
+	return !reflect.DeepEqual(current.PrimaryKeyFields, requested.PrimaryKeyFields) ||
+		!reflect.DeepEqual(current.IncrementalFields, requested.IncrementalFields)
 }
 
 // SetEnabled changes only a Resource's enabled state.
@@ -1506,7 +1526,7 @@ func (rs *resourceService) validateResourceUpdateScope(ctx context.Context,
 }
 
 func (rs *resourceService) validateIndexConfigModels(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
-	if err := validateIndexConfigBuildKeyFields(ctx, schema, indexConfig); err != nil {
+	if err := validateIndexConfigKeyFields(ctx, schema, indexConfig); err != nil {
 		return err
 	}
 	defaultEmbeddingModelID := ""
@@ -1609,8 +1629,8 @@ func fulltextAnalyzerConfigValue(config map[string]any) string {
 	return value
 }
 
-func validateIndexConfigBuildKeyFields(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
-	if indexConfig == nil || len(indexConfig.BuildKeyFields) == 0 {
+func validateIndexConfigKeyFields(ctx context.Context, schema []*interfaces.Property, indexConfig *interfaces.ResourceIndexConfig) error {
+	if indexConfig == nil {
 		return nil
 	}
 
@@ -1620,22 +1640,34 @@ func validateIndexConfigBuildKeyFields(ctx context.Context, schema []*interfaces
 			schemaFields[prop.Name] = prop
 		}
 	}
-	seen := make(map[string]struct{}, len(indexConfig.BuildKeyFields))
-	for _, field := range indexConfig.BuildKeyFields {
+	primaryKeys := make(map[string]struct{}, len(indexConfig.PrimaryKeyFields))
+	for _, field := range indexConfig.PrimaryKeyFields {
 		prop, exists := schemaFields[field]
 		if !exists {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields field %q is not in the resource schema", field))
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields field %q is not in the resource schema", field))
 		}
-		if _, duplicate := seen[field]; duplicate {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields contains duplicate field %q", field))
+		if _, duplicate := primaryKeys[field]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields contains duplicate field %q", field))
 		}
-		if !interfaces.DataType_IsBuildKey(prop.Type) {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields).
-				WithErrorDetails(fmt.Sprintf("build_key_fields field %q has unsupported type %q", field, prop.Type))
+		if !interfaces.IndexConfig_IsPrimaryKeyType(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_PrimaryKeyFields).WithErrorDetails(fmt.Sprintf("primary_key_fields field %q has unsupported type %q", field, prop.Type))
 		}
-		seen[field] = struct{}{}
+		primaryKeys[field] = struct{}{}
+	}
+
+	incrementalKeys := make(map[string]struct{}, len(indexConfig.IncrementalFields))
+	for _, field := range indexConfig.IncrementalFields {
+		prop, exists := schemaFields[field]
+		if !exists {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields field %q is not in the resource schema", field))
+		}
+		if _, duplicate := incrementalKeys[field]; duplicate {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields contains duplicate field %q", field))
+		}
+		if !interfaces.IndexConfig_IsIncrementalFieldType(prop.Type) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Resource_InvalidParameter_IncrementalFields).WithErrorDetails(fmt.Sprintf("incremental_fields field %q has unsupported type %q", field, prop.Type))
+		}
+		incrementalKeys[field] = struct{}{}
 	}
 	return nil
 }

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1048,11 +1049,13 @@ func (rs *resourceService) Update(ctx context.Context, resource *interfaces.Reso
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_Resource_UpdateConflict)
 	}
 	if keyFieldsChanged {
-		updated, err := rs.ra.UpdateLocalIndexState(ctx, tx, resource.ID,
-			resource.LocalIndexStatus, resource.LocalIndexName, "")
-		if err != nil || !updated {
-			return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_UpdateFailed).
-				WithErrorDetails("failed to clear resource incremental checkpoint")
+		if resource.SyncMark != "" {
+			updated, err := rs.ra.UpdateLocalIndexState(ctx, tx, resource.ID,
+				resource.LocalIndexStatus, resource.LocalIndexName, "")
+			if err != nil || !updated {
+				return rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError_UpdateFailed).
+					WithErrorDetails("failed to clear resource incremental checkpoint")
+			}
 		}
 		resource.SyncMark = ""
 	} else if buildRelevantChanged && previousFingerprint != currentFingerprint &&
@@ -1089,8 +1092,8 @@ func indexConfigKeyFieldsChanged(current, requested *interfaces.ResourceIndexCon
 	if current == nil {
 		return len(requested.PrimaryKeyFields) > 0 || len(requested.IncrementalFields) > 0
 	}
-	return !reflect.DeepEqual(current.PrimaryKeyFields, requested.PrimaryKeyFields) ||
-		!reflect.DeepEqual(current.IncrementalFields, requested.IncrementalFields)
+	return !slices.Equal(current.PrimaryKeyFields, requested.PrimaryKeyFields) ||
+		!slices.Equal(current.IncrementalFields, requested.IncrementalFields)
 }
 
 // SetEnabled changes only a Resource's enabled state.

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -1300,6 +1300,43 @@ func TestResourceServiceUpdate(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
+	t.Run("update key fields without a checkpoint does not update local index state", func(t *testing.T) {
+		rs, mockRA, mockPS, _, _, mockCS, mockBTA := newTestService(t)
+		expectResourceServiceTransaction(t, rs, true)
+		mockPS.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockCS.EXPECT().CheckExistByID(gomock.Any(), "cat1").Return(true, nil)
+		mockRA.EXPECT().Update(gomock.Any(), gomock.Not(nil), gomock.Any(), int64(0)).Return(int64(1), nil)
+
+		err := rs.Update(context.Background(), &interfaces.Resource{
+			ID:               "r1",
+			CatalogID:        "cat1",
+			Category:         interfaces.ResourceCategoryTable,
+			Name:             "table",
+			LocalIndexName:   "vega-build-r1-task-1",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
+			SourceIdentifier: "public.orders",
+			SchemaDefinition: []*interfaces.Property{
+				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "updated_at", Type: interfaces.DataType_Timestamp},
+			},
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
+			},
+		}, &interfaces.ResourceRequest{
+			CatalogID:        "cat1",
+			Category:         interfaces.ResourceCategoryTable,
+			Name:             "table",
+			SourceIdentifier: "public.orders",
+			IndexConfig: &interfaces.ResourceIndexConfig{
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"updated_at", "id"},
+			},
+		})
+
+		require.NoError(t, err)
+	})
 	t.Run("update rejects missing default embedding model ID", func(t *testing.T) {
 		rs, _, mockPS, _, _, _, mockBTA := newTestService(t)
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -148,43 +148,44 @@ func TestResourceServiceInternalMetadataUpdateConflict(t *testing.T) {
 	})
 }
 
-func TestValidateIndexConfigBuildKeyFields(t *testing.T) {
+func TestValidateIndexConfigKeyFields(t *testing.T) {
 	schema := []*interfaces.Property{
 		{Name: "id", Type: interfaces.DataType_Integer},
 		{Name: "updated_at", Type: interfaces.DataType_Timestamp},
 		{Name: "body", Type: interfaces.DataType_Text},
 	}
 
-	t.Run("allows an empty build key configuration", func(t *testing.T) {
-		require.NoError(t, validateIndexConfigBuildKeyFields(context.Background(), schema, nil))
+	t.Run("allows an empty key configuration", func(t *testing.T) {
+		require.NoError(t, validateIndexConfigKeyFields(context.Background(), schema, nil))
 	})
 
-	t.Run("allows build keys defined in schema", func(t *testing.T) {
-		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
-			BuildKeyFields: []string{"updated_at", "id"},
+	t.Run("allows configured primary and incremental fields", func(t *testing.T) {
+		err := validateIndexConfigKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			PrimaryKeyFields:  []string{"id"},
+			IncrementalFields: []string{"updated_at", "id"},
 		})
 		require.NoError(t, err)
 	})
 
-	t.Run("rejects build keys absent from schema", func(t *testing.T) {
-		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
-			BuildKeyFields: []string{"missing_id"},
+	t.Run("rejects primary keys absent from schema", func(t *testing.T) {
+		err := validateIndexConfigKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			PrimaryKeyFields: []string{"missing_id"},
 		})
-		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_PrimaryKeyFields)
 		require.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
-		require.Contains(t, httpErr.BaseError.ErrorDetails, `build_key_fields field "missing_id"`)
+		require.Contains(t, httpErr.BaseError.ErrorDetails, `primary_key_fields field "missing_id"`)
 	})
 
-	t.Run("rejects duplicate and unsupported build key types", func(t *testing.T) {
-		err := validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
-			BuildKeyFields: []string{"id", "id"},
+	t.Run("rejects duplicate primary keys and unsupported incremental types", func(t *testing.T) {
+		err := validateIndexConfigKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			PrimaryKeyFields: []string{"id", "id"},
 		})
-		requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
+		requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_PrimaryKeyFields)
 
-		err = validateIndexConfigBuildKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
-			BuildKeyFields: []string{"body"},
+		err = validateIndexConfigKeyFields(context.Background(), schema, &interfaces.ResourceIndexConfig{
+			IncrementalFields: []string{"body"},
 		})
-		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_BuildKeyFields)
+		httpErr := requireResourceHTTPError(t, err, verrors.VegaBackend_Resource_InvalidParameter_IncrementalFields)
 		assert.Contains(t, httpErr.BaseError.ErrorDetails, `unsupported type "text"`)
 	})
 }
@@ -1130,6 +1131,8 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			Description:      "old",
 			LocalIndexName:   "vega-build-r1-task-1",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
+			SyncMark:         `{"mode":"batch","cursor":[]}`,
 			SourceIdentifier: "public.orders",
 			SchemaDefinition: []*interfaces.Property{{Name: "id", Type: interfaces.DataType_String}},
 		}, &interfaces.ResourceRequest{
@@ -1221,7 +1224,8 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			SourceIdentifier: "public.orders",
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields: []string{"id"},
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
 			},
 		}, &interfaces.ResourceRequest{
 			CatalogID:        "cat1",
@@ -1229,7 +1233,8 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			SourceIdentifier: "public.orders",
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields: []string{"updated_at", "id"},
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"updated_at", "id"},
 			},
 		})
 
@@ -1255,24 +1260,29 @@ func TestResourceServiceUpdate(t *testing.T) {
 				if got.LocalIndexName != "vega-build-r1-task-1" {
 					t.Fatalf("expected LocalIndexName to be preserved, got %q", got.LocalIndexName)
 				}
-				if got.IndexConfig == nil || len(got.IndexConfig.BuildKeyFields) != 2 {
+				if got.IndexConfig == nil || len(got.IndexConfig.IncrementalFields) != 2 {
 					t.Fatalf("expected updated index config, got %#v", got.IndexConfig)
 				}
 				return 1, nil
 			})
+		mockRA.EXPECT().UpdateLocalIndexState(gomock.Any(), gomock.Not(nil), "r1",
+			interfaces.ResourceLocalIndexStatusAvailable, "vega-build-r1-task-1", "").Return(true, nil)
 		err := rs.Update(context.Background(), &interfaces.Resource{
 			ID:               "r1",
 			CatalogID:        "cat1",
 			Category:         interfaces.ResourceCategoryTable,
 			Name:             "table",
 			LocalIndexName:   "vega-build-r1-task-1",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
+			SyncMark:         `{"mode":"batch","cursor":[]}`,
 			SourceIdentifier: "public.orders",
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
 				{Name: "updated_at", Type: interfaces.DataType_Timestamp},
 			},
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields: []string{"id"},
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
 			},
 		}, &interfaces.ResourceRequest{
 			CatalogID:        "cat1",
@@ -1280,7 +1290,8 @@ func TestResourceServiceUpdate(t *testing.T) {
 			Name:             "table",
 			SourceIdentifier: "public.orders",
 			IndexConfig: &interfaces.ResourceIndexConfig{
-				BuildKeyFields:          []string{"updated_at", "id"},
+				PrimaryKeyFields:        []string{"id"},
+				IncrementalFields:       []string{"updated_at", "id"},
 				DefaultFulltextAnalyzer: "ik_max_word",
 				DefaultEmbeddingModel:   "embedding",
 			},

--- a/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint.go
+++ b/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint.go
@@ -68,15 +68,15 @@ func DecodeBatch(mark string) (*SyncCheckpoint, error) {
 // keys and converts JSON numbers to the exact integer types required by the
 // schema. An empty cursor is a valid established baseline and starts from the
 // first source row without a cursor filter.
-func ValidateCursor(checkpoint *SyncCheckpoint, buildKeyFields []string, schema []*interfaces.Property) error {
+func ValidateCursor(checkpoint *SyncCheckpoint, incrementalFields []string, schema []*interfaces.Property) error {
 	if checkpoint == nil {
 		return fmt.Errorf("validate batch checkpoint: checkpoint is required")
 	}
 	if len(checkpoint.Cursor) == 0 {
 		return nil
 	}
-	if len(checkpoint.Cursor) != len(buildKeyFields) {
-		return fmt.Errorf("validate batch checkpoint: expected %d cursor values, got %d", len(buildKeyFields), len(checkpoint.Cursor))
+	if len(checkpoint.Cursor) != len(incrementalFields) {
+		return fmt.Errorf("validate batch checkpoint: expected %d cursor values, got %d", len(incrementalFields), len(checkpoint.Cursor))
 	}
 
 	properties := make(map[string]*interfaces.Property, len(schema))
@@ -90,7 +90,7 @@ func ValidateCursor(checkpoint *SyncCheckpoint, buildKeyFields []string, schema 
 		properties[property.Name] = property
 	}
 
-	for i, field := range buildKeyFields {
+	for i, field := range incrementalFields {
 		cursorValue := &checkpoint.Cursor[i]
 		if cursorValue.Key != field {
 			return fmt.Errorf("validate batch checkpoint: expected key %q at position %d, got %q", field, i, cursorValue.Key)
@@ -142,6 +142,7 @@ func convertCursorValue(value any, dataType string) (any, error) {
 		}
 	case interfaces.DataType_String,
 		interfaces.DataType_Date,
+		interfaces.DataType_Time,
 		interfaces.DataType_Datetime,
 		interfaces.DataType_Timestamp:
 		text, ok := value.(string)

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -320,13 +320,6 @@ func buildTaskHasEmbedding(buildTask *interfaces.BuildTask) bool {
 	return false
 }
 
-func buildTaskBuildKeyFields(buildTask *interfaces.BuildTask) []string {
-	if buildTask == nil || buildTask.IndexConfig == nil {
-		return nil
-	}
-	return append([]string(nil), buildTask.IndexConfig.BuildKeyFields...)
-}
-
 // The hasFulltextFeature determines whether a field already has the fulltext feature.
 func hasFulltextFeature(prop *interfaces.Property) bool {
 	for _, f := range prop.Features {

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -287,7 +287,7 @@ func TestCompleteFullBuildTask(t *testing.T) {
 		ts := vmock.NewMockBuildTaskService(ctrl)
 		resource := workerTestResource()
 		task := workerTestFullTask(t, resource)
-		resource.IndexConfig.BuildKeyFields = []string{"updated_at"}
+		resource.IndexConfig.IncrementalFields = []string{"updated_at"}
 		resource.SchemaDefinition = []*interfaces.Property{{Name: "updated_at", Type: interfaces.DataType_Timestamp}}
 
 		db, mock, err := sqlmock.New()
@@ -313,9 +313,12 @@ func TestCompleteFullBuildTask(t *testing.T) {
 
 func workerTestResource() *interfaces.Resource {
 	return &interfaces.Resource{
-		ID:          "r1",
-		Category:    interfaces.ResourceCategoryTable,
-		IndexConfig: &interfaces.ResourceIndexConfig{BuildKeyFields: []string{"id"}},
+		ID:       "r1",
+		Category: interfaces.ResourceCategoryTable,
+		IndexConfig: &interfaces.ResourceIndexConfig{
+			PrimaryKeyFields:  []string{"id"},
+			IncrementalFields: []string{"id"},
+		},
 		SchemaDefinition: []*interfaces.Property{
 			{Name: "id", Type: interfaces.DataType_Integer},
 		},
@@ -333,8 +336,9 @@ func workerTestFullTask(t *testing.T, resource *interfaces.Resource) *interfaces
 		ExecuteType: interfaces.BuildTaskExecuteTypeFull,
 		IndexConfig: &interfaces.BuildTaskIndexConfig{
 			IndexConfigContract: interfaces.IndexConfigContract{
-				BuildKeyFields: []string{"id"},
-				Fields:         fields,
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
+				Fields:            fields,
 			},
 		},
 	}

--- a/adp/vega/vega-backend/server/worker/build_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/build_task_worker.go
@@ -318,6 +318,18 @@ func (btw *BuildTaskWorker) runBatchTask(ctx context.Context, taskID string) err
 		}
 		return nil
 	}
+	if resource.IndexConfig == nil || len(resource.IndexConfig.PrimaryKeyFields) == 0 ||
+		len(resource.IndexConfig.IncrementalFields) == 0 {
+		err = errors.New("batch build resource requires primary_key_fields and incremental_fields")
+		btw.failTask(taskCtx, taskID, err.Error())
+		return err
+	}
+	if task.IndexConfig == nil || len(task.IndexConfig.PrimaryKeyFields) == 0 ||
+		len(task.IndexConfig.IncrementalFields) == 0 {
+		err = errors.New("batch build task snapshot requires primary_key_fields and incremental_fields")
+		btw.failTask(taskCtx, taskID, err.Error())
+		return err
+	}
 	if err := validateBuildTaskResourceFingerprint(resource, task); err != nil {
 		btw.failTask(taskCtx, taskID, err.Error())
 		return err
@@ -438,7 +450,7 @@ func validateIncrementalBatchResource(resource *interfaces.Resource, task *inter
 		return fmt.Errorf("invalid incremental checkpoint: %w", err)
 	}
 	if err := sync_checkpoint.ValidateCursor(checkpoint,
-		resource.IndexConfig.BuildKeyFields, resource.SchemaDefinition); err != nil {
+		resource.IndexConfig.IncrementalFields, resource.SchemaDefinition); err != nil {
 		return fmt.Errorf("invalid incremental checkpoint: %w", err)
 	}
 	return nil

--- a/adp/vega/vega-backend/server/worker/build_task_worker_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_worker_test.go
@@ -294,7 +294,7 @@ func TestBuildTaskWorkerRejectsChangedBatchTaskBeforeClaim(t *testing.T) {
 			task.ID = "task-1"
 			task.Status = interfaces.BuildTaskStatusPending
 			task.ExecuteType = executeType
-			resource.IndexConfig.BuildKeyFields = []string{"updated_at"}
+			resource.IndexConfig.IncrementalFields = []string{"updated_at"}
 			resource.SchemaDefinition = []*interfaces.Property{{Name: "updated_at", Type: interfaces.DataType_Timestamp}}
 			worker := &BuildTaskWorker{
 				bts: bts,
@@ -310,6 +310,26 @@ func TestBuildTaskWorkerRejectsChangedBatchTaskBeforeClaim(t *testing.T) {
 			require.EqualError(t, err, "resource index config has changed")
 		})
 	}
+}
+
+func TestBuildTaskWorkerRejectsBatchTaskWithoutNewKeyFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	bts := vmock.NewMockBuildTaskService(ctrl)
+	rs := vmock.NewMockResourceService(ctrl)
+	resource := workerTestResource()
+	task := workerTestFullTask(t, resource)
+	task.ID = "task-1"
+	task.Status = interfaces.BuildTaskStatusPending
+	task.IndexConfig.PrimaryKeyFields = nil
+	worker := &BuildTaskWorker{bts: bts, bbw: &batchBuildWorker{rs: rs}}
+
+	bts.EXPECT().InternalGetByID(gomock.Any(), "task-1").Return(task, nil)
+	rs.EXPECT().InternalGetByID(gomock.Any(), nil, "r1").Return(resource, nil)
+	bts.EXPECT().InternalMarkFailed(gomock.Any(), nil, "task-1",
+		"batch build task snapshot requires primary_key_fields and incremental_fields").Return(true, nil)
+
+	err := worker.runBatchTask(context.Background(), "task-1")
+	require.EqualError(t, err, "batch build task snapshot requires primary_key_fields and incremental_fields")
 }
 
 func TestBuildTaskWorkerCancelsBatchTaskWhenResourceWasDeleted(t *testing.T) {

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -302,14 +302,15 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		}
 	}
 
-	keys := buildTaskBuildKeyFields(buildTaskInfo)
+	primaryKeyFields := buildTaskInfo.IndexConfig.PrimaryKeyFields
+	incrementalFields := buildTaskInfo.IndexConfig.IncrementalFields
 	var lastBatchKeyValues []interfaces.KeyValue
 	if lastSyncedMark != "" {
 		checkpoint, err := sync_checkpoint.DecodeBatch(lastSyncedMark)
 		if err != nil {
 			return fmt.Errorf("decode synced mark: %w", err)
 		}
-		if err := sync_checkpoint.ValidateCursor(checkpoint, keys, resource.SchemaDefinition); err != nil {
+		if err := sync_checkpoint.ValidateCursor(checkpoint, incrementalFields, resource.SchemaDefinition); err != nil {
 			return fmt.Errorf("validate synced mark: %w", err)
 		}
 		lastBatchKeyValues = checkpoint.Cursor
@@ -334,8 +335,8 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 	}
 
 	// Build sort fields
-	sortFields := make([]*interfaces.SortField, len(keys))
-	for i, field := range keys {
+	sortFields := make([]*interfaces.SortField, len(incrementalFields))
+	for i, field := range incrementalFields {
 		sortFields[i] = &interfaces.SortField{
 			Field: field,
 		}
@@ -387,7 +388,7 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 
 		// Add filter condition for batch fields if we have last values
 		if len(lastBatchKeyValues) > 0 {
-			params.FilterCondCfg = buildBatchCursorFilter(keys, lastBatchKeyValues)
+			params.FilterCondCfg = buildBatchCursorFilter(incrementalFields, lastBatchKeyValues)
 
 			// Convert FilterCondCfg to ActualFilterCond
 			fieldMap := map[string]*interfaces.Property{}
@@ -424,25 +425,25 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		if readRows > 0 {
 			// Update lastBatchKeyValues with the last values in this batch
 			lastItem := result.Entries[readRows-1]
-			lastBatchKeyValues, err = extractKeyValues(keys, lastItem)
+			lastBatchKeyValues, err = extractKeyValues(incrementalFields, lastItem)
 			if err != nil {
 				return fmt.Errorf("extract cursor key values: %w", err)
 			}
 			indexDocuments := make(map[string]map[string]any, readRows)
 			for _, doc := range result.Entries {
-				keyValues, err := extractKeyValues(keys, doc)
+				keyValues, err := extractKeyValues(primaryKeyFields, doc)
 				if err != nil {
 					return err
-				}
-				if err := normalizeJSONDocumentFields(doc, resource.SchemaDefinition); err != nil {
-					return fmt.Errorf("normalize document for local index: %w", err)
 				}
 				docID, err := generateDocumentID(keyValues)
 				if err != nil {
 					return err
 				}
 				if _, exists := indexDocuments[docID]; exists {
-					return fmt.Errorf("build document ID: duplicate build key values %q", docID)
+					return fmt.Errorf("build document ID: duplicate primary key values %q", docID)
+				}
+				if err := normalizeJSONDocumentFields(doc, resource.SchemaDefinition); err != nil {
+					return fmt.Errorf("normalize document for local index: %w", err)
 				}
 				indexDocuments[docID] = doc
 			}

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming.go
@@ -321,7 +321,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 						document[k] = v
 					}
 
-					kafkaKeyValues, err := getKafkaKeyValues(buildTaskBuildKeyFields(buildTaskInfo), keyMap)
+					kafkaKeyValues, err := getKafkaKeyValues(buildTaskInfo.IndexConfig.PrimaryKeyFields, keyMap)
 					if err != nil {
 						return fmt.Errorf("extract Kafka key values: %w", err)
 					}
@@ -553,7 +553,7 @@ func streamingDatabase(catalog *interfaces.Catalog) (string, error) {
 
 // handleUpdateOperation handles update operations.
 func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyMap, after map[string]any, indexName string, buildTaskInfo *interfaces.BuildTask, pipeline *embeddingPipeline) error {
-	documentIDFields := buildTaskBuildKeyFields(buildTaskInfo)
+	documentIDFields := buildTaskInfo.IndexConfig.PrimaryKeyFields
 	kafkaKeyValues, err := getKafkaKeyValues(documentIDFields, keyMap)
 	if err != nil {
 		return fmt.Errorf("extract Kafka key values: %w", err)
@@ -597,7 +597,7 @@ func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyM
 
 // handleDeleteOperation handles deletion operations.
 func (sbw *streamingBuildWorker) handleDeleteOperation(ctx context.Context, keyMap map[string]any, indexName string, buildTaskInfo *interfaces.BuildTask) error {
-	kafkaKeyValues, err := getKafkaKeyValues(buildTaskBuildKeyFields(buildTaskInfo), keyMap)
+	kafkaKeyValues, err := getKafkaKeyValues(buildTaskInfo.IndexConfig.PrimaryKeyFields, keyMap)
 	if err != nil {
 		return fmt.Errorf("extract Kafka key values: %w", err)
 	}

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
@@ -145,7 +145,14 @@ func TestHandleUpdateOperationWritesReplacementBeforeDeletingOldDocument(t *test
 	ctrl := gomock.NewController(t)
 	lim := vmock.NewMockLocalIndexManager(ctrl)
 	worker := &streamingBuildWorker{lim: lim}
-	buildTask := &interfaces.BuildTask{IndexConfig: &interfaces.BuildTaskIndexConfig{IndexConfigContract: interfaces.IndexConfigContract{BuildKeyFields: []string{"id"}}}}
+	buildTask := &interfaces.BuildTask{
+		IndexConfig: &interfaces.BuildTaskIndexConfig{
+			IndexConfigContract: interfaces.IndexConfigContract{
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
+			},
+		},
+	}
 	oldID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 1}})
 	require.NoError(t, err)
 	newID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 2}})
@@ -170,7 +177,14 @@ func TestHandleUpdateOperationKeepsOldDocumentWhenReplacementWriteFails(t *testi
 	ctrl := gomock.NewController(t)
 	lim := vmock.NewMockLocalIndexManager(ctrl)
 	worker := &streamingBuildWorker{lim: lim}
-	buildTask := &interfaces.BuildTask{IndexConfig: &interfaces.BuildTaskIndexConfig{IndexConfigContract: interfaces.IndexConfigContract{BuildKeyFields: []string{"id"}}}}
+	buildTask := &interfaces.BuildTask{
+		IndexConfig: &interfaces.BuildTaskIndexConfig{
+			IndexConfigContract: interfaces.IndexConfigContract{
+				PrimaryKeyFields:  []string{"id"},
+				IncrementalFields: []string{"id"},
+			},
+		},
+	}
 	newID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 2}})
 	require.NoError(t, err)
 

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -129,8 +129,8 @@ paths:
         （`pending` / `running` / `stopping`）；已存在 active Task 时返回 400
         `VegaBackend.BuildTask.Exist`。终态 Task 不阻止创建新任务。
 
-        - `streaming` 模式要求 Resource 在 `source_metadata.primary_keys` 中声明主键。
-        - `batch` 模式要求 `build_key_fields` 非空。
+        - 当前版本暂不支持 `streaming` 模式。
+        - `batch` 模式要求 `primary_key_fields` 和 `incremental_fields` 均非空。
         - 所有字段都需要在 Resource 的 schema 中存在；否则 400。
         - 创建后 status = `pending`。
       requestBody:
@@ -470,7 +470,11 @@ components:
       description: 创建任务时从 Resource 派生的索引配置快照
       type: object
       properties:
-        build_key_fields:
+        primary_key_fields:
+          type: array
+          items:
+            type: string
+        incremental_fields:
           type: array
           items:
             type: string

--- a/docs/api/vega/resource.yaml
+++ b/docs/api/vega/resource.yaml
@@ -773,7 +773,11 @@ components:
       description: 本地索引构建配置
       type: object
       properties:
-        build_key_fields:
+        primary_key_fields:
+          type: array
+          items:
+            type: string
+        incremental_fields:
           type: array
           items:
             type: string


### PR DESCRIPTION
## What Changed

- [x] Replace legacy `build_key_fields` with `primary_key_fields` and `incremental_fields`.
- [x] Use primary keys exclusively for document IDs and incremental fields exclusively for batch cursors/checkpoints.
- [x] Reject streaming task creation and start; update OpenAPI and localized errors.

---

## Why

- Related Issue: Closes #1240
- Related Feature: N/A
- Background: UUID v4 is suitable as a document primary key but not as a monotonically advancing batch cursor. The legacy shared field conflated these responsibilities.

---

## How

- Key implementation points: validate both field groups against schema and their separate supported types; snapshot both groups on task creation; preserve available local index name/status while clearing the checkpoint when either group changes.
- Breaking changes (API, config, database, etc.): `build_key_fields` is removed without compatibility. Existing resources must be reconfigured with both new fields before running a batch build. No database schema migration is required.

---

## Testing

- [x] Unit tests passed locally (`make ci`).
- [ ] Integration tests passed locally (N/A: hermetic unit suite; no integration environment used).
- [ ] Verified in test environment (not performed).

Test notes:

- `make ci` passed: golangci-lint, unit tests, coverage gate.
- `make api-docs-lint` passed; it reports two pre-existing warnings in `docs/api/bkn/action-schedules.yaml`.

---

## Risk & Rollback

- Potential risks: intentional breaking configuration contract; resources configured only with the removed field cannot start new batch builds until reconfigured.
- Rollback plan: revert commit `d59c7e908`; no data or schema migration is involved.

---

## Additional Notes

- Streaming is temporarily unavailable through Create/Start APIs.
- `incremental_fields` use best-effort offline keyset progression; users are responsible for selecting appropriate ordered fields.