### PR TITLE
docs(bkn): correct knowledge network creation response schema

### DIFF
--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -99,9 +99,9 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/ID"
+                $ref: "#/components/schemas/ID"
+              example:
+                id: "example-knowledge-network-id"
           description: Creation succeeded
       summary: Create a business knowledge network
   /api/bkn-backend/v1/knowledge-networks/{kn_id}:


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Correct the HTTP 201 response for `POST /api/bkn-backend/v1/knowledge-networks` to reference a single `ID` object.
- [x] Add an object response example with an ID available at `$.id`.

---

## Why

- Related Issue: Closes #1277
- Related Feature: N/A — documentation correction for the existing creation API.
- Background: The backend returns `{"id":"..."}`, while the OpenAPI document declared an array. Contract-generated clients and tests could therefore attempt to extract `$[0].id` and fail after successful creation.

---

## How

- Replace the array wrapper with a direct reference to `#/components/schemas/ID` and add a media-type example.
- Breaking changes (API, config, database, etc.): No runtime API, configuration, or database changes. The documented response shape now matches the existing backend. Other API definitions, including batch array responses, are unchanged.

---

## Testing

- [ ] Unit tests passed locally — N/A: documentation-only change; focused schema checks performed instead.
- [ ] Integration tests passed locally — not run; no backend implementation changes.
- [ ] Verified in test environment — not rerun; no deployment or resource creation performed.

Test notes:

- Redocly CLI 1.34.16: `redocly lint --config .redocly.yaml docs/api/bkn/business-knowledge-network.yaml --format summary` passed with 12 existing warnings (security declarations, servers, and unrelated GET examples); no unresolved references.
- Python/PyYAML/jsonschema checks passed: the object example validates and exposes `$.id`; array responses, missing IDs, and numeric IDs are rejected. The original schema rejects the object example.
- A parsed-document comparison confirmed that every definition outside this POST's 201 response is unchanged.
- `git diff --check` passed. Remote CI results are pending.

---

## Risk & Rollback

- Potential risks: Consumers generated from the incorrect schema should regenerate against the corrected object response. No backend behavior changes.
- Rollback plan: Revert this documentation commit; no data migration or operational rollback is required.

---

## Additional Notes

- Branch: `fix/1277-kn-create-response`, based on main commit `14bdccb3`.
- Source cross-check: `CreateKN` in `adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go` returns an ID map with HTTP 201.
- Screenshots: N/A — OpenAPI documentation change.
