### PR TITLE
fix(vega): align calendar intervals with server timezone

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -130,6 +130,13 @@ func (r *restHandler) queryResourceData(c *gin.Context, ctx context.Context, spa
 		rest.ReplyError(c, err)
 		return
 	}
+	if err := validateResourceDataQueryGroupByFields(ctx, &params, resource.SchemaDefinition); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, "Validate resource data group by fields failed", httpErr)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
 
 	warning, err := resourcelogic.EnsureResourceQueryable(ctx, resource)
 	if err != nil {

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -141,14 +141,12 @@ func (r *restHandler) queryResourceData(c *gin.Context, ctx context.Context, spa
 	if warning != "" {
 		otellog.LogWarn(ctx, "Query hit deprecated resource: "+warning)
 	}
-	if resource.Category == interfaces.ResourceCategoryTable {
-		if err := validateResourceDataQueryGroupByFields(ctx, &params, resource.SchemaDefinition); err != nil {
-			httpErr := err.(*rest.HTTPError)
-			otellog.LogError(ctx, "Validate resource data group by fields failed", httpErr)
-			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-			rest.ReplyError(c, httpErr)
-			return
-		}
+	if err := validateResourceDataQueryGroupByFields(ctx, &params, resource.SchemaDefinition); err != nil {
+		httpErr := err.(*rest.HTTPError)
+		otellog.LogError(ctx, "Validate resource data group by fields failed", httpErr)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
 	}
 
 	result, err := r.rds.QueryWithPaging(ctx, resource, &params)

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -130,14 +130,6 @@ func (r *restHandler) queryResourceData(c *gin.Context, ctx context.Context, spa
 		rest.ReplyError(c, err)
 		return
 	}
-	if err := validateResourceDataQueryGroupByFields(ctx, &params, resource.SchemaDefinition); err != nil {
-		httpErr := err.(*rest.HTTPError)
-		otellog.LogError(ctx, "Validate resource data group by fields failed", httpErr)
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		rest.ReplyError(c, httpErr)
-		return
-	}
-
 	warning, err := resourcelogic.EnsureResourceQueryable(ctx, resource)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
@@ -148,6 +140,15 @@ func (r *restHandler) queryResourceData(c *gin.Context, ctx context.Context, spa
 	}
 	if warning != "" {
 		otellog.LogWarn(ctx, "Query hit deprecated resource: "+warning)
+	}
+	if resource.Category == interfaces.ResourceCategoryTable {
+		if err := validateResourceDataQueryGroupByFields(ctx, &params, resource.SchemaDefinition); err != nil {
+			httpErr := err.(*rest.HTTPError)
+			otellog.LogError(ctx, "Validate resource data group by fields failed", httpErr)
+			oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+			rest.ReplyError(c, httpErr)
+			return
+		}
 	}
 
 	result, err := r.rds.QueryWithPaging(ctx, resource, &params)

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -134,6 +134,23 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.Offset")
 	})
 
+	t.Run("rejects group by fields outside the resource schema", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(sampleDatasetResource(), nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"createdAt","calendar_interval":"day"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
+		assert.Contains(t, w.Body.String(), "createdAt")
+	})
+
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {
 		engine, rs, _, rds := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -136,7 +136,9 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 
 	t.Run("rejects group by fields outside the resource schema", func(t *testing.T) {
 		engine, rs, _, _ := setupResourceDataHandlerTest(t)
-		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(sampleDatasetResource(), nil)
+		resource := sampleDatasetResource()
+		resource.Category = interfaces.ResourceCategoryTable
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
 
 		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
 			strings.NewReader(`{"group_by":[{"property":"createdAt","calendar_interval":"day"}]}`))
@@ -149,6 +151,25 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
 		assert.Contains(t, w.Body.String(), "createdAt")
+	})
+
+	t.Run("does not reject index subfields absent from schema definition", func(t *testing.T) {
+		engine, rs, _, rds := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.Category = interfaces.ResourceCategoryIndex
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+		rds.EXPECT().QueryWithPaging(gomock.Any(), resource, gomock.Any()).
+			Return(&interfaces.ResourceDataQueryResult{Entries: []map[string]any{}}, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"title.keyword"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
 
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -153,13 +153,11 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "createdAt")
 	})
 
-	t.Run("does not reject index subfields absent from schema definition", func(t *testing.T) {
-		engine, rs, _, rds := setupResourceDataHandlerTest(t)
+	t.Run("rejects index subfields absent from schema definition", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()
 		resource.Category = interfaces.ResourceCategoryIndex
 		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
-		rds.EXPECT().QueryWithPaging(gomock.Any(), resource, gomock.Any()).
-			Return(&interfaces.ResourceDataQueryResult{Entries: []map[string]any{}}, nil)
 
 		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
 			strings.NewReader(`{"group_by":[{"property":"title.keyword"}]}`))
@@ -169,7 +167,47 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 
 		engine.ServeHTTP(w, req)
 
-		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
+	})
+
+	t.Run("rejects local index subfields outside the resource schema", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.Category = interfaces.ResourceCategoryTable
+		resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
+		resource.LocalIndexName = "resource-index"
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"title.keyword"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
+	})
+
+	t.Run("rejects group by fields addressed by original name", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.Category = interfaces.ResourceCategoryTable
+		resource.SchemaDefinition = []*interfaces.Property{{Name: "createdAt", OriginalName: "created_at"}}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"created_at"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
 	})
 
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -350,3 +350,24 @@ func validateAggregateParams(ctx context.Context, params *interfaces.ResourceDat
 
 	return nil
 }
+
+// validateResourceDataQueryGroupByFields verifies that group-by fields are declared by the resource.
+// It runs after the resource is loaded so request-level validation can remain resource independent.
+func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfaces.ResourceDataQueryParams,
+	schemaDefinition []*interfaces.Property) error {
+	fields := make(map[string]struct{}, len(schemaDefinition))
+	for _, property := range schemaDefinition {
+		if property != nil {
+			fields[property.Name] = struct{}{}
+		}
+	}
+
+	for _, groupByItem := range params.GroupBy {
+		if _, ok := fields[groupByItem.Property]; !ok {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_GroupBy).
+				WithErrorDetails(fmt.Sprintf("GroupBy property %q is not defined by the resource", groupByItem.Property))
+		}
+	}
+
+	return nil
+}

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -357,7 +357,7 @@ func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfa
 	schemaDefinition []*interfaces.Property) error {
 	fields := make(map[string]struct{}, len(schemaDefinition))
 	for _, property := range schemaDefinition {
-		if property != nil {
+		if property != nil && property.Name != "" {
 			fields[property.Name] = struct{}{}
 		}
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"vega-backend/interfaces"
+	"vega-backend/logics/connector/local/table"
 )
 
 type mariadbConfig struct {
@@ -162,6 +163,8 @@ func (c *MariaDBConnector) connectionString() string {
 	for k, v := range c.config.Options {
 		values.Set(k, fmt.Sprintf("%v", v))
 	}
+	values.Set("loc", table.ServerTimeZone())
+	values.Set("time_zone", "'"+table.ServerTimeZone()+"'")
 
 	return fmt.Sprintf("%s:%s@tcp(%s)/?%s",
 		c.config.Username,

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -466,7 +466,7 @@ func (c *MariaDBConnector) buildDateFormat(alias, dateField, calendarInterval st
 	case interfaces.CALENDAR_UNIT_MONTH:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y-%m`)
 	case interfaces.CALENDAR_UNIT_QUARTER:
-		dateFmt = fmt.Sprintf(`format('%%d-Q%%d',year(%s),quarter(%s))`, dateField, dateField)
+		dateFmt = fmt.Sprintf(`concat(year(%s),'-Q',quarter(%s))`, dateField, dateField)
 	case interfaces.CALENDAR_UNIT_YEAR:
 		dateFmt = fmt.Sprintf(`date_format(%s,'%s')`, dateField, `%Y`)
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -116,7 +116,7 @@ func TestBuildDateFormat(t *testing.T) {
 		{name: "day", interval: interfaces.CALENDAR_UNIT_DAY, want: "date_format(created_at,'%Y-%m-%d')"},
 		{name: "week", interval: interfaces.CALENDAR_UNIT_WEEK, want: "date_format(created_at,'%x-%v')"},
 		{name: "month", interval: interfaces.CALENDAR_UNIT_MONTH, want: "date_format(created_at,'%Y-%m')"},
-		{name: "quarter", interval: interfaces.CALENDAR_UNIT_QUARTER, want: "format('%d-Q%d',year(created_at),quarter(created_at))"},
+		{name: "quarter", interval: interfaces.CALENDAR_UNIT_QUARTER, want: "concat(year(created_at),'-Q',quarter(created_at))"},
 		{name: "year", interval: interfaces.CALENDAR_UNIT_YEAR, want: "date_format(created_at,'%Y')"},
 		{name: "unknown", interval: "unknown", want: ""},
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_test.go
@@ -112,11 +112,15 @@ func TestMariaDBConnectorNew(t *testing.T) {
 }
 
 func TestMariaDBConnectorConnectionStringSupportsIPv6(t *testing.T) {
+	t.Setenv("TZ", "Asia/Shanghai")
 	connector := &MariaDBConnector{config: &mariadbConfig{
 		Host: "2001:db8::1", Port: 3306, Username: "root", Password: "secret",
 	}}
 
-	assert.Contains(t, connector.connectionString(), "@tcp([2001:db8::1]:3306)/")
+	connectionString := connector.connectionString()
+	assert.Contains(t, connectionString, "@tcp([2001:db8::1]:3306)/")
+	assert.Contains(t, connectionString, "loc=Asia%2FShanghai")
+	assert.Contains(t, connectionString, "time_zone=%27Asia%2FShanghai%27")
 }
 
 func TestMariaDBConnectorValidateDatabases(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 
 	"vega-backend/interfaces"
+	"vega-backend/logics/connector/local/table"
 )
 
 type postgresqlConfig struct {
@@ -168,6 +169,7 @@ func (c *PostgresqlConnector) connectionString() string {
 	if q.Get("sslmode") == "" {
 		q.Set("sslmode", "disable")
 	}
+	q.Set("timezone", table.ServerTimeZone())
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -145,6 +145,12 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	for _, prop := range resource.SchemaDefinition {
 		fieldMap[prop.Name] = prop
 	}
+	originalName := func(property string) string {
+		if field, ok := fieldMap[property]; ok && field.OriginalName != "" {
+			return field.OriginalName
+		}
+		return property
+	}
 
 	// Build the origTypeMap in advance to only store the correspondence between column names and primitive types
 	origTypeMap := map[string]string{}
@@ -182,25 +188,19 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 
 	// Add the GROUP BY field (when aggregating queries)
 	for _, groupByItem := range params.GroupBy {
-		if field, ok := fieldMap[groupByItem.Property]; ok {
-			if groupByItem.CalendarInterval != "" {
-				selectFields = append(selectFields,
-					c.buildDateFormat(quoteColumnName(field.OriginalName), groupByItem.CalendarInterval)+" AS "+quoteColumnName(groupByItem.Property))
-			} else {
-				selectFields = append(selectFields, field.OriginalName)
-			}
+		column := quoteColumnName(originalName(groupByItem.Property))
+		if groupByItem.CalendarInterval != "" {
+			selectFields = append(selectFields,
+				c.buildDateFormat(column, groupByItem.CalendarInterval)+" AS "+quoteColumnName(groupByItem.Property))
 		} else {
-			selectFields = append(selectFields, groupByItem.Property)
+			selectFields = append(selectFields, column)
 		}
 	}
 
 	// Add aggregated fields (when performing aggregated queries)
 	var aggAlias string
 	if params.Aggregation != nil {
-		aggField := params.Aggregation.Property
-		if field, ok := fieldMap[aggField]; ok {
-			aggField = field.OriginalName
-		}
+		aggField := quoteColumnName(originalName(params.Aggregation.Property))
 
 		// Determine the aggregation function
 		aggFunc := params.Aggregation.Aggr
@@ -218,7 +218,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 			aggAlias = "__value"
 		}
 
-		selectFields = append(selectFields, aggFunc+" AS "+aggAlias)
+		selectFields = append(selectFields, aggFunc+" AS "+quoteColumnName(aggAlias))
 	}
 
 	// If it is not an aggregated query and GROUP BY is not specified, add all fields
@@ -251,14 +251,11 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	if len(params.GroupBy) > 0 {
 		groupByFields := []string{}
 		for _, groupByItem := range params.GroupBy {
-			if field, ok := fieldMap[groupByItem.Property]; ok {
-				if groupByItem.CalendarInterval != "" {
-					groupByFields = append(groupByFields, c.buildDateFormat(quoteColumnName(field.OriginalName), groupByItem.CalendarInterval))
-				} else {
-					groupByFields = append(groupByFields, field.OriginalName)
-				}
+			column := quoteColumnName(originalName(groupByItem.Property))
+			if groupByItem.CalendarInterval != "" {
+				groupByFields = append(groupByFields, c.buildDateFormat(column, groupByItem.CalendarInterval))
 			} else {
-				groupByFields = append(groupByFields, groupByItem.Property)
+				groupByFields = append(groupByFields, column)
 			}
 		}
 		builder = builder.GroupBy(groupByFields...)
@@ -282,10 +279,13 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 			if sortItem.Direction == interfaces.DESC_DIRECTION {
 				dir = "DESC"
 			}
-			sortField := sortItem.Field
+			sortField := quoteColumnName(originalName(sortItem.Field))
+			if aggAlias != "" && sortItem.Field == aggAlias {
+				sortField = quoteColumnName(aggAlias)
+			}
 			for _, groupByItem := range params.GroupBy {
 				if groupByItem.Property == sortItem.Field && groupByItem.CalendarInterval != "" {
-					sortField = quoteColumnName(sortItem.Field)
+					sortField = c.buildDateFormat(quoteColumnName(originalName(groupByItem.Property)), groupByItem.CalendarInterval)
 					break
 				}
 			}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -185,7 +185,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		if field, ok := fieldMap[groupByItem.Property]; ok {
 			if groupByItem.CalendarInterval != "" {
 				selectFields = append(selectFields,
-					c.buildDateFormat(field.OriginalName, groupByItem.CalendarInterval)+" AS "+groupByItem.Property)
+					c.buildDateFormat(quoteColumnName(field.OriginalName), groupByItem.CalendarInterval)+" AS "+quoteColumnName(groupByItem.Property))
 			} else {
 				selectFields = append(selectFields, field.OriginalName)
 			}
@@ -253,7 +253,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		for _, groupByItem := range params.GroupBy {
 			if field, ok := fieldMap[groupByItem.Property]; ok {
 				if groupByItem.CalendarInterval != "" {
-					groupByFields = append(groupByFields, c.buildDateFormat(field.OriginalName, groupByItem.CalendarInterval))
+					groupByFields = append(groupByFields, c.buildDateFormat(quoteColumnName(field.OriginalName), groupByItem.CalendarInterval))
 				} else {
 					groupByFields = append(groupByFields, field.OriginalName)
 				}
@@ -282,7 +282,14 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 			if sortItem.Direction == interfaces.DESC_DIRECTION {
 				dir = "DESC"
 			}
-			builder = builder.OrderBy(sortItem.Field + " " + dir)
+			sortField := sortItem.Field
+			for _, groupByItem := range params.GroupBy {
+				if groupByItem.Property == sortItem.Field && groupByItem.CalendarInterval != "" {
+					sortField = quoteColumnName(sortItem.Field)
+					break
+				}
+			}
+			builder = builder.OrderBy(sortField + " " + dir)
 		}
 	}
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -183,7 +183,12 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	// Add the GROUP BY field (when aggregating queries)
 	for _, groupByItem := range params.GroupBy {
 		if field, ok := fieldMap[groupByItem.Property]; ok {
-			selectFields = append(selectFields, field.OriginalName)
+			if groupByItem.CalendarInterval != "" {
+				selectFields = append(selectFields,
+					c.buildDateFormat(field.OriginalName, groupByItem.CalendarInterval)+" AS "+groupByItem.Property)
+			} else {
+				selectFields = append(selectFields, field.OriginalName)
+			}
 		} else {
 			selectFields = append(selectFields, groupByItem.Property)
 		}
@@ -247,7 +252,11 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		groupByFields := []string{}
 		for _, groupByItem := range params.GroupBy {
 			if field, ok := fieldMap[groupByItem.Property]; ok {
-				groupByFields = append(groupByFields, field.OriginalName)
+				if groupByItem.CalendarInterval != "" {
+					groupByFields = append(groupByFields, c.buildDateFormat(field.OriginalName, groupByItem.CalendarInterval))
+				} else {
+					groupByFields = append(groupByFields, field.OriginalName)
+				}
 			} else {
 				groupByFields = append(groupByFields, groupByItem.Property)
 			}
@@ -349,6 +358,27 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	}
 
 	return result, nil
+}
+
+func (c *PostgresqlConnector) buildDateFormat(dateField, calendarInterval string) string {
+	switch calendarInterval {
+	case interfaces.CALENDAR_UNIT_MINUTE:
+		return fmt.Sprintf(`to_char(date_trunc('minute',%s),'YYYY-MM-DD HH24:MI')`, dateField)
+	case interfaces.CALENDAR_UNIT_HOUR:
+		return fmt.Sprintf(`to_char(date_trunc('hour',%s),'YYYY-MM-DD HH24')`, dateField)
+	case interfaces.CALENDAR_UNIT_DAY:
+		return fmt.Sprintf(`to_char(date_trunc('day',%s),'YYYY-MM-DD')`, dateField)
+	case interfaces.CALENDAR_UNIT_WEEK:
+		return fmt.Sprintf(`to_char(date_trunc('week',%s),'IYYY-IW')`, dateField)
+	case interfaces.CALENDAR_UNIT_MONTH:
+		return fmt.Sprintf(`to_char(date_trunc('month',%s),'YYYY-MM')`, dateField)
+	case interfaces.CALENDAR_UNIT_QUARTER:
+		return fmt.Sprintf(`to_char(date_trunc('quarter',%s),'YYYY-"Q"Q')`, dateField)
+	case interfaces.CALENDAR_UNIT_YEAR:
+		return fmt.Sprintf(`to_char(date_trunc('year',%s),'YYYY')`, dateField)
+	default:
+		return ""
+	}
 }
 
 // buildHavingCondition builds the HAVING condition

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
@@ -1,9 +1,11 @@
 package postgresql
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,6 +42,36 @@ func TestPostgresqlConnectorBuildDateFormat(t *testing.T) {
 			assert.Equal(t, tt.want, connector.buildDateFormat("created_at", tt.interval))
 		})
 	}
+}
+
+func TestPostgresqlConnectorExecuteQueryQuotesCalendarIntervalIdentifiers(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	connector := &PostgresqlConnector{db: db, connected: true}
+	resource := &interfaces.Resource{
+		SourceIdentifier: "public.events",
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "createdAt", OriginalName: "createdAt"},
+			{Name: "id", OriginalName: "id"},
+		},
+	}
+	params := &interfaces.ResourceDataQueryParams{
+		GroupBy:     []*interfaces.GroupByItem{{Property: "createdAt", CalendarInterval: interfaces.CALENDAR_UNIT_DAY}},
+		Aggregation: &interfaces.Aggregation{Property: "id", Aggr: "count"},
+		Sort:        []*interfaces.SortField{{Field: "createdAt", Direction: interfaces.ASC_DIRECTION}},
+		Limit:       20,
+	}
+	expectedQuery := "SELECT to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') AS \"createdAt\", COUNT(id) AS __value " +
+		"FROM \"public\".\"events\" GROUP BY to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') ORDER BY \"createdAt\" ASC LIMIT 20 OFFSET 0"
+	mock.ExpectQuery(expectedQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"createdAt", "__value"}).AddRow("2024-01-01", 1))
+
+	result, err := connector.ExecuteQuery(context.Background(), resource, params)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"createdAt", "__value"}, result.Columns)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestPostgresqlBuildHavingCondition(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
@@ -18,6 +18,30 @@ func TestPostgresqlConnectorBuildPagedSQL(t *testing.T) {
 	)
 }
 
+func TestPostgresqlConnectorBuildDateFormat(t *testing.T) {
+	connector := &PostgresqlConnector{}
+	tests := []struct {
+		name     string
+		interval string
+		want     string
+	}{
+		{name: "minute", interval: interfaces.CALENDAR_UNIT_MINUTE, want: "to_char(date_trunc('minute',created_at),'YYYY-MM-DD HH24:MI')"},
+		{name: "hour", interval: interfaces.CALENDAR_UNIT_HOUR, want: "to_char(date_trunc('hour',created_at),'YYYY-MM-DD HH24')"},
+		{name: "day", interval: interfaces.CALENDAR_UNIT_DAY, want: "to_char(date_trunc('day',created_at),'YYYY-MM-DD')"},
+		{name: "week", interval: interfaces.CALENDAR_UNIT_WEEK, want: "to_char(date_trunc('week',created_at),'IYYY-IW')"},
+		{name: "month", interval: interfaces.CALENDAR_UNIT_MONTH, want: "to_char(date_trunc('month',created_at),'YYYY-MM')"},
+		{name: "quarter", interval: interfaces.CALENDAR_UNIT_QUARTER, want: "to_char(date_trunc('quarter',created_at),'YYYY-\"Q\"Q')"},
+		{name: "year", interval: interfaces.CALENDAR_UNIT_YEAR, want: "to_char(date_trunc('year',created_at),'YYYY')"},
+		{name: "unknown", interval: "unknown", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, connector.buildDateFormat("created_at", tt.interval))
+		})
+	}
+}
+
 func TestPostgresqlBuildHavingCondition(t *testing.T) {
 	connector := &PostgresqlConnector{}
 	tests := []struct {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
@@ -63,8 +63,8 @@ func TestPostgresqlConnectorExecuteQueryQuotesCalendarIntervalIdentifiers(t *tes
 		Sort:        []*interfaces.SortField{{Field: "createdAt", Direction: interfaces.ASC_DIRECTION}},
 		Limit:       20,
 	}
-	expectedQuery := "SELECT to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') AS \"createdAt\", COUNT(id) AS __value " +
-		"FROM \"public\".\"events\" GROUP BY to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') ORDER BY \"createdAt\" ASC LIMIT 20 OFFSET 0"
+	expectedQuery := "SELECT to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') AS \"createdAt\", COUNT(\"id\") AS \"__value\" " +
+		"FROM \"public\".\"events\" GROUP BY to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') ORDER BY to_char(date_trunc('day',\"createdAt\"),'YYYY-MM-DD') ASC LIMIT 20 OFFSET 0"
 	mock.ExpectQuery(expectedQuery).
 		WillReturnRows(sqlmock.NewRows([]string{"createdAt", "__value"}).AddRow("2024-01-01", 1))
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_test.go
@@ -126,6 +126,7 @@ func TestPostgresqlConnectorNew(t *testing.T) {
 }
 
 func TestPostgresqlConnectorConnectionStringSupportsIPv6(t *testing.T) {
+	t.Setenv("TZ", "Asia/Shanghai")
 	connector := &PostgresqlConnector{config: &postgresqlConfig{
 		Host: "2001:db8::1", Port: 5432, Username: "user", Password: "secret", Database: "app",
 	}}
@@ -134,6 +135,7 @@ func TestPostgresqlConnectorConnectionStringSupportsIPv6(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "2001:db8::1", connectionURL.Hostname())
 	assert.Equal(t, "5432", connectionURL.Port())
+	assert.Equal(t, "Asia/Shanghai", connectionURL.Query().Get("timezone"))
 }
 
 func TestPostgresqlConnectorValidateSchemas(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/timezone.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/timezone.go
@@ -1,0 +1,14 @@
+package table
+
+import (
+	"os"
+	"strings"
+)
+
+// ServerTimeZone 返回日历分桶使用的服务时区。
+func ServerTimeZone() string {
+	if timeZone := strings.TrimSpace(os.Getenv("TZ")); timeZone != "" {
+		return timeZone
+	}
+	return "UTC"
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix MariaDB/MySQL quarterly calendar bucket SQL generation.
- [x] Add PostgreSQL calendar bucketing for minute, hour, day, week, month, quarter, and year.
- [x] Align MariaDB/MySQL and PostgreSQL connection sessions with the Vega server time zone.

---

## Why

- Related Issue: Closes #504
- Related Feature: N/A
- Background: MariaDB used numeric FORMAT for a quarter label, causing calendar grouping queries to fail. PostgreSQL did not apply calendar_interval grouping.

---

## How

- Key implementation points:
  - Use concat(year(...), '-Q', quarter(...)) for MariaDB/MySQL quarter labels.
  - Generate ISO-week and YYYY-QN labels that match ontology-query calendar bucket parsing.
  - Pass the service TZ to database sessions and the MariaDB driver.
- Breaking changes (API, config, database, etc.): No API or schema changes. Data sources must support the configured IANA time zone name.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no real MariaDB/PostgreSQL instance was used)
- [ ] Verified in test environment (not run)

Test notes:

- make lint
- make test

---

## Risk & Rollback

- Potential risks: A database without IANA time zone data rejects the connection session setting; test-connection exposes the database error.
- Rollback plan: Revert commit 6eb3982e0.

---

## Additional Notes

- SQL generation and DSN coverage were added for MariaDB/MySQL and PostgreSQL.