### PR TITLE
docs(context-loader): describe every bkn_context field in the MCP schema

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/bkn_context_docs_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/bkn_context_docs_test.go
@@ -1,0 +1,159 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// bknContextDocumentedFields lists the direct children of bkn_context that a
+// client renders as rows of a parameter table. Every one of them must carry its
+// own description: bkn_context is injected into every business tool, so a field
+// without text shows up as an undocumented parameter on all of them.
+var bknContextDocumentedFields = []string{
+	"conversation_id", "interaction_id", "parent_operation_id",
+	"causation_event_ids", "business_refs",
+}
+
+var businessRefDocumentedFields = []string{"ref_type", "ref_id", "version"}
+
+type documentedSchema struct {
+	Type                 string                     `json:"type"`
+	Description          string                     `json:"description"`
+	Enum                 []string                   `json:"enum"`
+	MaxItems             int                        `json:"maxItems"`
+	Required             []string                   `json:"required"`
+	AdditionalProperties any                        `json:"additionalProperties"`
+	Properties           map[string]json.RawMessage `json:"properties"`
+	Items                json.RawMessage            `json:"items"`
+}
+
+func decodeDocumentedSchema(t *testing.T, label string, raw json.RawMessage) documentedSchema {
+	t.Helper()
+	var schema documentedSchema
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("decode %s: %v", label, err)
+	}
+	return schema
+}
+
+func bknContextOf(t *testing.T, label string, input json.RawMessage) documentedSchema {
+	t.Helper()
+	tool := decodeDocumentedSchema(t, label, input)
+	raw, ok := tool.Properties["bkn_context"]
+	if !ok {
+		t.Fatalf("%s: input schema has no bkn_context", label)
+	}
+	return decodeDocumentedSchema(t, label+".bkn_context", raw)
+}
+
+// assertBKNContextIsDocumented is the acceptance guard for #1093: the served
+// schema is the only place Studio and a model can read what the managed Trace
+// parameters mean.
+func assertBKNContextIsDocumented(t *testing.T, label string, input json.RawMessage) {
+	t.Helper()
+	context := bknContextOf(t, label, input)
+	if context.Description == "" {
+		t.Fatalf("%s: bkn_context itself must be described", label)
+	}
+	seen := map[string]string{context.Description: "bkn_context"}
+	for _, field := range bknContextDocumentedFields {
+		raw, ok := context.Properties[field]
+		if !ok {
+			t.Fatalf("%s: bkn_context must declare %s", label, field)
+		}
+		child := decodeDocumentedSchema(t, label+".bkn_context."+field, raw)
+		if child.Description == "" {
+			t.Fatalf("%s: bkn_context.%s has no description", label, field)
+		}
+		if owner, duplicate := seen[child.Description]; duplicate {
+			t.Fatalf("%s: bkn_context.%s repeats the description of %s", label, field, owner)
+		}
+		seen[child.Description] = field
+	}
+
+	refs := decodeDocumentedSchema(t, label+".business_refs", context.Properties["business_refs"])
+	item := decodeDocumentedSchema(t, label+".business_refs.items", refs.Items)
+	if item.Description == "" {
+		t.Fatalf("%s: business_refs.items has no description", label)
+	}
+	for _, field := range businessRefDocumentedFields {
+		raw, ok := item.Properties[field]
+		if !ok {
+			t.Fatalf("%s: business_refs item must declare %s", label, field)
+		}
+		child := decodeDocumentedSchema(t, label+".business_refs.items."+field, raw)
+		if child.Description == "" {
+			t.Fatalf("%s: business_refs.items.%s has no description", label, field)
+		}
+		if owner, duplicate := seen[child.Description]; duplicate {
+			t.Fatalf("%s: business_refs.items.%s repeats the description of %s", label, field, owner)
+		}
+		seen[child.Description] = "business_refs.items." + field
+	}
+}
+
+// assertBKNContextValidationIsUnchanged pins what the descriptions must not
+// touch. Documentation and the lifecycle contract share one declaration, so a
+// wording change must not quietly widen a type, drop a required field or edit
+// the ref_type vocabulary the evidence parser accepts.
+func assertBKNContextValidationIsUnchanged(t *testing.T, label string, input json.RawMessage) {
+	t.Helper()
+	context := bknContextOf(t, label, input)
+	if context.Type != "object" || context.AdditionalProperties != false {
+		t.Fatalf("%s: bkn_context must stay a closed object: %#v", label, context)
+	}
+	if !sameStringSet(context.Required, []string{"conversation_id", "interaction_id"}) {
+		t.Fatalf("%s: bkn_context required set changed: %v", label, context.Required)
+	}
+	for _, field := range []string{"conversation_id", "interaction_id", "parent_operation_id"} {
+		child := decodeDocumentedSchema(t, label+"."+field, context.Properties[field])
+		if child.Type != "string" {
+			t.Fatalf("%s: bkn_context.%s must stay a string", label, field)
+		}
+	}
+	causation := decodeDocumentedSchema(t, label+".causation_event_ids", context.Properties["causation_event_ids"])
+	if causation.Type != "array" || causation.MaxItems != 64 {
+		t.Fatalf("%s: causation_event_ids must stay a bounded array: %#v", label, causation)
+	}
+
+	refs := decodeDocumentedSchema(t, label+".business_refs", context.Properties["business_refs"])
+	if refs.Type != "array" || refs.MaxItems != 64 {
+		t.Fatalf("%s: business_refs must stay a bounded array: %#v", label, refs)
+	}
+	item := decodeDocumentedSchema(t, label+".business_refs.items", refs.Items)
+	if item.AdditionalProperties != false ||
+		!sameStringSet(item.Required, []string{"ref_type", "ref_id"}) {
+		t.Fatalf("%s: business_refs item must stay a closed declaration: %#v", label, item)
+	}
+	refType := decodeDocumentedSchema(t, label+".business_refs.items.ref_type", item.Properties["ref_type"])
+	if !sameStringSet(refType.Enum, []string{
+		"knowledge_network", "object_type", "object_instance", "property", "relation_type",
+		"data_resource", "metric", "logic", "function", "action_type", "action_instance",
+	}) {
+		t.Fatalf("%s: ref_type vocabulary changed: %v", label, refType.Enum)
+	}
+}
+
+// TestBKNContextSchemaDocumentsEveryTraceField checks the schema every business
+// tool publishes, in every served locale, because the locale overlay rebuilds
+// the declaration after bkn_context is injected.
+func TestBKNContextSchemaDocumentsEveryTraceField(t *testing.T) {
+	for _, locale := range []string{defaultMCPLocale, "en-US"} {
+		bundle := loadMCPLocaleBundle(locale)
+		for toolKey := range allToolMeta() {
+			if !isBusinessTool(toolKey) {
+				continue
+			}
+			t.Run(locale+"/"+toolKey, func(t *testing.T) {
+				input, _ := bundle.ToolSchemas(toolKey)
+				label := locale + "/" + toolKey
+				assertBKNContextIsDocumented(t, label, input)
+				assertBKNContextValidationIsUnchanged(t, label, input)
+			})
+		}
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -356,6 +356,14 @@ func enumSchema(values ...string) map[string]any {
 	return map[string]any{"type": "string", "enum": values}
 }
 
+func describedStringSchema(description string) map[string]any {
+	return map[string]any{"type": "string", "description": description}
+}
+
+func describedEnumSchema(description string, values ...string) map[string]any {
+	return map[string]any{"type": "string", "enum": values, "description": description}
+}
+
 func expectedResourceSchema(idField string) map[string]any {
 	return map[string]any{
 		"type": "array",
@@ -402,27 +410,70 @@ func offerBKNContext(input json.RawMessage) json.RawMessage {
 	return raw
 }
 
+// bknContextInputSchema declares the managed Trace context that offerBKNContext
+// injects into every business tool.
+//
+// The field descriptions are documentation, not validation: this schema is the
+// only place a client can learn what the Trace parameters mean, since a UI that
+// renders a tool's inputSchema as a field table (bkn-studio#347) and a model
+// choosing arguments both read the declaration and nothing else. Cross-field
+// rules stay in requireBKNContext and the lifecycle guard.
+//
+// The text is English in the baseline because this schema is built in Go, where
+// hard-coded Chinese is barred; en-US therefore needs no overlay entry, and a
+// zh-CN client sees the same English it already sees for the object-level
+// description above.
 func bknContextInputSchema() map[string]any {
 	return map[string]any{
 		"type":        "object",
 		"description": "BKN Trace managed context. Use only IDs returned by lifecycle tools.",
 		"properties": map[string]any{
-			"conversation_id":     stringSchema(),
-			"interaction_id":      stringSchema(),
-			"parent_operation_id": stringSchema(),
+			"conversation_id": describedStringSchema(
+				"Conversation this call belongs to. Copy the conversation_id returned by bkn_start_interaction; " +
+					"it stays the same for every call in the conversation.",
+			),
+			"interaction_id": describedStringSchema(
+				"Turn this call belongs to. Copy the interaction_id returned by bkn_start_interaction for the " +
+					"current user question; the next question gets a new one.",
+			),
+			"parent_operation_id": describedStringSchema(
+				"operation_id of the enclosing step, which records this call as its child. Omit it when the call " +
+					"is made directly for the user's question.",
+			),
 			"causation_event_ids": map[string]any{
-				"type": "array", "maxItems": 64, "items": stringSchema(),
+				"type": "array", "maxItems": 64,
+				"items": describedStringSchema("Event id of one upstream Trace event."),
+				"description": "Trace event ids that caused this call, when the host propagates them. Omit them " +
+					"if unknown: the recorded causality is then parent_operation_id alone.",
 			},
 			"business_refs": map[string]any{
 				"type": "array", "maxItems": 64,
+				"description": "Business objects this call reads or acts on, declared for the evidence chain. " +
+					"Except for data_resource, every ref must belong to the knowledge network this call addresses; " +
+					"a ref that is not canonical is rejected.",
 				"items": map[string]any{
-					"type": "object",
+					"type":        "object",
+					"description": "One declared business object.",
 					"properties": map[string]any{
-						"ref_type": enumSchema(
+						"ref_type": describedEnumSchema(
+							"Kind of business object being declared, which also fixes the prefix of ref_id: "+
+								"knowledge_network=kn, object_type=object, object_instance=object_instance, "+
+								"property=property, relation_type=relation, data_resource=resource, metric=metric, "+
+								"logic=logic, function=function, action_type=action_type, "+
+								"action_instance=action_instance.",
 							"knowledge_network", "object_type", "object_instance", "property", "relation_type",
 							"data_resource", "metric", "logic", "function", "action_type", "action_instance",
 						),
-						"ref_id": stringSchema(), "version": stringSchema(),
+						"ref_id": describedStringSchema(
+							"Canonical colon-separated identifier of the object. Its first segment is the prefix " +
+								"ref_type requires and, for every kind except data_resource, its second segment is " +
+								"the kn_id this call addresses, for example object:<kn_id>:<object_type_id>. " +
+								"Instance-level and property-level kinds carry one further segment.",
+						),
+						"version": describedStringSchema(
+							"Version of the referenced object. Omit it when the object is unversioned; the " +
+								"declaration is then recorded as \"unversioned\".",
+						),
 					},
 					"required": []string{"ref_type", "ref_id"}, "additionalProperties": false,
 				},

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas.go
@@ -429,46 +429,44 @@ func bknContextInputSchema() map[string]any {
 		"description": "BKN Trace managed context. Use only IDs returned by lifecycle tools.",
 		"properties": map[string]any{
 			"conversation_id": describedStringSchema(
-				"Conversation this call belongs to. Copy the conversation_id returned by bkn_start_interaction; " +
-					"it stays the same for every call in the conversation.",
+				"Conversation this call belongs to. Copy the conversation_id returned by " +
+					"bkn_start_interaction; it is the same for every call in the conversation.",
 			),
 			"interaction_id": describedStringSchema(
-				"Turn this call belongs to. Copy the interaction_id returned by bkn_start_interaction for the " +
-					"current user question; the next question gets a new one.",
+				"Turn this call belongs to. Copy the interaction_id returned by bkn_start_interaction; " +
+					"the next user question gets a new one.",
 			),
 			"parent_operation_id": describedStringSchema(
-				"operation_id of the enclosing step, which records this call as its child. Omit it when the call " +
-					"is made directly for the user's question.",
+				"operation_id of the enclosing step, which records this call as its child. Omit it for a " +
+					"call made directly for the user's question.",
 			),
 			"causation_event_ids": map[string]any{
 				"type": "array", "maxItems": 64,
-				"items": describedStringSchema("Event id of one upstream Trace event."),
-				"description": "Trace event ids that caused this call, when the host propagates them. Omit them " +
-					"if unknown: the recorded causality is then parent_operation_id alone.",
+				"items": describedStringSchema("One upstream Trace event id."),
+				"description": "Trace event ids that caused this call, when the host propagates them. Omit " +
+					"if unknown: causality is then parent_operation_id alone.",
 			},
 			"business_refs": map[string]any{
 				"type": "array", "maxItems": 64,
 				"description": "Business objects this call reads or acts on, declared for the evidence chain. " +
-					"Except for data_resource, every ref must belong to the knowledge network this call addresses; " +
-					"a ref that is not canonical is rejected.",
+					"Refs are checked against the knowledge network this call addresses, taken from the tool's " +
+					"kn_id argument or the X-Kn-ID header; with neither present declare only data_resource refs, " +
+					"because any other kind is then rejected and the call fails.",
 				"items": map[string]any{
 					"type":        "object",
 					"description": "One declared business object.",
 					"properties": map[string]any{
 						"ref_type": describedEnumSchema(
-							"Kind of business object being declared, which also fixes the prefix of ref_id: "+
-								"knowledge_network=kn, object_type=object, object_instance=object_instance, "+
-								"property=property, relation_type=relation, data_resource=resource, metric=metric, "+
-								"logic=logic, function=function, action_type=action_type, "+
-								"action_instance=action_instance.",
+							"Kind of business object declared. It also fixes the prefix of ref_id, which is this "+
+								"value itself except: knowledge_network=kn, object_type=object, "+
+								"relation_type=relation, data_resource=resource.",
 							"knowledge_network", "object_type", "object_instance", "property", "relation_type",
 							"data_resource", "metric", "logic", "function", "action_type", "action_instance",
 						),
 						"ref_id": describedStringSchema(
-							"Canonical colon-separated identifier of the object. Its first segment is the prefix " +
-								"ref_type requires and, for every kind except data_resource, its second segment is " +
-								"the kn_id this call addresses, for example object:<kn_id>:<object_type_id>. " +
-								"Instance-level and property-level kinds carry one further segment.",
+							"Canonical colon-separated id: the prefix ref_type requires, then, for every kind " +
+								"except data_resource, the kn_id this call addresses, as in " +
+								"object:<kn_id>:<object_type_id>. Instance and property kinds add one segment.",
 						),
 						"version": describedStringSchema(
 							"Version of the referenced object. Omit it when the object is unversioned; the " +


### PR DESCRIPTION
Closes #1093

## What

`bkn_context` is injected by `offerBKNContext` into the input schema of every business tool, but only the object itself carried a `description`. Its children — `conversation_id`, `interaction_id`, `parent_operation_id`, `causation_event_ids`, and `business_refs` with `ref_type` / `ref_id` / `version` — declared a type, a bound, or an enum and nothing else.

That declaration is the only source of field semantics for two readers: Studio, which since openbkn-ai/bkn-studio#347 renders `inputSchema` as a parameter table (these rows showed "暂无字段说明"), and the model itself, which had no statement of what the IDs mean or where they come from — the 11 `ref_type` values appeared as bare strings.

This adds a description to each field. `ref_type`'s text carries the value-to-prefix mapping and `ref_id`'s the canonical shape, both taken from `bkntrace.ParseBusinessRefs`, which is what actually accepts or rejects a declaration.

## Language

The text is English in the Go baseline, like the lifecycle tool schemas next to it. This declaration is built in code, where `ci-i18n-hardcoded` bars hard-coded Chinese, so `en-US` needs no `schema_descriptions.json` entry and `TestEnglishCatalogHasNoHanText` stays green. A zh-CN client sees English here, exactly as it already does for the object-level description and for every lifecycle tool. Moving `bkn_context` to a localized baseline would mean restructuring where the schema is built, which is outside this issue's boundary.

## Not changed

Types, required sets, `maxItems`, `additionalProperties`, the `ref_type` vocabulary, `requireBKNContext`, and the lifecycle guard. Documentation only.

## Testing

New `bkn_context_docs_test.go`:
- walks the served schema (`bundle.ToolSchemas`) of every business tool in both `zh-CN` and `en-US` — the locale overlay rebuilds the declaration after injection, so the assertion has to run on what `tools/list` serves, not on the raw file;
- fails on any `bkn_context` child, `business_refs` item field, or the item itself without a description, and on two fields sharing one description;
- pins the validation shape (types, required sets, bounds, closedness, the full `ref_type` enum) so a future wording edit cannot quietly widen the contract.

Verified locally (go1.25.6):
- `go test ./server/driveradapters/... -count=1` — all packages pass, 50 subtests in the new test.
- Mutation check: reverting `parent_operation_id` to a bare `stringSchema()` makes the new test fail (`bkn_context.parent_operation_id has no description`).
- `python3.12 tools/check_hardcoded_chinese.py` — passed, 0 new violations.
- Dumped the served `en-US` schema for `search_schema` and read it back to confirm every field carries its text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)