### PR TITLE
fix(platform): converge auth defaults and reject silent ISF fallback (#352)

### DIFF
--- a/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
@@ -83,7 +83,8 @@ spec:
             value: {{ .Values.env.timezone }}
           - name: LANG
             value: {{ .Values.env.language }}
-          # bkn-safe (ISF replacement) cutover; empty = ISF (default), revertible.
+          # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
+          # An unset or misspelled value refuses to start rather than falling back to ISF.
           - name: AUTHZ_PROVIDER
             value: {{ .Values.bknSafe.authzProvider | quote }}
           - name: DIRECTORY_PROVIDER

--- a/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           - name: LANG
             value: {{ .Values.env.language }}
           # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
-          # An unset or misspelled value refuses to start rather than falling back to ISF.
+          # A misspelled value refuses to start; an unset one warns and falls back to ISF.
           - name: AUTHZ_PROVIDER
             value: {{ .Values.bknSafe.authzProvider | quote }}
           - name: DIRECTORY_PROVIDER

--- a/adp/vega/vega-backend/helm/vega-backend/values.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/values.yaml
@@ -6,13 +6,17 @@ env:
   timezone: Asia/Shanghai
   language: en_US.UTF-8
 
-# bkn-safe (ISF replacement) cutover knobs. Default empty = ISF behavior.
-# provider: "" | "shadow" (ISF authoritative, diff-logged) | "bkn-safe" (authoritative).
-# url: bkn-safe ClusterIP base URL. Flip is env-revertible.
+# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
+# value and is retired; anything else refuses to start.
+# provider: "bkn-safe" (authoritative) | "shadow" (ISF authoritative, diff-logged) | "isf".
+# url: bkn-safe ClusterIP base URL.
 bknSafe:
-  authzProvider: ""
-  directoryProvider: ""
-  url: ""
+  # Defaults match what the installer writes. A chart-only install therefore
+  # lands on a working bkn-safe deployment instead of the retired ISF: an
+  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  authzProvider: "bkn-safe"
+  directoryProvider: "bkn-safe"
+  url: "http://bkn-safe:3000"
 
 # 节点选择器
 nodeSelector: {}

--- a/adp/vega/vega-backend/helm/vega-backend/values.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/values.yaml
@@ -6,14 +6,13 @@ env:
   timezone: Asia/Shanghai
   language: en_US.UTF-8
 
-# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
-# value and is retired; anything else refuses to start.
+# bkn-safe (ISF replacement) cutover knobs. isf is accepted but retired; a
+# misspelled value refuses to start, an unset one falls back to ISF and warns.
 # provider: "bkn-safe" (authoritative) | "shadow" (ISF authoritative, diff-logged) | "isf".
 # url: bkn-safe ClusterIP base URL.
 bknSafe:
-  # Defaults match what the installer writes. A chart-only install therefore
-  # lands on a working bkn-safe deployment instead of the retired ISF: an
-  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  # Defaults match what the installer writes, so a chart-only install lands on
+  # a working bkn-safe deployment instead of the retired ISF.
   authzProvider: "bkn-safe"
   directoryProvider: "bkn-safe"
   url: "http://bkn-safe:3000"

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -506,15 +506,47 @@ func TestMaybeShadow(t *testing.T) {
 		t.Setenv("AUTHZ_PROVIDER", "isf")
 		t.Setenv("BKN_SAFE_URL", "http://safe")
 
-		assert.Same(t, inner, MaybeShadow(inner))
+		got, err := MaybeShadow(inner)
+
+		require.NoError(t, err)
+		assert.Same(t, inner, got)
 	})
 
-	t.Run("returns inner for unknown provider or empty safe url", func(t *testing.T) {
+	// An unset or misspelled provider used to fall back to the retired ISF.
+	// It has to surface as a startup error instead.
+	t.Run("rejects unset provider", func(t *testing.T) {
 		inner, _ := newMockPermissionAccessWithoutExpectation(t)
-		t.Setenv("AUTHZ_PROVIDER", "unknown")
-		t.Setenv("BKN_SAFE_URL", "")
+		t.Setenv("AUTHZ_PROVIDER", "")
+		t.Setenv("BKN_SAFE_URL", "http://safe")
 
-		assert.Same(t, inner, MaybeShadow(inner))
+		got, err := MaybeShadow(inner)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("rejects unknown provider", func(t *testing.T) {
+		inner, _ := newMockPermissionAccessWithoutExpectation(t)
+		t.Setenv("AUTHZ_PROVIDER", "bkn_safe")
+		t.Setenv("BKN_SAFE_URL", "http://safe")
+
+		got, err := MaybeShadow(inner)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("rejects empty safe url", func(t *testing.T) {
+		for _, provider := range []string{"bkn-safe", "shadow"} {
+			inner, _ := newMockPermissionAccessWithoutExpectation(t)
+			t.Setenv("AUTHZ_PROVIDER", provider)
+			t.Setenv("BKN_SAFE_URL", "  ")
+
+			got, err := MaybeShadow(inner)
+
+			require.Error(t, err, provider)
+			assert.Nil(t, got, provider)
+		}
 	})
 
 	t.Run("wraps inner in shadow mode", func(t *testing.T) {
@@ -522,8 +554,9 @@ func TestMaybeShadow(t *testing.T) {
 		t.Setenv("AUTHZ_PROVIDER", "shadow")
 		t.Setenv("BKN_SAFE_URL", "http://safe")
 
-		got := MaybeShadow(inner)
+		got, err := MaybeShadow(inner)
 
+		require.NoError(t, err)
 		require.IsType(t, &shadowPermissionAccess{}, got)
 		assert.Same(t, inner, got.(*shadowPermissionAccess).PermissionAccess)
 	})
@@ -533,8 +566,9 @@ func TestMaybeShadow(t *testing.T) {
 		t.Setenv("AUTHZ_PROVIDER", "bkn-safe")
 		t.Setenv("BKN_SAFE_URL", "http://safe")
 
-		got := MaybeShadow(inner)
+		got, err := MaybeShadow(inner)
 
+		require.NoError(t, err)
 		require.IsType(t, &safePermissionAccess{}, got)
 	})
 }

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -512,17 +512,30 @@ func TestMaybeShadow(t *testing.T) {
 		assert.Same(t, inner, got)
 	})
 
-	// An unset or misspelled provider used to fall back to the retired ISF.
-	// It has to surface as a startup error instead.
-	t.Run("rejects unset provider", func(t *testing.T) {
+	// An unset provider keeps the ISF fallback so an upgrade does not
+	// CrashLoopBackOff; only a misspelled one is a startup error.
+	t.Run("returns inner for unset provider", func(t *testing.T) {
 		inner, _ := newMockPermissionAccessWithoutExpectation(t)
 		t.Setenv("AUTHZ_PROVIDER", "")
 		t.Setenv("BKN_SAFE_URL", "http://safe")
 
 		got, err := MaybeShadow(inner)
 
-		require.Error(t, err)
-		assert.Nil(t, got)
+		require.NoError(t, err)
+		assert.Same(t, inner, got)
+	})
+
+	// A values file with a trailing space has to select the same backend the
+	// runtime then compares against, not fall through to ISF unnoticed.
+	t.Run("tolerates surrounding whitespace", func(t *testing.T) {
+		inner, _ := newMockPermissionAccessWithoutExpectation(t)
+		t.Setenv("AUTHZ_PROVIDER", " bkn-safe ")
+		t.Setenv("BKN_SAFE_URL", " http://safe ")
+
+		got, err := MaybeShadow(inner)
+
+		require.NoError(t, err)
+		require.IsType(t, &safePermissionAccess{}, got)
 	})
 
 	t.Run("rejects unknown provider", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
@@ -21,11 +22,12 @@ import (
 	"vega-backend/interfaces"
 )
 
-// bkn-safe authz cutover (revertible via AUTHZ_PROVIDER):
-//   - unset / "isf" : ISF PermissionAccess unchanged (default)
-//   - "shadow"      : ISF authoritative + bkn-safe queried in parallel, diffs logged
-//   - "bkn-safe"    : bkn-safe authoritative (full adapter)
-// BKN_SAFE_URL points at bkn-safe. Flip the env to revert; ISF impl untouched.
+// bkn-safe authz cutover (selected by AUTHZ_PROVIDER):
+//   - "bkn-safe" : bkn-safe authoritative (full adapter)
+//   - "shadow"   : ISF authoritative + bkn-safe queried in parallel, diffs logged
+//   - "isf"      : ISF PermissionAccess unchanged; retired, kept as an escape hatch
+// "bkn-safe" and "shadow" both need BKN_SAFE_URL. There is no implicit default:
+// an unset or misspelled value is a misconfiguration, not a silent ISF fallback.
 
 // safeClient talks to bkn-safe's clean authz API (/api/safe/v1/authz/*).
 type safeClient struct {
@@ -307,27 +309,36 @@ func (s *safePermissionAccess) DeleteResources(ctx context.Context, resources []
 	return nil
 }
 
-// MaybeShadow applies the AUTHZ_PROVIDER switch. Default/unknown => ISF (inner).
-func MaybeShadow(inner interfaces.PermissionAccess) interfaces.PermissionAccess {
-	provider := os.Getenv("AUTHZ_PROVIDER")
-	if provider == "" || provider == "isf" {
-		return inner
+// supportedAuthzProviders lists every accepted AUTHZ_PROVIDER value, in the
+// order the error message should offer them.
+var supportedAuthzProviders = []string{"bkn-safe", "shadow", "isf"}
+
+// MaybeShadow applies the AUTHZ_PROVIDER switch.
+//
+// An unset or misspelled provider, and "bkn-safe" without BKN_SAFE_URL, used to
+// print one line and fall back to ISF. ISF is retired, so that fallback turned a
+// typo into an authorization surface whose answers are unpredictable, and the
+// single log line made it invisible at runtime. Report the misconfiguration and
+// let the caller refuse to start.
+func MaybeShadow(inner interfaces.PermissionAccess) (interfaces.PermissionAccess, error) {
+	provider := strings.TrimSpace(os.Getenv("AUTHZ_PROVIDER"))
+	if provider == "isf" {
+		log.Printf("[authz] provider=isf selects the retired authorization service; migrate to bkn-safe")
+		return inner, nil
 	}
-	url := os.Getenv("BKN_SAFE_URL")
-	if url == "" {
-		log.Printf("[authz] AUTHZ_PROVIDER=%s but BKN_SAFE_URL empty; using ISF", provider)
-		return inner
+	if provider != "bkn-safe" && provider != "shadow" {
+		return nil, fmt.Errorf("AUTHZ_PROVIDER=%q is not a supported authorization backend; set it to one of %s",
+			provider, strings.Join(supportedAuthzProviders, ", "))
 	}
-	sc := newSafeClient(url)
-	switch provider {
-	case "bkn-safe":
-		log.Printf("[authz] provider=bkn-safe (authoritative) at %s", url)
-		return &safePermissionAccess{safe: sc}
-	case "shadow":
-		log.Printf("[authz] provider=shadow; ISF authoritative, comparing bkn-safe at %s", url)
-		return &shadowPermissionAccess{PermissionAccess: inner, safe: sc}
-	default:
-		log.Printf("[authz] unknown AUTHZ_PROVIDER=%s; using ISF", provider)
-		return inner
+	safeURL := strings.TrimSpace(os.Getenv("BKN_SAFE_URL"))
+	if safeURL == "" {
+		return nil, fmt.Errorf("AUTHZ_PROVIDER=%s requires BKN_SAFE_URL to be set", provider)
 	}
+	sc := newSafeClient(safeURL)
+	if provider == "shadow" {
+		log.Printf("[authz] provider=shadow; ISF authoritative, comparing bkn-safe at %s", safeURL)
+		return &shadowPermissionAccess{PermissionAccess: inner, safe: sc}, nil
+	}
+	log.Printf("[authz] provider=bkn-safe (authoritative) at %s", safeURL)
+	return &safePermissionAccess{safe: sc}, nil
 }

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -26,8 +26,10 @@ import (
 //   - "bkn-safe" : bkn-safe authoritative (full adapter)
 //   - "shadow"   : ISF authoritative + bkn-safe queried in parallel, diffs logged
 //   - "isf"      : ISF PermissionAccess unchanged; retired, kept as an escape hatch
-// "bkn-safe" and "shadow" both need BKN_SAFE_URL. There is no implicit default:
-// an unset or misspelled value is a misconfiguration, not a silent ISF fallback.
+// "bkn-safe" and "shadow" both need BKN_SAFE_URL. A misspelled value is a
+// misconfiguration and refuses to start; an unset value still falls back to ISF
+// but says so loudly, because existing deployments carry an explicit empty value
+// in their own values overrides and an upgrade must not CrashLoopBackOff.
 
 // safeClient talks to bkn-safe's clean authz API (/api/safe/v1/authz/*).
 type safeClient struct {
@@ -315,18 +317,27 @@ var supportedAuthzProviders = []string{"bkn-safe", "shadow", "isf"}
 
 // MaybeShadow applies the AUTHZ_PROVIDER switch.
 //
-// An unset or misspelled provider, and "bkn-safe" without BKN_SAFE_URL, used to
-// print one line and fall back to ISF. ISF is retired, so that fallback turned a
-// typo into an authorization surface whose answers are unpredictable, and the
-// single log line made it invisible at runtime. Report the misconfiguration and
+// A misspelled provider, and "bkn-safe" without BKN_SAFE_URL, used to print one
+// line and fall back to ISF. ISF is retired, so that fallback turned a typo into
+// an authorization surface whose answers are unpredictable, and the single log
+// line made it invisible at runtime. Both now report the misconfiguration and
 // let the caller refuse to start.
+//
+// An unset provider keeps the old fallback, loudly: deployments upgraded with
+// their own values override still carry an explicit empty value, and refusing to
+// start would turn an upgrade into a CrashLoopBackOff. Flipping that to an error
+// waits until those deployments are counted.
 func MaybeShadow(inner interfaces.PermissionAccess) (interfaces.PermissionAccess, error) {
 	provider := strings.TrimSpace(os.Getenv("AUTHZ_PROVIDER"))
-	if provider == "isf" {
+	switch provider {
+	case "":
+		log.Printf("[authz] AUTHZ_PROVIDER is unset, so authorization falls back to the retired ISF; set it to bkn-safe")
+		return inner, nil
+	case "isf":
 		log.Printf("[authz] provider=isf selects the retired authorization service; migrate to bkn-safe")
 		return inner, nil
-	}
-	if provider != "bkn-safe" && provider != "shadow" {
+	case "bkn-safe", "shadow":
+	default:
 		return nil, fmt.Errorf("AUTHZ_PROVIDER=%q is not a supported authorization backend; set it to one of %s",
 			provider, strings.Join(supportedAuthzProviders, ", "))
 	}

--- a/adp/vega/vega-backend/server/drivenadapters/user_mgmt/user_mgmt_access.go
+++ b/adp/vega/vega-backend/server/drivenadapters/user_mgmt/user_mgmt_access.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/bytedance/sonic"
@@ -34,11 +35,14 @@ type userMgmtAccess struct {
 func NewUserMgmtAccess(appSetting *common.AppSetting) interfaces.UserMgmtAccess {
 	umAccessOnce.Do(func() {
 		umAccess = &userMgmtAccess{
-			appSetting:        appSetting,
-			httpClient:        common.NewHTTPClient(),
-			userMgmtUrl:       appSetting.UserMgmtUrl,
-			directoryProvider: os.Getenv("DIRECTORY_PROVIDER"),
-			bknSafeURL:        os.Getenv("BKN_SAFE_URL"),
+			appSetting:  appSetting,
+			httpClient:  common.NewHTTPClient(),
+			userMgmtUrl: appSetting.UserMgmtUrl,
+			// Trimmed for the same reason the authz side trims: a values file
+			// with a trailing space would otherwise fail the equality check
+			// below and silently resolve names through the retired ISF.
+			directoryProvider: strings.TrimSpace(os.Getenv("DIRECTORY_PROVIDER")),
+			bknSafeURL:        strings.TrimSpace(os.Getenv("BKN_SAFE_URL")),
 		}
 	})
 

--- a/adp/vega/vega-backend/server/main.go
+++ b/adp/vega/vega-backend/server/main.go
@@ -132,7 +132,11 @@ func main() {
 	// The Set order is sorted in ascending alphabetical order
 	if common.GetAuthEnabled() {
 		logics.SetAuthAccess(auth.NewHydraAuthAccess(appSetting))
-		logics.SetPermissionAccess(permission.MaybeShadow(permission.NewPermissionAccess(appSetting)))
+		permissionAccess, err := permission.MaybeShadow(permission.NewPermissionAccess(appSetting))
+		if err != nil {
+			logger.Fatalf("authorization provider is misconfigured: %v", err)
+		}
+		logics.SetPermissionAccess(permissionAccess)
 		logics.SetUserMgmtAccess(user_mgmt.NewUserMgmtAccess(appSetting))
 	}
 

--- a/infra/mf-model-api/app/commons/get_user_info.py
+++ b/infra/mf-model-api/app/commons/get_user_info.py
@@ -2,7 +2,7 @@ import json
 import os
 
 import aiohttp
-from app.core.config import base_config
+from app.core.config import base_config, directory_settings
 from app.commons.errors import UserManagementError
 from app.commons.locale import internal_request_headers
 
@@ -34,8 +34,7 @@ async def get_username_by_ids(user_ids):
         return {}
     # bkn-safe directory cutover (revertible): DIRECTORY_PROVIDER=bkn-safe +
     # BKN_SAFE_URL resolves names via bkn-safe instead of ISF. Unset to revert.
-    provider = os.getenv("DIRECTORY_PROVIDER", "")
-    bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
+    provider, bkn_safe_url = directory_settings()
     if provider == "bkn-safe" and bkn_safe_url:
         return await _resolve_names_bkn_safe(bkn_safe_url, user_ids)
     user_management_url = f"http://{base_config.USERMANAGEMENTPRIVATEHOST}:{base_config.USERMANAGEMENTPRIVATEPORT}/api/user-management/v1/batch-get-user-info"

--- a/infra/mf-model-api/app/core/config.py
+++ b/infra/mf-model-api/app/core/config.py
@@ -107,7 +107,10 @@ class BaseConfig(object):
     METERINGSTREAMMAXLEN = int(os.getenv('METERING_STREAM_MAXLEN', '100000'))
 
     # Authorization switch: true enables authentication and resource filtering.
-    AUTH_ENABLED = os.getenv('AUTH_ENABLED', 'false').lower() == 'true'
+    # Defaults to true so a deployment that never sets the variable fails
+    # closed, matching every Go service. Local runs and tests that want an
+    # open surface have to say AUTH_ENABLED=false out loud.
+    AUTH_ENABLED = os.getenv('AUTH_ENABLED', 'true').lower() == 'true'
     # Anonymous identity used for audit correlation when authorization is disabled.
     ANONYMOUS_USER_ID = "anonymous-user"
 
@@ -127,6 +130,42 @@ def resolve_metering_backend():
 
 
 base_config = BaseConfig()
+
+# Authorization backends this service can talk to. bkn-safe and shadow both
+# reach bkn-safe and therefore need BKN_SAFE_URL; isf is retired and stays
+# reachable only for environments that have not finished the cutover.
+AUTHZ_PROVIDERS_REQUIRING_SAFE_URL = ('bkn-safe', 'shadow')
+AUTHZ_PROVIDER_ISF = 'isf'
+SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
+
+
+def validate_authz_config():
+    """Refuse to start when the authorization backend cannot be honoured.
+
+    A misspelled AUTHZ_PROVIDER, or bkn-safe selected while BKN_SAFE_URL is
+    empty, used to print one line and fall back to ISF. ISF is retired, so
+    that fallback turned a typo into an authorization surface whose answers
+    are unpredictable, and the single log line made it invisible at runtime.
+    """
+    if not base_config.AUTH_ENABLED:
+        return
+    provider = os.getenv('AUTHZ_PROVIDER', '').strip()
+    safe_url = os.getenv('BKN_SAFE_URL', '').strip()
+    if provider in AUTHZ_PROVIDERS_REQUIRING_SAFE_URL:
+        if not safe_url:
+            raise RuntimeError(
+                f'AUTHZ_PROVIDER={provider} requires BKN_SAFE_URL to be set')
+        return
+    if provider == AUTHZ_PROVIDER_ISF:
+        logging.getLogger(__name__).warning(
+            'AUTHZ_PROVIDER=isf selects the retired authorization service; '
+            'migrate the deployment to bkn-safe')
+        return
+    raise RuntimeError(
+        f'AUTHZ_PROVIDER={provider!r} is not a supported authorization '
+        f'backend; set it to one of {", ".join(SUPPORTED_AUTHZ_PROVIDERS)}')
+
+
 server_info = ServerInfo(
     server_name="agent-executor",
     server_version="1.0.0",

--- a/infra/mf-model-api/app/core/config.py
+++ b/infra/mf-model-api/app/core/config.py
@@ -139,17 +139,31 @@ AUTHZ_PROVIDER_ISF = 'isf'
 SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
 
 
-def authz_settings():
-    """Read the authorization backend selection through one normalisation.
+def _stripped_env(name):
+    """Read one bkn-safe cutover variable, whitespace removed.
 
-    Both the startup check and PermissionManager go through here so a value
-    that passes validation is the same value the runtime compares against.
-    Normalising in only one of the two would let "bkn-safe " start the service
-    and then miss every equality check, which is the silent ISF fallback this
-    validation exists to remove.
+    Every reader of these variables goes through here. Normalising in only
+    some of them would let "bkn-safe " pass the startup check and then miss
+    the equality comparisons that select the backend, which is the silent ISF
+    fallback this validation exists to remove.
     """
-    return (os.getenv('AUTHZ_PROVIDER', '').strip(),
-            os.getenv('BKN_SAFE_URL', '').strip())
+    return os.getenv(name, '').strip()
+
+
+def authz_settings():
+    """Authorization backend selection, shared by the startup check and
+    PermissionManager."""
+    return _stripped_env('AUTHZ_PROVIDER'), _stripped_env('BKN_SAFE_URL')
+
+
+def directory_settings():
+    """Directory (name resolution) backend selection, same normalisation."""
+    return _stripped_env('DIRECTORY_PROVIDER'), _stripped_env('BKN_SAFE_URL')
+
+
+def bkn_safe_url():
+    """bkn-safe base URL, same normalisation."""
+    return _stripped_env('BKN_SAFE_URL')
 
 
 def validate_authz_config():

--- a/infra/mf-model-api/app/core/config.py
+++ b/infra/mf-model-api/app/core/config.py
@@ -139,6 +139,19 @@ AUTHZ_PROVIDER_ISF = 'isf'
 SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
 
 
+def authz_settings():
+    """Read the authorization backend selection through one normalisation.
+
+    Both the startup check and PermissionManager go through here so a value
+    that passes validation is the same value the runtime compares against.
+    Normalising in only one of the two would let "bkn-safe " start the service
+    and then miss every equality check, which is the silent ISF fallback this
+    validation exists to remove.
+    """
+    return (os.getenv('AUTHZ_PROVIDER', '').strip(),
+            os.getenv('BKN_SAFE_URL', '').strip())
+
+
 def validate_authz_config():
     """Refuse to start when the authorization backend cannot be honoured.
 
@@ -146,15 +159,24 @@ def validate_authz_config():
     empty, used to print one line and fall back to ISF. ISF is retired, so
     that fallback turned a typo into an authorization surface whose answers
     are unpredictable, and the single log line made it invisible at runtime.
+
+    An unset provider keeps working: existing deployments carry an explicit
+    empty value in their own values overrides, and refusing to start would
+    turn an upgrade into a CrashLoopBackOff. It warns loudly instead, and the
+    flip to a hard failure waits until those deployments are counted.
     """
     if not base_config.AUTH_ENABLED:
         return
-    provider = os.getenv('AUTHZ_PROVIDER', '').strip()
-    safe_url = os.getenv('BKN_SAFE_URL', '').strip()
+    provider, safe_url = authz_settings()
     if provider in AUTHZ_PROVIDERS_REQUIRING_SAFE_URL:
         if not safe_url:
             raise RuntimeError(
                 f'AUTHZ_PROVIDER={provider} requires BKN_SAFE_URL to be set')
+        return
+    if provider == '':
+        logging.getLogger(__name__).warning(
+            'AUTHZ_PROVIDER is unset, so authorization falls back to the '
+            'retired ISF; set it to bkn-safe')
         return
     if provider == AUTHZ_PROVIDER_ISF:
         logging.getLogger(__name__).warning(

--- a/infra/mf-model-api/app/test/conftest.py
+++ b/infra/mf-model-api/app/test/conftest.py
@@ -1,6 +1,12 @@
 """Tests for conftest."""
 import sys
 import os
+
+# The service now defaults to AUTH_ENABLED=true so a deployment that forgets
+# the variable fails closed. The suite predates that default and asserts the
+# anonymous-allow behaviour, so pin the open value before project code is
+# imported; cases that exercise the auth path patch base_config themselves.
+os.environ.setdefault("AUTH_ENABLED", "false")
 from unittest.mock import Mock, AsyncMock, MagicMock, patch
 
 # Add the project root directory to sys.path.

--- a/infra/mf-model-api/app/test/test_authz_config.py
+++ b/infra/mf-model-api/app/test/test_authz_config.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest import mock
 
-from app.core.config import base_config, validate_authz_config
+from app.core.config import authz_settings, base_config, validate_authz_config
 
 
 class ValidateAuthzConfigTest(unittest.TestCase):
@@ -32,13 +32,24 @@ class ValidateAuthzConfigTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self._run("shadow", "")
 
-    def test_unset_provider_is_rejected(self):
-        with self.assertRaises(RuntimeError):
-            self._run("", "http://bkn-safe:3000")
+    def test_unset_provider_is_accepted_with_a_warning(self):
+        # Refusing to start would turn an upgrade of a deployment that pins an
+        # explicit empty value into a CrashLoopBackOff.
+        self._run("", "http://bkn-safe:3000")
 
     def test_misspelled_provider_is_rejected(self):
         with self.assertRaises(RuntimeError):
             self._run("bkn_safe", "http://bkn-safe:3000")
+
+    def test_padded_provider_matches_the_runtime_comparison(self):
+        # A values file with a trailing space has to reach PermissionManager as
+        # the same normalised value the startup check accepted, or the service
+        # boots and then falls back to ISF on every decision.
+        env = {"AUTHZ_PROVIDER": " bkn-safe ", "BKN_SAFE_URL": " http://bkn-safe:3000 "}
+        with mock.patch.dict(os.environ, env, clear=False), \
+                mock.patch.object(base_config, "AUTH_ENABLED", True):
+            validate_authz_config()
+            self.assertEqual(authz_settings(), ("bkn-safe", "http://bkn-safe:3000"))
 
     def test_disabled_auth_skips_validation(self):
         # No authorization backend is consulted at all, so a missing provider

--- a/infra/mf-model-api/app/test/test_authz_config.py
+++ b/infra/mf-model-api/app/test/test_authz_config.py
@@ -1,0 +1,50 @@
+"""Tests for the AUTHZ_PROVIDER startup validation."""
+import os
+import unittest
+from unittest import mock
+
+from app.core.config import base_config, validate_authz_config
+
+
+class ValidateAuthzConfigTest(unittest.TestCase):
+    """The retired ISF fallback has to surface as a startup failure."""
+
+    def _run(self, provider, safe_url, auth_enabled=True):
+        env = {"AUTHZ_PROVIDER": provider, "BKN_SAFE_URL": safe_url}
+        with mock.patch.dict(os.environ, env, clear=False), \
+                mock.patch.object(base_config, "AUTH_ENABLED", auth_enabled):
+            validate_authz_config()
+
+    def test_bkn_safe_with_url_is_accepted(self):
+        self._run("bkn-safe", "http://bkn-safe:3000")
+
+    def test_shadow_with_url_is_accepted(self):
+        self._run("shadow", "http://bkn-safe:3000")
+
+    def test_isf_is_accepted_as_escape_hatch(self):
+        self._run("isf", "")
+
+    def test_bkn_safe_without_url_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("bkn-safe", "  ")
+
+    def test_shadow_without_url_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("shadow", "")
+
+    def test_unset_provider_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("", "http://bkn-safe:3000")
+
+    def test_misspelled_provider_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("bkn_safe", "http://bkn-safe:3000")
+
+    def test_disabled_auth_skips_validation(self):
+        # No authorization backend is consulted at all, so a missing provider
+        # is not a misconfiguration.
+        self._run("", "", auth_enabled=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-api/app/utils/app_utils.py
+++ b/infra/mf-model-api/app/utils/app_utils.py
@@ -18,7 +18,8 @@ from app.commons.locale import (
     is_openai_compat_path,
     localized_error_content,
 )
-from app.core.config import base_config, server_info, observability_config
+from app.core.config import (base_config, observability_config, server_info,
+                            validate_authz_config)
 from app.logs import log_init, sys_log
 from app.mydb.ConnectUtil import get_redis_util
 from app.routers import router_init
@@ -270,6 +271,9 @@ def create_app():
 
     # Initialize logging.
     log_init()
+    # Reject an authorization backend that cannot be honoured before the
+    # service starts answering requests with it.
+    validate_authz_config()
     # Load runtime configuration.
     conf_init(app)
     # Register application routes.

--- a/infra/mf-model-api/app/utils/permission_manager.py
+++ b/infra/mf-model-api/app/utils/permission_manager.py
@@ -1,9 +1,7 @@
-import os
-
 import aiohttp
 from typing import List, Dict, Optional
 
-from app.core.config import base_config
+from app.core.config import authz_settings, base_config
 from app.dao.small_model_dao import small_model_dao
 from app.logs.stand_log import StandLogger
 from app.commons.locale import internal_request_headers
@@ -23,9 +21,10 @@ class PermissionManager:
         #                              parallel, diffs logged (decision path only)
         #   AUTHZ_PROVIDER=bkn-safe -> bkn-safe AUTHORITATIVE for all methods
         #                              (ISF not consulted)
-        # Unset to revert (default = pure ISF). BKN_SAFE_URL points at bkn-safe.
-        self.authz_provider = os.getenv("AUTHZ_PROVIDER", "")
-        self.bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
+        # Unset falls back to ISF and warns at startup. BKN_SAFE_URL points at bkn-safe.
+        # Same normalisation the startup check uses, so a provider that was
+        # accepted at boot is the one compared here.
+        self.authz_provider, self.bkn_safe_url = authz_settings()
 
     def _bkn_safe_authoritative(self) -> bool:
         return self.authz_provider == "bkn-safe" and bool(self.bkn_safe_url)

--- a/infra/mf-model-api/charts/templates/deployment.yaml
+++ b/infra/mf-model-api/charts/templates/deployment.yaml
@@ -63,7 +63,8 @@ spec:
           env:
             - name: DEVICE_CODE
               value: {{ .Values.env.devicecode }}
-            # bkn-safe (ISF replacement) cutover; empty = ISF (default), revertible.
+            # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
+            # An unset or misspelled value refuses to start rather than falling back to ISF.
             - name: AUTHZ_PROVIDER
               value: {{ .Values.bknSafe.authzProvider | quote }}
             - name: DIRECTORY_PROVIDER

--- a/infra/mf-model-api/charts/templates/deployment.yaml
+++ b/infra/mf-model-api/charts/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             - name: DEVICE_CODE
               value: {{ .Values.env.devicecode }}
             # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
-            # An unset or misspelled value refuses to start rather than falling back to ISF.
+            # A misspelled value refuses to start; an unset one warns and falls back to ISF.
             - name: AUTHZ_PROVIDER
               value: {{ .Values.bknSafe.authzProvider | quote }}
             - name: DIRECTORY_PROVIDER

--- a/infra/mf-model-api/charts/values.yaml
+++ b/infra/mf-model-api/charts/values.yaml
@@ -30,12 +30,16 @@ ingress:
 env:
   devicecode: ""
 
-# bkn-safe (ISF replacement) cutover knobs. Default empty = ISF behavior.
-# provider: "" | "shadow" | "bkn-safe". url: bkn-safe ClusterIP base. Revertible.
+# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
+# value and is retired; anything else refuses to start.
+# provider: "bkn-safe" | "shadow" | "isf". url: bkn-safe ClusterIP base URL.
 bknSafe:
-  authzProvider: ""
-  directoryProvider: ""
-  url: ""
+  # Defaults match what the installer writes. A chart-only install therefore
+  # lands on a working bkn-safe deployment instead of the retired ISF: an
+  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  authzProvider: "bkn-safe"
+  directoryProvider: "bkn-safe"
+  url: "http://bkn-safe:3000"
 
 bknTrace:
   evidence:

--- a/infra/mf-model-api/charts/values.yaml
+++ b/infra/mf-model-api/charts/values.yaml
@@ -30,13 +30,12 @@ ingress:
 env:
   devicecode: ""
 
-# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
-# value and is retired; anything else refuses to start.
+# bkn-safe (ISF replacement) cutover knobs. isf is accepted but retired; a
+# misspelled value refuses to start, an unset one falls back to ISF and warns.
 # provider: "bkn-safe" | "shadow" | "isf". url: bkn-safe ClusterIP base URL.
 bknSafe:
-  # Defaults match what the installer writes. A chart-only install therefore
-  # lands on a working bkn-safe deployment instead of the retired ISF: an
-  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  # Defaults match what the installer writes, so a chart-only install lands on
+  # a working bkn-safe deployment instead of the retired ISF.
   authzProvider: "bkn-safe"
   directoryProvider: "bkn-safe"
   url: "http://bkn-safe:3000"

--- a/infra/mf-model-api/coverage_ut.py
+++ b/infra/mf-model-api/coverage_ut.py
@@ -1,3 +1,11 @@
+import os
+
+# The service now defaults to AUTH_ENABLED=true so a deployment that forgets the
+# variable fails closed. The suite predates that default and asserts the
+# anonymous-allow behaviour, so pin the open value here instead of rewriting
+# every case; tests that exercise the auth path patch base_config themselves.
+os.environ.setdefault("AUTH_ENABLED", "false")
+
 import unittest
 from os import path
 

--- a/infra/mf-model-manager/app/commons/get_user_info.py
+++ b/infra/mf-model-manager/app/commons/get_user_info.py
@@ -4,7 +4,7 @@ import os
 import time
 
 import aiohttp
-from app.core.config import base_config
+from app.core.config import base_config, directory_settings
 
 
 _DIRECTORY_TIMEOUT = aiohttp.ClientTimeout(total=3, sock_connect=1, sock_read=2)
@@ -75,8 +75,7 @@ async def get_username_by_ids(user_ids):
         return {}
     # bkn-safe directory cutover (revertible): DIRECTORY_PROVIDER=bkn-safe +
     # BKN_SAFE_URL resolves names via bkn-safe instead of ISF. Unset to revert.
-    provider = os.getenv("DIRECTORY_PROVIDER", "")
-    bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
+    provider, bkn_safe_url = directory_settings()
     if provider == "bkn-safe" and bkn_safe_url:
         return await _resolve_names_bkn_safe(bkn_safe_url, user_ids)
     user_management_url = f"http://{base_config.USERMANAGEMENTPRIVATEHOST}:{base_config.USERMANAGEMENTPRIVATEPORT}/api/user-management/v1/batch-get-user-info"

--- a/infra/mf-model-manager/app/core/config.py
+++ b/infra/mf-model-manager/app/core/config.py
@@ -141,17 +141,31 @@ AUTHZ_PROVIDER_ISF = 'isf'
 SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
 
 
-def authz_settings():
-    """Read the authorization backend selection through one normalisation.
+def _stripped_env(name):
+    """Read one bkn-safe cutover variable, whitespace removed.
 
-    Both the startup check and PermissionManager go through here so a value
-    that passes validation is the same value the runtime compares against.
-    Normalising in only one of the two would let "bkn-safe " start the service
-    and then miss every equality check, which is the silent ISF fallback this
-    validation exists to remove.
+    Every reader of these variables goes through here. Normalising in only
+    some of them would let "bkn-safe " pass the startup check and then miss
+    the equality comparisons that select the backend, which is the silent ISF
+    fallback this validation exists to remove.
     """
-    return (os.getenv('AUTHZ_PROVIDER', '').strip(),
-            os.getenv('BKN_SAFE_URL', '').strip())
+    return os.getenv(name, '').strip()
+
+
+def authz_settings():
+    """Authorization backend selection, shared by the startup check and
+    PermissionManager."""
+    return _stripped_env('AUTHZ_PROVIDER'), _stripped_env('BKN_SAFE_URL')
+
+
+def directory_settings():
+    """Directory (name resolution) backend selection, same normalisation."""
+    return _stripped_env('DIRECTORY_PROVIDER'), _stripped_env('BKN_SAFE_URL')
+
+
+def bkn_safe_url():
+    """bkn-safe base URL, same normalisation."""
+    return _stripped_env('BKN_SAFE_URL')
 
 
 def validate_authz_config():

--- a/infra/mf-model-manager/app/core/config.py
+++ b/infra/mf-model-manager/app/core/config.py
@@ -111,7 +111,10 @@ class BaseConfig(object):
     METERINGSTREAMMAXLEN = int(os.getenv('METERING_STREAM_MAXLEN', '100000'))
 
     # Authorization switch: true enables authentication and resource filtering.
-    AUTH_ENABLED = os.getenv('AUTH_ENABLED', 'false').lower() == 'true'
+    # Defaults to true so a deployment that never sets the variable fails
+    # closed, matching every Go service. Local runs and tests that want an
+    # open surface have to say AUTH_ENABLED=false out loud.
+    AUTH_ENABLED = os.getenv('AUTH_ENABLED', 'true').lower() == 'true'
     # Anonymous identity used for audit correlation when authorization is disabled.
     ANONYMOUS_USER_ID = "anonymous-user"
 
@@ -129,6 +132,42 @@ def resolve_metering_backend():
 
 
 base_config = BaseConfig()
+
+# Authorization backends this service can talk to. bkn-safe and shadow both
+# reach bkn-safe and therefore need BKN_SAFE_URL; isf is retired and stays
+# reachable only for environments that have not finished the cutover.
+AUTHZ_PROVIDERS_REQUIRING_SAFE_URL = ('bkn-safe', 'shadow')
+AUTHZ_PROVIDER_ISF = 'isf'
+SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
+
+
+def validate_authz_config():
+    """Refuse to start when the authorization backend cannot be honoured.
+
+    A misspelled AUTHZ_PROVIDER, or bkn-safe selected while BKN_SAFE_URL is
+    empty, used to print one line and fall back to ISF. ISF is retired, so
+    that fallback turned a typo into an authorization surface whose answers
+    are unpredictable, and the single log line made it invisible at runtime.
+    """
+    if not base_config.AUTH_ENABLED:
+        return
+    provider = os.getenv('AUTHZ_PROVIDER', '').strip()
+    safe_url = os.getenv('BKN_SAFE_URL', '').strip()
+    if provider in AUTHZ_PROVIDERS_REQUIRING_SAFE_URL:
+        if not safe_url:
+            raise RuntimeError(
+                f'AUTHZ_PROVIDER={provider} requires BKN_SAFE_URL to be set')
+        return
+    if provider == AUTHZ_PROVIDER_ISF:
+        logging.getLogger(__name__).warning(
+            'AUTHZ_PROVIDER=isf selects the retired authorization service; '
+            'migrate the deployment to bkn-safe')
+        return
+    raise RuntimeError(
+        f'AUTHZ_PROVIDER={provider!r} is not a supported authorization '
+        f'backend; set it to one of {", ".join(SUPPORTED_AUTHZ_PROVIDERS)}')
+
+
 server_info = ServerInfo(
     server_name="agent-executor",
     server_version="1.0.0",

--- a/infra/mf-model-manager/app/core/config.py
+++ b/infra/mf-model-manager/app/core/config.py
@@ -141,6 +141,19 @@ AUTHZ_PROVIDER_ISF = 'isf'
 SUPPORTED_AUTHZ_PROVIDERS = AUTHZ_PROVIDERS_REQUIRING_SAFE_URL + (AUTHZ_PROVIDER_ISF,)
 
 
+def authz_settings():
+    """Read the authorization backend selection through one normalisation.
+
+    Both the startup check and PermissionManager go through here so a value
+    that passes validation is the same value the runtime compares against.
+    Normalising in only one of the two would let "bkn-safe " start the service
+    and then miss every equality check, which is the silent ISF fallback this
+    validation exists to remove.
+    """
+    return (os.getenv('AUTHZ_PROVIDER', '').strip(),
+            os.getenv('BKN_SAFE_URL', '').strip())
+
+
 def validate_authz_config():
     """Refuse to start when the authorization backend cannot be honoured.
 
@@ -148,15 +161,24 @@ def validate_authz_config():
     empty, used to print one line and fall back to ISF. ISF is retired, so
     that fallback turned a typo into an authorization surface whose answers
     are unpredictable, and the single log line made it invisible at runtime.
+
+    An unset provider keeps working: existing deployments carry an explicit
+    empty value in their own values overrides, and refusing to start would
+    turn an upgrade into a CrashLoopBackOff. It warns loudly instead, and the
+    flip to a hard failure waits until those deployments are counted.
     """
     if not base_config.AUTH_ENABLED:
         return
-    provider = os.getenv('AUTHZ_PROVIDER', '').strip()
-    safe_url = os.getenv('BKN_SAFE_URL', '').strip()
+    provider, safe_url = authz_settings()
     if provider in AUTHZ_PROVIDERS_REQUIRING_SAFE_URL:
         if not safe_url:
             raise RuntimeError(
                 f'AUTHZ_PROVIDER={provider} requires BKN_SAFE_URL to be set')
+        return
+    if provider == '':
+        logging.getLogger(__name__).warning(
+            'AUTHZ_PROVIDER is unset, so authorization falls back to the '
+            'retired ISF; set it to bkn-safe')
         return
     if provider == AUTHZ_PROVIDER_ISF:
         logging.getLogger(__name__).warning(

--- a/infra/mf-model-manager/app/routers/operation_audit_router.py
+++ b/infra/mf-model-manager/app/routers/operation_audit_router.py
@@ -1,10 +1,10 @@
 import asyncio
-import os
 from datetime import datetime
 
 import aiohttp
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from app.core.config import bkn_safe_url
 from app.mydb.pymysql_pool import PymysqlPool
 from app.commons.locale import internal_request_headers
 
@@ -24,7 +24,7 @@ def _audit_error(name):
 
 async def _require_audit_reader(request: Request):
     token = request.headers.get("authorization", "")
-    safe = os.getenv("BKN_SAFE_URL", "").rstrip("/")
+    safe = bkn_safe_url().rstrip("/")
     if not token or not safe:
         raise _audit_error("access_denied")
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:

--- a/infra/mf-model-manager/app/test/conftest.py
+++ b/infra/mf-model-manager/app/test/conftest.py
@@ -1,0 +1,8 @@
+"""Shared test setup for mf-model-manager."""
+import os
+
+# The service now defaults to AUTH_ENABLED=true so a deployment that forgets the
+# variable fails closed. The suite predates that default and asserts the
+# anonymous-allow behaviour, so pin the open value before project code is
+# imported; cases that exercise the auth path patch base_config themselves.
+os.environ.setdefault("AUTH_ENABLED", "false")

--- a/infra/mf-model-manager/app/test/test_authz_config.py
+++ b/infra/mf-model-manager/app/test/test_authz_config.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest import mock
 
-from app.core.config import base_config, validate_authz_config
+from app.core.config import authz_settings, base_config, validate_authz_config
 
 
 class ValidateAuthzConfigTest(unittest.TestCase):
@@ -32,13 +32,24 @@ class ValidateAuthzConfigTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self._run("shadow", "")
 
-    def test_unset_provider_is_rejected(self):
-        with self.assertRaises(RuntimeError):
-            self._run("", "http://bkn-safe:3000")
+    def test_unset_provider_is_accepted_with_a_warning(self):
+        # Refusing to start would turn an upgrade of a deployment that pins an
+        # explicit empty value into a CrashLoopBackOff.
+        self._run("", "http://bkn-safe:3000")
 
     def test_misspelled_provider_is_rejected(self):
         with self.assertRaises(RuntimeError):
             self._run("bkn_safe", "http://bkn-safe:3000")
+
+    def test_padded_provider_matches_the_runtime_comparison(self):
+        # A values file with a trailing space has to reach PermissionManager as
+        # the same normalised value the startup check accepted, or the service
+        # boots and then falls back to ISF on every decision.
+        env = {"AUTHZ_PROVIDER": " bkn-safe ", "BKN_SAFE_URL": " http://bkn-safe:3000 "}
+        with mock.patch.dict(os.environ, env, clear=False), \
+                mock.patch.object(base_config, "AUTH_ENABLED", True):
+            validate_authz_config()
+            self.assertEqual(authz_settings(), ("bkn-safe", "http://bkn-safe:3000"))
 
     def test_disabled_auth_skips_validation(self):
         # No authorization backend is consulted at all, so a missing provider

--- a/infra/mf-model-manager/app/test/test_authz_config.py
+++ b/infra/mf-model-manager/app/test/test_authz_config.py
@@ -1,0 +1,50 @@
+"""Tests for the AUTHZ_PROVIDER startup validation."""
+import os
+import unittest
+from unittest import mock
+
+from app.core.config import base_config, validate_authz_config
+
+
+class ValidateAuthzConfigTest(unittest.TestCase):
+    """The retired ISF fallback has to surface as a startup failure."""
+
+    def _run(self, provider, safe_url, auth_enabled=True):
+        env = {"AUTHZ_PROVIDER": provider, "BKN_SAFE_URL": safe_url}
+        with mock.patch.dict(os.environ, env, clear=False), \
+                mock.patch.object(base_config, "AUTH_ENABLED", auth_enabled):
+            validate_authz_config()
+
+    def test_bkn_safe_with_url_is_accepted(self):
+        self._run("bkn-safe", "http://bkn-safe:3000")
+
+    def test_shadow_with_url_is_accepted(self):
+        self._run("shadow", "http://bkn-safe:3000")
+
+    def test_isf_is_accepted_as_escape_hatch(self):
+        self._run("isf", "")
+
+    def test_bkn_safe_without_url_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("bkn-safe", "  ")
+
+    def test_shadow_without_url_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("shadow", "")
+
+    def test_unset_provider_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("", "http://bkn-safe:3000")
+
+    def test_misspelled_provider_is_rejected(self):
+        with self.assertRaises(RuntimeError):
+            self._run("bkn_safe", "http://bkn-safe:3000")
+
+    def test_disabled_auth_skips_validation(self):
+        # No authorization backend is consulted at all, so a missing provider
+        # is not a misconfiguration.
+        self._run("", "", auth_enabled=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/mf-model-manager/app/utils/app_utils.py
+++ b/infra/mf-model-manager/app/utils/app_utils.py
@@ -15,7 +15,8 @@ from app.commons.locale import (
     is_business_api_path,
     localized_error_content,
 )
-from app.core.config import base_config, server_info, observability_config
+from app.core.config import (base_config, observability_config, server_info,
+                            validate_authz_config)
 from app.logs import log_init, sys_log
 from app.mydb.ConnectUtil import get_redis_util
 from app.mydb.pymysql_pool import PymysqlPool
@@ -241,6 +242,9 @@ def create_app():
 
     # Initialize logging.
     log_init()
+    # Reject an authorization backend that cannot be honoured before the
+    # service starts answering requests with it.
+    validate_authz_config()
     # Load runtime configuration.
     conf_init(app)
     # Register application routes.

--- a/infra/mf-model-manager/app/utils/permission_manager.py
+++ b/infra/mf-model-manager/app/utils/permission_manager.py
@@ -1,10 +1,8 @@
 import asyncio
-import os
-
 import aiohttp
 from typing import List, Dict, Optional
 
-from app.core.config import base_config
+from app.core.config import authz_settings, base_config
 from app.dao.small_model_dao import small_model_dao
 from app.commons.locale import internal_request_headers
 from app.logs.stand_log import StandLogger
@@ -24,9 +22,10 @@ class PermissionManager:
         #                              parallel, diffs logged (decision path only)
         #   AUTHZ_PROVIDER=bkn-safe -> bkn-safe AUTHORITATIVE for all methods
         #                              (ISF not consulted)
-        # Unset to revert (default = pure ISF). BKN_SAFE_URL points at bkn-safe.
-        self.authz_provider = os.getenv("AUTHZ_PROVIDER", "")
-        self.bkn_safe_url = os.getenv("BKN_SAFE_URL", "")
+        # Unset falls back to ISF and warns at startup. BKN_SAFE_URL points at bkn-safe.
+        # Same normalisation the startup check uses, so a provider that was
+        # accepted at boot is the one compared here.
+        self.authz_provider, self.bkn_safe_url = authz_settings()
 
     def _bkn_safe_authoritative(self) -> bool:
         return self.authz_provider == "bkn-safe" and bool(self.bkn_safe_url)

--- a/infra/mf-model-manager/charts/templates/deployment.yaml
+++ b/infra/mf-model-manager/charts/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
             - name: DEVICE_CODE
               value: {{ .Values.env.devicecode }}
             # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
-            # An unset or misspelled value refuses to start rather than falling back to ISF.
+            # A misspelled value refuses to start; an unset one warns and falls back to ISF.
             - name: AUTHZ_PROVIDER
               value: {{ .Values.bknSafe.authzProvider | quote }}
             - name: DIRECTORY_PROVIDER

--- a/infra/mf-model-manager/charts/templates/deployment.yaml
+++ b/infra/mf-model-manager/charts/templates/deployment.yaml
@@ -82,7 +82,8 @@ spec:
           env:
             - name: DEVICE_CODE
               value: {{ .Values.env.devicecode }}
-            # bkn-safe (ISF replacement) cutover; empty = ISF (default), revertible.
+            # bkn-safe (ISF replacement) cutover. Accepted: bkn-safe, shadow, isf.
+            # An unset or misspelled value refuses to start rather than falling back to ISF.
             - name: AUTHZ_PROVIDER
               value: {{ .Values.bknSafe.authzProvider | quote }}
             - name: DIRECTORY_PROVIDER

--- a/infra/mf-model-manager/charts/values.yaml
+++ b/infra/mf-model-manager/charts/values.yaml
@@ -30,13 +30,12 @@ ingress:
 env:
   devicecode: ""
 
-# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
-# value and is retired; anything else refuses to start.
+# bkn-safe (ISF replacement) cutover knobs. isf is accepted but retired; a
+# misspelled value refuses to start, an unset one falls back to ISF and warns.
 # provider: "bkn-safe" | "shadow" | "isf". url: bkn-safe ClusterIP base URL.
 bknSafe:
-  # Defaults match what the installer writes. A chart-only install therefore
-  # lands on a working bkn-safe deployment instead of the retired ISF: an
-  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  # Defaults match what the installer writes, so a chart-only install lands on
+  # a working bkn-safe deployment instead of the retired ISF.
   authzProvider: "bkn-safe"
   directoryProvider: "bkn-safe"
   url: "http://bkn-safe:3000"

--- a/infra/mf-model-manager/charts/values.yaml
+++ b/infra/mf-model-manager/charts/values.yaml
@@ -30,12 +30,16 @@ ingress:
 env:
   devicecode: ""
 
-# bkn-safe (ISF replacement) cutover knobs. Default empty = ISF behavior.
-# provider: "" | "shadow" | "bkn-safe". url: bkn-safe ClusterIP base. Revertible.
+# bkn-safe (ISF replacement) cutover knobs. isf is the only other accepted
+# value and is retired; anything else refuses to start.
+# provider: "bkn-safe" | "shadow" | "isf". url: bkn-safe ClusterIP base URL.
 bknSafe:
-  authzProvider: ""
-  directoryProvider: ""
-  url: ""
+  # Defaults match what the installer writes. A chart-only install therefore
+  # lands on a working bkn-safe deployment instead of the retired ISF: an
+  # unset or misspelled authzProvider is now a startup error, not a fallback.
+  authzProvider: "bkn-safe"
+  directoryProvider: "bkn-safe"
+  url: "http://bkn-safe:3000"
 
 nodeSelector: {}
 

--- a/infra/mf-model-manager/coverage_ut.py
+++ b/infra/mf-model-manager/coverage_ut.py
@@ -1,3 +1,11 @@
+import os
+
+# The service now defaults to AUTH_ENABLED=true so a deployment that forgets the
+# variable fails closed. The suite predates that default and asserts the
+# anonymous-allow behaviour, so pin the open value here instead of rewriting
+# every case; tests that exercise the auth path patch base_config themselves.
+os.environ.setdefault("AUTH_ENABLED", "false")
+
 import unittest
 from os import path
 


### PR DESCRIPTION
Closes #352.

## Problem

Two defaults let a deployment lose its authorization surface without saying so.

**`AUTH_ENABLED` defaulted to `false` in the Python services.** Every Go service defaults to true; `mf-model-api` and `mf-model-manager` did not. Unless the installer injected the variable, both answered without checking identity and `get_permission_ids` returned every model id. The installer is an operations convention, not a code guarantee — any deployment that bypassed it landed on "no authorization".

**`AUTHZ_PROVIDER` fell back to the retired ISF.** A misspelled value, or `bkn-safe` with an empty `BKN_SAFE_URL`, printed one line and used ISF. ISF is retired, so the fallback turned a typo into an authorization backend whose answers are unpredictable, and the log line made that nearly invisible at runtime.

## Change

- `AUTH_ENABLED` now defaults to `true` in both Python services, matching the Go side.
- A misspelled `AUTHZ_PROVIDER`, or `bkn-safe`/`shadow` without `BKN_SAFE_URL`, is now fatal: vega's `MaybeShadow` returns an error that `main` turns into a `Fatalf`, and the Python services run the same check in `create_app`.
- An **unset** provider keeps the ISF fallback and warns loudly. Refusing to start would CrashLoopBackOff any deployment that pins an explicit empty `bknSafe.authzProvider` in its own values override; flipping that to an error belongs in a later stage, after a shadow period counts them. `isf` stays accepted as an explicit escape hatch and warns the same way.
- Provider and URL are normalised in one place (`config.authz_settings()`), shared by the startup check and `PermissionManager`. Stripping in only one of the two let `"bkn-safe "` pass validation and then match neither equality check, which is exactly the silent ISF fallback this PR removes.
- Chart defaults for `bknSafe.{authzProvider,directoryProvider,url}` move from empty to the values the installer already writes, so a chart-only install lands on a working bkn-safe deployment.
- Test harnesses (`coverage_ut.py`, `conftest.py`) pin `AUTH_ENABLED=false`: the suites predate the flip and assert the anonymous-allow behaviour.

## Compatibility

- Installer path unchanged — `deploy/conf/config.yaml` and `config.sh` already write `authzProvider: bkn-safe`, `url: http://bkn-safe:3000`, `auth.enabled: "true"`.
- Deployments carrying an explicit empty `authzProvider` keep booting, with a warning.
- Chart-only installs get working defaults instead of the retired ISF.
- No request or response contract changes; the flip is a startup-time configuration check.

## Verification

- `go build ./...`, `go vet`, `gofmt -l` clean in `vega-backend`; `go test ./drivenadapters/permission/...` passes, with `TestMaybeShadow` covering unset provider, misspelled provider, padded value, and empty `BKN_SAFE_URL` for both bkn-safe and shadow.
- New `test_authz_config.py` in both Python services: 9 cases each, all passing.
- `helm template` renders cleanly for `vega-backend`, `mf-model-api`, `mf-model-manager`; rendered `AUTHZ_PROVIDER` is `bkn-safe`.

Test-server acceptance on 14.103.77.23 (fresh install and upgrade paths) still to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)