### PR TITLE
feat(execution-factory): add the whitelist-scoped tool search endpoint

### DIFF
--- a/adp/execution-factory/operator-integration/server/dbaccess/tool.go
+++ b/adp/execution-factory/operator-integration/server/dbaccess/tool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -534,6 +535,46 @@ func (t *toolDB) SelectToolBySource(ctx context.Context, sourceType model.Source
 	err = orm.Select().From(tbTool).WhereEq("f_source_type", sourceType).WhereEq("f_source_id", sourceID).Get(ctx, &tools)
 	if err != nil {
 		err = errors.Wrapf(err, "select tool by source error")
+	}
+	return
+}
+
+// escapeLikeLiteral makes a user-supplied keyword match literally in a LIKE pattern.
+//
+// The platform's like contract is substring containment, so % and _ typed by a caller are data,
+// not wildcards. Left unescaped, a query containing "%" would match everything and a query
+// containing "_" would match any single character in that position.
+func escapeLikeLiteral(keyword string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(keyword)
+}
+
+// SearchToolsByIDs returns tools inside an ID whitelist whose name or description contains the
+// keyword. The whitelist is part of the query rather than applied to its results: filtering after
+// the fact would drop a caller's tools whenever unrelated ones sort ahead of them.
+func (t *toolDB) SearchToolsByIDs(ctx context.Context, toolIDs []string, keyword string,
+	limit int) (tools []*model.ToolDB, err error) {
+	tools = []*model.ToolDB{}
+	if len(toolIDs) == 0 {
+		return
+	}
+	args := make([]interface{}, 0, len(toolIDs))
+	for _, id := range toolIDs {
+		args = append(args, id)
+	}
+
+	query := t.orm.Select().From(tbTool).WhereIn("f_tool_id", args...)
+	if keyword != "" {
+		pattern := "%" + escapeLikeLiteral(keyword) + "%"
+		query = query.Or(func(w *ormhelper.WhereBuilder) {
+			w.Like("f_name", pattern).Like("f_description", pattern)
+		})
+	}
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	if err = query.Get(ctx, &tools); err != nil {
+		err = errors.Wrapf(err, "search tools by ids error")
 	}
 	return
 }

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/index.go
@@ -21,6 +21,7 @@ type ToolBoxHandler interface {
 	QueryToolBox(c *gin.Context)
 	DeleteToolBox(c *gin.Context)
 	QueryToolBoxPage(c *gin.Context)
+	SearchTools(c *gin.Context)
 	QueryToolBoxNamesByIDs(c *gin.Context)
 	UpdateToolBoxStatus(c *gin.Context)
 	// Tool operation interface.

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
@@ -725,3 +725,18 @@ func (h *toolBoxHandler) GetReleaseToolBoxInfo(c *gin.Context) {
 	}
 	rest.ReplyOK(c, http.StatusOK, resp)
 }
+
+// SearchTools retrieves tools inside an explicit whitelist (#1261).
+func (h *toolBoxHandler) SearchTools(c *gin.Context) {
+	req := &interfaces.SearchToolsReq{}
+	if err := utils.GetBindJSONRaw(c, req); err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	resp, err := h.ToolService.SearchTools(c.Request.Context(), req)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, resp)
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox_handler.go
@@ -47,6 +47,9 @@ func (r *toolboxRestHandler) RegisterPrivate(engine *gin.RouterGroup) {
 	engine.GET("/tool-box/:box_id", r.ToolBoxHandler.QueryToolBox)
 	engine.GET("/tool-box/:box_id/tool/:tool_id", r.ToolBoxHandler.QueryTool)
 	engine.GET("/tool-box/:box_id/tools/list", r.ToolBoxHandler.QueryBoxToolPage)
+	// Retrieval interface. Internal face only: the whitelist carries the caller's authorization
+	// decision, and a public caller supplying its own whitelist would be deciding its own scope.
+	engine.POST("/tool-box/tools/search", r.ToolBoxHandler.SearchTools)
 	engine.POST("/tool-box/:box_id/proxy/:tool_id", middlewareProxyRequest(), r.ToolBoxHandler.ExecuteTool)
 }
 

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -425,6 +425,8 @@ type GetReleaseToolBoxInfoResp struct {
 
 // IToolService toolbox service interface.
 type IToolService interface {
+	// SearchTools retrieves tools inside an explicit whitelist (#1261).
+	SearchTools(ctx context.Context, req *SearchToolsReq) (resp *SearchToolsResp, err error)
 	// Toolbox management.
 	CreateToolBox(ctx context.Context, req *CreateToolBoxReq) (resp *CreateToolBoxResp, err error)
 	UpdateToolBox(ctx context.Context, req *UpdateToolBoxReq) (resp *UpdateToolBoxResp, err error)
@@ -467,4 +469,37 @@ type IToolService interface {
 // ToolBoxEventHandler event handling interface.
 type ToolBoxEventHandler interface {
 	HandleOperatorDeleteEvent(ctx context.Context, message []byte) error
+}
+
+// Retrieval channel reported on every tool search hit. Only "like" occurs today: the tool index
+// does not exist yet, so retrieval is literal substring containment. The field is here so the
+// contract does not change when the semantic index lands.
+const ToolMatchedByLike = "like"
+
+// SearchToolsReq searches tools inside an explicit whitelist (#1261).
+//
+// ToolRefs are flat "{box_id}/{tool_id}" references. A tool id is scoped to its box in the
+// execution factory, so the pair is what identifies a tool. The list is mandatory and
+// fail-closed: empty or missing returns nothing rather than every tool on the platform.
+type SearchToolsReq struct {
+	Query    string   `json:"query"`
+	ToolRefs []string `json:"tool_refs"`
+	TopK     int      `json:"top_k"`
+}
+
+// SearchToolHit is one retrieved tool.
+type SearchToolHit struct {
+	BoxID       string  `json:"box_id"`
+	ToolID      string  `json:"tool_id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Status      string  `json:"status"`
+	// Score is absent while retrieval is substring matching; it is part of the contract so the
+	// semantic implementation can fill it without changing the response shape.
+	Score     float64 `json:"score"`
+	MatchedBy string  `json:"matched_by"`
+}
+
+type SearchToolsResp struct {
+	Entries []*SearchToolHit `json:"entries"`
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/model/tool.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/model/tool.go
@@ -57,5 +57,8 @@ type IToolDB interface {
 	// Get the toolbox ID according to query conditions and GROUP BY.
 	SelectToolBoxIDsByFilter(ctx context.Context, filter map[string]interface{}) ([]string, error)
 	SelectToolBoxByToolIDs(ctx context.Context, toolIDs []string) ([]*ToolDB, error)
+	// SearchToolsByIDs returns the tools among toolIDs whose name or description contains the
+	// keyword. An empty keyword returns every tool in the set.
+	SearchToolsByIDs(ctx context.Context, toolIDs []string, keyword string, limit int) ([]*ToolDB, error)
 	SelectToolBySource(ctx context.Context, sourceType SourceType, sourceID string) ([]*ToolDB, error)
 }

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/search.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/search.go
@@ -1,0 +1,124 @@
+package toolbox
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
+)
+
+const (
+	defaultToolSearchTopK = 10
+	maxToolSearchTopK     = 100
+	// maxToolSearchWhitelist bounds one request. Past this the caller should resolve the
+	// whitelist server-side rather than post a list nobody can read in a log.
+	maxToolSearchWhitelist = 1000
+)
+
+// toolRef is the (box, tool) pair a flat "{box_id}/{tool_id}" reference denotes.
+type toolRef struct {
+	boxID  string
+	toolID string
+}
+
+// parseToolRefs normalises the whitelist. Malformed entries are dropped rather than rejected: the
+// list is assembled from stored bindings, and one stale entry should narrow the search, not fail
+// the request.
+func parseToolRefs(refs []string) []toolRef {
+	seen := make(map[toolRef]struct{}, len(refs))
+	parsed := make([]toolRef, 0, len(refs))
+	for _, raw := range refs {
+		boxID, toolID, ok := strings.Cut(strings.TrimSpace(raw), "/")
+		boxID, toolID = strings.TrimSpace(boxID), strings.TrimSpace(toolID)
+		if !ok || boxID == "" || toolID == "" {
+			continue
+		}
+		ref := toolRef{boxID: boxID, toolID: toolID}
+		if _, exists := seen[ref]; exists {
+			continue
+		}
+		seen[ref] = struct{}{}
+		parsed = append(parsed, ref)
+	}
+	return parsed
+}
+
+// SearchTools retrieves tools from the whitelist by literal substring containment.
+//
+// There is no tool index yet — the execution factory has never built one, and the whole "search"
+// surface on tools is SQL matching — so retrieval is a LIKE over name and description, reported
+// honestly as matched_by=like. The response shape is the semantic one so that replacing the
+// implementation later does not change the contract.
+func (s *ToolServiceImpl) SearchTools(ctx context.Context,
+	req *interfaces.SearchToolsReq) (*interfaces.SearchToolsResp, error) {
+	ctx, _ = oteltrace.StartInternalSpan(ctx)
+	var err error
+	defer func() { oteltrace.EndSpan(ctx, err) }()
+
+	empty := &interfaces.SearchToolsResp{Entries: []*interfaces.SearchToolHit{}}
+
+	// Fail closed. An empty or missing whitelist means "no tool is in scope", never "do not
+	// filter" — the second reading would hand every tool on the platform to a caller that has
+	// bound none.
+	refs := parseToolRefs(req.ToolRefs)
+	if len(refs) == 0 {
+		s.Logger.WithContext(ctx).Infof("tool search short-circuited: empty whitelist")
+		return empty, nil
+	}
+	if len(refs) > maxToolSearchWhitelist {
+		err = errors.DefaultHTTPError(ctx, http.StatusBadRequest,
+			"tool_refs exceeds the maximum of 1000 entries")
+		return nil, err
+	}
+
+	topK := req.TopK
+	if topK <= 0 {
+		topK = defaultToolSearchTopK
+	}
+	if topK > maxToolSearchTopK {
+		topK = maxToolSearchTopK
+	}
+
+	allowed := make(map[toolRef]struct{}, len(refs))
+	toolIDs := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		allowed[ref] = struct{}{}
+		toolIDs = append(toolIDs, ref.toolID)
+	}
+
+	// The database filter is on tool_id alone because a tool id is scoped to its box, so the
+	// same id can exist in another box. The rows are narrowed to the exact pairs below; without
+	// that step a caller could reach a tool of the same id in a box it never bound.
+	// No SQL limit either: the cap applies after pair filtering, or a page full of same-id tools
+	// from other boxes would crowd out the caller's own.
+	tools, err := s.ToolDB.SearchToolsByIDs(ctx, toolIDs, strings.TrimSpace(req.Query), 0)
+	if err != nil {
+		s.Logger.WithContext(ctx).Errorf("tool search query failed: %v", err)
+		return nil, errors.DefaultHTTPError(ctx, http.StatusInternalServerError, err.Error())
+	}
+
+	entries := make([]*interfaces.SearchToolHit, 0, len(tools))
+	for _, tool := range tools {
+		if tool == nil || tool.IsDeleted {
+			continue
+		}
+		if _, ok := allowed[toolRef{boxID: tool.BoxID, toolID: tool.ToolID}]; !ok {
+			continue
+		}
+		entries = append(entries, &interfaces.SearchToolHit{
+			BoxID:       tool.BoxID,
+			ToolID:      tool.ToolID,
+			Name:        tool.Name,
+			Description: tool.Description,
+			Status:      tool.Status,
+			MatchedBy:   interfaces.ToolMatchedByLike,
+		})
+		if len(entries) >= topK {
+			break
+		}
+	}
+	return &interfaces.SearchToolsResp{Entries: entries}, nil
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/search_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/search_test.go
@@ -1,0 +1,109 @@
+package toolbox
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/logger"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/mocks"
+)
+
+// TestSearchToolsFailClosed covers the security boundary of #1261: an empty whitelist means
+// "nothing is in scope", never "do not filter". Both spellings are locked because the difference
+// between them is exactly how a platform-wide leak would slip in.
+func TestSearchToolsFailClosed(t *testing.T) {
+	Convey("白名单为空时不查库、返回空", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// No EXPECT on the tool store: the controller fails the test if a query is issued.
+		service := &ToolServiceImpl{ToolDB: mocks.NewMockIToolDB(ctrl), Logger: logger.DefaultLogger()}
+
+		Convey("tool_refs 为空数组", func() {
+			resp, err := service.SearchTools(context.Background(), &interfaces.SearchToolsReq{
+				Query: "sql", ToolRefs: []string{},
+			})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+
+		Convey("tool_refs 字段缺失", func() {
+			resp, err := service.SearchTools(context.Background(), &interfaces.SearchToolsReq{Query: "sql"})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+
+		Convey("tool_refs 全是格式非法的引用", func() {
+			resp, err := service.SearchTools(context.Background(), &interfaces.SearchToolsReq{
+				Query: "sql", ToolRefs: []string{"no-slash", "/", " / ", "box-only/"},
+			})
+			So(err, ShouldBeNil)
+			So(resp.Entries, ShouldBeEmpty)
+		})
+	})
+}
+
+// TestSearchToolsPairScoping locks that a whitelist entry admits one (box, tool) pair rather than
+// a bare tool id. Tool ids are scoped to their box, so filtering on the id alone would let a
+// caller reach a same-id tool in a box it never bound.
+func TestSearchToolsPairScoping(t *testing.T) {
+	Convey("白名单按 (box, tool) 配对收窄", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		toolDB := mocks.NewMockIToolDB(ctrl)
+		// "dangling/gone" is well formed, so its id still goes to the store; it simply matches
+		// no row. Only malformed refs are dropped before the query.
+		toolDB.EXPECT().SearchToolsByIDs(gomock.Any(), []string{"tool-1", "gone"}, "sql", 0).
+			Return([]*model.ToolDB{
+				{BoxID: "box-1", ToolID: "tool-1", Name: "run_sql", Description: "执行 SQL", Status: "published"},
+				{BoxID: "box-other", ToolID: "tool-1", Name: "run_sql", Description: "别的箱里同 id 的工具"},
+				{BoxID: "box-1", ToolID: "tool-1", Name: "已删除", IsDeleted: true},
+			}, nil)
+
+		service := &ToolServiceImpl{ToolDB: toolDB, Logger: logger.DefaultLogger()}
+
+		resp, err := service.SearchTools(context.Background(), &interfaces.SearchToolsReq{
+			Query: "sql", ToolRefs: []string{"box-1/tool-1", "box-1/tool-1", "dangling/gone"},
+		})
+
+		So(err, ShouldBeNil)
+		So(len(resp.Entries), ShouldEqual, 1)
+		So(resp.Entries[0].BoxID, ShouldEqual, "box-1")
+		So(resp.Entries[0].ToolID, ShouldEqual, "tool-1")
+		So(resp.Entries[0].MatchedBy, ShouldEqual, interfaces.ToolMatchedByLike)
+	})
+}
+
+// TestSearchToolsTopK keeps the cap on the pair-filtered results. Applying it in SQL instead would
+// let same-id tools from other boxes fill the page and crowd out the caller's own.
+func TestSearchToolsTopK(t *testing.T) {
+	Convey("top_k 作用在配对过滤之后", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		toolDB := mocks.NewMockIToolDB(ctrl)
+		toolDB.EXPECT().SearchToolsByIDs(gomock.Any(), gomock.Any(), gomock.Any(), 0).
+			Return([]*model.ToolDB{
+				{BoxID: "other", ToolID: "tool-1", Name: "别的箱"},
+				{BoxID: "other", ToolID: "tool-2", Name: "别的箱"},
+				{BoxID: "box-1", ToolID: "tool-1", Name: "第一个"},
+				{BoxID: "box-1", ToolID: "tool-2", Name: "第二个"},
+			}, nil)
+
+		service := &ToolServiceImpl{ToolDB: toolDB, Logger: logger.DefaultLogger()}
+
+		resp, err := service.SearchTools(context.Background(), &interfaces.SearchToolsReq{
+			ToolRefs: []string{"box-1/tool-1", "box-1/tool-2"}, TopK: 1,
+		})
+
+		So(err, ShouldBeNil)
+		So(len(resp.Entries), ShouldEqual, 1)
+		So(resp.Entries[0].Name, ShouldEqual, "第一个")
+	})
+}

--- a/adp/execution-factory/operator-integration/server/mocks/model_tool.go
+++ b/adp/execution-factory/operator-integration/server/mocks/model_tool.go
@@ -101,6 +101,21 @@ func (mr *MockIToolDBMockRecorder) InsertTools(ctx, tx, tools any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertTools", reflect.TypeOf((*MockIToolDB)(nil).InsertTools), ctx, tx, tools)
 }
 
+// SearchToolsByIDs mocks base method.
+func (m *MockIToolDB) SearchToolsByIDs(ctx context.Context, toolIDs []string, keyword string, limit int) ([]*model.ToolDB, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchToolsByIDs", ctx, toolIDs, keyword, limit)
+	ret0, _ := ret[0].([]*model.ToolDB)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchToolsByIDs indicates an expected call of SearchToolsByIDs.
+func (mr *MockIToolDBMockRecorder) SearchToolsByIDs(ctx, toolIDs, keyword, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchToolsByIDs", reflect.TypeOf((*MockIToolDB)(nil).SearchToolsByIDs), ctx, toolIDs, keyword, limit)
+}
+
 // SelectBoxToolByName mocks base method.
 func (m *MockIToolDB) SelectBoxToolByName(ctx context.Context, boxID, name string) (bool, *model.ToolDB, error) {
 	m.ctrl.T.Helper()

--- a/adp/execution-factory/operator-integration/server/mocks/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/mocks/toolbox.go
@@ -340,6 +340,21 @@ func (mr *MockIToolServiceMockRecorder) RegisterOpenApiBundle(ctx, req any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterOpenApiBundle", reflect.TypeOf((*MockIToolService)(nil).RegisterOpenApiBundle), ctx, req)
 }
 
+// SearchTools mocks base method.
+func (m *MockIToolService) SearchTools(ctx context.Context, req *interfaces.SearchToolsReq) (*interfaces.SearchToolsResp, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchTools", ctx, req)
+	ret0, _ := ret[0].(*interfaces.SearchToolsResp)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchTools indicates an expected call of SearchTools.
+func (mr *MockIToolServiceMockRecorder) SearchTools(ctx, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchTools", reflect.TypeOf((*MockIToolService)(nil).SearchTools), ctx, req)
+}
+
 // UpdateTool mocks base method.
 func (m *MockIToolService) UpdateTool(ctx context.Context, req *interfaces.UpdateToolReq) (*interfaces.UpdateToolResp, error) {
 	m.ctrl.T.Helper()

--- a/docs/api/execution-factory/toolbox.yaml
+++ b/docs/api/execution-factory/toolbox.yaml
@@ -23,6 +23,25 @@ info:
 
     **认证**：`Authorization: Bearer <token>`（OAuth access token 或 `bak_` 前缀的
     AppKey）。
+
+    **检索入口在内部面**：`POST /internal-v1/tool-box/tools/search`，请求体
+    `{ query, tool_refs, top_k }`，出参每项带 `matched_by` 与 `score`。
+
+    `tool_refs` 是扁平引用 `"{box_id}/{tool_id}"` 的列表。**工具 id 在执行工厂里按箱
+    限定作用域**，所以配对才是一个工具的身份——只按 tool_id 收窄会让调用方够到另一个
+    箱里同 id 的工具。格式非法的引用被静默丢弃(白名单来自存量绑定,一条失效条目应当
+    让范围变窄,而不是让整个请求失败);悬空引用查不到行,同样静默略过。
+
+    `tool_refs` 必填,**空数组与字段缺失都返回空结果,不是「不过滤」**——后者会把全平台
+    工具交给一个没有任何绑定的调用方。白名单进查询条件做 pre-filter,不是先取 top_k
+    再过滤;执行工厂只收一组引用,不认识 `kn_id`。
+
+    **本期是字面子串匹配,不是语义检索**:工具侧至今没有向量索引(技能侧有,工具侧
+    从零建一条链路体量相当),因此 `matched_by` 恒为 `like`、`score` 缺省。`%` 与 `_`
+    按字面处理,不当通配符。出参形状按语义检索预留,届时替换实现不改契约。
+
+    不收进下面的 `paths`:内部面不校验令牌,按 `docs/api/README.md` 的口径不作为集成
+    合同发布。
   version: 0.1.3
 servers:
   - url: /api/agent-operator-integration/v1


### PR DESCRIPTION
Closes #1261. Part of Epic #1266. Also the server side of #1009's `search_factory_tools` — one implementation for both.

## Substring, and it says so

`matched_by` is `like` and `score` is absent. The tool side has no vector index; the skill side has one, and building the equivalent for tools (dataset schema, embedding input, build task, incremental sync) is a comparable piece of work that would take over the epic. The whitelist's boundary does not depend on an index, so this ships now and the response shape is already the semantic one — replacing the implementation later does not change the contract.

## The boundary

Fail-closed: an empty array and a missing `tool_refs` both return nothing, never every tool on the platform. Both spellings have a test and both were checked against the running service. The whitelist is a pre-filter in the query, not a filter over the results.

## What the pairing is for

A whitelist entry admits one **(box, tool) pair**, not a bare tool id. Tool ids are scoped to their box in the execution factory, so the SQL filter on `tool_id` is narrowed to the exact pairs afterwards — without that step a caller could reach a same-id tool in a box it never bound. `top_k` applies after that narrowing for the same reason: capping in SQL would let other boxes' rows crowd out the caller's own.

Malformed references are dropped rather than rejected — the list comes from stored bindings, and one stale entry should narrow the search, not fail the request. Dangling ones simply match no row.

`%` and `_` are escaped before reaching LIKE. They are data typed by a caller; unescaped, a query of `%` matches everything.

## Verified on the test server (14.103.77.23)

Against real tools, on an isolated deployment copy sharing the same config and database (the shared deployment is left alone), with the binary's md5 checked local → server → pod:

| Check | Result |
|---|---|
| `tool_refs: []` / field absent | `{"entries":[]}` |
| Substring search inside the whitelist | 2 hits, `matched_by: like` |
| Box with only one of its two tools bound | only that one returned |
| Dangling reference in the whitelist | skipped, no error |
| Same-id tool in an unbound box | unreachable (0 results) |
| `query: "%"` | 0 results — literal, not a wildcard |
| Public face | 404, internal only |

`go build ./...` passes; `go test ./...` has the same pre-existing `tests/local` failures as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)