### PR TITLE
feat(execution-factory): expose skill detail and batch names on internal-v1

### DIFF
--- a/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
@@ -37,6 +37,14 @@ func (r *skillRestHandler) RegisterPrivate(engine *gin.RouterGroup) {
 	engine.GET("/skills/market", r.SkillHandler.QuerySkillMarketList)
 	// Check skills market details.
 	engine.GET("/skills/market/:skill_id", r.SkillHandler.GetSkillMarketDetail)
+	// Metadata interface.
+	// Batch names by skill ID. Same handler as the public face; FilterViewableIDs returns
+	// the IDs unchanged on the internal face, so callers see existence, not their own grants.
+	engine.POST("/skills/names", r.SkillHandler.QuerySkillNamesByIDs)
+	// Query skill details. Registered here for bkn-backend, whose execution-factory client
+	// is pinned to internal-v1. Unlike /skills/market/:skill_id it applies no public_access
+	// filter and reports an unpublished skill through `status` instead of 404.
+	engine.GET("/skills/:skill_id", r.SkillHandler.GetSkillDetail)
 	// Read interface.
 	// Query skill content.
 	engine.GET("/skills/:skill_id/content", r.SkillHandler.GetSkillContent)

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -785,7 +785,9 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{}, nil)
 			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
-			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+			// Public face: object-level view still applies there (see registry_internal_face_test.go
+			// for the internal face, which answers the same way for every caller).
+			resp, err := registry.GetSkillDetail(skillPublicCtx(), &interfaces.GetSkillDetailReq{
 				SkillID: "skill-7",
 			})
 
@@ -819,7 +821,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockUserMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).Return(map[string]string{}, nil)
 			mockCategoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("").AnyTimes()
 
-			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+			resp, err := registry.GetSkillDetail(skillPublicCtx(), &interfaces.GetSkillDetailReq{
 				SkillID: "skill-7b",
 			})
 
@@ -869,7 +871,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 				SkillID: "skill-12", Status: interfaces.BizStatusPublished.String(), IsDeleted: true,
 			}, nil)
 
-			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+			resp, err := registry.GetSkillDetail(skillPublicCtx(), &interfaces.GetSkillDetailReq{
 				SkillID: "skill-12",
 			})
 
@@ -885,7 +887,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
 			mockAuthService.EXPECT().CheckViewPermission(gomock.Any(), gomock.Any(), "skill-12b", interfaces.AuthResourceTypeSkill).Return(errors.New("view forbidden"))
 
-			resp, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+			resp, err := registry.GetSkillDetail(skillPublicCtx(), &interfaces.GetSkillDetailReq{
 				SkillID: "skill-12b",
 			})
 

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -1241,19 +1241,25 @@ func (r *skillRegistry) GetSkillDetail(ctx context.Context, req *interfaces.GetS
 		"user_id":  req.UserID,
 		"skill_id": req.SkillID,
 	})
-	accessor, err := r.AuthService.GetAccessor(ctx, req.UserID)
-	if err != nil {
-		return nil, err
-	}
-	if err = r.AuthService.CheckViewPermission(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill); err != nil {
-		return nil, err
+	// Object-level view is a caller-scoped judgement, so it only applies on the public face.
+	// The internal face answers "does this skill exist and what is its status" identically for
+	// every caller: bkn-backend validates capability bindings through it and must be able to
+	// tell "no such skill" apart from "exists but unpublished".
+	if infracommon.IsPublicAPIFromCtx(ctx) {
+		accessor, aerr := r.AuthService.GetAccessor(ctx, req.UserID)
+		if aerr != nil {
+			return nil, aerr
+		}
+		if err = r.AuthService.CheckViewPermission(ctx, accessor, req.SkillID, interfaces.AuthResourceTypeSkill); err != nil {
+			return nil, err
+		}
 	}
 	skill, err := r.skillRepo.SelectSkillByID(ctx, nil, req.SkillID)
 	if err != nil {
 		return nil, err
 	}
 	if skill == nil || skill.IsDeleted {
-		return nil, fmt.Errorf("skill not found: %s", req.SkillID)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusNotFound, fmt.Sprintf("skill not found: %s", req.SkillID))
 	}
 	skillInfo := convertSkillDetail(skill, r.CategoryManager.GetCategoryName(ctx, interfaces.BizCategory(skill.Category)))
 	// Get user information.

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry_internal_face_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry_internal_face_test.go
@@ -1,0 +1,160 @@
+package skill
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/mocks"
+)
+
+// TestGetSkillDetailInternalFace covers #1255: skill details are registered on internal-v1 so
+// bkn-backend can validate capability bindings. The internal face must answer the same way for
+// every caller and must not turn "unpublished" into "not found".
+func TestGetSkillDetailInternalFace(t *testing.T) {
+	Convey("内部面技能详情", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		newRegistry := func(skillRepo model.ISkillRepository, authService interfaces.IAuthorizationService) *skillRegistry {
+			categoryManager := mocks.NewMockCategoryManager(ctrl)
+			categoryManager.EXPECT().GetCategoryName(gomock.Any(), gomock.Any()).Return("通用").AnyTimes()
+			userMgnt := mocks.NewMockUserManagement(ctrl)
+			userMgnt.EXPECT().GetUsersName(gomock.Any(), gomock.Any()).
+				Return(map[string]string{"user-1": "创建者"}, nil).AnyTimes()
+			return &skillRegistry{
+				skillRepo:       skillRepo,
+				AuthService:     authService,
+				CategoryManager: categoryManager,
+				UserMgnt:        userMgnt,
+				Logger:          logger.DefaultLogger(),
+			}
+		}
+
+		Convey("未发布技能返回 200 与 status，不是 404", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			skillRepo.EXPECT().SelectSkillByID(gomock.Any(), gomock.Nil(), "skill-1").
+				Return(&model.SkillRepositoryDB{
+					SkillID: "skill-1", Name: "交期评估", Description: "评估交期",
+					Status: interfaces.BizStatusUnpublish.String(), CreateUser: "user-1", UpdateUser: "user-1",
+				}, nil)
+			// No authorization call is expected at all: the mock controller fails the test if one happens.
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+
+			resp, err := newRegistry(skillRepo, authService).GetSkillDetail(context.Background(),
+				&interfaces.GetSkillDetailReq{SkillID: "skill-1"})
+
+			So(err, ShouldBeNil)
+			So(resp.SkillID, ShouldEqual, "skill-1")
+			So(resp.Name, ShouldEqual, "交期评估")
+			So(resp.Status, ShouldEqual, interfaces.BizStatusUnpublish)
+		})
+
+		Convey("技能不存在返回 404，与「存在但未发布」可区分", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			skillRepo.EXPECT().SelectSkillByID(gomock.Any(), gomock.Nil(), "skill-missing").Return(nil, nil)
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+
+			resp, err := newRegistry(skillRepo, authService).GetSkillDetail(context.Background(),
+				&interfaces.GetSkillDetailReq{SkillID: "skill-missing"})
+
+			So(resp, ShouldBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusNotFound)
+		})
+
+		Convey("同一技能对不同调用者返回相同结果", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			skillRepo.EXPECT().SelectSkillByID(gomock.Any(), gomock.Nil(), "skill-1").
+				Return(&model.SkillRepositoryDB{
+					SkillID: "skill-1", Name: "交期评估",
+					Status: interfaces.BizStatusPublished.String(), CreateUser: "user-1", UpdateUser: "user-1",
+				}, nil).Times(2)
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			registry := newRegistry(skillRepo, authService)
+
+			first, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+				UserID: "user-1", SkillID: "skill-1",
+			})
+			So(err, ShouldBeNil)
+			second, err := registry.GetSkillDetail(context.Background(), &interfaces.GetSkillDetailReq{
+				UserID: "user-2", SkillID: "skill-1",
+			})
+			So(err, ShouldBeNil)
+			So(second.Name, ShouldEqual, first.Name)
+			So(second.Status, ShouldEqual, first.Status)
+		})
+
+		Convey("公开面仍按账户判定查看权限", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-2").
+				Return(&interfaces.AuthAccessor{ID: "user-2"}, nil)
+			authService.EXPECT().CheckViewPermission(gomock.Any(), gomock.Any(), "skill-1",
+				interfaces.AuthResourceTypeSkill).
+				Return(errors.NewHTTPError(context.Background(), http.StatusForbidden, errors.ErrExtCommonViewForbidden, nil))
+
+			resp, err := newRegistry(skillRepo, authService).GetSkillDetail(skillPublicCtx(),
+				&interfaces.GetSkillDetailReq{UserID: "user-2", SkillID: "skill-1"})
+
+			So(resp, ShouldBeNil)
+			httpErr, ok := err.(*errors.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusForbidden)
+		})
+	})
+}
+
+// TestGetSkillNamesByIDsInternalFace locks the internal-face contract of the batch name endpoint:
+// no per-caller filtering, non-existing IDs silently skipped, response IDs a subset of the request.
+func TestGetSkillNamesByIDsInternalFace(t *testing.T) {
+	Convey("内部面技能批量取名", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("不按调用者过滤，不存在的 ID 静默略过", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			skillRepo.EXPECT().SelectSkillListByIDs(gomock.Any(), []string{"skill-1", "skill-2"}).
+				Return([]*model.SkillRepositoryDB{
+					{SkillID: "skill-1", Name: "skill one"},
+					{SkillID: "skill-2", Name: "skill two"},
+				}, nil)
+			// No GetAccessor / ResourceListIDs: FilterViewableIDs short-circuits off the public face.
+			registry := &skillRegistry{
+				skillRepo:   skillRepo,
+				AuthService: mocks.NewMockIAuthorizationService(ctrl),
+				Logger:      logger.DefaultLogger(),
+			}
+
+			resp, err := registry.GetSkillNamesByIDs(context.Background(), []string{"skill-1", "skill-2"})
+
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 2)
+		})
+
+		Convey("返回的 ID 集合是请求集合的子集", func() {
+			skillRepo := mocks.NewMockISkillRepository(ctrl)
+			skillRepo.EXPECT().SelectSkillListByIDs(gomock.Any(), []string{"skill-1", "skill-missing"}).
+				Return([]*model.SkillRepositoryDB{{SkillID: "skill-1", Name: "skill one"}}, nil)
+			registry := &skillRegistry{
+				skillRepo:   skillRepo,
+				AuthService: mocks.NewMockIAuthorizationService(ctrl),
+				Logger:      logger.DefaultLogger(),
+			}
+
+			resp, err := registry.GetSkillNamesByIDs(context.Background(), []string{"skill-1", "skill-missing"})
+
+			So(err, ShouldBeNil)
+			So(len(resp.Entries), ShouldEqual, 1)
+			So(resp.Entries[0].ID, ShouldEqual, "skill-1")
+		})
+	})
+}

--- a/docs/api/execution-factory/skill.yaml
+++ b/docs/api/execution-factory/skill.yaml
@@ -37,6 +37,10 @@ info:
     放行等于任意账户可读任意技能全文，但直接翻强制会误伤，先影子观察再翻。
     调用方没带账户身份时任何档位都跳过判定——那是「无从判断」，不是「判定为无权」。
     `/execute` 不受该档位影响，一直按账户强制。
+
+    内部面另有两个只读元数据接口：`GET /skills/{skill_id}` 与 `POST /skills/names`。
+    它们不做调用者维度的判定，答的是「技能是否存在、什么状态」，供 bkn-backend 校验
+    知识网络能力绑定与回填元数据。
   version: 0.1.3
 servers:
   - url: /api/agent-operator-integration/v1
@@ -159,6 +163,10 @@ paths:
       operationId: getSkillNames
       description: |
         与 `/operator/names`、`/tool-box/names` 同契约：不存在的 ID 静默略过、不占位。
+
+        **也注册在 `internal-v1`**。公开面按调用者的 `view` 过滤（无权限的 ID 与不存在的
+        ID 一样被略过），内部面不过滤——服务间调用要的是「这些 ID 还在不在」，用于知识网络
+        能力绑定的元数据回填与悬空判定。
       requestBody:
         required: true
         content:
@@ -264,7 +272,15 @@ paths:
         - Skill
       summary: 查询技能详情
       operationId: getSkill
-      description: 取技能的元数据。文件清单与内容走 `/content`，包体走 `/download`。
+      description: |
+        取技能的元数据。文件清单与内容走 `/content`，包体走 `/download`。
+
+        **也注册在 `internal-v1`**，供 bkn-backend 校验知识网络能力绑定。内部面不做
+        调用者维度的 `view` 判定，同一技能对任何调用者返回相同结果；未发布的技能通过
+        `status` 字段体现，不返回 404。别拿 `/skills/market/{skill_id}` 代替它——那条路
+        走 `public_access` 且未发布即 404，会把「存在但未发布」误报成「不存在」。
+
+        `404` 只表示技能不存在或已删除。
       parameters:
         - $ref: '#/components/parameters/SkillID'
       responses:


### PR DESCRIPTION
Closes #1255. First work package of Epic #1266 (knowledge-network capability binding).

## Why

bkn-backend's execution-factory client is pinned to the `internal-v1` base URL (`adp/bkn/bkn-backend/server/common/setting.go:316`) and sends only `account-id` / `account-type` headers — the public face's introspect middleware rejects it. `GET /skills/{skill_id}` and `POST /skills/names` were registered on `RegisterPublic` only, so the capability-binding work would have hit "404 on internal, 401 on public".

`/skills/market/{skill_id}` is deliberately not reused: it filters by `public_access` and 404s on unpublished skills, which collapses "exists but unpublished" into "does not exist" — exactly the distinction binding validation has to make.

## What changed

- **Routes**: both endpoints added to `RegisterPrivate`.
- **`GetSkillDetail`**: the object-level `view` check now runs only when the request comes from the public face, gated on `IsPublicAPIFromCtx` — the same pattern `GetToolBox` already uses for the Function-side endpoint BKN validates against today. The internal face answers "does this skill exist and what is its status" identically for every caller.
- **Not-found**: a missing or deleted skill now returns a 404 `HTTPError` instead of a bare `fmt.Errorf` that surfaced as 500. `skill.yaml` already documented 404 for this operation, so this aligns behavior with the published contract.
- **`/skills/names`**: no logic change needed — `FilterViewableIDs` already returns IDs unchanged off the public face.
- **Docs**: `docs/api/execution-factory/skill.yaml` records the internal-face registration and its authorization semantics for both endpoints.

## Acceptance

| Criterion | Where |
|---|---|
| Both endpoints reachable on internal-v1 with the existing client config | `skill_handler.go` `RegisterPrivate`; prefix wired at `server/main.go:64` |
| Unpublished skill returns 200 + `status`, not 404 | `registry_internal_face_test.go` |
| Same result for different callers | `registry_internal_face_test.go` |
| `/skills/names` silently skips non-existing IDs, response is a subset of the request | `registry_internal_face_test.go` |
| Public-face behavior unchanged | `registry_internal_face_test.go` (view check still enforced) + existing tests moved onto `skillPublicCtx()` |

Three existing cases in `reader_registry_test.go` drove `GetSkillDetail` on a bare `context.Background()` while asserting the authorization calls; they now use `skillPublicCtx()`, which is where those expectations belong.

`go test ./server/logics/skill/... ./server/driveradapters/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)