### PR TITLE
fix(context-loader): enforce trusted KN retrieval authorization

### DIFF
--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/configmap.yaml
@@ -49,6 +49,9 @@ data:
       private_protocol: {{ index .Values "depServices" "bkn-safe" "privateProtocol" | quote }}
       private_host: {{ index .Values "depServices" "bkn-safe" "privateHost" | quote }}
       private_port: {{ index .Values "depServices" "bkn-safe" "privatePort" }}
+    auth:
+      context_loader_kn_pep_enabled: {{ .Values.auth.contextLoaderKnPepEnabled | default false }}
+      resource_filter_chunk_size: {{ .Values.auth.resourceFilterChunkSize | default 200 }}
     redis:
       connectType: {{ .Values.depServices.redis.connectType | quote }}
       enableSSL: {{ .Values.depServices.redis.enableSSL }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
             {{- if hasKey .Values "auth" }}
               - name: AUTH_ENABLED
                 value: {{ .Values.auth.enabled | quote }}
+              - name: CONTEXT_LOADER_KN_PEP_ENABLED
+                value: {{ .Values.auth.contextLoaderKnPepEnabled | default false | quote }}
+              - name: CONTEXT_LOADER_KN_PEP_CHUNK_SIZE
+                value: {{ .Values.auth.resourceFilterChunkSize | default 200 | quote }}
             {{- end}}
               - name: BKN_TRACE_CORE_URL
                 value: {{ required "observability.lifecycle.core_url is required" .Values.observability.lifecycle.core_url | quote }}

--- a/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
+++ b/adp/context-loader/agent-retrieval/helm/agent-retrieval/values.yaml
@@ -66,6 +66,10 @@ service:
 # Authentication switches.
 auth:
   enabled: true
+  # Temporary migration switch for #517. #1253 removes it after cutover.
+  contextLoaderKnPepEnabled: false
+  # Per-request batch size; this is not a cap on total retrieval candidates.
+  resourceFilterChunkSize: 200
 
 depServices:
   rds:

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/hydra.go
@@ -70,7 +70,7 @@ func NewHydra() interfaces.Hydra {
 	once.Do(func() {
 		conf := config.NewConfigLoader()
 		if !config.GetAuthEnabled() {
-			conf.GetLogger().Warn("ISF authentication disabled via AUTH_ENABLED env, using noop hydra")
+			conf.GetLogger().Warn("authentication disabled via AUTH_ENABLED env, using noop hydra")
 			h = &noopHydra{}
 		} else {
 			h = &hydra{

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/permission.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/permission.go
@@ -1,0 +1,82 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/bytedance/sonic"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infrarest "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+const permissionRequestTimeoutSeconds = 5
+
+type permissionAccess struct {
+	baseURL    string
+	httpClient interfaces.HTTPClient
+}
+
+// NewPermissionAccess creates the context-loader bkn-safe adapter.
+func NewPermissionAccess(conf *config.Config) interfaces.PermissionAccess {
+	baseURL := ""
+	if conf != nil {
+		baseURL = strings.TrimRight(conf.BknSafe.BuildURL(""), "/")
+	}
+	return &permissionAccess{
+		baseURL: baseURL,
+		httpClient: infrarest.NewHTTPClientWithOptions(infrarest.HTTPClientOptions{
+			TimeOut: permissionRequestTimeoutSeconds,
+		}),
+	}
+}
+
+func (a *permissionAccess) FilterResources(ctx context.Context,
+	request interfaces.PermissionFilterRequest,
+) (interfaces.PermissionFilterResponse, error) {
+	var response interfaces.PermissionFilterResponse
+	endpoint, err := a.resourceFilterEndpoint()
+	if err != nil {
+		return response, err
+	}
+
+	headers := common.GetHeaderForChildOperation(ctx, "safe.query_candidate.filter", 1)
+	headers[infrarest.ContentTypeKey] = infrarest.ContentTypeJSON
+	status, body, err := a.httpClient.PostNoUnmarshal(ctx, endpoint, headers, request)
+	if err != nil {
+		return response, fmt.Errorf("call bkn-safe resource-filter: %w", err)
+	}
+	if status != http.StatusOK {
+		return response, fmt.Errorf("bkn-safe resource-filter returned status %d", status)
+	}
+	if len(body) == 0 {
+		return response, fmt.Errorf("bkn-safe resource-filter returned an empty response")
+	}
+	if err := sonic.Unmarshal(body, &response); err != nil {
+		return response, fmt.Errorf("decode bkn-safe resource-filter response: %w", err)
+	}
+	if response.Resources == nil {
+		return response, fmt.Errorf("bkn-safe resource-filter response omitted resources")
+	}
+	return response, nil
+}
+
+func (a *permissionAccess) resourceFilterEndpoint() (string, error) {
+	if a == nil || a.httpClient == nil {
+		return "", fmt.Errorf("bkn-safe permission client is not configured")
+	}
+	parsed, err := url.Parse(a.baseURL)
+	if err != nil || parsed == nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", fmt.Errorf("bkn-safe URL is missing or invalid")
+	}
+	return a.baseURL + "/api/safe/v1/authz/resource-filter", nil
+}

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/permission_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/permission_test.go
@@ -1,0 +1,81 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	infrarest "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func TestPermissionAccessFilterResources(t *testing.T) {
+	var got interfaces.PermissionFilterRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/safe/v1/authz/resource-filter" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resources":[{"resource_type":"object_type","resource_id":"kn-1/ot-1","operations":["query_data"]}]}`))
+	}))
+	defer server.Close()
+
+	access := &permissionAccess{
+		baseURL:    server.URL,
+		httpClient: infrarest.NewHTTPClientWithRawClient(server.Client()),
+	}
+	request := interfaces.PermissionFilterRequest{
+		AccessorID: "user-1",
+		Resources: []interfaces.PermissionResource{{
+			Type: interfaces.PermissionResourceTypeObjectType,
+			ID:   "kn-1/ot-1",
+		}},
+		VisibilityOperations: []string{interfaces.PermissionOperationQueryData},
+		CandidateOperations:  []string{interfaces.PermissionOperationQueryData},
+	}
+	response, err := access.FilterResources(context.Background(), request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessorID != request.AccessorID || len(got.Resources) != 1 {
+		t.Fatalf("request = %#v", got)
+	}
+	if response.Resources == nil || len(*response.Resources) != 1 {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
+func TestPermissionAccessRejectsInvalidResponses(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "non-200", status: http.StatusServiceUnavailable, body: `{}`},
+		{name: "empty body", status: http.StatusOK, body: ``},
+		{name: "invalid json", status: http.StatusOK, body: `{`},
+		{name: "missing resources", status: http.StatusOK, body: `{}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+			access := &permissionAccess{baseURL: server.URL, httpClient: infrarest.NewHTTPClientWithRawClient(server.Client())}
+			if _, err := access.FilterResources(context.Background(), interfaces.PermissionFilterRequest{}); err == nil {
+				t.Fatal("expected response validation error")
+			}
+		})
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/knquerytools/index.go
@@ -45,6 +45,7 @@ type knQueryToolsHandler struct {
 	resources  knresources.KnResourcesService
 	bknBackend interfaces.BknBackendAccess
 	metrics    knmetrics.KnMetricsService
+	pepEnabled bool
 }
 
 var (
@@ -62,6 +63,7 @@ func NewKnQueryToolsHandler() KnQueryToolsHandler {
 			resources:  knresources.NewKnResourcesService(),
 			bknBackend: drivenadapters.NewBknBackendAccess(),
 			metrics:    knmetrics.NewKnMetricsService(),
+			pepEnabled: conf.Auth.ContextLoaderKNPEPEnabled,
 		}
 	})
 	return handler
@@ -79,6 +81,10 @@ func (h *knQueryToolsHandler) RunSQL(c *gin.Context) {
 	resp, err := h.runSQL.RunSQL(ctx, req)
 	if err != nil {
 		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#RunSQL] run sql failed: %v", err)
+		if _, ok := errors.HTTPStatus(err); h.pepEnabled && ok {
+			rest.ReplyError(c, err)
+			return
+		}
 		rest.ReplyError(c, errors.DefaultHTTPError(ctx, http.StatusBadRequest, err.Error()))
 		return
 	}
@@ -132,7 +138,11 @@ func (h *knQueryToolsHandler) GetKnDetail(c *gin.Context) {
 		return
 	}
 	// Only the count is attached but not the details: it is enough for the Agent to judge which object type is worthy of drill-down metrics.
-	h.metrics.AttachRelatedMetricCounts(ctx, req.KnID, resp.ObjectTypes)
+	if err := h.metrics.AttachRelatedMetricCounts(ctx, req.KnID, resp.ObjectTypes); err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetKnDetail] metric authorization failed: %v", err)
+		rest.ReplyError(c, err)
+		return
+	}
 	detailLevel := req.DetailLevel
 	if detailLevel == "" {
 		detailLevel = interfaces.DetailLevelSummary
@@ -211,15 +221,31 @@ func (h *knQueryToolsHandler) GetObjectTypes(c *gin.Context) {
 		return
 	}
 
-	detail, err := h.bknBackend.GetKnowledgeNetworkDetail(ctx, knID)
-	if err != nil {
-		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetObjectTypes] failed: %v", err)
+	var matched []*interfaces.ObjectType
+	var missing []string
+	if h.pepEnabled {
+		var err error
+		matched, err = h.bknBackend.GetObjectTypeDetail(ctx, knID, req.IDs, true)
+		if err != nil {
+			h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetObjectTypes] failed: %v", err)
+			rest.ReplyError(c, err)
+			return
+		}
+	} else {
+		detail, err := h.bknBackend.GetKnowledgeNetworkDetail(ctx, knID)
+		if err != nil {
+			h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetObjectTypes] failed: %v", err)
+			rest.ReplyError(c, err)
+			return
+		}
+		matched, missing = detail.FilterObjectTypes(req.IDs)
+	}
+	// OT-first step 2: scoped metrics with unbound logical properties are only visible here.
+	if err := h.metrics.AttachRelatedMetrics(ctx, knID, matched); err != nil {
+		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetObjectTypes] metric authorization failed: %v", err)
 		rest.ReplyError(c, err)
 		return
 	}
-	matched, missing := detail.FilterObjectTypes(req.IDs)
-	// OT-first step 2: scoped metrics with unbound logical properties are only visible here.
-	h.metrics.AttachRelatedMetrics(ctx, knID, matched)
 	bkntrace.EmitSchemaDefinitionEvents(ctx, h.logger, "object", knID, req.IDs, len(matched))
 	rest.ReplyOK(c, http.StatusOK, &interfaces.ObjectTypesResp{KnID: knID, ObjectTypes: matched, Missing: missing})
 }
@@ -240,13 +266,25 @@ func (h *knQueryToolsHandler) GetRelationTypes(c *gin.Context) {
 		return
 	}
 
-	detail, err := h.bknBackend.GetKnowledgeNetworkDetail(ctx, knID)
-	if err != nil {
-		h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetRelationTypes] failed: %v", err)
-		rest.ReplyError(c, err)
-		return
+	var matched []*interfaces.RelationType
+	var missing []string
+	if h.pepEnabled {
+		var err error
+		matched, err = h.bknBackend.GetRelationTypeDetail(ctx, knID, req.IDs, true)
+		if err != nil {
+			h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetRelationTypes] failed: %v", err)
+			rest.ReplyError(c, err)
+			return
+		}
+	} else {
+		detail, err := h.bknBackend.GetKnowledgeNetworkDetail(ctx, knID)
+		if err != nil {
+			h.logger.WithContext(ctx).Warnf("[KnQueryToolsHandler#GetRelationTypes] failed: %v", err)
+			rest.ReplyError(c, err)
+			return
+		}
+		matched, missing = detail.FilterRelationTypes(req.IDs)
 	}
-	matched, missing := detail.FilterRelationTypes(req.IDs)
 	bkntrace.EmitSchemaDefinitionEvents(ctx, h.logger, "relation", knID, req.IDs, len(matched))
 	rest.ReplyOK(c, http.StatusOK, &interfaces.RelationTypesResp{KnID: knID, RelationTypes: matched, Missing: missing})
 }

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/extension/mcptool"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
 	logicsKar "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knactionrecall"
 	logicsFs "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knfindskills"
 	logicsKlp "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knlogicpropertyresolver"
@@ -140,6 +141,7 @@ func newMCPServer(lifecycleClient *bkntrace.LifecycleClient) (*server.MCPServer,
 func newMCPServerForLocale(lifecycleClient *bkntrace.LifecycleClient, locale string) (*server.MCPServer, *toolBuilder) {
 	localeBundle := loadMCPLocaleBundle(locale)
 	b := newToolBuilder(localeBundle)
+	conf := config.NewConfigLoader()
 
 	knSearchService := knsearch.NewKnSearchService()
 	b.add(toolKeySearchSchema, handleSearchSchema(knSearchService))
@@ -170,8 +172,8 @@ func newMCPServerForLocale(lifecycleClient *bkntrace.LifecycleClient, locale str
 	bknBackend := drivenadapters.NewBknBackendAccess()
 	b.add(toolKeyListKnowledgeNetworks, handleListKnowledgeNetworks(bknBackend))
 	b.add(toolKeyGetKnDetail, handleGetKnDetail(bknBackend, metricsService))
-	b.add(toolKeyGetObjectTypes, handleGetObjectTypes(bknBackend, metricsService))
-	b.add(toolKeyGetRelationTypes, handleGetRelationTypes(bknBackend))
+	b.add(toolKeyGetObjectTypes, handleGetObjectTypesWithPEP(bknBackend, metricsService, conf.Auth.ContextLoaderKNPEPEnabled))
+	b.add(toolKeyGetRelationTypes, handleGetRelationTypesWithPEP(bknBackend, conf.Auth.ContextLoaderKNPEPEnabled))
 
 	runSQLService := knrunsql.NewKnRunSQLService()
 	b.add(toolKeyRunSQL, handleRunSQL(runSQLService))

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools.go
@@ -579,7 +579,9 @@ func handleGetKnDetail(bkn interfaces.BknBackendAccess, metrics knmetrics.KnMetr
 		}
 		// Counts only: which object types have metrics worth drilling into, without
 		// carrying the metric list itself at this level.
-		metrics.AttachRelatedMetricCounts(ctx, knID, resp.ObjectTypes)
+		if err := metrics.AttachRelatedMetricCounts(ctx, knID, resp.ObjectTypes); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 		resp.Slim(getStringArg(req, "detail_level", interfaces.DetailLevelSummary))
 		result, err := BuildMCPToolResult(resp, format)
 		if err != nil {
@@ -608,6 +610,12 @@ func (a *knDrillArgs) resolveKnID(req mcp.CallToolRequest) string {
 // ids, plus the metrics scoped to them. Pairs with get_kn_detail summary, which
 // omits that heavy detail.
 func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnMetricsService) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return handleGetObjectTypesWithPEP(bkn, metrics, false)
+}
+
+func handleGetObjectTypesWithPEP(bkn interfaces.BknBackendAccess, metrics knmetrics.KnMetricsService,
+	pepEnabled bool,
+) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		format, err := GetResponseFormatFromRequest(req)
 		if err != nil {
@@ -628,18 +636,23 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 		// Prioritize the endpoint that retrieves details by id: the export view only lists object types, does not enrich the data source, and does not enrich the data source.
 		// condition_operations is always empty, and the caller uses this to determine whether the field can match / knn.
 		//
-		// But this endpoint requires all ids to be hit. If an invalid id is mixed in, the whole batch will be 404. Return to the export view at this time:
+		// In legacy mode this endpoint requires all ids to be hit. If an invalid id is mixed in, the whole batch will be 404. Return to the export view at this time:
 		// It would be better to have fewer operators in this batch than to throw away the remaining valid object types because of an invalid id——.
 		// Exported views also support fallback matching by name, which is also existing behavior.
+		// PEP mode never uses that unfiltered export fallback and does not report
+		// omitted IDs as missing, because an omission may be an authorization filter.
 		matched, err := bkn.GetObjectTypeDetail(ctx, knID, args.IDs, true)
 		var missing []string
-		if err != nil || len(matched) < len(args.IDs) {
+		if pepEnabled && err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if !pepEnabled && (err != nil || len(matched) < len(args.IDs)) {
 			detail, detailErr := bkn.GetKnowledgeNetworkDetail(ctx, knID)
 			if detailErr != nil {
 				return mcp.NewToolResultError(detailErr.Error()), nil
 			}
 			matched, missing = detail.FilterObjectTypes(args.IDs)
-		} else {
+		} else if !pepEnabled {
 			missing = missingObjectTypeIDs(args.IDs, matched)
 		}
 		// The same rule as search_schema: only emit underivable operators. Comparison operators (==/in/like/range…)
@@ -648,7 +661,9 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 
 		// Step 2 of the OT-first metric path: a metric that is not bound to a logic
 		// property is unreachable from the object type without this.
-		metrics.AttachRelatedMetrics(ctx, knID, matched)
+		if err := metrics.AttachRelatedMetrics(ctx, knID, matched); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 		bkntrace.EmitSchemaDefinitionEvents(ctx, nil, "object", knID, args.IDs, len(matched))
 		resp := &interfaces.ObjectTypesResp{KnID: knID, ObjectTypes: matched, Missing: missing}
 		result, err := BuildMCPToolResult(resp, format)
@@ -662,6 +677,10 @@ func handleGetObjectTypes(bkn interfaces.BknBackendAccess, metrics knmetrics.KnM
 // handleGetRelationTypes handles get_relation_types tool calls: return the full
 // definition (incl. mapping_rules) of the requested relation type ids.
 func handleGetRelationTypes(bkn interfaces.BknBackendAccess) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return handleGetRelationTypesWithPEP(bkn, false)
+}
+
+func handleGetRelationTypesWithPEP(bkn interfaces.BknBackendAccess, pepEnabled bool) func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		format, err := GetResponseFormatFromRequest(req)
 		if err != nil {
@@ -679,11 +698,21 @@ func handleGetRelationTypes(bkn interfaces.BknBackendAccess) func(ctx context.Co
 			return mcp.NewToolResultError("ids is required (relation type ids from get_kn_detail)"), nil
 		}
 
-		detail, err := bkn.GetKnowledgeNetworkDetail(ctx, knID)
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
+		var matched []*interfaces.RelationType
+		var missing []string
+		if pepEnabled {
+			var err error
+			matched, err = bkn.GetRelationTypeDetail(ctx, knID, args.IDs, true)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+		} else {
+			detail, err := bkn.GetKnowledgeNetworkDetail(ctx, knID)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			matched, missing = detail.FilterRelationTypes(args.IDs)
 		}
-		matched, missing := detail.FilterRelationTypes(args.IDs)
 		bkntrace.EmitSchemaDefinitionEvents(ctx, nil, "relation", knID, args.IDs, len(matched))
 		resp := &interfaces.RelationTypesResp{KnID: knID, RelationTypes: matched, Missing: missing}
 		result, err := BuildMCPToolResult(resp, format)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_metric_test.go
@@ -161,6 +161,30 @@ func TestHandleGetObjectTypes_UsesEnrichedEndpoint(t *testing.T) {
 	})
 }
 
+func TestHandleGetObjectTypes_PEPDoesNotFallbackOrReportDeniedIDs(t *testing.T) {
+	stub := &capsBknBackend{}
+	handler := handleGetObjectTypesWithPEP(stub, knmetrics.NewKnMetricsServiceWith(nil, stub, nil), true)
+	req := mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{
+		Arguments: map[string]any{
+			"kn_id":           "kn1",
+			"ids":             []any{"stadiums", "denied"},
+			"response_format": "json",
+		},
+	}}
+
+	result, err := handler(context.Background(), req)
+	if err != nil || result.IsError {
+		t.Fatalf("unexpected result: err=%v result=%v", err, result)
+	}
+	if stub.detailCalls != 1 || stub.exportCalls != 0 {
+		t.Fatalf("PEP path must use only the typed endpoint: detail=%d export=%d", stub.detailCalls, stub.exportCalls)
+	}
+	response := resultToMap(t, result)
+	if _, exists := response["missing"]; exists {
+		t.Fatalf("filtered IDs must not appear in missing diagnostics: %#v", response["missing"])
+	}
+}
+
 // capsBknBackend only returns an object type with an operator, and records the number of times the two access paths are called.
 type capsBknBackend struct {
 	interfaces.BknBackendAccess

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware.go
@@ -56,6 +56,12 @@ func getToken(c *gin.Context) (token string) {
 // Choose one of the two credentials: the one starting with the AppKey prefix (bak_) is submitted to bkn-safe for verification (API Key issued by the user),
 // The rest of the bearer token goes hydra introspection. The two paths produce the same TokenInfo, and the downstream authentication context is consistent.
 func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKeyVerifier) gin.HandlerFunc {
+	return middlewareIntrospectVerifyWithMode(hydra, appKeys, false)
+}
+
+func middlewareIntrospectVerifyWithMode(hydra interfaces.Hydra, appKeys interfaces.AppKeyVerifier,
+	strict bool,
+) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		// Set language information to context.
@@ -76,6 +82,19 @@ func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKe
 			c.Abort()
 			return
 		}
+		if tokenInfo == nil {
+			rest.ReplyError(c, aerrors.DefaultHTTPError(ctx, http.StatusUnauthorized,
+				"authenticated execution subject is missing"))
+			c.Abort()
+			return
+		}
+		accountType := tokenInfo.VisitorTyp.ToAccessorType()
+		if strict && !validInternalExecutionSubject(tokenInfo.VisitorID, accountType) {
+			rest.ReplyError(c, aerrors.DefaultHTTPError(ctx, http.StatusUnauthorized,
+				"authenticated execution subject is missing or invalid"))
+			c.Abort()
+			return
+		}
 		if tokenInfo.LoginIP == "" {
 			// If the returned IP is empty, use clientIP.
 			tokenInfo.LoginIP = c.ClientIP()
@@ -91,11 +110,17 @@ func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKe
 		// Set the authentication context on the context.
 		authContext := &interfaces.AccountAuthContext{
 			AccountID:   tokenInfo.VisitorID,
-			AccountType: tokenInfo.VisitorTyp.ToAccessorType(),
+			AccountType: accountType,
 			AuthMethod:  authMethod,
 			TokenInfo:   tokenInfo,
 		}
 		ctx = common.SetAccountAuthContextToCtx(ctx, authContext)
+		// Normalize caller-controlled aliases before handlers bind headers. The
+		// context remains authoritative for all outbound propagation, and request
+		// DTOs observe the same authenticated subject rather than spoofed values.
+		c.Request.Header.Set(string(interfaces.HeaderXAccountID), authContext.AccountID)
+		c.Request.Header.Set(string(interfaces.HeaderXAccountType), string(authContext.AccountType))
+		c.Request.Header.Set(string(interfaces.HeaderUserID), authContext.AccountID)
 		c.Request = c.Request.WithContext(ctx)
 		c.Request.Header.Set(string(interfaces.IsPublic), "true")
 		c.Next()
@@ -104,16 +129,51 @@ func middlewareIntrospectVerify(hydra interfaces.Hydra, appKeys interfaces.AppKe
 
 // Internal interface Header authentication account information processing middleware.
 func middlewareHeaderAuthContext() gin.HandlerFunc {
+	return middlewareHeaderAuthContextWithMode(false)
+}
+
+// middlewareHeaderAuthContextWithMode resolves the execution subject carried
+// by a trusted internal hop. Strict validation is tied to the temporary #517
+// rollout switch so the implementation can merge before all callers migrate.
+func middlewareHeaderAuthContextWithMode(strict bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		ctx = common.SetTraceContextToCtx(ctx, common.TraceContextFromHeaders(c.GetHeader))
 		// Get the xAccountType account type in the Header.
-		xAccountType := c.GetHeader(string(interfaces.HeaderXAccountType))
+		rawAccountType := c.GetHeader(string(interfaces.HeaderXAccountType))
+		rawUserID := c.GetHeader(string(interfaces.HeaderUserID))
+		rawAccountID := c.GetHeader(string(interfaces.HeaderXAccountID))
+		xAccountType, userID, xAccountID := rawAccountType, rawUserID, rawAccountID
+		if strict {
+			xAccountType = strings.TrimSpace(rawAccountType)
+			userID = strings.TrimSpace(rawUserID)
+			xAccountID = strings.TrimSpace(rawAccountID)
+			if rawUserID != userID || rawAccountID != xAccountID || rawAccountType != xAccountType {
+				rest.ReplyError(c, aerrors.DefaultHTTPError(ctx, http.StatusUnauthorized,
+					"internal execution subject contains invalid whitespace"))
+				c.Abort()
+				return
+			}
+		}
 
 		// Compatible with user_id parameter passing, when user_id is empty, xAccountID is used.
-		xAccountID := c.GetHeader(string(interfaces.HeaderUserID))
-		if xAccountID == "" {
-			xAccountID = c.GetHeader(string(interfaces.HeaderXAccountID))
+		if strict && userID != "" && xAccountID != "" && userID != xAccountID {
+			rest.ReplyError(c, aerrors.DefaultHTTPError(ctx, http.StatusUnauthorized,
+				"conflicting internal execution subject headers"))
+			c.Abort()
+			return
+		}
+		if userID != "" {
+			xAccountID = userID
+		}
+		if strict && xAccountType == "realname" {
+			xAccountType = string(interfaces.AccessorTypeUser)
+		}
+		if strict && !validInternalExecutionSubject(xAccountID, interfaces.AccessorType(xAccountType)) {
+			rest.ReplyError(c, aerrors.DefaultHTTPError(ctx, http.StatusUnauthorized,
+				"internal execution subject is missing or invalid"))
+			c.Abort()
+			return
 		}
 		// Set user_id to Header, TODO: Do you need to check required?.
 		c.Request.Header.Set(string(interfaces.HeaderUserID), xAccountID)
@@ -130,6 +190,18 @@ func middlewareHeaderAuthContext() gin.HandlerFunc {
 		ctx = common.SetAccountAuthContextToCtx(ctx, authContext)
 		c.Request = c.Request.WithContext(ctx)
 		c.Next()
+	}
+}
+
+func validInternalExecutionSubject(accountID string, accountType interfaces.AccessorType) bool {
+	if accountID == "" || strings.TrimSpace(accountID) != accountID || strings.ContainsAny(accountID, " \t\r\n*") {
+		return false
+	}
+	switch accountType {
+	case interfaces.AccessorTypeUser, interfaces.AccessorTypeApp:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/middleware_test.go
@@ -106,6 +106,121 @@ func TestMiddlewareHeaderAuthContext_LeavesMissingAccountHeadersEmpty(t *testing
 	})
 }
 
+func TestMiddlewareHeaderAuthContext_StrictModeRejectsInvalidSubjects(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name    string
+		headers map[string]string
+	}{
+		{name: "missing", headers: map[string]string{}},
+		{name: "unsupported type", headers: map[string]string{"x-account-id": "user-1", "x-account-type": "role"}},
+		{name: "invalid id", headers: map[string]string{"x-account-id": "user *", "x-account-type": "user"}},
+		{name: "surrounding whitespace", headers: map[string]string{"x-account-id": " user-1 ", "x-account-type": "user"}},
+		{name: "conflicting ids", headers: map[string]string{"user_id": "user-1", "x-account-id": "user-2", "x-account-type": "user"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+			for key, value := range tt.headers {
+				c.Request.Header.Set(key, value)
+			}
+
+			middlewareHeaderAuthContextWithMode(true)(c)
+
+			if w.Code != http.StatusUnauthorized || !c.IsAborted() {
+				t.Fatalf("status=%d aborted=%v body=%s", w.Code, c.IsAborted(), w.Body.String())
+			}
+			if _, ok := common.GetAccountAuthContextFromCtx(c.Request.Context()); ok {
+				t.Fatal("invalid internal subject must not be stored in context")
+			}
+		})
+	}
+}
+
+func TestMiddlewareHeaderAuthContext_StrictModeStoresCanonicalSubject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	c.Request.Header.Set(string(interfaces.HeaderXAccountID), "user-1")
+	c.Request.Header.Set(string(interfaces.HeaderXAccountType), "realname")
+
+	middlewareHeaderAuthContextWithMode(true)(c)
+
+	auth, ok := common.GetAccountAuthContextFromCtx(c.Request.Context())
+	if !ok || auth.AccountID != "user-1" || auth.AccountType != interfaces.AccessorTypeUser {
+		t.Fatalf("auth context = %#v", auth)
+	}
+	if got := common.GetHeaderFromCtx(c.Request.Context()); got[string(interfaces.HeaderXAccountID)] != "user-1" ||
+		got[string(interfaces.HeaderXAccountType)] != "user" {
+		t.Fatalf("downstream headers = %#v", got)
+	}
+}
+
+func TestMiddlewareIntrospectIgnoresSpoofedAccountHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+	c.Request.Header.Set(string(interfaces.HeaderXAccountID), "attacker")
+	c.Request.Header.Set(string(interfaces.HeaderXAccountType), "app")
+
+	middlewareIntrospectVerify(stubPublicHydra{}, nil)(c)
+
+	auth, ok := common.GetAccountAuthContextFromCtx(c.Request.Context())
+	if !ok || auth.AccountID != "user-1" || auth.AccountType != interfaces.AccessorTypeUser {
+		t.Fatalf("auth context = %#v", auth)
+	}
+	got := common.GetHeaderFromCtx(c.Request.Context())
+	if got[string(interfaces.HeaderXAccountID)] != "user-1" || got[string(interfaces.HeaderXAccountType)] != "user" {
+		t.Fatalf("spoofed subject reached downstream headers: %#v", got)
+	}
+}
+
+func TestMiddlewareIntrospect_BodyCannotOverrideAuthenticatedSubject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(
+		`{"query":"orders","XAccountID":"attacker","XAccountType":"app"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set(string(interfaces.HeaderXAccountID), "attacker")
+	c.Request.Header.Set(string(interfaces.HeaderXAccountType), "app")
+
+	middlewareIntrospectVerifyWithMode(stubPublicHydra{}, nil, true)(c)
+	if c.IsAborted() {
+		t.Fatalf("valid authenticated subject was rejected: %s", w.Body.String())
+	}
+	req := &interfaces.SearchSchemaReq{}
+	if err := c.ShouldBindHeader(req); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.ShouldBindJSON(req); err != nil {
+		t.Fatal(err)
+	}
+	if req.XAccountID != "user-1" || req.XAccountType != "user" {
+		t.Fatalf("spoofed subject overrode authentication: %#v", req)
+	}
+}
+
+func TestMiddlewareIntrospect_StrictModeRejectsInvalidResolvedSubject(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/test", http.NoBody)
+
+	middlewareIntrospectVerifyWithMode(invalidSubjectHydra{}, nil, true)(c)
+
+	if w.Code != http.StatusUnauthorized || !c.IsAborted() {
+		t.Fatalf("status=%d aborted=%v body=%s", w.Code, c.IsAborted(), w.Body.String())
+	}
+	if _, ok := common.GetAccountAuthContextFromCtx(c.Request.Context()); ok {
+		t.Fatal("invalid authenticated subject must not be stored in context")
+	}
+}
+
 func TestMiddlewareHeaderAuthContext_SetsTraceContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -165,6 +280,12 @@ func (stubPublicHydra) Introspect(_ context.Context, _ string) (*interfaces.Toke
 		VisitorID:  "user-1",
 		VisitorTyp: interfaces.RealName,
 	}, nil
+}
+
+type invalidSubjectHydra struct{}
+
+func (invalidSubjectHydra) Introspect(_ context.Context, _ string) (*interfaces.TokenInfo, error) {
+	return &interfaces.TokenInfo{VisitorTyp: interfaces.Anonymous}, nil
 }
 
 type stubLogicPropertyResolverHandler struct{}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_private_handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/knskills"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcpproxy"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 	logicsSkills "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/knskills"
 )
@@ -39,10 +40,12 @@ type restPrivateHandler struct {
 	KnSkillsHandler                knskills.KnSkillsHandler
 	Logger                         interfaces.Logger
 	LifecycleClient                *bkntrace.LifecycleClient
+	KNPEPEnabled                   bool
 }
 
 // NewRestPrivateHandler createrestHandlerinstance.
 func NewRestPrivateHandler(logger interfaces.Logger) interfaces.HTTPRouterInterface {
+	conf := config.NewConfigLoader()
 	return &restPrivateHandler{
 		KnLogicPropertyResolverHandler: knlogicpropertyresolver.NewKnLogicPropertyResolverHandler(),
 		KnActionRecallHandler:          knactionrecall.NewKnActionRecallHandler(),
@@ -55,13 +58,14 @@ func NewRestPrivateHandler(logger interfaces.Logger) interfaces.HTTPRouterInterf
 		KnSkillsHandler:                knskills.NewKnSkillsHandler(),
 		Logger:                         logger,
 		LifecycleClient:                bkntrace.NewLifecycleClientFromEnv(),
+		KNPEPEnabled:                   conf.Auth.ContextLoaderKNPEPEnabled,
 	}
 }
 
 // RegisterRouter registers routes.
 func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareHeaderAuthContext(), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareHeaderAuthContextWithMode(r.KNPEPEnabled), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
 	engine.Use(mws...)
 
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)

--- a/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/rest_public_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/driveradapters/mcp"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
 	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 	infrarest "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
@@ -46,7 +47,8 @@ type restPublicHandler struct {
 	Logger                         interfaces.Logger
 	LifecycleClient                *bkntrace.LifecycleClient
 	// ServicePort is used to deduce the address for the sandbox to return to this service (see PTC toolkit endpoint).
-	ServicePort int
+	ServicePort  int
+	KNPEPEnabled bool
 }
 
 var buildMCPInfo = mcp.BuildMCPInfoForLocale
@@ -54,6 +56,7 @@ var buildMCPInfo = mcp.BuildMCPInfoForLocale
 // NewRestPublicHandler createrestHandlerinstance.
 // servicePort is used to derive the sandbox return address; the sandbox is within the cluster and cannot reach the gateway address on the browser side.
 func NewRestPublicHandler(logger interfaces.Logger, servicePort int) interfaces.HTTPRouterInterface {
+	conf := config.NewConfigLoader()
 	return &restPublicHandler{
 		Hydra:                          drivenadapters.NewHydra(),
 		AppKeys:                        drivenadapters.NewAppKeyVerifier(),
@@ -69,13 +72,14 @@ func NewRestPublicHandler(logger interfaces.Logger, servicePort int) interfaces.
 		Logger:                         logger,
 		LifecycleClient:                bkntrace.NewLifecycleClientFromEnv(),
 		ServicePort:                    servicePort,
+		KNPEPEnabled:                   conf.Auth.ContextLoaderKNPEPEnabled,
 	}
 }
 
 // RegisterRouter registers public routes.
 func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareIntrospectVerify(r.Hydra, r.AppKeys), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
+	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareIntrospectVerifyWithMode(r.Hydra, r.AppKeys, r.KNPEPEnabled), middlewareResponseFormat(), middlewareLifecycle(r.LifecycleClient))
 	engine.Use(mws...)
 
 	engine.POST("/kn/logic-property-resolver", r.KnLogicPropertyResolverHandler.ResolveLogicProperties)

--- a/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
+++ b/adp/context-loader/agent-retrieval/server/infra/config/agent-retrieval.yaml
@@ -55,6 +55,11 @@ bkn_safe: # bkn-safe authorization service, used to validate user self-issued Ap
   private_protocol: "http"
   private_host: "bkn-safe"
   private_port: 3000
+auth:
+  # Temporary migration switch. Keep false until #1248 and #1239 complete.
+  context_loader_kn_pep_enabled: false
+  # Limits one bkn-safe request only; the complete candidate set is processed in chunks.
+  resource_filter_chunk_size: 200
 redis:
   connectType: "sentinel"
   enableSSL: false

--- a/adp/context-loader/agent-retrieval/server/infra/config/config.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	Vega                 PrivateBaseConfig      `yaml:"vega"`                 // Vega data-catalog backend (run_sql / resource query)
 	OperatorIntegration  PrivateBaseConfig      `yaml:"operator_integration"` // Operator integration service configuration
 	BknSafe              PrivateBaseConfig      `yaml:"bkn_safe"`             // bkn-safe auth service (AppKey verification)
+	Auth                 AuthorizationConfig    `yaml:"auth"`                 // KN retrieval authorization rollout configuration
 	RedisConfig          RedisConfig            `yaml:"redis"`
 	Logger               interfaces.Logger      `yaml:"-"`
 	ConceptSearchConfig  KnConceptSearchConfig  `yaml:"concept_search_config"`  // Knowledge network concept search configuration
@@ -48,6 +49,16 @@ type Config struct {
 	// New configuration - knowledge rearrangement and retrieval related.
 	MFModelAPI PrivateBaseConfig `yaml:"mf_model_api"` // MF-Model API unified service configuration.
 	FindSkills FindSkillsConfig  `yaml:"find_skills"`  // find_skills Skill recall configuration.
+}
+
+// AuthorizationConfig controls context-loader's temporary KN retrieval PEP.
+// The switch is intentionally disabled until existing policies and
+// ResourceParent rows have been migrated and the cross-service flow is
+// validated. The chunk size bounds one Safe request, not the number of
+// candidates a business request may contain.
+type AuthorizationConfig struct {
+	ContextLoaderKNPEPEnabled bool `yaml:"context_loader_kn_pep_enabled" env:"CONTEXT_LOADER_KN_PEP_ENABLED"`
+	ResourceFilterChunkSize   int  `yaml:"resource_filter_chunk_size" env:"CONTEXT_LOADER_KN_PEP_CHUNK_SIZE" default:"200"`
 }
 
 // ObservabilityConfig trace configuration
@@ -228,7 +239,7 @@ func parseAuthEnabled(envVal string) bool {
 	return v != "false" && v != "0"
 }
 
-// GetAuthEnabled returns whether ISF authentication is enabled.
+// GetAuthEnabled returns whether authentication is enabled.
 // Defaults to true (secure by default). Only returns false when
 // AUTH_ENABLED is explicitly set to "false" or "0" (case-insensitive).
 func GetAuthEnabled() bool {

--- a/adp/context-loader/agent-retrieval/server/infra/config/config_test.go
+++ b/adp/context-loader/agent-retrieval/server/infra/config/config_test.go
@@ -43,3 +43,23 @@ func TestParseAuthEnabled(t *testing.T) {
 		}
 	})
 }
+
+func TestContextLoaderKNPEPConfigDefaultsAndEnvironment(t *testing.T) {
+	conf := &Config{}
+	if err := conf.localConfig("/path/that/does/not/exist"); err == nil {
+		t.Fatal("expected missing fixture error")
+	}
+	if conf.Auth.ContextLoaderKNPEPEnabled {
+		t.Fatal("context-loader KN PEP must default to disabled")
+	}
+	if conf.Auth.ResourceFilterChunkSize != 200 {
+		t.Fatalf("default chunk size = %d, want 200", conf.Auth.ResourceFilterChunkSize)
+	}
+
+	t.Setenv("CONTEXT_LOADER_KN_PEP_ENABLED", "true")
+	t.Setenv("CONTEXT_LOADER_KN_PEP_CHUNK_SIZE", "73")
+	overrideWithEnv(conf)
+	if !conf.Auth.ContextLoaderKNPEPEnabled || conf.Auth.ResourceFilterChunkSize != 73 {
+		t.Fatalf("environment override failed: %+v", conf.Auth)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/errors/error.go
+++ b/adp/context-loader/agent-retrieval/server/infra/errors/error.go
@@ -9,6 +9,7 @@ package errors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,6 +18,30 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/localize"
 )
+
+// HTTPStatus returns the status carried by a public HTTPError.
+func HTTPStatus(err error) (int, bool) {
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		return 0, false
+	}
+	return httpErr.HTTPCode, true
+}
+
+// IsAuthorizationError identifies statuses that must never be flattened into a
+// successful retrieval fallback while the KN PEP is enabled.
+func IsAuthorizationError(err error) bool {
+	status, ok := HTTPStatus(err)
+	if !ok {
+		return false
+	}
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusServiceUnavailable:
+		return true
+	default:
+		return false
+	}
+}
 
 // HTTPError represents a public HTTP error.
 type HTTPError struct {

--- a/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/drivenadapters.go
@@ -274,8 +274,8 @@ type KnSearchScope struct {
 // KnSearchReq kn_search request
 type KnSearchReq struct {
 	// Header Parameters
-	XAccountID   string `header:"x-account-id"`
-	XAccountType string `header:"x-account-type"`
+	XAccountID   string `json:"-" header:"x-account-id"`
+	XAccountType string `json:"-" header:"x-account-type"`
 
 	// Body Parameters - use any to avoid defining complex structures explicitly
 	// Corresponds to the complete request structure of data-retrieval interface

--- a/adp/context-loader/agent-retrieval/server/interfaces/permission.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/permission.go
@@ -1,0 +1,53 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import "context"
+
+const (
+	PermissionResourceTypeObjectType = "object_type"
+	PermissionOperationQueryData     = "query_data"
+)
+
+// PermissionResource is one concrete bkn-safe authorization resource.
+type PermissionResource struct {
+	Type string `json:"type"`
+	ID   string `json:"id"`
+}
+
+// PermissionFilterRequest is bkn-safe's mixed-resource filter contract.
+type PermissionFilterRequest struct {
+	AccessorID           string               `json:"accessor_id"`
+	Resources            []PermissionResource `json:"resources"`
+	VisibilityOperations []string             `json:"visibility_operations"`
+	CandidateOperations  []string             `json:"candidate_operations"`
+}
+
+// PermissionFilterResult is one allowed resource returned by bkn-safe.
+type PermissionFilterResult struct {
+	ResourceType string   `json:"resource_type"`
+	ResourceID   string   `json:"resource_id"`
+	Operations   []string `json:"operations"`
+}
+
+// PermissionFilterResponse keeps Resources as a pointer so an omitted field is
+// distinguishable from the valid empty result used for deny-all and disabled
+// accounts.
+type PermissionFilterResponse struct {
+	Resources *[]PermissionFilterResult `json:"resources"`
+}
+
+// PermissionAccess is the outbound bkn-safe resource-filter boundary.
+type PermissionAccess interface {
+	FilterResources(ctx context.Context, request PermissionFilterRequest) (PermissionFilterResponse, error)
+}
+
+// QueryCandidateAuthorizer filters server-generated Object Type candidates
+// before context-loader fans out instance queries. It authorizes only the
+// primary Object Type; ontology-query remains responsible for every actual data
+// dependency.
+type QueryCandidateAuthorizer interface {
+	FilterObjectTypeIDs(ctx context.Context, knID string, candidateIDs []string) ([]string, error)
+}

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_instance.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_instance.go
@@ -11,8 +11,8 @@ package interfaces
 // Depth(max_instances_per_type). Candidate pool size, vector sub-condition budget, correlation threshold and other operational levels.
 // Parameters are not entered here - the Agent cannot determine how to adjust them. If you want to adjust them, go to kn_search's retrieval_config.
 type SearchInstanceReq struct {
-	XAccountID   string `header:"x-account-id"`
-	XAccountType string `header:"x-account-type"`
+	XAccountID   string `json:"-" header:"x-account-id"`
+	XAccountType string `json:"-" header:"x-account-type"`
 	XKnID        string `header:"x-kn-id"`
 
 	Query string `json:"query" validate:"required"`

--- a/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/search_schema.go
@@ -8,8 +8,8 @@ package interfaces
 
 // SearchSchemaReq search_schema standard request
 type SearchSchemaReq struct {
-	XAccountID   string `header:"x-account-id"`
-	XAccountType string `header:"x-account-type"`
+	XAccountID   string `json:"-" header:"x-account-id"`
+	XAccountType string `json:"-" header:"x-account-type"`
 	XKnID        string `header:"x-kn-id"`
 
 	Query        string             `json:"query" validate:"required"`

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index.go
@@ -39,10 +39,11 @@ var validSteps = map[string]struct{}{
 
 // KnMetricsService metric visibility and metric access.
 type KnMetricsService interface {
-	// AttachRelatedMetrics attaches the metrics under its scope to the object type (failed to downgrade to not attached).
-	AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType)
+	// AttachRelatedMetrics attaches the metrics under its scope to the object type.
+	// Legacy mode degrades failures; PEP mode returns them.
+	AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) error
 	// AttachRelatedMetricCounts Attach only counts, used for progressive drill-down of get_kn_detail.
-	AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType)
+	AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) error
 	// QueryMetric takes the number based on the metric's own semantics.
 	QueryMetric(ctx context.Context, req *interfaces.QueryMetricReq) (*interfaces.QueryMetricResp, error)
 }
@@ -51,6 +52,7 @@ type knMetricsService struct {
 	logger        interfaces.Logger
 	bknBackend    interfaces.BknBackendAccess
 	ontologyQuery interfaces.DrivenOntologyQuery
+	pepEnabled    bool
 }
 
 var (
@@ -66,6 +68,7 @@ func NewKnMetricsService() KnMetricsService {
 			logger:        conf.GetLogger(),
 			bknBackend:    drivenadapters.NewBknBackendAccess(),
 			ontologyQuery: drivenadapters.NewOntologyQueryAccess(),
+			pepEnabled:    conf.Auth.ContextLoaderKNPEPEnabled,
 		}
 	})
 	return instance
@@ -77,14 +80,25 @@ func NewKnMetricsServiceWith(logger interfaces.Logger, bkn interfaces.BknBackend
 	return &knMetricsService{logger: logger, bknBackend: bkn, ontologyQuery: oq}
 }
 
+// NewKnMetricsServiceWithPEP injects dependencies and the rollout state for focused tests.
+func NewKnMetricsServiceWithPEP(logger interfaces.Logger, bkn interfaces.BknBackendAccess,
+	oq interfaces.DrivenOntologyQuery, pepEnabled bool,
+) KnMetricsService {
+	return &knMetricsService{logger: logger, bknBackend: bkn, ontologyQuery: oq, pepEnabled: pepEnabled}
+}
+
 // AttachRelatedMetrics distributes metrics to each object type according to scope_ref.
 //
-// Failure to get the index is not fatal: the object type definition itself has been obtained, and marking the entire get_object_types as failed will only.
-// The Agent cannot even read the schema. Downgrade to "no related_metrics" and leave logs.
-func (s *knMetricsService) AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) {
-	byScope := s.metricsByScope(ctx, knID, objectTypes)
-	if byScope == nil {
-		return
+// Legacy mode keeps metric enrichment best-effort. PEP mode cannot distinguish
+// a registry outage from an authorization dependency failure, so it fails closed.
+func (s *knMetricsService) AttachRelatedMetrics(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) error {
+	byScope, err := s.metricsByScope(ctx, knID, objectTypes)
+	if err != nil {
+		if s.pepEnabled {
+			return err
+		}
+		s.warnf(ctx, "[KnMetrics] list metrics for kn=%s failed, object types answered without metrics: %v", knID, err)
+		return nil
 	}
 	for _, ot := range objectTypes {
 		if ot == nil {
@@ -93,13 +107,18 @@ func (s *knMetricsService) AttachRelatedMetrics(ctx context.Context, knID string
 		ot.RelatedMetrics = byScope[ot.ID]
 		ot.RelatedMetricCount = len(ot.RelatedMetrics)
 	}
+	return nil
 }
 
 // AttachRelatedMetricCounts only writes counts, not details (used for get_kn_detail summary).
-func (s *knMetricsService) AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) {
-	byScope := s.metricsByScope(ctx, knID, objectTypes)
-	if byScope == nil {
-		return
+func (s *knMetricsService) AttachRelatedMetricCounts(ctx context.Context, knID string, objectTypes []*interfaces.ObjectType) error {
+	byScope, err := s.metricsByScope(ctx, knID, objectTypes)
+	if err != nil {
+		if s.pepEnabled {
+			return err
+		}
+		s.warnf(ctx, "[KnMetrics] list metrics for kn=%s failed, object types answered without metrics: %v", knID, err)
+		return nil
 	}
 	for _, ot := range objectTypes {
 		if ot == nil {
@@ -107,11 +126,12 @@ func (s *knMetricsService) AttachRelatedMetricCounts(ctx context.Context, knID s
 		}
 		ot.RelatedMetricCount = len(byScope[ot.ID])
 	}
+	return nil
 }
 
-// metricsByScope retrieves the metrics under this batch of object types in batches at one time and sorts them according to scope_ref; returns nil on failure.
+// metricsByScope retrieves the metrics under this batch of object types and groups them by scope_ref.
 func (s *knMetricsService) metricsByScope(ctx context.Context, knID string,
-	objectTypes []*interfaces.ObjectType) map[string][]*interfaces.RelatedMetric {
+	objectTypes []*interfaces.ObjectType) (map[string][]*interfaces.RelatedMetric, error) {
 	ids := make([]string, 0, len(objectTypes))
 	for _, ot := range objectTypes {
 		if ot != nil && strings.TrimSpace(ot.ID) != "" {
@@ -119,13 +139,12 @@ func (s *knMetricsService) metricsByScope(ctx context.Context, knID string,
 		}
 	}
 	if len(ids) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	metrics, err := s.bknBackend.ListMetricsByObjectTypes(ctx, knID, ids)
 	if err != nil {
-		s.warnf(ctx, "[KnMetrics] list metrics for kn=%s failed, object types answered without metrics: %v", knID, err)
-		return nil
+		return nil, err
 	}
 
 	byScope := make(map[string][]*interfaces.RelatedMetric, len(ids))
@@ -135,7 +154,7 @@ func (s *knMetricsService) metricsByScope(ctx context.Context, knID string,
 		}
 		byScope[m.ScopeRef] = append(byScope[m.ScopeRef], m)
 	}
-	return byScope
+	return byScope, nil
 }
 
 // QueryMetric forwards ontology-query's metric fetching endpoint after verifying the input parameters.

--- a/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knmetrics/index_test.go
@@ -7,10 +7,12 @@ package knmetrics
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
 
+	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
@@ -110,6 +112,38 @@ func TestAttachRelatedMetricCounts(t *testing.T) {
 		convey.So(ots[0].RelatedMetrics, convey.ShouldBeNil)
 		convey.So(ots[1].RelatedMetricCount, convey.ShouldEqual, 0)
 	})
+}
+
+func TestAttachRelatedMetrics_PEPFailureIsNotDowngraded(t *testing.T) {
+	ctx := context.Background()
+	authErr := infraerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable, "safe unavailable")
+	bkn := &stubBknBackend{err: authErr}
+	svc := NewKnMetricsServiceWithPEP(nil, bkn, nil, true)
+
+	err := svc.AttachRelatedMetrics(ctx, "kn1", []*interfaces.ObjectType{{ID: "ot1"}})
+	if !errors.Is(err, authErr) {
+		t.Fatalf("expected authorization dependency error, got %v", err)
+	}
+}
+
+func TestAttachRelatedMetrics_PEPUnknownFailureIsNotDowngraded(t *testing.T) {
+	dependencyErr := errors.New("connection reset")
+	bkn := &stubBknBackend{err: dependencyErr}
+	svc := NewKnMetricsServiceWithPEP(nil, bkn, nil, true)
+
+	err := svc.AttachRelatedMetrics(context.Background(), "kn1", []*interfaces.ObjectType{{ID: "ot1"}})
+	if !errors.Is(err, dependencyErr) {
+		t.Fatalf("expected protected dependency error, got %v", err)
+	}
+}
+
+func TestAttachRelatedMetricCounts_LegacyFailureStillDegrades(t *testing.T) {
+	bkn := &stubBknBackend{err: errors.New("backend down")}
+	svc := NewKnMetricsServiceWithPEP(nil, bkn, nil, false)
+
+	if err := svc.AttachRelatedMetricCounts(context.Background(), "kn1", []*interfaces.ObjectType{{ID: "ot1"}}); err != nil {
+		t.Fatalf("legacy rollout state should keep best-effort behavior, got %v", err)
+	}
 }
 
 func TestQueryMetric(t *testing.T) {

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
 	infraErr "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
@@ -94,8 +95,9 @@ type KnResourcesService interface {
 }
 
 type knResourcesService struct {
-	vega interfaces.DrivenVega
-	bkn  interfaces.BknBackendAccess
+	vega       interfaces.DrivenVega
+	bkn        interfaces.BknBackendAccess
+	pepEnabled bool
 }
 
 var (
@@ -106,9 +108,11 @@ var (
 // NewKnResourcesService create KnResourcesService singleton.
 func NewKnResourcesService() KnResourcesService {
 	once.Do(func() {
+		conf := config.NewConfigLoader()
 		instance = &knResourcesService{
-			vega: drivenadapters.NewVegaAccess(),
-			bkn:  drivenadapters.NewBknBackendAccess(),
+			vega:       drivenadapters.NewVegaAccess(),
+			bkn:        drivenadapters.NewBknBackendAccess(),
+			pepEnabled: conf.Auth.ContextLoaderKNPEPEnabled,
 		}
 	})
 	return instance
@@ -117,6 +121,13 @@ func NewKnResourcesService() KnResourcesService {
 // NewKnResourcesServiceWith injection dependency creation (for testing).
 func NewKnResourcesServiceWith(vega interfaces.DrivenVega, bkn interfaces.BknBackendAccess) KnResourcesService {
 	return &knResourcesService{vega: vega, bkn: bkn}
+}
+
+// NewKnResourcesServiceWithPEP injects dependencies and the rollout state for focused tests.
+func NewKnResourcesServiceWithPEP(vega interfaces.DrivenVega, bkn interfaces.BknBackendAccess,
+	pepEnabled bool,
+) KnResourcesService {
+	return &knResourcesService{vega: vega, bkn: bkn, pepEnabled: pepEnabled}
 }
 
 // ListResources lists queryable data resources (output condensed fields; type is vega category).
@@ -136,6 +147,10 @@ func (s *knResourcesService) ListResources(ctx context.Context, req *ListResourc
 	})
 	if err != nil {
 		return nil, err
+	}
+	if vegaResp == nil {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+			"vega returned an incomplete protected response")
 	}
 
 	out := &ListResourcesResp{
@@ -172,6 +187,10 @@ func (s *knResourcesService) listByKnowledgeNetwork(ctx context.Context, knID, t
 
 	out := &ListResourcesResp{Entries: make([]ResourceLite, 0)}
 	if detail == nil {
+		if s.pepEnabled {
+			return nil, infraErr.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+				"BKN returned an incomplete protected response")
+		}
 		return out, nil
 	}
 
@@ -211,8 +230,9 @@ func (s *knResourcesService) listByKnowledgeNetwork(ctx context.Context, knID, t
 		targets = append(targets, target{objectTypeID: ot.ID, resourceID: resourceID})
 	}
 
-	// Concurrent retrieval is limited. A single failure will only fall into missing, and the entire call cannot fail - a dangling binding.
-	// It shouldn't drag down the other dozens of tables.
+	// Retrieval is bounded and stable by target position. Legacy mode classifies
+	// isolated failures as missing; PEP mode omits explicit 403 denials, preserves
+	// authoritative 404s, and fails the whole aggregate on every other failure.
 	type fetched struct {
 		resource *interfaces.VegaResource
 		err      error
@@ -235,7 +255,20 @@ func (s *knResourcesService) listByKnowledgeNetwork(ctx context.Context, knID, t
 	var firstFetchErr error
 	for i, t := range targets {
 		r := results[i]
-		if r.err != nil || r.resource == nil {
+		if r.err != nil {
+			if s.pepEnabled {
+				status, hasStatus := infraErr.HTTPStatus(r.err)
+				switch {
+				case hasStatus && status == http.StatusForbidden:
+					// A denied physical resource is not a missing/stale diagnostic:
+					// exposing the binding would reveal a resource the caller cannot view.
+					continue
+				case hasStatus && status == http.StatusNotFound:
+					// A genuine not-found remains a modelling diagnostic below.
+				default:
+					return nil, r.err
+				}
+			}
 			if firstFetchErr == nil && r.err != nil {
 				firstFetchErr = r.err
 			}
@@ -243,6 +276,18 @@ func (s *knResourcesService) listByKnowledgeNetwork(ctx context.Context, knID, t
 				ObjectTypeID: t.objectTypeID,
 				ResourceID:   t.resourceID,
 				Reason:       unresolvedReason(r.err),
+			})
+			continue
+		}
+		if r.resource == nil {
+			if s.pepEnabled {
+				return nil, infraErr.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+					"vega returned an incomplete protected response")
+			}
+			out.Missing = append(out.Missing, UnresolvedBinding{
+				ObjectTypeID: t.objectTypeID,
+				ResourceID:   t.resourceID,
+				Reason:       unresolvedReason(nil),
 			})
 			continue
 		}
@@ -261,13 +306,14 @@ func (s *knResourcesService) listByKnowledgeNetwork(ctx context.Context, knID, t
 			CatalogID:  r.resource.CatalogID,
 		})
 	}
-	// There is binding, none is retrieved, and the failure is not caused by a single resource such as "this resource is gone/no permissions".
+	// In legacy mode, when every binding fails for something other than a
+	// per-resource 404/403, surface the outage instead of returning an empty list.
 	// That basically leaves the entire game unavailable (vega hangs, ctx times out). At this time, "success + empty list" is returned.
 	// The caller must regard "the backend is down" as "this network has no tables" - exactly what this issue wants to eliminate.
 	// Dumb failure. Transparently transmit the first error so that the downstream status code and reason can surface.
 	//
-	// On the contrary, 404/403 still remains in missing: only one table is bound to a network, and this table happened to be deleted.
-	// That's a solid modeling fact and shouldn't be disguised as a service failure.
+	// PEP mode has already returned on outages and omitted 403 bindings above;
+	// only an authoritative 404 can remain in missing there.
 	if len(targets) > 0 && len(out.Missing) == len(targets) && isDownstreamOutage(firstFetchErr) {
 		return nil, firstFetchErr
 	}
@@ -310,6 +356,10 @@ func (s *knResourcesService) DescribeResource(ctx context.Context, resourceID st
 	res, err := s.vega.GetResource(ctx, resourceID)
 	if err != nil {
 		return nil, err
+	}
+	if res == nil {
+		return nil, infraErr.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+			"vega returned an incomplete protected response")
 	}
 
 	connectorType, err := s.vega.GetResourceConnectorType(ctx, resourceID)

--- a/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knresources/index_test.go
@@ -333,6 +333,73 @@ func TestListResources_ByKnID_PartialFailureStillReturnsTheRest(t *testing.T) {
 	}
 }
 
+func TestListResources_ByKnID_PEPDeniedBindingIsOmitted(t *testing.T) {
+	ctx := context.Background()
+	fake := &fakeVega{
+		byID: map[string]*interfaces.VegaResource{
+			"r1": {ID: "r1", Name: "orders", Category: "table"},
+		},
+		errByID: map[string]error{
+			"secret": infraErr.DefaultHTTPError(ctx, http.StatusForbidden, "forbidden"),
+		},
+	}
+	bkn := &fakeBkn{detail: &interfaces.KnowledgeNetworkDetail{
+		ObjectTypes: []*interfaces.ObjectType{
+			ot("order", "resource", "r1"),
+			ot("secret_order", "resource", "secret"),
+		},
+	}}
+	svc := NewKnResourcesServiceWithPEP(fake, bkn, true)
+
+	resp, err := svc.ListResources(ctx, &ListResourcesReq{KnID: "kn1"})
+	if err != nil {
+		t.Fatalf("an explicit resource denial should be filtered, got %v", err)
+	}
+	if len(resp.Entries) != 1 || resp.Entries[0].ResourceID != "r1" {
+		t.Fatalf("expected only the allowed resource, got %+v", resp)
+	}
+	if len(resp.Missing) != 0 {
+		t.Fatalf("denied binding must not leak through missing diagnostics: %+v", resp.Missing)
+	}
+}
+
+func TestListResources_ByKnID_PEPPartialDependencyFailureFailsWholeRequest(t *testing.T) {
+	ctx := context.Background()
+	downstreamErr := infraErr.DefaultHTTPError(ctx, http.StatusServiceUnavailable, "vega unavailable")
+	fake := &fakeVega{
+		byID: map[string]*interfaces.VegaResource{
+			"r1": {ID: "r1", Name: "orders", Category: "table"},
+		},
+		errByID: map[string]error{"r2": downstreamErr},
+	}
+	bkn := &fakeBkn{detail: &interfaces.KnowledgeNetworkDetail{
+		ObjectTypes: []*interfaces.ObjectType{
+			ot("order", "resource", "r1"),
+			ot("shipment", "resource", "r2"),
+		},
+	}}
+	svc := NewKnResourcesServiceWithPEP(fake, bkn, true)
+
+	_, err := svc.ListResources(ctx, &ListResourcesReq{KnID: "kn1"})
+	if !errors.Is(err, downstreamErr) {
+		t.Fatalf("expected the whole aggregate to fail, got %v", err)
+	}
+}
+
+func TestListResources_ByKnID_PEPIncompleteResourceFailsWholeRequest(t *testing.T) {
+	fake := &fakeVega{byID: map[string]*interfaces.VegaResource{"r1": nil}}
+	bkn := &fakeBkn{detail: &interfaces.KnowledgeNetworkDetail{
+		ObjectTypes: []*interfaces.ObjectType{ot("order", "resource", "r1")},
+	}}
+	svc := NewKnResourcesServiceWithPEP(fake, bkn, true)
+
+	resp, err := svc.ListResources(context.Background(), &ListResourcesReq{KnID: "kn1"})
+	status, ok := infraErr.HTTPStatus(err)
+	if resp != nil || !ok || status != http.StatusServiceUnavailable {
+		t.Fatalf("resp=%+v error=%v, want complete failure with 503", resp, err)
+	}
+}
+
 func TestListResources_ByKnID_AppliesTypeFilter(t *testing.T) {
 	fake := &fakeVega{byID: map[string]*interfaces.VegaResource{
 		"r1": {ID: "r1", Name: "orders", Category: "table"},

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/authorization.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/authorization.go
@@ -1,0 +1,79 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knsearch
+
+import (
+	"context"
+	"net/http"
+
+	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+func (s *localSearchImpl) knPEPEnabled() bool {
+	return s != nil && s.config != nil && s.config.Auth.ContextLoaderKNPEPEnabled
+}
+
+func (s *localSearchImpl) filterAuthorizedObjectTypes(ctx context.Context, knID string,
+	objectTypes []*interfaces.KnSearchObjectType,
+) ([]*interfaces.KnSearchObjectType, error) {
+	if s == nil || s.authorizer == nil {
+		return nil, infraerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+			"query authorization is not configured")
+	}
+	ids := make([]string, 0, len(objectTypes))
+	for _, objectType := range objectTypes {
+		if objectType != nil {
+			ids = append(ids, objectType.ConceptID)
+		}
+	}
+	allowedIDs, err := s.authorizer.FilterObjectTypeIDs(ctx, knID, ids)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(allowedIDs))
+	for _, id := range allowedIDs {
+		allowed[id] = struct{}{}
+	}
+	filtered := make([]*interfaces.KnSearchObjectType, 0, len(allowed))
+	for _, objectType := range objectTypes {
+		if objectType == nil {
+			continue
+		}
+		if _, ok := allowed[objectType.ConceptID]; ok {
+			filtered = append(filtered, objectType)
+		}
+	}
+	return filtered, nil
+}
+
+// fetchAuthorizedSampleData keeps schema visibility and data-query permission
+// independent. Object types denied query_data remain in the schema result, but
+// are removed from the candidate set before any ontology-query request is sent.
+func (s *localSearchImpl) fetchAuthorizedSampleData(ctx context.Context, knID string,
+	objectTypes []*interfaces.KnSearchObjectType, brief bool,
+) error {
+	targets := objectTypes
+	if s.knPEPEnabled() {
+		var err error
+		targets, err = s.filterAuthorizedObjectTypes(ctx, knID, objectTypes)
+		if err != nil {
+			return err
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	return s.fetchSampleData(ctx, knID, targets, brief)
+}
+
+func isAuthorizationError(err error) bool {
+	return infraerrors.IsAuthorizationError(err)
+}
+
+func protectedDependencyUnavailable(ctx context.Context, dependency string) error {
+	return infraerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+		dependency+" returned an incomplete protected response")
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/authorization_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/authorization_test.go
@@ -1,0 +1,196 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package knsearch
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+type stubQueryCandidateAuthorizer struct {
+	allowed      []string
+	err          error
+	gotKnID      string
+	gotCandidate []string
+	calls        int
+}
+
+func (s *stubQueryCandidateAuthorizer) FilterObjectTypeIDs(_ context.Context, knID string,
+	candidateIDs []string,
+) ([]string, error) {
+	s.calls++
+	s.gotKnID = knID
+	s.gotCandidate = append([]string(nil), candidateIDs...)
+	return append([]string(nil), s.allowed...), s.err
+}
+
+func pepSearch(authorizer interfaces.QueryCandidateAuthorizer, oq interfaces.DrivenOntologyQuery) *localSearchImpl {
+	return &localSearchImpl{
+		logger:        &mockLogger{},
+		config:        &config.Config{Auth: config.AuthorizationConfig{ContextLoaderKNPEPEnabled: true}},
+		ontologyQuery: oq,
+		authorizer:    authorizer,
+	}
+}
+
+func TestFilterAuthorizedObjectTypes_PreservesCandidateOrder(t *testing.T) {
+	authorizer := &stubQueryCandidateAuthorizer{allowed: []string{"ot3", "ot1"}}
+	svc := pepSearch(authorizer, nil)
+	candidates := []*interfaces.KnSearchObjectType{
+		{ConceptID: "ot1"}, {ConceptID: "ot2"}, {ConceptID: "ot3"},
+	}
+
+	got, err := svc.filterAuthorizedObjectTypes(context.Background(), "kn1", candidates)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	gotIDs := []string{got[0].ConceptID, got[1].ConceptID}
+	if !reflect.DeepEqual(gotIDs, []string{"ot1", "ot3"}) {
+		t.Fatalf("candidate order changed: %v", gotIDs)
+	}
+	if authorizer.gotKnID != "kn1" || !reflect.DeepEqual(authorizer.gotCandidate, []string{"ot1", "ot2", "ot3"}) {
+		t.Fatalf("unexpected authorization request: kn=%q ids=%v", authorizer.gotKnID, authorizer.gotCandidate)
+	}
+}
+
+func TestConceptRetrieval_PEPUsesTypedBKNEndpointsWithoutExportFallback(t *testing.T) {
+	backend := &mockBknBackend{
+		networkDetail:     &interfaces.KnowledgeNetworkDetail{ObjectTypes: []*interfaces.ObjectType{{ID: "export-only"}}},
+		objectTypesResp:   &interfaces.ObjectTypeConcepts{Entries: []*interfaces.ObjectType{{ID: "allowed", Name: "Allowed"}}},
+		relationTypesResp: &interfaces.RelationTypeConcepts{},
+		actionTypesResp:   &interfaces.ActionTypeConcepts{},
+	}
+	svc := pepSearch(&stubQueryCandidateAuthorizer{}, nil)
+	svc.bknBackend = backend
+	retrievalConfig := DefaultRetrievalConfig()
+
+	result, err := svc.conceptRetrieval(context.Background(), &interfaces.KnSearchLocalRequest{KnID: "kn1", Query: "allowed"},
+		retrievalConfig.ConceptRetrieval)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if backend.networkCalls != 0 || backend.objectTypesReq == nil || backend.relationTypesReq == nil || backend.actionTypesReq == nil {
+		t.Fatalf("unexpected BKN calls: export=%d object=%v relation=%v action=%v",
+			backend.networkCalls, backend.objectTypesReq, backend.relationTypesReq, backend.actionTypesReq)
+	}
+	if len(result.ObjectTypes) != 1 || result.ObjectTypes[0].ConceptID != "allowed" {
+		t.Fatalf("typed candidate result not used: %+v", result.ObjectTypes)
+	}
+}
+
+func TestConceptRetrieval_PEPRejectsIncompleteTypedResponse(t *testing.T) {
+	backend := &mockBknBackend{
+		objectTypesResp:   &interfaces.ObjectTypeConcepts{},
+		relationTypesResp: nil,
+		actionTypesResp:   &interfaces.ActionTypeConcepts{},
+	}
+	svc := pepSearch(&stubQueryCandidateAuthorizer{}, nil)
+	svc.bknBackend = backend
+	retrievalConfig := DefaultRetrievalConfig()
+
+	result, err := svc.conceptRetrieval(context.Background(), &interfaces.KnSearchLocalRequest{KnID: "kn1", Query: "query"},
+		retrievalConfig.ConceptRetrieval)
+	status, ok := infraerrors.HTTPStatus(err)
+	if result != nil || !ok || status != http.StatusServiceUnavailable {
+		t.Fatalf("result=%+v error=%v, want complete failure with 503", result, err)
+	}
+}
+
+func TestFetchAuthorizedSampleData_FiltersBeforeOntologyQuery(t *testing.T) {
+	authorizer := &stubQueryCandidateAuthorizer{allowed: []string{"allowed"}}
+	var queried []string
+	oq := &mockOntologyQuery{instancesFunc: func(req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+		queried = append(queried, req.OtID)
+		return &interfaces.QueryObjectInstancesResp{Data: []any{map[string]any{"id": req.OtID}}}, nil
+	}}
+	svc := pepSearch(authorizer, oq)
+	allowed := &interfaces.KnSearchObjectType{ConceptID: "allowed"}
+	denied := &interfaces.KnSearchObjectType{ConceptID: "denied"}
+
+	if err := svc.fetchAuthorizedSampleData(context.Background(), "kn1", []*interfaces.KnSearchObjectType{allowed, denied}, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(queried, []string{"allowed"}) {
+		t.Fatalf("denied object type reached ontology-query: %v", queried)
+	}
+	if allowed.SampleData == nil {
+		t.Fatal("allowed object type should receive sample data")
+	}
+	if denied.SampleData != nil {
+		t.Fatalf("denied object type must stay in schema without sample data: %+v", denied.SampleData)
+	}
+}
+
+func TestFetchAuthorizedSampleData_AuthorizationFailureStopsFanout(t *testing.T) {
+	ctx := context.Background()
+	authErr := infraerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable, "safe unavailable")
+	authorizer := &stubQueryCandidateAuthorizer{err: authErr}
+	oq := &mockOntologyQuery{instancesResp: &interfaces.QueryObjectInstancesResp{}}
+	svc := pepSearch(authorizer, oq)
+
+	err := svc.fetchAuthorizedSampleData(ctx, "kn1", []*interfaces.KnSearchObjectType{{ConceptID: "ot1"}}, false)
+	if !errors.Is(err, authErr) {
+		t.Fatalf("expected authorization error, got %v", err)
+	}
+	if oq.calls() != 0 {
+		t.Fatalf("ontology-query must not be called after authorization failure, calls=%d", oq.calls())
+	}
+}
+
+func TestFetchAuthorizedSampleData_IncompleteQueryResponseFailsClosed(t *testing.T) {
+	authorizer := &stubQueryCandidateAuthorizer{allowed: []string{"ot1"}}
+	oq := &mockOntologyQuery{instancesFunc: func(_ *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+		return nil, nil
+	}}
+	svc := pepSearch(authorizer, oq)
+
+	err := svc.fetchAuthorizedSampleData(context.Background(), "kn1", []*interfaces.KnSearchObjectType{{ConceptID: "ot1"}}, false)
+	status, ok := infraerrors.HTTPStatus(err)
+	if !ok || status != http.StatusServiceUnavailable {
+		t.Fatalf("error=%v, want 503", err)
+	}
+}
+
+func TestSemanticInstanceRetrieval_PEPFailureDoesNotReturnPartialNodes(t *testing.T) {
+	for _, status := range []int{http.StatusForbidden, http.StatusServiceUnavailable} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			ctx := context.Background()
+			dependencyErr := infraerrors.DefaultHTTPError(ctx, status, "ontology-query PEP failure")
+			authorizer := &stubQueryCandidateAuthorizer{allowed: []string{"ot1", "ot2"}}
+			oq := &mockOntologyQuery{instancesFunc: func(req *interfaces.QueryObjectInstancesReq) (*interfaces.QueryObjectInstancesResp, error) {
+				if req.OtID == "ot2" {
+					return nil, dependencyErr
+				}
+				return &interfaces.QueryObjectInstancesResp{Data: []any{
+					map[string]any{"instance_name": "visible", "_score": 1.0},
+				}}, nil
+			}}
+			svc := pepSearch(authorizer, oq)
+			matchOnly := []interfaces.KnOperationType{interfaces.KnOperationTypeMatch}
+			objectTypes := []*interfaces.KnSearchObjectType{
+				{ConceptID: "ot1", DataProperties: []*interfaces.KnSearchDataProperty{{Name: "name", Type: "text", ConditionOperations: matchOnly}}},
+				{ConceptID: "ot2", DataProperties: []*interfaces.KnSearchDataProperty{{Name: "name", Type: "text", ConditionOperations: matchOnly}}},
+			}
+			retrievalConfig := DefaultRetrievalConfig()
+			retrievalConfig.SemanticInstanceRetrieval.ObjectTypeConcurrency = 2
+
+			result, err := svc.semanticInstanceRetrieval(ctx, &interfaces.KnSearchLocalRequest{KnID: "kn1", Query: "visible"},
+				objectTypes, retrievalConfig)
+			if result != nil {
+				t.Fatalf("authorization failure must not return partial nodes: %+v", result)
+			}
+			if !errors.Is(err, dependencyErr) {
+				t.Fatalf("expected dependency error, got %v", err)
+			}
+		})
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/concept_retrieval.go
@@ -24,7 +24,8 @@ const objectTypeRelationMultiplier = 2
 // conceptRetrieval concept recall main logic.
 //
 // Routing strategy:
-// - When config.ConceptGroups is not empty, use conceptRetrievalByGroups: call BKN directly.
+// - When config.ConceptGroups is not empty or the KN PEP rollout is enabled, use
+// conceptRetrievalByGroups: call BKN directly.
 // of SearchObjectTypes/SearchRelationTypes/SearchActionTypes, grouped by BKN in.
 // Complete the recall within the scope, skipping the local full GetKnowledgeNetworkDetail and local filtering.
 // - When config.ConceptGroups is empty, follow the historical path: pull all network details -> optional rough call.
@@ -43,7 +44,7 @@ func (s *localSearchImpl) conceptRetrieval(
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer oteltrace.EndSpan(ctx, err)
 
-	if len(config.ConceptGroups) > 0 {
+	if s.knPEPEnabled() || len(config.ConceptGroups) > 0 {
 		return s.conceptRetrievalByGroups(ctx, req, config)
 	}
 
@@ -105,7 +106,9 @@ func (s *localSearchImpl) conceptRetrieval(
 
 	// 7. Get sample data (optional)
 	if boolValue(config.IncludeSampleData) && len(objectTypesLocal) > 0 {
-		s.fetchSampleData(ctx, req.KnID, objectTypesLocal, boolValue(config.SchemaBrief))
+		if err := s.fetchAuthorizedSampleData(ctx, req.KnID, objectTypesLocal, boolValue(config.SchemaBrief)); err != nil {
+			return nil, err
+		}
 	}
 
 	return &interfaces.KnSearchConceptResult{
@@ -116,7 +119,8 @@ func (s *localSearchImpl) conceptRetrieval(
 	}, nil
 }
 
-// conceptRetrievalByGroups is the concept recall path in the scenario where concept_groups is not empty.
+// conceptRetrievalByGroups is the typed BKN concept recall path used by
+// concept-group searches and by the KN PEP rollout.
 //
 // Design points:
 // - Directly call BKN's typed search API (SearchObjectTypes / SearchRelationTypes /.
@@ -163,6 +167,9 @@ func (s *localSearchImpl) conceptRetrievalByGroups(
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("[ConceptRetrieval][Groups] SearchActionTypes failed: %v", err)
 		return nil, err
+	}
+	if s.knPEPEnabled() && (objectResp == nil || relationResp == nil || actionResp == nil) {
+		return nil, protectedDependencyUnavailable(ctx, "BKN typed concept search")
 	}
 
 	var (
@@ -212,7 +219,9 @@ func (s *localSearchImpl) conceptRetrievalByGroups(
 	actionTypesLocal := s.convertActionTypesToLocal(actions, req.KnID, objects)
 
 	if boolValue(config.IncludeSampleData) && len(objectTypesLocal) > 0 {
-		s.fetchSampleData(ctx, req.KnID, objectTypesLocal, brief)
+		if err := s.fetchAuthorizedSampleData(ctx, req.KnID, objectTypesLocal, brief); err != nil {
+			return nil, err
+		}
 	}
 
 	return &interfaces.KnSearchConceptResult{
@@ -280,15 +289,35 @@ func (s *localSearchImpl) completeReferencedObjectTypes(
 
 	out := make([]*interfaces.ObjectType, 0, len(objects)+len(enriched))
 	out = append(out, objects...)
+	returned := make(map[string]struct{}, len(enriched))
 	for _, obj := range enriched {
 		if obj == nil || obj.ID == "" {
+			if s.knPEPEnabled() {
+				return nil, protectedDependencyUnavailable(ctx, "BKN object type detail")
+			}
 			continue
 		}
+		if _, requested := missingSeen[obj.ID]; !requested {
+			if s.knPEPEnabled() {
+				return nil, protectedDependencyUnavailable(ctx, "BKN object type detail")
+			}
+			continue
+		}
+		if _, duplicate := returned[obj.ID]; duplicate {
+			if s.knPEPEnabled() {
+				return nil, protectedDependencyUnavailable(ctx, "BKN object type detail")
+			}
+			continue
+		}
+		returned[obj.ID] = struct{}{}
 		if _, ok := known[obj.ID]; ok {
 			continue
 		}
 		known[obj.ID] = struct{}{}
 		out = append(out, obj)
+	}
+	if s.knPEPEnabled() && len(returned) != len(missingIDs) {
+		return nil, protectedDependencyUnavailable(ctx, "BKN object type detail")
 	}
 
 	return out, nil
@@ -1107,7 +1136,9 @@ func (s *localSearchImpl) pruneProperties(
 }
 
 // fetchSampleData gets sample data.
-func (s *localSearchImpl) fetchSampleData(ctx context.Context, knID string, objectTypes []*interfaces.KnSearchObjectType, schemaBrief bool) {
+func (s *localSearchImpl) fetchSampleData(ctx context.Context, knID string,
+	objectTypes []*interfaces.KnSearchObjectType, schemaBrief bool,
+) error {
 	for _, obj := range objectTypes {
 		// Call instance retrieval to obtain a piece of sample data.
 		req := &interfaces.QueryObjectInstancesReq{
@@ -1121,6 +1152,15 @@ func (s *localSearchImpl) fetchSampleData(ctx context.Context, knID string, obje
 		resp, err := s.ontologyQuery.QueryObjectInstances(ctx, req)
 		if err != nil {
 			s.logger.WithContext(ctx).Warnf("[FetchSampleData] Failed to fetch sample for %s: %v", obj.ConceptID, err)
+			if s.knPEPEnabled() && isAuthorizationError(err) {
+				return err
+			}
+			continue
+		}
+		if resp == nil {
+			if s.knPEPEnabled() {
+				return protectedDependencyUnavailable(ctx, "ontology-query")
+			}
 			continue
 		}
 
@@ -1141,6 +1181,7 @@ func (s *localSearchImpl) fetchSampleData(ctx context.Context, knID string, obje
 			}
 		}
 	}
+	return nil
 }
 
 // ==================== Type conversion function ====================.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/index.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+	permissionlogic "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/logics/permission"
 )
 
 // localSearchImpl local search implementation body.
@@ -23,6 +24,7 @@ type localSearchImpl struct {
 	bknBackend    interfaces.BknBackendAccess
 	ontologyQuery interfaces.DrivenOntologyQuery
 	rerankClient  interfaces.DrivenMFModelAPIClient
+	authorizer    interfaces.QueryCandidateAuthorizer
 }
 
 var (
@@ -40,6 +42,7 @@ func NewLocalSearchService() interfaces.IKnSearchLocalService {
 			bknBackend:    drivenadapters.NewBknBackendAccess(),
 			ontologyQuery: drivenadapters.NewOntologyQueryAccess(),
 			rerankClient:  drivenadapters.NewMFModelAPIClient(),
+			authorizer:    permissionlogic.NewQueryCandidateAuthorizer(configLoader),
 		}
 	})
 	return localSearchService

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/semantic_instance_retrieval.go
@@ -65,6 +65,18 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 		}, nil
 	}
 
+	if s.knPEPEnabled() {
+		objectTypes, err = s.filterAuthorizedObjectTypes(ctx, req.KnID, objectTypes)
+		if err != nil {
+			return nil, err
+		}
+		if len(objectTypes) == 0 {
+			return &interfaces.KnSearchSemanticInstanceResult{
+				Message: infraErr.LocalizedDetail(ctx, "NoSearchableObjectTypes"),
+			}, nil
+		}
+	}
+
 	instanceConfig := config.SemanticInstanceRetrieval
 	propertyConfig := config.PropertyFilter
 
@@ -125,6 +137,7 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 	// Results are collected per position, not appended as they arrive, so the response does not depend
 	// on which object type happened to answer first.
 	perType := make([][]*interfaces.KnSearchNode, len(objectTypes))
+	perTypeErrs := make([]error, len(objectTypes))
 	concurrency := instanceConfig.ObjectTypeConcurrency
 	if concurrency <= 0 {
 		concurrency = 1
@@ -148,12 +161,18 @@ func (s *localSearchImpl) semanticInstanceRetrieval(
 				// whose declared operators lie must not empty the whole result.
 				s.logger.WithContext(ctx).Warnf("[SemanticInstanceRetrieval] Failed to retrieve instances for %s: %v",
 					objType.ConceptID, err)
+				perTypeErrs[idx] = err
 				return
 			}
 			perType[idx] = nodes
 		}(i, objType)
 	}
 	wg.Wait()
+	for _, queryErr := range perTypeErrs {
+		if s.knPEPEnabled() && queryErr != nil && isAuthorizationError(queryErr) {
+			return nil, queryErr
+		}
+	}
 
 	var allNodes []*interfaces.KnSearchNode
 	var maxScore float64
@@ -442,6 +461,9 @@ func (s *localSearchImpl) retrieveInstancesFused(
 	live := make([]channelOutcome, 0, len(outcomes))
 	for _, o := range outcomes {
 		if o.err != nil {
+			if s.knPEPEnabled() && isAuthorizationError(o.err) {
+				return nil, o.err
+			}
 			// Failure of a single channel does not destroy the entire object type. Knn returns 400 when hitting a field without vector mapping.
 			// (condition_operations is declared by the network builder and stored as it is, so it is not trustworthy). In the past, this 400.
 			// It will fail together with match, and no instance of the object type will be recalled.
@@ -509,6 +531,12 @@ func (s *localSearchImpl) fetchChannel(
 	resp, err := s.ontologyQuery.QueryObjectInstances(ctx, queryReq)
 	if err != nil {
 		return channelOutcome{name: ch.name, err: fmt.Errorf("query instances failed: %w", err)}
+	}
+	if resp == nil {
+		if s.knPEPEnabled() {
+			return channelOutcome{name: ch.name, err: protectedDependencyUnavailable(ctx, "ontology-query")}
+		}
+		return channelOutcome{name: ch.name, err: fmt.Errorf("ontology-query returned an empty response")}
 	}
 
 	out := channelOutcome{name: ch.name, nodes: make([]*interfaces.KnSearchNode, 0, len(resp.Data))}
@@ -598,6 +626,12 @@ func (s *localSearchImpl) retrieveInstancesSingleQuery(
 	resp, err := s.ontologyQuery.QueryObjectInstances(ctx, queryReq)
 	if err != nil {
 		return nil, fmt.Errorf("query instances failed: %w", err)
+	}
+	if resp == nil {
+		if s.knPEPEnabled() {
+			return nil, protectedDependencyUnavailable(ctx, "ontology-query")
+		}
+		return nil, fmt.Errorf("ontology-query returned an empty response")
 	}
 
 	// Convert to KnSearchNode format.

--- a/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
+++ b/adp/context-loader/agent-retrieval/server/logics/knsearch/service.go
@@ -80,6 +80,9 @@ func (s *localSearchImpl) Search(ctx context.Context, req *interfaces.KnSearchLo
 
 	instanceResult, instanceErr := s.semanticInstanceRetrieval(ctx, req, conceptResult.ObjectTypes, mergedConfig)
 	if instanceErr != nil {
+		if s.knPEPEnabled() && isAuthorizationError(instanceErr) {
+			return nil, instanceErr
+		}
 		// Instance recall failure does not bring down the entire search: the Schema itself is already a useful result and is returned in a degraded manner.
 		s.logger.WithContext(ctx).Warnf("[KnSearchLocal] Semantic instance retrieval failed, degrade to schema-only: %v", instanceErr)
 		trimToIndexBackedOperations(response.ObjectTypes, req.IndexOpsOnly)

--- a/adp/context-loader/agent-retrieval/server/logics/permission/index.go
+++ b/adp/context-loader/agent-retrieval/server/logics/permission/index.go
@@ -1,0 +1,164 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package permission implements context-loader's narrow KN query-candidate
+// authorization boundary.
+package permission
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/drivenadapters"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/config"
+	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+const defaultResourceFilterChunkSize = 200
+
+type queryCandidateAuthorizer struct {
+	access    interfaces.PermissionAccess
+	chunkSize int
+}
+
+// NewQueryCandidateAuthorizer wires the production Safe adapter.
+func NewQueryCandidateAuthorizer(conf *config.Config) interfaces.QueryCandidateAuthorizer {
+	chunkSize := defaultResourceFilterChunkSize
+	if conf != nil && conf.Auth.ResourceFilterChunkSize > 0 {
+		chunkSize = conf.Auth.ResourceFilterChunkSize
+	}
+	return NewQueryCandidateAuthorizerWith(drivenadapters.NewPermissionAccess(conf), chunkSize)
+}
+
+// NewQueryCandidateAuthorizerWith allows focused tests to inject the outbound boundary.
+func NewQueryCandidateAuthorizerWith(access interfaces.PermissionAccess, chunkSize int) interfaces.QueryCandidateAuthorizer {
+	if chunkSize <= 0 {
+		chunkSize = defaultResourceFilterChunkSize
+	}
+	return &queryCandidateAuthorizer{access: access, chunkSize: chunkSize}
+}
+
+func (a *queryCandidateAuthorizer) FilterObjectTypeIDs(ctx context.Context,
+	knID string, candidateIDs []string,
+) ([]string, error) {
+	if len(candidateIDs) == 0 {
+		return []string{}, nil
+	}
+	account, ok := trustedAccount(ctx)
+	if !ok {
+		return nil, infraerrors.DefaultHTTPError(ctx, http.StatusUnauthorized, "request subject is missing or invalid")
+	}
+	knID = strings.TrimSpace(knID)
+	if !validAuthorizationID(knID) {
+		return nil, infraerrors.DefaultHTTPError(ctx, http.StatusBadRequest, "invalid knowledge network id")
+	}
+	if a == nil || a.access == nil {
+		return nil, permissionUnavailable(ctx)
+	}
+
+	normalized := make([]string, 0, len(candidateIDs))
+	seen := make(map[string]struct{}, len(candidateIDs))
+	for _, candidateID := range candidateIDs {
+		candidateID = strings.TrimSpace(candidateID)
+		if !validAuthorizationID(candidateID) {
+			return nil, permissionUnavailable(ctx)
+		}
+		if _, exists := seen[candidateID]; exists {
+			continue
+		}
+		seen[candidateID] = struct{}{}
+		normalized = append(normalized, candidateID)
+	}
+
+	allowed := make(map[string]struct{}, len(normalized))
+	for start := 0; start < len(normalized); start += a.chunkSize {
+		end := start + a.chunkSize
+		if end > len(normalized) {
+			end = len(normalized)
+		}
+		resources := make([]interfaces.PermissionResource, 0, end-start)
+		requested := make(map[string]struct{}, end-start)
+		for _, candidateID := range normalized[start:end] {
+			canonicalID := knID + "/" + candidateID
+			resources = append(resources, interfaces.PermissionResource{
+				Type: interfaces.PermissionResourceTypeObjectType,
+				ID:   canonicalID,
+			})
+			requested[canonicalID] = struct{}{}
+		}
+
+		response, err := a.access.FilterResources(ctx, interfaces.PermissionFilterRequest{
+			AccessorID:           account.AccountID,
+			Resources:            resources,
+			VisibilityOperations: []string{interfaces.PermissionOperationQueryData},
+			CandidateOperations:  []string{interfaces.PermissionOperationQueryData},
+		})
+		if err != nil || response.Resources == nil {
+			return nil, permissionUnavailable(ctx)
+		}
+		returned := make(map[string]struct{}, len(*response.Resources))
+		for _, result := range *response.Resources {
+			if result.ResourceType != interfaces.PermissionResourceTypeObjectType {
+				return nil, permissionUnavailable(ctx)
+			}
+			if _, exists := requested[result.ResourceID]; !exists {
+				return nil, permissionUnavailable(ctx)
+			}
+			if _, duplicate := returned[result.ResourceID]; duplicate {
+				return nil, permissionUnavailable(ctx)
+			}
+			if !contains(result.Operations, interfaces.PermissionOperationQueryData) {
+				return nil, permissionUnavailable(ctx)
+			}
+			returned[result.ResourceID] = struct{}{}
+			allowed[result.ResourceID] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(allowed))
+	for _, candidateID := range normalized {
+		if _, ok := allowed[knID+"/"+candidateID]; ok {
+			result = append(result, candidateID)
+		}
+	}
+	return result, nil
+}
+
+func trustedAccount(ctx context.Context) (*interfaces.AccountAuthContext, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+	account, ok := common.GetAccountAuthContextFromCtx(ctx)
+	if !ok || account == nil || account.AccountID == "" ||
+		strings.TrimSpace(account.AccountID) != account.AccountID || strings.ContainsAny(account.AccountID, " \t\r\n*") {
+		return nil, false
+	}
+	switch account.AccountType {
+	case interfaces.AccessorTypeUser, interfaces.AccessorTypeApp:
+		return account, true
+	default:
+		return nil, false
+	}
+}
+
+func validAuthorizationID(id string) bool {
+	return id != "" && strings.TrimSpace(id) == id && !strings.ContainsAny(id, "/*")
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func permissionUnavailable(ctx context.Context) error {
+	return infraerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable,
+		"query authorization is unavailable")
+}

--- a/adp/context-loader/agent-retrieval/server/logics/permission/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/permission/index_test.go
@@ -1,0 +1,164 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permission
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	infraerrors "github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+type fakePermissionAccess struct {
+	allowed  map[string]bool
+	requests []interfaces.PermissionFilterRequest
+	err      error
+	errAt    int
+	mutate   func(*[]interfaces.PermissionFilterResult)
+}
+
+func (f *fakePermissionAccess) FilterResources(_ context.Context,
+	request interfaces.PermissionFilterRequest,
+) (interfaces.PermissionFilterResponse, error) {
+	f.requests = append(f.requests, request)
+	if f.err != nil && (f.errAt == 0 || len(f.requests) == f.errAt) {
+		return interfaces.PermissionFilterResponse{}, f.err
+	}
+	results := make([]interfaces.PermissionFilterResult, 0)
+	for _, resource := range request.Resources {
+		if f.allowed[resource.ID] {
+			results = append(results, interfaces.PermissionFilterResult{
+				ResourceType: resource.Type,
+				ResourceID:   resource.ID,
+				Operations:   []string{interfaces.PermissionOperationQueryData},
+			})
+		}
+	}
+	if f.mutate != nil {
+		f.mutate(&results)
+	}
+	return interfaces.PermissionFilterResponse{Resources: &results}, nil
+}
+
+func TestFilterObjectTypeIDsFailsWholeRequestWhenLaterChunkFails(t *testing.T) {
+	access := &fakePermissionAccess{
+		allowed: map[string]bool{"kn-a/ot-a": true, "kn-a/ot-b": true},
+		err:     errors.New("timeout"),
+		errAt:   2,
+	}
+	authorizer := NewQueryCandidateAuthorizerWith(access, 1)
+
+	got, err := authorizer.FilterObjectTypeIDs(authorizedContext(), "kn-a", []string{"ot-a", "ot-b"})
+	if got != nil {
+		t.Fatalf("partial authorization result leaked: %v", got)
+	}
+	status, ok := infraerrors.HTTPStatus(err)
+	if !ok || status != http.StatusServiceUnavailable || len(access.requests) != 2 {
+		t.Fatalf("error=%v calls=%d, want 503 after second chunk", err, len(access.requests))
+	}
+}
+
+func authorizedContext() context.Context {
+	return common.SetAccountAuthContextToCtx(context.Background(), &interfaces.AccountAuthContext{
+		AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+	})
+}
+
+func TestFilterObjectTypeIDsChunksDeduplicatesAndPreservesOrder(t *testing.T) {
+	access := &fakePermissionAccess{allowed: map[string]bool{
+		"kn-a/ot-a": true,
+		"kn-a/ot-c": true,
+	}}
+	authorizer := NewQueryCandidateAuthorizerWith(access, 2)
+
+	got, err := authorizer.FilterObjectTypeIDs(authorizedContext(), "kn-a", []string{"ot-a", "ot-b", "ot-a", "ot-c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"ot-a", "ot-c"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("allowed = %v, want %v", got, want)
+	}
+	if len(access.requests) != 2 {
+		t.Fatalf("calls = %d, want 2", len(access.requests))
+	}
+	for _, request := range access.requests {
+		if request.AccessorID != "user-1" || !reflect.DeepEqual(request.VisibilityOperations, []string{"query_data"}) ||
+			!reflect.DeepEqual(request.CandidateOperations, []string{"query_data"}) {
+			t.Fatalf("request contract = %#v", request)
+		}
+	}
+}
+
+func TestFilterObjectTypeIDsTreatsEmptySafeResultAsDenyAll(t *testing.T) {
+	authorizer := NewQueryCandidateAuthorizerWith(&fakePermissionAccess{allowed: map[string]bool{}}, 10)
+	got, err := authorizer.FilterObjectTypeIDs(authorizedContext(), "kn-a", []string{"ot-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("allowed = %v, want empty", got)
+	}
+}
+
+func TestFilterObjectTypeIDsRejectsMissingSubjectBeforeSafe(t *testing.T) {
+	access := &fakePermissionAccess{}
+	authorizer := NewQueryCandidateAuthorizerWith(access, 10)
+	_, err := authorizer.FilterObjectTypeIDs(context.Background(), "kn-a", []string{"ot-a"})
+	status, ok := infraerrors.HTTPStatus(err)
+	if !ok || status != http.StatusUnauthorized {
+		t.Fatalf("error = %v, want 401", err)
+	}
+	if len(access.requests) != 0 {
+		t.Fatal("Safe must not be called without a trusted subject")
+	}
+}
+
+func TestFilterObjectTypeIDsFailsClosedOnSafeErrorsAndInvalidRows(t *testing.T) {
+	tests := []struct {
+		name   string
+		access *fakePermissionAccess
+	}{
+		{name: "transport error", access: &fakePermissionAccess{err: errors.New("timeout")}},
+		{name: "unexpected resource", access: &fakePermissionAccess{allowed: map[string]bool{"kn-a/ot-a": true}, mutate: func(rows *[]interfaces.PermissionFilterResult) {
+			(*rows)[0].ResourceID = "kn-b/ot-a"
+		}}},
+		{name: "wrong type", access: &fakePermissionAccess{allowed: map[string]bool{"kn-a/ot-a": true}, mutate: func(rows *[]interfaces.PermissionFilterResult) {
+			(*rows)[0].ResourceType = "relation_type"
+		}}},
+		{name: "missing operation", access: &fakePermissionAccess{allowed: map[string]bool{"kn-a/ot-a": true}, mutate: func(rows *[]interfaces.PermissionFilterResult) {
+			(*rows)[0].Operations = nil
+		}}},
+		{name: "duplicate row", access: &fakePermissionAccess{allowed: map[string]bool{"kn-a/ot-a": true}, mutate: func(rows *[]interfaces.PermissionFilterResult) {
+			*rows = append(*rows, (*rows)[0])
+		}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := NewQueryCandidateAuthorizerWith(tt.access, 10)
+			_, err := authorizer.FilterObjectTypeIDs(authorizedContext(), "kn-a", []string{"ot-a"})
+			status, ok := infraerrors.HTTPStatus(err)
+			if !ok || status != http.StatusServiceUnavailable {
+				t.Fatalf("error = %v, want 503", err)
+			}
+		})
+	}
+}
+
+func TestFilterObjectTypeIDsKeepsSameChildSeparateAcrossNetworks(t *testing.T) {
+	access := &fakePermissionAccess{allowed: map[string]bool{"kn-b/shared": true}}
+	authorizer := NewQueryCandidateAuthorizerWith(access, 10)
+	got, err := authorizer.FilterObjectTypeIDs(authorizedContext(), "kn-a", []string{"shared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 || access.requests[0].Resources[0].ID != "kn-a/shared" {
+		t.Fatalf("cross-network candidate leaked: got=%v request=%#v", got, access.requests[0])
+	}
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added trusted execution-subject validation for public REST/MCP and internal `/in` routes behind `CONTEXT_LOADER_KN_PEP_ENABLED`.
- [x] Added a mockable bkn-safe `resource-filter` adapter and ordered/chunked Object Type `query_data` candidate filtering before ontology-query fan-out.
- [x] Prevented authorization and protected-dependency failures from degrading into schema-only, partial metrics/resources/nodes, or `missing` diagnostics.
- [x] Switched PEP-enabled schema drill-down/retrieval to BKN typed endpoints without full export fallback and added regression coverage.
- [x] Added the default-off rollout flag to application and Helm configuration; removed the remaining legacy `ISF` wording.

---

## Why

- Related Issue: [Issue #517](https://github.com/openbkn-ai/bkn-foundry/issues/517)
- Related Feature: [KN authorization implementation epic #1241](https://github.com/openbkn-ai/bkn-foundry/issues/1241)
- Background: context-loader creates schema and Object Type candidates locally and aggregates multiple protected downstream calls. It needs a trusted subject boundary, a local primary-candidate prefilter, and fail-closed aggregation semantics while BKN and ontology-query remain authoritative for metadata and actual data dependencies.

---

## How

- Key implementation points:
  - Canonicalizes authenticated subject headers and excludes account fields from JSON binding.
  - Validates internal user/app subjects before business handlers when the rollout flag is enabled.
  - Builds only server-generated `object_type:{kn_id}/{object_type_id}:query_data` checks, deduplicates and chunks them, and preserves candidate order.
  - Uses BKN typed search/detail endpoints in PEP mode; ontology-query remains the final PEP for published models and actual dependencies.
  - Treats explicit candidate omission as filtering; fails complete aggregates on malformed/incomplete authorization responses and protected dependency failures.
  - Preserves legacy behavior while the flag is off.
- Breaking changes (API, config, database, etc.): No database or public payload shape changes. Adds default-off config `CONTEXT_LOADER_KN_PEP_ENABLED` and optional chunk config `CONTEXT_LOADER_KN_PEP_CHUNK_SIZE`. Enabling the flag rejects invalid internal subjects and changes authorization failures from partial success to explicit failure.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; cross-service validation is tracked by #1239.
- [ ] Verified in test environment — not performed in this PR.

Test notes:

- `go test ./server/...`
- `go vet ./server/...`
- Focused race checks passed for permission, PEP search/resource paths, trusted-subject middleware, and MCP PEP handlers.
- A full knsearch race run still reports a pre-existing test-only concurrent map write in `object_type_prefilter_test.go:186`; it is outside this change.
- `helm lint` and `golangci-lint` were not run locally because those binaries are unavailable.

---

## Risk & Rollback

- Potential risks: When enabled, internal callers that do not propagate a valid user/app subject fail before downstream calls. Safe/BKN/ontology-query/Vega failures no longer return partial context. The flag defaults to false to support staged migration.
- Rollback plan: Keep or set `CONTEXT_LOADER_KN_PEP_ENABLED=false` to restore the legacy context-loader path without bypassing downstream PEPs. If needed, revert this commit or roll back the service image; no data rollback is required.

---

## Additional Notes

- Closes #517
- Current bkn-safe `resource-filter` represents both denied candidates and disabled/missing accounts as `200` with an empty `resources` array. This implementation therefore treats omitted candidate rows as normal denial and treats an omitted top-level `resources` field or malformed rows as an authorization dependency failure. Distinguishing disabled accounts from ordinary denial requires an explicit Safe contract extension; this PR does not infer it from an empty filter result.
- The rollout flag is temporary and should be removed by #1253 after migration (#1248) and end-to-end validation (#1239).
- No screenshots are applicable.
