### PR TITLE
fix(trace): retain metrics in signed projection exports

### DIFF
--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend.go
@@ -283,13 +283,14 @@ type MetricTypeConcepts struct {
 
 // KnowledgeNetworkDetail Knowledge network detail with full schema
 type KnowledgeNetworkDetail struct {
-	ID            string          `json:"id"`             // Knowledge network ID
-	Name          string          `json:"name"`           // Knowledge network name
-	Comment       string          `json:"comment"`        // Comment/description
-	ConceptGroups []*ConceptGroup `json:"concept_groups"` // Concept groups
-	ObjectTypes   []*ObjectType   `json:"object_types"`   // Object types
-	RelationTypes []*RelationType `json:"relation_types"` // Relation types
-	ActionTypes   []*ActionType   `json:"action_types"`   // Action types
+	ID            string          `json:"id"`                // Knowledge network ID
+	Name          string          `json:"name"`              // Knowledge network name
+	Comment       string          `json:"comment"`           // Comment/description
+	ConceptGroups []*ConceptGroup `json:"concept_groups"`    // Concept groups
+	ObjectTypes   []*ObjectType   `json:"object_types"`      // Object types
+	RelationTypes []*RelationType `json:"relation_types"`    // Relation types
+	ActionTypes   []*ActionType   `json:"action_types"`      // Action types
+	Metrics       []*MetricType   `json:"metrics,omitempty"` // Metrics included by a sealed projection export
 }
 
 // Detail levels for get_kn_detail progressive disclosure.

--- a/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend_test.go
+++ b/adp/context-loader/agent-retrieval/server/interfaces/driven_bkn_backend_test.go
@@ -1,0 +1,25 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package interfaces
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestKnowledgeNetworkDetailDecodesExportedMetrics(t *testing.T) {
+	var detail KnowledgeNetworkDetail
+	if err := json.Unmarshal([]byte(`{
+		"id":"supply",
+		"metrics":[{"id":"monthly-revenue","name":"月度营收","scope_ref":"purchase_order"}]
+	}`), &detail); err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Metrics) != 1 || detail.Metrics[0].ID != "monthly-revenue" || detail.Metrics[0].Name != "月度营收" || detail.Metrics[0].ScopeRef != "purchase_order" {
+		t.Fatalf("decoded metrics = %+v", detail.Metrics)
+	}
+}


### PR DESCRIPTION
## What

Retains `metrics` from BKN's existing single-network projection export in `KnowledgeNetworkDetail`.

## Why

Historical facts containing `metric_id` otherwise become permanently `not_evaluable` after the DTO drops a field BKN already exports.

## Boundary

No endpoint, identity propagation, Vega call, or new authorization path is added. EE reads metrics from the cached signed network snapshot.

## Verification

`go test ./server/interfaces -run TestKnowledgeNetworkDetailDecodesExportedMetrics -count=1`