### PR TITLE
feat(bkn): expose child resource operations

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/action_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/action_type.go
@@ -119,7 +119,8 @@ type ActionType struct {
 	Updater    AccountInfo `json:"updater" mapstructure:"updater"`
 	UpdateTime int64       `json:"update_time" mapstructure:"update_time"`
 
-	ModuleType string `json:"module_type" mapstructure:"module_type"`
+	ModuleType string   `json:"module_type" mapstructure:"module_type"`
+	Operations []string `json:"operations,omitempty"`
 
 	IfNameModify bool `json:"-"`
 	// Vector.

--- a/adp/bkn/bkn-backend/server/interfaces/metric.go
+++ b/adp/bkn/bkn-backend/server/interfaces/metric.go
@@ -273,6 +273,7 @@ type MetricDefinition struct {
 	Updater    AccountInfo `json:"updater,omitempty" mapstructure:"updater"`
 	UpdateTime int64       `json:"update_time,omitempty" mapstructure:"update_time"`
 	ModuleType string      `json:"module_type,omitempty" mapstructure:"module_type"`
+	Operations []string    `json:"operations,omitempty"`
 
 	Vector []float32 `json:"_vector,omitempty"`
 	Score  *float64  `json:"_score,omitempty"`

--- a/adp/bkn/bkn-backend/server/interfaces/object_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type.go
@@ -104,7 +104,8 @@ type ObjectType struct {
 	Updater    AccountInfo `json:"updater" mapstructure:"updater"`
 	UpdateTime int64       `json:"update_time" mapstructure:"update_time"`
 
-	ModuleType string `json:"module_type" mapstructure:"module_type"`
+	ModuleType string   `json:"module_type" mapstructure:"module_type"`
+	Operations []string `json:"operations,omitempty"`
 
 	PropertyMap  map[string]string `json:"-"` // Map from property name to display name
 	IfNameModify bool              `json:"-"`

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type.go
@@ -44,7 +44,8 @@ type RelationType struct {
 	Updater    AccountInfo `json:"updater" mapstructure:"updater"`
 	UpdateTime int64       `json:"update_time" mapstructure:"update_time"`
 
-	ModuleType string `json:"module_type" mapstructure:"module_type"`
+	ModuleType string   `json:"module_type" mapstructure:"module_type"`
+	Operations []string `json:"operations,omitempty"`
 
 	IfNameModify bool `json:"-"`
 

--- a/adp/bkn/bkn-backend/server/interfaces/risk_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/risk_type.go
@@ -27,6 +27,7 @@ type RiskType struct {
 	Updater    AccountInfo `json:"updater" mapstructure:"updater"`
 	UpdateTime int64       `json:"update_time" mapstructure:"update_time"`
 	ModuleType string      `json:"module_type" mapstructure:"module_type"`
+	Operations []string    `json:"operations,omitempty"`
 
 	Vector []float32 `json:"_vector,omitempty"`
 	Score  *float64  `json:"_score,omitempty"` // OpenSearch relevance score used for concept searches.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -430,7 +430,6 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 			return []*interfaces.ActionType{}, 0, err
 		}
 	}
-
 	listQuery := query
 	if pepEnabled {
 		listQuery.Offset = 0
@@ -446,17 +445,19 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 
 	var total int
 	if pepEnabled {
-		actionTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ats.ps,
+		var operationMap map[string]interfaces.PermissionResourceOps
+		actionTypes, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, ats.ps,
 			interfaces.RESOURCE_TYPE_ACTION_TYPE, query.KNID, actionTypes,
 			func(actionType *interfaces.ActionType) string { return actionType.ATID }, query.Offset, query.Limit)
 		if err != nil {
 			return []*interfaces.ActionType{}, 0, err
 		}
+		for _, actionType := range actionTypes {
+			actionType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, actionType.ATID)].Operations
+		}
 	} else {
 		total, err = ats.ata.GetActionTypesTotal(ctx, query)
 		if err != nil {
-			logger.Errorf("GetActionTypesTotal error: %s", err.Error())
-			span.SetStatus(codes.Error, "Get action types total error")
 			return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
 		}
@@ -516,7 +517,7 @@ func (ats *actionTypeService) GetActionTypesByIDs(ctx context.Context, knID stri
 	}
 	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
 	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(atIDs) == 1 {
+	if len(atIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_ACTION_TYPE,
 			knID, atIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	}
@@ -544,6 +545,14 @@ func (ats *actionTypeService) GetActionTypesByIDs(ctx context.Context, knID stri
 	}
 	if err = ats.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 		return nil, err
+	}
+	if len(atIDs) == 1 && permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, knID, atIDs[0])
+		if err != nil {
+			return nil, err
+		}
+		actionTypes[0].Operations = operations
 	}
 
 	// TODO: localize bound and impacted object types and their API documents.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -458,8 +458,18 @@ func (ats *actionTypeService) ListActionTypes(ctx context.Context, query interfa
 	} else {
 		total, err = ats.ata.GetActionTypesTotal(ctx, query)
 		if err != nil {
+			logger.Errorf("GetActionTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get action types total error")
 			return []*interfaces.ActionType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ActionType_InternalError).WithErrorDetails(err.Error())
+		}
+		operations, err := permission.GetKNChildOperations(ctx, ats.ps,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, query.KNID, "")
+		if err != nil {
+			return []*interfaces.ActionType{}, 0, err
+		}
+		for _, actionType := range actionTypes {
+			actionType.Operations = operations
 		}
 	}
 	if len(actionTypes) == 0 {
@@ -515,12 +525,6 @@ func (ats *actionTypeService) GetActionTypesByIDs(ctx context.Context, knID stri
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, atIDs); err != nil {
 		return nil, err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(atIDs) == 1 && permission.KNChildResourcePEPEnabled() {
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_ACTION_TYPE,
-			knID, atIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-	}
 	var err error
 
 	// De-duplicate IDs before querying.
@@ -543,9 +547,6 @@ func (ats *actionTypeService) GetActionTypesByIDs(ctx context.Context, knID stri
 		return []*interfaces.ActionType{}, rest.NewHTTPError(ctx, http.StatusNotFound,
 			berrors.BknBackend_ActionType_ActionTypeNotFound).WithErrorDetails(errStr)
 	}
-	if err = ats.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return nil, err
-	}
 	if len(atIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		operations, err := permission.GetKNChildOperations(ctx, ats.ps,
 			interfaces.RESOURCE_TYPE_ACTION_TYPE, knID, atIDs[0])
@@ -553,6 +554,11 @@ func (ats *actionTypeService) GetActionTypesByIDs(ctx context.Context, knID stri
 			return nil, err
 		}
 		actionTypes[0].Operations = operations
+	} else if err = ats.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 
 	// TODO: localize bound and impacted object types and their API documents.

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -203,6 +203,10 @@ func Test_actionTypeService_GetActionTypesByIDs(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		ata := bmock.NewMockActionTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
 
 		service := &actionTypeService{
@@ -375,6 +379,10 @@ func Test_actionTypeService_ListActionTypes(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		ata := bmock.NewMockActionTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
 

--- a/adp/bkn/bkn-backend/server/logics/action_type/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/authorization_pep_test.go
@@ -49,9 +49,14 @@ func TestActionTypeSingleResourcePEP(t *testing.T) {
 				ata.EXPECT().CheckActionTypeExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "at-1").
 					Return("action", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, ID: "kn-1/at-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_ACTION_TYPE,
+					[]string{"kn-1/at-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_ACTION_TYPE, ID: "kn-1/at-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			service := &actionTypeService{ata: ata, ps: ps}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)

--- a/adp/bkn/bkn-backend/server/logics/concept_group/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/authorization_pep_test.go
@@ -57,9 +57,14 @@ func TestConceptGroupSingleResourcePEP(t *testing.T) {
 				cga.EXPECT().CheckConceptGroupExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "cg-1").
 					Return("group", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_CONCEPT_GROUP, ID: "kn-1/cg-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_CONCEPT_GROUP,
+					[]string{"kn-1/cg-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_CONCEPT_GROUP, ID: "kn-1/cg-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			service := &conceptGroupService{cga: cga, ps: ps}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -458,8 +458,18 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 	} else {
 		total, err = cgs.cga.GetConceptGroupsTotal(ctx, query)
 		if err != nil {
+			logger.Errorf("GetConceptGroupsTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get concept groups total error")
 			return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
+		}
+		operations, err := permission.GetKNChildOperations(ctx, cgs.ps,
+			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, query.KNID, "")
+		if err != nil {
+			return []*interfaces.ConceptGroup{}, 0, err
+		}
+		for _, conceptGroup := range conceptGroups {
+			conceptGroup.Operations = operations
 		}
 	}
 	if len(conceptGroups) == 0 {
@@ -537,11 +547,6 @@ func (cgs *conceptGroupService) GetConceptGroupByID(ctx context.Context, knID st
 		return nil, rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_ConceptGroup_ConceptGroupNotFound).
 			WithErrorDetails(errStr)
 	}
-	resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_CONCEPT_GROUP,
-		knID, cgID, interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-	if err = cgs.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return nil, err
-	}
 	if permission.KNChildResourcePEPEnabled() {
 		operations, err := permission.GetKNChildOperations(ctx, cgs.ps,
 			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, knID, cgID)
@@ -549,6 +554,11 @@ func (cgs *conceptGroupService) GetConceptGroupByID(ctx context.Context, knID st
 			return nil, err
 		}
 		conceptGroup.Operations = operations
+	} else if err = cgs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 
 	otIDs, err := cgs.cga.GetConceptIDsByConceptGroupIDs(ctx, conceptGroup.KNID,

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -429,7 +429,6 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 			return []*interfaces.ConceptGroup{}, 0, err
 		}
 	}
-
 	listQuery := query
 	if pepEnabled {
 		listQuery.Offset = 0
@@ -446,17 +445,19 @@ func (cgs *conceptGroupService) ListConceptGroups(ctx context.Context,
 
 	var total int
 	if pepEnabled {
-		conceptGroups, total, err = permission.FilterAndPaginateKNChildren(ctx, cgs.ps,
+		var operationMap map[string]interfaces.PermissionResourceOps
+		conceptGroups, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, cgs.ps,
 			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, query.KNID, conceptGroups,
 			func(group *interfaces.ConceptGroup) string { return group.CGID }, query.Offset, query.Limit)
 		if err != nil {
 			return []*interfaces.ConceptGroup{}, 0, err
 		}
+		for _, conceptGroup := range conceptGroups {
+			conceptGroup.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, conceptGroup.CGID)].Operations
+		}
 	} else {
 		total, err = cgs.cga.GetConceptGroupsTotal(ctx, query)
 		if err != nil {
-			logger.Errorf("GetConceptGroupsTotal error: %s", err.Error())
-			span.SetStatus(codes.Error, "Get concept groups total error")
 			return []*interfaces.ConceptGroup{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ConceptGroup_InternalError).WithErrorDetails(err.Error())
 		}
@@ -540,6 +541,14 @@ func (cgs *conceptGroupService) GetConceptGroupByID(ctx context.Context, knID st
 		knID, cgID, interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	if err = cgs.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 		return nil, err
+	}
+	if permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, cgs.ps,
+			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, knID, cgID)
+		if err != nil {
+			return nil, err
+		}
+		conceptGroup.Operations = operations
 	}
 
 	otIDs, err := cgs.cga.GetConceptIDsByConceptGroupIDs(ctx, conceptGroup.KNID,

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -299,6 +299,10 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 
 		service := &conceptGroupService{
 			appSetting: appSetting,
@@ -536,6 +540,10 @@ func Test_conceptGroupService_GetConceptGroupByID(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 
 		service := &conceptGroupService{
 			appSetting: appSetting,

--- a/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
@@ -51,9 +51,14 @@ func TestMetricSingleResourcePEP(t *testing.T) {
 				ma.EXPECT().CheckMetricExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "metric-1").
 					Return("metric", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_METRIC, ID: "kn-1/metric-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+					[]string{"kn-1/metric-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_METRIC, ID: "kn-1/metric-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			service := &metricService{ma: ma, ps: ps}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)

--- a/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/authorization_pep_test.go
@@ -88,7 +88,13 @@ func TestMetricListPEPFiltersBeforeTotalAndPagination(t *testing.T) {
 	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
 		[]string{"kn-1/metric-1", "kn-1/metric-2", "kn-1/metric-3"},
 		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(map[string]interfaces.PermissionResourceOps{
+		[]string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_QUERY_DATA,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_DELETE,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+		}).Return(map[string]interfaces.PermissionResourceOps{
 		"kn-1/metric-1": {ResourceID: "kn-1/metric-1"},
 		"kn-1/metric-3": {ResourceID: "kn-1/metric-3"},
 	}, nil)

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -375,7 +375,8 @@ func (ms *metricService) handleMetricImportMode(ctx context.Context, mode string
 func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.MetricsListQueryParams) (*interfaces.MetricsList, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListMetrics")
 	defer span.End()
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -383,7 +384,6 @@ func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.Metri
 			return nil, err
 		}
 	}
-
 	candidateQuery := query
 	candidateQuery.Offset = 0
 	candidateQuery.Limit = -1
@@ -392,12 +392,16 @@ func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.Metri
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
 	}
 	total := len(list)
-	if permission.KNChildResourcePEPEnabled() {
-		list, total, err = permission.FilterAndPaginateKNChildren(ctx, ms.ps,
+	if pepEnabled {
+		var operationMap map[string]interfaces.PermissionResourceOps
+		list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, ms.ps,
 			interfaces.RESOURCE_TYPE_METRIC, query.KNID, list,
 			func(metric *interfaces.MetricDefinition) string { return metric.ID }, query.Offset, query.Limit)
 		if err != nil {
 			return nil, err
+		}
+		for _, metric := range list {
+			metric.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, metric.ID)].Operations
 		}
 	} else {
 		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
@@ -435,6 +439,14 @@ func (ms *metricService) GetMetricByID(ctx context.Context, knID, branch, metric
 	if err = ms.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 		return nil, err
 	}
+	if permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, knID, metricID)
+		if err != nil {
+			return nil, err
+		}
+		def.Operations = operations
+	}
 	span.SetStatus(codes.Ok, "")
 	return def, nil
 }
@@ -448,6 +460,14 @@ func (ms *metricService) GetMetricsByIDs(ctx context.Context, knID, branch strin
 	if err != nil {
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_Metric_InternalError_GetMetricsByIDsFailed).WithErrorDetails(err.Error())
+	}
+	if len(metricIDs) == 1 && len(list) == 1 && permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, ms.ps,
+			interfaces.RESOURCE_TYPE_METRIC, knID, metricIDs[0])
+		if err != nil {
+			return nil, err
+		}
+		list[0].Operations = operations
 	}
 	span.SetStatus(codes.Ok, "")
 	return list, nil

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service.go
@@ -375,8 +375,7 @@ func (ms *metricService) handleMetricImportMode(ctx context.Context, mode string
 func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.MetricsListQueryParams) (*interfaces.MetricsList, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListMetrics")
 	defer span.End()
-	pepEnabled := permission.KNChildResourcePEPEnabled()
-	if !pepEnabled {
+	if !permission.KNChildResourcePEPEnabled() {
 		if err := ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -391,20 +390,16 @@ func (ms *metricService) ListMetrics(ctx context.Context, query interfaces.Metri
 	if err != nil {
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
 	}
+	var operationMap map[string]interfaces.PermissionResourceOps
 	total := len(list)
-	if pepEnabled {
-		var operationMap map[string]interfaces.PermissionResourceOps
-		list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, ms.ps,
-			interfaces.RESOURCE_TYPE_METRIC, query.KNID, list,
-			func(metric *interfaces.MetricDefinition) string { return metric.ID }, query.Offset, query.Limit)
-		if err != nil {
-			return nil, err
-		}
-		for _, metric := range list {
-			metric.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, metric.ID)].Operations
-		}
-	} else {
-		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
+	list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, ms.ps,
+		interfaces.RESOURCE_TYPE_METRIC, query.KNID, list,
+		func(metric *interfaces.MetricDefinition) string { return metric.ID }, query.Offset, query.Limit)
+	if err != nil {
+		return nil, err
+	}
+	for _, metric := range list {
+		metric.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, metric.ID)].Operations
 	}
 
 	if len(list) > 0 && ms.uma != nil {
@@ -434,11 +429,6 @@ func (ms *metricService) GetMetricByID(ctx context.Context, knID, branch, metric
 		}
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Metric_InternalError).WithErrorDetails(err.Error())
 	}
-	resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_METRIC,
-		knID, metricID, interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-	if err = ms.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return nil, err
-	}
 	if permission.KNChildResourcePEPEnabled() {
 		operations, err := permission.GetKNChildOperations(ctx, ms.ps,
 			interfaces.RESOURCE_TYPE_METRIC, knID, metricID)
@@ -446,6 +436,11 @@ func (ms *metricService) GetMetricByID(ctx context.Context, knID, branch, metric
 			return nil, err
 		}
 		def.Operations = operations
+	} else if err = ms.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 	span.SetStatus(codes.Ok, "")
 	return def, nil

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -212,6 +212,10 @@ func Test_metricService_ListMetrics(t *testing.T) {
 
 		ma := bmock.NewMockMetricAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		service := &metricService{
 			appSetting: &common.AppSetting{},
 			ma:         ma,

--- a/adp/bkn/bkn-backend/server/logics/object_type/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/authorization_pep_test.go
@@ -59,9 +59,14 @@ func TestObjectTypeSingleResourcePEP(t *testing.T) {
 				ota.EXPECT().CheckObjectTypeExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "ot-1").
 					Return("object", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE, ID: "kn-1/ot-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+					[]string{"kn-1/ot-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE, ID: "kn-1/ot-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)
 			}

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -417,7 +417,6 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 			return []*interfaces.ObjectType{}, 0, err
 		}
 	}
-
 	// 0. Begin the transaction.
 	var err error
 	if tx == nil {
@@ -464,17 +463,19 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 
 	var total int
 	if pepEnabled {
-		objectTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, ots.ps,
+		var operationMap map[string]interfaces.PermissionResourceOps
+		objectTypes, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, ots.ps,
 			interfaces.RESOURCE_TYPE_OBJECT_TYPE, query.KNID, objectTypes,
 			func(objectType *interfaces.ObjectType) string { return objectType.OTID }, query.Offset, query.Limit)
 		if err != nil {
 			return []*interfaces.ObjectType{}, 0, err
 		}
+		for _, objectType := range objectTypes {
+			objectType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, objectType.OTID)].Operations
+		}
 	} else {
 		total, err = ots.ota.GetObjectTypesTotal(ctx, query)
 		if err != nil {
-			logger.Errorf("GetObjectTypesTotal error: %s", err.Error())
-			span.SetStatus(codes.Error, "Get object types total error")
 			return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
 		}
@@ -559,7 +560,7 @@ func (ots *objectTypeService) GetObjectTypesByIDs(ctx context.Context, tx *sql.T
 	}
 	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
 	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(otIDs) == 1 {
+	if len(otIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_OBJECT_TYPE,
 			knID, otIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	}
@@ -617,6 +618,14 @@ func (ots *objectTypeService) GetObjectTypesByIDs(ctx context.Context, tx *sql.T
 	}
 	if err = ots.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 		return nil, err
+	}
+	if len(otIDs) == 1 && permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, knID, otIDs[0])
+		if err != nil {
+			return nil, err
+		}
+		objectTypes[0].Operations = operations
 	}
 
 	// Get object type groups.

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -476,8 +476,18 @@ func (ots *objectTypeService) ListObjectTypes(ctx context.Context, tx *sql.Tx,
 	} else {
 		total, err = ots.ota.GetObjectTypesTotal(ctx, query)
 		if err != nil {
+			logger.Errorf("GetObjectTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get object types total error")
 			return []*interfaces.ObjectType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_ObjectType_InternalError).WithErrorDetails(err.Error())
+		}
+		operations, err := permission.GetKNChildOperations(ctx, ots.ps,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, query.KNID, "")
+		if err != nil {
+			return []*interfaces.ObjectType{}, 0, err
+		}
+		for _, objectType := range objectTypes {
+			objectType.Operations = operations
 		}
 	}
 	if len(objectTypes) == 0 {
@@ -558,12 +568,6 @@ func (ots *objectTypeService) GetObjectTypesByIDs(ctx context.Context, tx *sql.T
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, otIDs); err != nil {
 		return nil, err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(otIDs) == 1 && permission.KNChildResourcePEPEnabled() {
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_OBJECT_TYPE,
-			knID, otIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-	}
 	var err error
 
 	// 0. Begin the transaction.
@@ -616,9 +620,6 @@ func (ots *objectTypeService) GetObjectTypesByIDs(ctx context.Context, tx *sql.T
 		return []*interfaces.ObjectType{}, rest.NewHTTPError(ctx, http.StatusNotFound,
 			berrors.BknBackend_ObjectType_ObjectTypeNotFound).WithErrorDetails(errStr)
 	}
-	if err = ots.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return nil, err
-	}
 	if len(otIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		operations, err := permission.GetKNChildOperations(ctx, ots.ps,
 			interfaces.RESOURCE_TYPE_OBJECT_TYPE, knID, otIDs[0])
@@ -626,6 +627,11 @@ func (ots *objectTypeService) GetObjectTypesByIDs(ctx context.Context, tx *sql.T
 			return nil, err
 		}
 		objectTypes[0].Operations = operations
+	} else if err = ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 
 	// Get object type groups.

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -201,6 +201,10 @@ func Test_objectTypeService_GetObjectTypesByIDs(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		ota := bmock.NewMockObjectTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
 		ma := bmock.NewMockMetricAccess(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
@@ -1185,6 +1189,10 @@ func Test_objectTypeService_ListObjectTypes(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		ota := bmock.NewMockObjectTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		cga := bmock.NewMockConceptGroupAccess(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
 		db, smock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep.go
@@ -19,6 +19,19 @@ import (
 const knChildResourcePEPEnabledEnv = "KN_CHILD_RESOURCE_PEP_ENABLED"
 const knChildResourceFilterChunkSizeEnv = "KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE"
 
+var knChildOperations = []string{
+	interfaces.OPERATION_TYPE_VIEW_DETAIL,
+	interfaces.OPERATION_TYPE_QUERY_DATA,
+	interfaces.OPERATION_TYPE_MODIFY,
+	interfaces.OPERATION_TYPE_DELETE,
+	interfaces.OPERATION_TYPE_AUTHORIZE,
+}
+
+var actionTypeOperations = append(append([]string{}, knChildOperations...),
+	interfaces.OPERATION_TYPE_TASK_MANAGE,
+	interfaces.OPERATION_TYPE_EXECUTE,
+)
+
 type knImportPermissionPrecheckedKey struct{}
 
 // WithKNImportPermissionPrechecked marks child creates invoked by an already
@@ -40,6 +53,15 @@ func KNImportPermissionPrechecked(ctx context.Context) bool {
 func KNChildResourcePEPEnabled() bool {
 	value := strings.ToLower(strings.TrimSpace(os.Getenv(knChildResourcePEPEnabledEnv)))
 	return value == "true" || value == "1"
+}
+
+// KNChildOperationCandidates returns the instance-level operations exposed to
+// the current accessor for one knowledge-network child resource type.
+func KNChildOperationCandidates(resourceType string) []string {
+	if resourceType == interfaces.RESOURCE_TYPE_ACTION_TYPE {
+		return append([]string{}, actionTypeOperations...)
+	}
+	return append([]string{}, knChildOperations...)
 }
 
 // ValidateKNChildPEPAuthorizationIDs applies canonical-ID validation only when
@@ -208,8 +230,163 @@ func FilterAndPaginateKNChildren[T any](ctx context.Context, ps interfaces.Permi
 	return PaginateKNChildCandidates(visible, offset, limit), len(visible), nil
 }
 
+// FilterAndPaginateKNChildrenWithOperations filters children by view_detail,
+// applies pagination after filtering, and returns the allowed operations for
+// every visible canonical child resource. Disabled PEP deployments retain the
+// legacy parent-KN checks while exposing the equivalent child operation set.
+func FilterAndPaginateKNChildrenWithOperations[T any](ctx context.Context, ps interfaces.PermissionService,
+	resourceType, knID string, candidates []T, childID func(T) string,
+	offset, limit int) ([]T, int, map[string]interfaces.PermissionResourceOps, error) {
+
+	candidateOperations := KNChildOperationCandidates(resourceType)
+	if !KNChildResourcePEPEnabled() {
+		legacyOperations, err := getLegacyKNChildOperations(ctx, ps, knID, candidateOperations)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		result := PaginateKNChildCandidates(candidates, offset, limit)
+		projected := make(map[string]interfaces.PermissionResourceOps, len(result))
+		for _, candidate := range result {
+			projected[interfaces.KNChildResourceID(knID, childID(candidate))] = interfaces.PermissionResourceOps{
+				ResourceID: interfaces.KNChildResourceID(knID, childID(candidate)),
+				Operations: legacyOperations,
+			}
+		}
+		return result, len(candidates), projected, nil
+	}
+
+	if len(candidates) == 0 {
+		return []T{}, 0, map[string]interfaces.PermissionResourceOps{}, nil
+	}
+	validCandidates := make([]T, 0, len(candidates))
+	childIDs := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		id := childID(candidate)
+		if interfaces.IsValidAuthorizationID(id) {
+			validCandidates = append(validCandidates, candidate)
+			childIDs = append(childIDs, id)
+		}
+	}
+	if len(validCandidates) == 0 {
+		return []T{}, 0, map[string]interfaces.PermissionResourceOps{}, nil
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, childIDs); err != nil {
+		return nil, 0, nil, err
+	}
+
+	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
+	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs,
+		interfaces.OPERATION_TYPE_VIEW_DETAIL, candidateOperations)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+
+	visible := make([]T, 0, len(matched))
+	for _, candidate := range validCandidates {
+		canonicalID := interfaces.KNChildResourceID(knID, childID(candidate))
+		if _, ok := matched[canonicalID]; ok {
+			visible = append(visible, candidate)
+		}
+	}
+	return PaginateKNChildCandidates(visible, offset, limit), len(visible), matched, nil
+}
+
+// GetKNChildOperations returns the allowed operations for a visible child.
+func GetKNChildOperations(ctx context.Context, ps interfaces.PermissionService,
+	resourceType, knID, childID string) ([]string, error) {
+
+	if !KNChildResourcePEPEnabled() {
+		return getLegacyKNChildOperations(ctx, ps, knID, KNChildOperationCandidates(resourceType))
+	}
+	if err := ValidateKNChildAuthorizationIDs(ctx, knID, []string{childID}); err != nil {
+		return nil, err
+	}
+	canonicalID := interfaces.KNChildResourceID(knID, childID)
+	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, []string{canonicalID},
+		interfaces.OPERATION_TYPE_VIEW_DETAIL, KNChildOperationCandidates(resourceType))
+	if err != nil {
+		return nil, err
+	}
+	resourceOps, ok := matched[canonicalID]
+	if !ok {
+		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
+	}
+	return resourceOps.Operations, nil
+}
+
+func getLegacyKNChildOperations(ctx context.Context, ps interfaces.PermissionService,
+	knID string, childOperations []string) ([]string, error) {
+
+	rootCandidates := legacyKNOperationCandidates(childOperations)
+	matched, err := ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, []string{knID},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, rootCandidates)
+	if err != nil {
+		return nil, err
+	}
+	rootOps, ok := matched[knID]
+	if !ok {
+		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
+	}
+	return projectLegacyKNChildOperations(rootOps.Operations, childOperations), nil
+}
+
+func legacyKNOperationCandidates(childOperations []string) []string {
+	candidates := make([]string, 0, len(childOperations))
+	seen := make(map[string]struct{}, len(childOperations))
+	for _, operation := range childOperations {
+		parentOperation, ok := legacyParentOperation(operation)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[parentOperation]; !exists {
+			seen[parentOperation] = struct{}{}
+			candidates = append(candidates, parentOperation)
+		}
+	}
+	return candidates
+}
+
+func projectLegacyKNChildOperations(rootOperations, childOperations []string) []string {
+	allowed := make(map[string]struct{}, len(rootOperations))
+	for _, operation := range rootOperations {
+		allowed[operation] = struct{}{}
+	}
+	projected := make([]string, 0, len(childOperations))
+	for _, operation := range childOperations {
+		parentOperation, ok := legacyParentOperation(operation)
+		if ok {
+			if _, exists := allowed[parentOperation]; exists {
+				projected = append(projected, operation)
+			}
+		}
+	}
+	return projected
+}
+
+func legacyParentOperation(operation string) (string, bool) {
+	switch operation {
+	case interfaces.OPERATION_TYPE_VIEW_DETAIL:
+		return interfaces.OPERATION_TYPE_VIEW_DETAIL, true
+	case interfaces.OPERATION_TYPE_QUERY_DATA:
+		return interfaces.OPERATION_TYPE_QUERY_DATA, true
+	case interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE:
+		return interfaces.OPERATION_TYPE_MODIFY, true
+	case interfaces.OPERATION_TYPE_AUTHORIZE:
+		return interfaces.OPERATION_TYPE_AUTHORIZE, true
+	case interfaces.OPERATION_TYPE_TASK_MANAGE:
+		return interfaces.OPERATION_TYPE_TASK_MANAGE, true
+	default:
+		return "", false
+	}
+}
+
 func filterKNChildResourceIDs(ctx context.Context, ps interfaces.PermissionService,
-	resourceType string, resourceIDs []string, operation string) (map[string]interfaces.PermissionResourceOps, error) {
+	resourceType string, resourceIDs []string, operation string, candidateOperations ...[]string) (map[string]interfaces.PermissionResourceOps, error) {
+
+	fullOperations := []string{operation}
+	if len(candidateOperations) > 0 {
+		fullOperations = candidateOperations[0]
+	}
 
 	chunkSize := len(resourceIDs)
 	if configured, err := strconv.Atoi(strings.TrimSpace(os.Getenv(knChildResourceFilterChunkSizeEnv))); err == nil && configured > 0 && configured < chunkSize {
@@ -223,7 +400,7 @@ func filterKNChildResourceIDs(ctx context.Context, ps interfaces.PermissionServi
 		}
 		blockIDs := resourceIDs[start:end]
 		block, err := ps.FilterResources(ctx, resourceType, blockIDs,
-			[]string{operation}, true, []string{operation})
+			[]string{operation}, true, fullOperations)
 		if err != nil {
 			return nil, err
 		}

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_pep_test.go
@@ -73,6 +73,133 @@ type childCandidate struct {
 	id string
 }
 
+func TestKNChildOperationCandidatesMatchResourceContract(t *testing.T) {
+	wantChild := []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_QUERY_DATA,
+		interfaces.OPERATION_TYPE_MODIFY,
+		interfaces.OPERATION_TYPE_DELETE,
+		interfaces.OPERATION_TYPE_AUTHORIZE,
+	}
+	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_RELATION_TYPE); !reflect.DeepEqual(got, wantChild) {
+		t.Fatalf("relation type operations = %#v, want %#v", got, wantChild)
+	}
+	wantAction := append(append([]string{}, wantChild...), interfaces.OPERATION_TYPE_TASK_MANAGE, interfaces.OPERATION_TYPE_EXECUTE)
+	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_ACTION_TYPE); !reflect.DeepEqual(got, wantAction) {
+		t.Fatalf("action type operations = %#v, want %#v", got, wantAction)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenWithOperationsProjectsLegacyParentOperations(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "false")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_QUERY_DATA,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+		}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1": {ResourceID: "kn-1", Operations: []string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+		}},
+	}, nil)
+
+	items, total, operations, err := FilterAndPaginateKNChildrenWithOperations(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn-1", []childCandidate{{id: "one"}, {id: "two"}},
+		func(candidate childCandidate) string { return candidate.id }, 1, 1)
+	if err != nil {
+		t.Fatalf("FilterAndPaginateKNChildrenWithOperations() error = %v", err)
+	}
+	if total != 2 || !reflect.DeepEqual(items, []childCandidate{{id: "two"}}) {
+		t.Fatalf("items = %#v, total = %d", items, total)
+	}
+	if got := operations["kn-1/two"].Operations; !reflect.DeepEqual(got, []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_MODIFY,
+		interfaces.OPERATION_TYPE_DELETE,
+		interfaces.OPERATION_TYPE_AUTHORIZE,
+	}) {
+		t.Fatalf("operations = %#v", got)
+	}
+}
+
+func TestFilterAndPaginateKNChildrenWithOperationsProjectsCanonicalOperations(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_ACTION_TYPE,
+		[]string{"kn-1/action-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_QUERY_DATA,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_DELETE,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+			interfaces.OPERATION_TYPE_TASK_MANAGE,
+			interfaces.OPERATION_TYPE_EXECUTE,
+		}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/action-1": {ResourceID: "kn-1/action-1", Operations: []string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+			interfaces.OPERATION_TYPE_EXECUTE,
+		}},
+	}, nil)
+
+	items, total, operations, err := FilterAndPaginateKNChildrenWithOperations(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_ACTION_TYPE, "kn-1", []childCandidate{{id: "action-1"}},
+		func(candidate childCandidate) string { return candidate.id }, 0, -1)
+	if err != nil {
+		t.Fatalf("FilterAndPaginateKNChildrenWithOperations() error = %v", err)
+	}
+	if total != 1 || len(items) != 1 {
+		t.Fatalf("items = %#v, total = %d", items, total)
+	}
+	if got := operations["kn-1/action-1"].Operations; !reflect.DeepEqual(got, []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_AUTHORIZE,
+		interfaces.OPERATION_TYPE_EXECUTE,
+	}) {
+		t.Fatalf("operations = %#v", got)
+	}
+}
+
+func TestGetKNChildOperationsUsesCanonicalDetailResource(t *testing.T) {
+	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "true")
+	ctrl := gomock.NewController(t)
+	ps := interfacemock.NewMockPermissionService(ctrl)
+	ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_METRIC,
+		[]string{"kn-1/metric-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+		[]string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_QUERY_DATA,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_DELETE,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+		}).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-1/metric-1": {ResourceID: "kn-1/metric-1", Operations: []string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_QUERY_DATA,
+		}},
+	}, nil)
+
+	operations, err := GetKNChildOperations(context.Background(), ps,
+		interfaces.RESOURCE_TYPE_METRIC, "kn-1", "metric-1")
+	if err != nil {
+		t.Fatalf("GetKNChildOperations() error = %v", err)
+	}
+	if !reflect.DeepEqual(operations, []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_QUERY_DATA,
+	}) {
+		t.Fatalf("operations = %#v", operations)
+	}
+}
+
 func TestFilterAndPaginateKNChildrenUsesLegacyKNWhenDisabled(t *testing.T) {
 	t.Setenv("KN_CHILD_RESOURCE_PEP_ENABLED", "false")
 	ctrl := gomock.NewController(t)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/authorization_pep_test.go
@@ -49,9 +49,14 @@ func TestRelationTypeSingleResourcePEP(t *testing.T) {
 				rta.EXPECT().CheckRelationTypeExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "rt-1").
 					Return("relation", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_RELATION_TYPE, ID: "kn-1/rt-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RELATION_TYPE,
+					[]string{"kn-1/rt-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_RELATION_TYPE, ID: "kn-1/rt-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			service := &relationTypeService{rta: rta, ps: ps}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -299,7 +299,6 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 			return []*interfaces.RelationType{}, 0, err
 		}
 	}
-
 	listQuery := query
 	if pepEnabled {
 		listQuery.Offset = 0
@@ -316,17 +315,19 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 
 	var total int
 	if pepEnabled {
-		relationTypes, total, err = permission.FilterAndPaginateKNChildren(ctx, rts.ps,
+		var operationMap map[string]interfaces.PermissionResourceOps
+		relationTypes, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, rts.ps,
 			interfaces.RESOURCE_TYPE_RELATION_TYPE, query.KNID, relationTypes,
 			func(relationType *interfaces.RelationType) string { return relationType.RTID }, query.Offset, query.Limit)
 		if err != nil {
 			return []*interfaces.RelationType{}, 0, err
 		}
+		for _, relationType := range relationTypes {
+			relationType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, relationType.RTID)].Operations
+		}
 	} else {
 		total, err = rts.rta.GetRelationTypesTotal(ctx, query)
 		if err != nil {
-			logger.Errorf("GetRelationTypesTotal error: %s", err.Error())
-			span.SetStatus(codes.Error, "Get relation types total error")
 			return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
 		}
@@ -398,7 +399,7 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 	}
 	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
 	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(rtIDs) == 1 {
+	if len(rtIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RELATION_TYPE,
 			knID, rtIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	}
@@ -428,6 +429,14 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 	}
 	if err = rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 		return nil, err
+	}
+	if len(rtIDs) == 1 && permission.KNChildResourcePEPEnabled() {
+		operations, err := permission.GetKNChildOperations(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, knID, rtIDs[0])
+		if err != nil {
+			return nil, err
+		}
+		relationTypes[0].Operations = operations
 	}
 
 	// Retrieve source and target object type names.

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -328,8 +328,18 @@ func (rts *relationTypeService) ListRelationTypes(ctx context.Context,
 	} else {
 		total, err = rts.rta.GetRelationTypesTotal(ctx, query)
 		if err != nil {
+			logger.Errorf("GetRelationTypesTotal error: %s", err.Error())
+			span.SetStatus(codes.Error, "Get relation types total error")
 			return []*interfaces.RelationType{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 				berrors.BknBackend_RelationType_InternalError).WithErrorDetails(err.Error())
+		}
+		operations, err := permission.GetKNChildOperations(ctx, rts.ps,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, query.KNID, "")
+		if err != nil {
+			return []*interfaces.RelationType{}, 0, err
+		}
+		for _, relationType := range relationTypes {
+			relationType.Operations = operations
 		}
 	}
 	if len(relationTypes) == 0 {
@@ -397,12 +407,6 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 	if err := permission.ValidateKNChildPEPAuthorizationIDs(ctx, knID, rtIDs); err != nil {
 		return nil, err
 	}
-	resource := interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID}
-	operation := interfaces.OPERATION_TYPE_VIEW_DETAIL
-	if len(rtIDs) == 1 && permission.KNChildResourcePEPEnabled() {
-		resource, operation = permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RELATION_TYPE,
-			knID, rtIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-	}
 	var err error
 
 	// De-duplicate IDs before querying.
@@ -427,9 +431,6 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 		return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusNotFound,
 			berrors.BknBackend_RelationType_RelationTypeNotFound).WithErrorDetails(errStr)
 	}
-	if err = rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-		return nil, err
-	}
 	if len(rtIDs) == 1 && permission.KNChildResourcePEPEnabled() {
 		operations, err := permission.GetKNChildOperations(ctx, rts.ps,
 			interfaces.RESOURCE_TYPE_RELATION_TYPE, knID, rtIDs[0])
@@ -437,6 +438,11 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 			return nil, err
 		}
 		relationTypes[0].Operations = operations
+	} else if err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 
 	// Retrieve source and target object type names.

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -144,6 +144,10 @@ func Test_relationTypeService_GetRelationTypesByIDs(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		rta := bmock.NewMockRelationTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
 
@@ -326,6 +330,10 @@ func Test_relationTypeService_ListRelationTypes(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		rta := bmock.NewMockRelationTypeAccess(mockCtrl)
 		ps := bmock.NewMockPermissionService(mockCtrl)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(map[string]interfaces.PermissionResourceOps{
+				"kn1": {ResourceID: "kn1", Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_AUTHORIZE}},
+			}, nil).AnyTimes()
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
 

--- a/adp/bkn/bkn-backend/server/logics/risk_type/authorization_pep_test.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/authorization_pep_test.go
@@ -48,9 +48,14 @@ func TestRiskTypeSingleResourcePEP(t *testing.T) {
 				rta.EXPECT().CheckRiskTypeExistByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH, "risk-1").
 					Return("risk", true, nil)
 			}
-			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
-				Type: interfaces.RESOURCE_TYPE_RISK_TYPE, ID: "kn-1/risk-1",
-			}, []string{tt.operation}).Return(denied)
+			if tt.name == "detail" {
+				ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RISK_TYPE,
+					[]string{"kn-1/risk-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).Return(nil, denied)
+			} else {
+				ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+					Type: interfaces.RESOURCE_TYPE_RISK_TYPE, ID: "kn-1/risk-1",
+				}, []string{tt.operation}).Return(denied)
+			}
 			service := &riskTypeService{rta: rta, ps: ps}
 			if err := tt.invoke(service, context.Background()); !errors.Is(err, denied) {
 				t.Fatalf("operation error = %v, want %v", err, denied)

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -310,8 +310,7 @@ func (rts *riskTypeService) handleImportMode(ctx context.Context, mode string, r
 func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.RiskTypesQueryParams) ([]*interfaces.RiskType, int, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListRiskTypes")
 	defer span.End()
-	pepEnabled := permission.KNChildResourcePEPEnabled()
-	if !pepEnabled {
+	if !permission.KNChildResourcePEPEnabled() {
 		if err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -329,20 +328,16 @@ func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.
 			berrors.BknBackend_RiskType_InternalError).WithErrorDetails(err.Error())
 	}
 
+	var operationMap map[string]interfaces.PermissionResourceOps
 	total := len(list)
-	if pepEnabled {
-		var operationMap map[string]interfaces.PermissionResourceOps
-		list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, rts.ps,
-			interfaces.RESOURCE_TYPE_RISK_TYPE, query.KNID, list,
-			func(riskType *interfaces.RiskType) string { return riskType.RTID }, query.Offset, query.Limit)
-		if err != nil {
-			return nil, 0, err
-		}
-		for _, riskType := range list {
-			riskType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, riskType.RTID)].Operations
-		}
-	} else {
-		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
+	list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, rts.ps,
+		interfaces.RESOURCE_TYPE_RISK_TYPE, query.KNID, list,
+		func(riskType *interfaces.RiskType) string { return riskType.RTID }, query.Offset, query.Limit)
+	if err != nil {
+		return nil, 0, err
+	}
+	for _, riskType := range list {
+		riskType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, riskType.RTID)].Operations
 	}
 
 	if len(list) > 0 && rts.uma != nil {
@@ -375,11 +370,6 @@ func (rts *riskTypeService) GetRiskTypesByIDs(ctx context.Context, knID string, 
 		if len(list) != 1 {
 			return nil, rest.NewHTTPError(ctx, http.StatusNotFound, berrors.BknBackend_RiskType_RiskTypeNotFound)
 		}
-		resource, operation := permission.ResolveKNChildPermissionTarget(interfaces.RESOURCE_TYPE_RISK_TYPE,
-			knID, rtIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
-		if err = rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
-			return nil, err
-		}
 		if permission.KNChildResourcePEPEnabled() {
 			operations, err := permission.GetKNChildOperations(ctx, rts.ps,
 				interfaces.RESOURCE_TYPE_RISK_TYPE, knID, rtIDs[0])
@@ -387,6 +377,11 @@ func (rts *riskTypeService) GetRiskTypesByIDs(ctx context.Context, knID string, 
 				return nil, err
 			}
 			list[0].Operations = operations
+		} else if err = rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
+			Type: interfaces.RESOURCE_TYPE_KN,
+			ID:   knID,
+		}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+			return nil, err
 		}
 	}
 	span.SetStatus(codes.Ok, "")

--- a/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/risk_type/risk_type_service.go
@@ -310,7 +310,8 @@ func (rts *riskTypeService) handleImportMode(ctx context.Context, mode string, r
 func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.RiskTypesQueryParams) ([]*interfaces.RiskType, int, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "ListRiskTypes")
 	defer span.End()
-	if !permission.KNChildResourcePEPEnabled() {
+	pepEnabled := permission.KNChildResourcePEPEnabled()
+	if !pepEnabled {
 		if err := rts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
 			ID:   query.KNID,
@@ -318,7 +319,6 @@ func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.
 			return nil, 0, err
 		}
 	}
-
 	candidateQuery := query
 	candidateQuery.Offset = 0
 	candidateQuery.Limit = -1
@@ -330,12 +330,16 @@ func (rts *riskTypeService) ListRiskTypes(ctx context.Context, query interfaces.
 	}
 
 	total := len(list)
-	if permission.KNChildResourcePEPEnabled() {
-		list, total, err = permission.FilterAndPaginateKNChildren(ctx, rts.ps,
+	if pepEnabled {
+		var operationMap map[string]interfaces.PermissionResourceOps
+		list, total, operationMap, err = permission.FilterAndPaginateKNChildrenWithOperations(ctx, rts.ps,
 			interfaces.RESOURCE_TYPE_RISK_TYPE, query.KNID, list,
 			func(riskType *interfaces.RiskType) string { return riskType.RTID }, query.Offset, query.Limit)
 		if err != nil {
 			return nil, 0, err
+		}
+		for _, riskType := range list {
+			riskType.Operations = operationMap[interfaces.KNChildResourceID(query.KNID, riskType.RTID)].Operations
 		}
 	} else {
 		list = permission.PaginateKNChildCandidates(list, query.Offset, query.Limit)
@@ -375,6 +379,14 @@ func (rts *riskTypeService) GetRiskTypesByIDs(ctx context.Context, knID string, 
 			knID, rtIDs[0], interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 		if err = rts.ps.CheckPermission(ctx, resource, []string{operation}); err != nil {
 			return nil, err
+		}
+		if permission.KNChildResourcePEPEnabled() {
+			operations, err := permission.GetKNChildOperations(ctx, rts.ps,
+				interfaces.RESOURCE_TYPE_RISK_TYPE, knID, rtIDs[0])
+			if err != nil {
+				return nil, err
+			}
+			list[0].Operations = operations
 		}
 	}
 	span.SetStatus(codes.Ok, "")

--- a/docs/api/bkn/action-type.yaml
+++ b/docs/api/bkn/action-type.yaml
@@ -1330,6 +1330,11 @@ components:
           enum:
             - action_type
           type: string
+        operations:
+          description: Operations allowed for the current accessor on this action type.
+          type: array
+          items:
+            type: string
         object_type:
           description: Summary information for the object type owned by the action
           type: object

--- a/docs/api/bkn/bkn-metrics.yaml
+++ b/docs/api/bkn/bkn-metrics.yaml
@@ -663,6 +663,11 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/MetricAnalysisDimension"
+        operations:
+          description: Operations allowed for the current accessor on this metric.
+          type: array
+          items:
+            type: string
     CreateMetricRequest:
       type: object
       required:

--- a/docs/api/bkn/concept-group.yaml
+++ b/docs/api/bkn/concept-group.yaml
@@ -463,6 +463,11 @@ components:
         module_type:
           description: Module type of the concept
           type: string
+        operations:
+          description: Operations allowed for the current accessor on this concept group.
+          type: array
+          items:
+            type: string
     Statistics:
       description: Concept statistics
       required:

--- a/docs/api/bkn/object-type.yaml
+++ b/docs/api/bkn/object-type.yaml
@@ -2130,6 +2130,11 @@ components:
           enum:
             - object_type
           type: string
+        operations:
+          description: Operations allowed for the current accessor on this object type.
+          type: array
+          items:
+            type: string
         incremental_key:
           description: Property name used for incremental synchronization
           type: string

--- a/docs/api/bkn/relation-type.yaml
+++ b/docs/api/bkn/relation-type.yaml
@@ -1533,6 +1533,11 @@ components:
         module_type:
           description: Module type of the concept
           type: string
+        operations:
+          description: Operations allowed for the current accessor on this relation type.
+          type: array
+          items:
+            type: string
     RelationType:
       description: Relation type
       required:
@@ -1640,6 +1645,11 @@ components:
         module_type:
           description: Module type of the concept
           type: string
+        operations:
+          description: Operations allowed for the current accessor on this relation type.
+          type: array
+          items:
+            type: string
     RelationTypeSearchResponse:
       description: Relation type search result
       required:

--- a/docs/api/bkn/risk-types.yaml
+++ b/docs/api/bkn/risk-types.yaml
@@ -376,6 +376,11 @@ components:
         module_type:
           type: string
           description: Always risk_type
+        operations:
+          description: Operations allowed for the current accessor on this risk type.
+          type: array
+          items:
+            type: string
         creator:
           $ref: "#/components/schemas/AccountInfo"
         create_time:


### PR DESCRIPTION
## What Changed

- [x] Return instance-level operation lists for concept groups, object types, relation types, action types, metrics, and risk types.
- [x] Preserve legacy authorization behavior while the child-resource PEP flag is disabled.
- [x] Document the operations response field in the BKN OpenAPI specifications.

---

## Why

- Related Issue: Closes #1284
- Related Feature: Knowledge-network child-resource authorization
- Background: Studio needs an authoritative per-resource operation set to decide which actions are visible to each accessor.

---

## How

- Added canonical child-resource operation candidates and permission projection helpers.
- List and single-resource APIs attach operations only when the child-resource PEP flag is enabled.
- Breaking changes: None by default. The feature remains inactive until the existing deployment flag is explicitly enabled.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable: the change is covered by mocked unit tests)
- [ ] Verified in test environment (not deployed)

Test notes:

- go vet ./...
- I18N_MODE_UT=true go test ./... -count=1
- make api-docs-lint

---

## Risk & Rollback

- Potential risks: Enabling the child-resource PEP requires corresponding authorization records in the permission service.
- Rollback plan: Keep or restore the deployment flag to false; the previous parent knowledge-network authorization behavior is retained.

---

## Additional Notes

- The deployment configuration is intentionally unchanged in this PR.
- Studio integration should be enabled only after this API contract is deployed and verified.