### PR TITLE
fix(health): expose version endpoints under API prefixes

### DIFF
--- a/adp/bkn/bkn-backend/README.md
+++ b/adp/bkn/bkn-backend/README.md
@@ -148,7 +148,7 @@ http://localhost:13014
 Health check:
 
 ```bash
-curl http://localhost:13014/health
+curl http://localhost:13014/api/bkn-backend/v1/health
 ```
 
 ## Testing

--- a/adp/bkn/bkn-backend/README.zh.md
+++ b/adp/bkn/bkn-backend/README.zh.md
@@ -140,7 +140,7 @@ http://localhost:13014
 健康检查：
 
 ```bash
-curl http://localhost:13014/health
+curl http://localhost:13014/api/bkn-backend/v1/health
 ```
 
 ## 测试

--- a/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
+++ b/adp/bkn/bkn-backend/helm/bkn-backend/templates/deployment.yaml
@@ -72,8 +72,9 @@ spec:
           timeoutSeconds: 30
           failureThreshold: 3
         readinessProbe:
-          tcpSocket:
-            port: {{ .Values.service.bknBackend.port }}
+          httpGet:
+            path: /api/bkn-backend/v1/health
+            port: backend
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 30

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -92,7 +92,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.LanguageMiddleware())
 	c.Use(r.OperationAudit())
 
-	c.GET("/health", r.HealthCheck)
+	c.GET("/api/bkn-backend/v1/health", r.HealthCheck)
 
 	bknApiV1 := c.Group("/api/bkn-backend/v1")
 	otlApiV1 := c.Group("/api/ontology-manager/v1")

--- a/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
@@ -41,11 +41,21 @@ func Test_RestHandler_HealthCheck(t *testing.T) {
 		handler := &restHandler{appSetting: &common.AppSetting{}}
 		handler.RegisterPublic(engine)
 
+		for _, path := range []string{"/api/bkn-backend/v1/health"} {
+			Convey("It serves health information without authentication at "+path, func() {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				w := httptest.NewRecorder()
+				engine.ServeHTTP(w, req)
+
+				So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldContainSubstring, "ServerVersion")
+			})
+		}
+
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		w := httptest.NewRecorder()
 		engine.ServeHTTP(w, req)
-
-		So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		So(w.Result().StatusCode, ShouldEqual, http.StatusNotFound)
 	})
 }
 

--- a/adp/bkn/bkn-backend/tests/testutil/http_client.go
+++ b/adp/bkn/bkn-backend/tests/testutil/http_client.go
@@ -53,7 +53,7 @@ func NewHTTPClient(baseURL string) *HTTPClient {
 
 // CheckHealth checks service health.
 func (c *HTTPClient) CheckHealth() error {
-	resp, err := c.Client.Get(c.BaseURL + "/health")
+	resp, err := c.Client.Get(c.BaseURL + "/api/bkn-backend/v1/health")
 	if err != nil {
 		return fmt.Errorf("健康检查失败: %w", err)
 	}

--- a/adp/bkn/ontology-query/README.md
+++ b/adp/bkn/ontology-query/README.md
@@ -83,7 +83,7 @@ server/
 
 ### System APIs
 
-- **Health check**: `GET /health`
+- **Health check**: `GET /api/ontology-query/v1/health`
 
 For detailed API documentation, see [API documentation](./api_doc/).
 
@@ -190,8 +190,8 @@ infrastructure failures return HTTP 503.
 
 ### Health checks
 
-- **Health check endpoint**: `GET /health`
-- **Readiness check endpoint**: `GET /ready`
+- **Health check endpoint**: `GET /api/ontology-query/v1/health`
+- **Readiness check endpoint**: `GET /api/ontology-query/v1/health`
 
 ### Logging configuration
 

--- a/adp/bkn/ontology-query/helm/ontology-query/templates/deployment.yaml
+++ b/adp/bkn/ontology-query/helm/ontology-query/templates/deployment.yaml
@@ -72,8 +72,9 @@ spec:
           timeoutSeconds: 30
           failureThreshold: 3
         readinessProbe:
-          tcpSocket:
-            port: {{ .Values.service.ontologyQuery.port }}
+          httpGet:
+            path: /api/ontology-query/v1/health
+            port: query
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 30

--- a/adp/bkn/ontology-query/server/driveradapters/routers.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers.go
@@ -70,7 +70,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.TraceContextMiddleware())
 	c.Use(r.LanguageMiddleware())
 
-	c.GET("/health", r.HealthCheck)
+	c.GET("/api/ontology-query/v1/health", r.HealthCheck)
 
 	apiV1 := c.Group("/api/ontology-query/v1")
 	apiV1.Use(rest.PrivateNoCacheMiddleware())

--- a/adp/bkn/ontology-query/server/driveradapters/routers_test.go
+++ b/adp/bkn/ontology-query/server/driveradapters/routers_test.go
@@ -102,13 +102,21 @@ func Test_RestHandler_HealthCheck(t *testing.T) {
 		handler := MockNewRestHandler(appSetting, as, ats, kns, ots)
 		handler.RegisterPublic(engine)
 
-		Convey("成功 - 健康检查", func() {
-			req := httptest.NewRequest(http.MethodGet, "/health", nil)
-			w := httptest.NewRecorder()
-			engine.ServeHTTP(w, req)
+		for _, path := range []string{"/api/ontology-query/v1/health"} {
+			Convey("成功 - 健康检查 "+path, func() {
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				w := httptest.NewRecorder()
+				engine.ServeHTTP(w, req)
 
-			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
-		})
+				So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+				So(w.Body.String(), ShouldContainSubstring, "ServerVersion")
+			})
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		w := httptest.NewRecorder()
+		engine.ServeHTTP(w, req)
+		So(w.Result().StatusCode, ShouldEqual, http.StatusNotFound)
 	})
 }
 

--- a/adp/vega/vega-backend/CLAUDE.md
+++ b/adp/vega/vega-backend/CLAUDE.md
@@ -69,7 +69,7 @@ server/
 | Catalog 状态 | GET `/catalogs/:id/status`, POST `/catalogs/:id/test-connection` |
 | Resource | GET/POST `/resources`, GET/PUT/DELETE `/resources/:id` |
 | Resource 操作 | GET `/resources/:id/schema`, POST `/resources/:id/enable\|disable\|sync` |
-| 健康检查 | GET `/health` |
+| 健康检查 | GET `/api/vega-backend/v1/health` |
 
 #### 端点设计规则
 

--- a/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
+++ b/adp/vega/vega-backend/helm/vega-backend/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             containerPort: {{ .Values.service.vegaBackend.port }}
         livenessProbe:
           httpGet:
-            path: /health
+            path: /api/vega-backend/v1/health
             port: backend
           initialDelaySeconds: 10
           periodSeconds: 10
@@ -72,7 +72,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /readyz
+            path: /api/vega-backend/v1/readyz
             port: backend
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -111,8 +111,8 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	c.Use(r.LanguageMiddleware())
 	c.Use(r.OperationAudit())
 
-	c.GET("/health", r.HealthCheck)
-	c.GET("/readyz", r.ReadinessCheck)
+	c.GET("/api/vega-backend/v1/health", r.HealthCheck)
+	c.GET("/api/vega-backend/v1/readyz", r.ReadinessCheck)
 
 	// External API (External
 	apiV1 := c.Group("/api/vega-backend/v1")

--- a/adp/vega/vega-backend/server/driveradapters/router_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/router_test.go
@@ -60,17 +60,40 @@ func Test_RestHandler_HealthCheck(t *testing.T) {
 	t.Run("returns server metadata", func(t *testing.T) {
 		engine := gin.New()
 		handler := &restHandler{}
-		engine.GET("/health", handler.HealthCheck)
+		for _, path := range []string{"/api/vega-backend/v1/health"} {
+			t.Run(path, func(t *testing.T) {
+				engine.GET(path, handler.HealthCheck)
+				req := httptest.NewRequest(http.MethodGet, path, nil)
+				w := httptest.NewRecorder()
 
-		req := httptest.NewRequest(http.MethodGet, "/health", nil)
-		w := httptest.NewRecorder()
+				engine.ServeHTTP(w, req)
 
-		engine.ServeHTTP(w, req)
-
-		require.Equal(t, http.StatusOK, w.Result().StatusCode)
-		assert.Contains(t, w.Body.String(), "ServerName")
-		assert.Contains(t, w.Body.String(), "ServerVersion")
+				require.Equal(t, http.StatusOK, w.Result().StatusCode)
+				assert.Contains(t, w.Body.String(), "ServerName")
+				assert.Contains(t, w.Body.String(), "ServerVersion")
+			})
+		}
 	})
+}
+
+func Test_RestHandler_RegisterPublicHealthRoutes(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	engine := gin.New()
+	(&restHandler{}).RegisterPublic(engine)
+
+	routes := make(map[string]bool)
+	for _, route := range engine.Routes() {
+		if route.Method == http.MethodGet {
+			routes[route.Path] = true
+		}
+	}
+
+	assert.True(t, routes["/api/vega-backend/v1/health"])
+	assert.True(t, routes["/api/vega-backend/v1/readyz"])
+	assert.False(t, routes["/health"])
+	assert.False(t, routes["/readyz"])
 }
 
 func Test_RestHandler_ReadinessCheck(t *testing.T) {
@@ -79,10 +102,10 @@ func Test_RestHandler_ReadinessCheck(t *testing.T) {
 
 	engine := gin.New()
 	handler := &restHandler{}
-	engine.GET("/readyz", handler.ReadinessCheck)
+	engine.GET("/api/vega-backend/v1/readyz", handler.ReadinessCheck)
 
 	handler.SetReady(true)
-	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	request := httptest.NewRequest(http.MethodGet, "/api/vega-backend/v1/readyz", nil)
 	readyResponse := httptest.NewRecorder()
 	engine.ServeHTTP(readyResponse, request)
 	require.Equal(t, http.StatusOK, readyResponse.Code)

--- a/adp/vega/vega-backend/tests/testutil/http_client.go
+++ b/adp/vega/vega-backend/tests/testutil/http_client.go
@@ -53,7 +53,7 @@ func NewHTTPClient(baseURL string) *HTTPClient {
 
 // CheckHealth 检查服务健康状态
 func (c *HTTPClient) CheckHealth() error {
-	resp, err := c.Client.Get(c.BaseURL + "/health")
+	resp, err := c.Client.Get(c.BaseURL + "/api/vega-backend/v1/health")
 	if err != nil {
 		return fmt.Errorf("健康检查失败: %w", err)
 	}

--- a/docs/api/bkn/bkn.yaml
+++ b/docs/api/bkn/bkn.yaml
@@ -16,6 +16,35 @@ tags:
     description: BKN import and export APIs
 
 paths:
+  /api/bkn-backend/v1/health:
+    get:
+      tags:
+        - BKN
+      summary: Get BKN backend health and platform version
+      description: Returns BKN backend runtime information. ServerVersion is the platform version for releases in which all services share one version.
+      operationId: getBKNBackendHealth
+      security: []
+      responses:
+        '200':
+          description: Health and version information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ServerName:
+                    type: string
+                  ServerVersion:
+                    type: string
+                    description: Platform version.
+                  Language:
+                    type: string
+                  GoVersion:
+                    type: string
+                  GoArch:
+                    type: string
+                required:
+                  - ServerVersion
   # ==================== BKN Import/Export ====================
   /api/bkn-backend/v1/bkns:
     post:

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -4,6 +4,33 @@ info:
   title: ontology-query
   version: 0.2.0
 paths:
+  /api/ontology-query/v1/health:
+    get:
+      summary: 获取 Ontology Query 健康状态和平台版本
+      description: 返回 Ontology Query 运行时信息。当前所有服务统一发布版本时，ServerVersion 表示平台版本。
+      operationId: getOntologyQueryHealth
+      security: []
+      responses:
+        "200":
+          description: 健康状态和版本信息
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ServerName:
+                    type: string
+                  ServerVersion:
+                    type: string
+                    description: 平台版本。
+                  Language:
+                    type: string
+                  GoVersion:
+                    type: string
+                  GoArch:
+                    type: string
+                required:
+                  - ServerVersion
   /api/ontology-query/v1/knowledge-networks/{kn_id}/object-types/{ot_id}:
     summary: 检索指定对象类的对象的详细数据
     post:

--- a/docs/api/vega/README.md
+++ b/docs/api/vega/README.md
@@ -12,6 +12,7 @@
 | [connector-type.yaml](connector-type.yaml) | ConnectorType | `GET/POST /connector-types`、`GET/PUT/DELETE /connector-types/{type}`、`POST .../enable`、`POST .../disable` |
 | [discover-task.yaml](discover-task.yaml) | DiscoverTask | `POST /catalogs/{id}/discover`、`GET /discover-tasks`、`GET /discover-tasks/{id}`、`DELETE /discover-tasks/{ids}` |
 | [discover-schedule.yaml](discover-schedule.yaml) | DiscoverSchedule | `GET/POST /discover-schedules`、`GET/PUT/DELETE /discover-schedules/{id}`、`POST .../enable`、`POST .../disable` |
+| [health.yaml](health.yaml) | Health | `GET /api/vega-backend/v1/health`（返回平台版本） |
 | [resource.yaml](resource.yaml) | Resource | `GET/POST /resources`、`GET/PUT/DELETE /resources/{id(s)}` |
 | [resource-data.yaml](resource-data.yaml) | ResourceData | `POST/PUT /resources/{id}/data`、`GET/PUT/DELETE /resources/{id}/data/{doc_id(s)}` |
 | [raw-query.yaml](raw-query.yaml) | RawQuery | `POST /resources/query` |

--- a/docs/api/vega/health.yaml
+++ b/docs/api/vega/health.yaml
@@ -1,0 +1,46 @@
+openapi: 3.1.1
+info:
+  title: Vega Backend Health API
+  description: Vega Backend 健康状态和平台版本接口。
+  version: 0.1.0
+servers:
+  - url: /api/vega-backend/v1
+paths:
+  /health:
+    get:
+      summary: 获取 Vega Backend 健康状态和平台版本
+      description: 返回 Vega Backend 运行时信息。当前所有服务统一发布版本时，ServerVersion 表示平台版本。
+      operationId: getVegaBackendHealth
+      security: []
+      responses:
+        '200':
+          description: 健康状态和版本信息
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ServerName:
+                    type: string
+                  ServerVersion:
+                    type: string
+                    description: 平台版本。
+                  Language:
+                    type: string
+                  GoVersion:
+                    type: string
+                  GoArch:
+                    type: string
+                required:
+                  - ServerVersion
+  /readyz:
+    get:
+      summary: 获取 Vega Backend 就绪状态
+      description: 返回 200 表示服务可接收流量；服务终止排空期间返回 503。
+      operationId: getVegaBackendReadiness
+      security: []
+      responses:
+        '200':
+          description: 服务已就绪
+        '503':
+          description: 服务正在排空或尚未就绪

--- a/help/en/manual/vega.md
+++ b/help/en/manual/vega.md
@@ -32,7 +32,7 @@ openbkn vega catalog list --limit 1
 openbkn vega catalog health <catalog_id> [<catalog_id> ...]
 ```
 
-The vega-backend pod's own `GET /health` is not under `/api/vega-backend/v1` and is usually not exposed through the ingress; reach it from inside the cluster when troubleshooting.
+Vega Backend exposes `GET /api/vega-backend/v1/health` through the standard API prefix. It returns service metadata including the platform version.
 
 ### Catalog management
 
@@ -329,8 +329,8 @@ curl -sk "https://<access-address>/api/vega-backend/v1/catalogs?limit=1" \
   -H "Authorization: Bearer $(openbkn auth token)" \
 
 
-# Optional: raw pod health (path is /health on vega-backend, not under /v1)
-# curl -sk "https://<access-address>/health" -H "Authorization: Bearer $(openbkn auth token)"
+# Platform version and Vega Backend health
+curl -sk "https://<access-address>/api/vega-backend/v1/health"
 
 # List / get catalogs
 curl -sk "https://<access-address>/api/vega-backend/v1/catalogs?status=healthy&limit=20" \

--- a/help/zh/manual/vega.md
+++ b/help/zh/manual/vega.md
@@ -32,7 +32,7 @@ openbkn vega catalog list --limit 1
 openbkn vega catalog health <catalog_id> [<catalog_id> ...]
 ```
 
-vega-backend Pod 自身的 `GET /health` 不在 `/api/vega-backend/v1` 下，通常也不经 Ingress 暴露，排障时在集群内访问。
+Vega Backend 通过标准 API 前缀暴露 `GET /api/vega-backend/v1/health`，返回包含平台版本的服务运行信息。
 
 ### Catalog 管理
 
@@ -324,8 +324,8 @@ curl -sk "https://<访问地址>/api/vega-backend/v1/catalogs?limit=1" \
   -H "Authorization: Bearer $(openbkn auth token)" \
 
 
-# 可选：直连 vega-backend Pod 的 /health（不在 /v1 下）
-# curl -sk "https://<访问地址>/health" -H "Authorization: Bearer $(openbkn auth token)"
+# 平台版本和 Vega Backend 健康状态
+curl -sk "https://<访问地址>/api/vega-backend/v1/health"
 
 curl -sk "https://<访问地址>/api/vega-backend/v1/catalogs?health_check_status=healthy&limit=20" \
   -H "Authorization: Bearer $(openbkn auth token)"


### PR DESCRIPTION
## What Changed

- [x] Move BKN Backend, Ontology Query, and Vega Backend health endpoints under their public API prefixes.
- [x] Return the existing `ServerVersion` metadata as the current platform-version source.
- [x] Update BKN and Ontology readiness probes to use HTTP health while retaining TCP liveness probes.
- [x] Update Vega health/readiness probes, OpenAPI, manuals, and route regression tests.

---

## Why

- Related Issue: [bkn-sdk#91](https://github.com/openbkn-ai/bkn-sdk/issues/91)
- Background: the SDK version gate needs a publicly routable platform-version endpoint; the prior root health paths were not exposed by the ingress API-prefix configuration.

---

## How

- BKN: `GET /api/bkn-backend/v1/health`.
- Ontology: `GET /api/ontology-query/v1/health`.
- Vega: `GET /api/vega-backend/v1/health` and `GET /api/vega-backend/v1/readyz`.
- Breaking changes: legacy root `/health` (and Vega `/readyz`) are removed.

---

## Testing

- [x] Unit tests passed locally
- [x] Helm templates rendered locally
- [ ] Verified in test environment (not run)

Test notes:

- Focused router tests for BKN Backend, Ontology Query, and Vega Backend passed.
- Helm template validation passed for all three charts.
- Documentation lint completed with existing warnings only.

---

## Risk & Rollback

- Potential risks: any external consumer still calling legacy root health paths receives 404.
- Rollback plan: revert this PR to restore legacy routing and probes.

---

## Additional Notes

- The corresponding SDK consumer change is [bkn-sdk#95](https://github.com/openbkn-ai/bkn-sdk/pull/95).