### PR TITLE
chore(vega): reuse Python base image

### DIFF
--- a/.github/workflows/release-adp-vega-backend.yml
+++ b/.github/workflows/release-adp-vega-backend.yml
@@ -17,6 +17,10 @@ on:
         description: 'Publish to GHCR (true) or verify build only (false)'
         type: boolean
         default: false
+      force-build-python-base:
+        description: 'Force build and publish the Vega Python base image (requires publish=true)'
+        type: boolean
+        default: false
 permissions:
   contents: read
   packages: write
@@ -28,8 +32,67 @@ jobs:
       service-path: adp/vega/vega-backend
       stack: chart-only
 
-  build-vega-backend:
+  prepare-python-base:
     needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      should-build: ${{ steps.base.outputs.should-build }}
+      tag: ${{ steps.base.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: base
+        name: Detect Python base changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_context='adp/vega/vega-backend/docker/python-base'
+          checksum="$(find "$base_context" -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum | cut -c1-16)"
+          tag="sha-$checksum"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          should_build=false
+
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
+            if [ "${{ inputs.force-build-python-base }}" = true ] \
+              && [ "${{ inputs.publish }}" != true ]; then
+              echo 'force-build-python-base requires publish=true.' >&2
+              exit 1
+            fi
+            should_build='${{ inputs.force-build-python-base }}'
+          else
+            before='${{ github.event.before }}'
+            if [ "$before" = '0000000000000000000000000000000000000000' ] \
+              || ! git diff --quiet "$before" "${{ github.sha }}" -- "$base_context"; then
+              should_build=true
+            else
+              should_build=false
+            fi
+          fi
+
+          echo "should-build=$should_build" >> "$GITHUB_OUTPUT"
+
+  build-python-base:
+    needs: [test, prepare-python-base]
+    if: needs.prepare-python-base.outputs.should-build == 'true'
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      service-path: adp/vega/vega-backend
+      dockerfile: docker/python-base/Dockerfile
+      context: docker/python-base
+      image-name: vega-backend-python-base
+      version: ${{ needs.prepare-python-base.outputs.tag }}
+      publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+
+  build-vega-backend:
+    needs: [test, prepare-python-base, build-python-base]
+    if: >-
+      always() &&
+      needs.test.result == 'success' &&
+      needs.prepare-python-base.result == 'success' &&
+      (needs.build-python-base.result == 'success' || needs.build-python-base.result == 'skipped')
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     with:
@@ -40,6 +103,7 @@ jobs:
       version: ${{ needs.test.outputs.version }}
       build-args: |
         SERVER_VERSION=${{ needs.test.outputs.version }}
+        PYTHON_BASE_IMAGE=ghcr.io/${{ github.repository_owner }}/vega-backend-python-base:${{ needs.prepare-python-base.outputs.tag }}
       publish: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
 
   chart-vega-backend:

--- a/adp/vega/vega-backend/docker/Dockerfile
+++ b/adp/vega/vega-backend/docker/Dockerfile
@@ -5,7 +5,7 @@
 
 ########################### Stage 0 ########################
 ARG BUILD_IMAGE=golang:1.25.14
-ARG BASE_IMAGE=ubuntu:24.04
+ARG PYTHON_BASE_IMAGE=ghcr.io/openbkn-ai/vega-backend-python-base:sha-c757948463031d6d
 
 FROM ${BUILD_IMAGE} AS builder
 
@@ -24,17 +24,10 @@ RUN set -ex; \
 
 ########################### Stage 1 ########################
 # Copy working directory to the actual release docker images
-FROM ${BASE_IMAGE} AS prod
+FROM ${PYTHON_BASE_IMAGE} AS prod
 
 ARG UID=1001
 ARG GID=1001
-
-RUN groupadd -r -g $GID openbkn \
-    && useradd -r -u $UID -g $GID openbkn \
-    && apt-get update \
-    && apt-get install -y python3 python3-pip \
-    && pip3 install --break-system-packages --index-url https://pypi.org/simple/ "sqlglot==30.14.0" \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder --chown=$UID:$GID /go/src/bin /opt/vega-backend
 

--- a/adp/vega/vega-backend/docker/python-base/Dockerfile
+++ b/adp/vega/vega-backend/docker/python-base/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2026 openbkn.ai
+# Copyright The kweaver.ai Authors.
+# Licensed under the Apache License, Version 2.0.
+# See the LICENSE file in the project root for details.
+
+# Vega Python Runtime Base
+# This image contains dependencies shared by Vega backend releases. Keep it free
+# of application artifacts so it only needs rebuilding when this context changes.
+ARG BASE_IMAGE=ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517
+
+FROM ${BASE_IMAGE}
+
+ARG UID=1001
+ARG GID=1001
+
+RUN groupadd -r -g $GID openbkn \
+    && useradd -r -u $UID -g $GID openbkn \
+    && DEBIAN_FRONTEND=noninteractive apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends python3 python3-pip \
+    && pip3 install --no-cache-dir --break-system-packages --index-url https://pypi.org/simple/ "sqlglot==30.14.0" \
+    && rm -rf /var/lib/apt/lists/*

--- a/deploy/notes/bkn-safe-image-republish.md
+++ b/deploy/notes/bkn-safe-image-republish.md
@@ -23,6 +23,7 @@ TAG=0.1.1            # bump (recommended) or reuse 0.1.0 to overwrite in place
 GOPROXY_URL=https://goproxy.cn,direct          # drop outside CN
 BUILD_IMAGE=docker.m.daocloud.io/library/golang:1.25.14   # or golang:1.25.14
 BASE_UBUNTU=docker.m.daocloud.io/library/ubuntu:24.04      # or ubuntu:24.04
+PYTHON_BASE_IMAGE="$(awk -F= '$1 == "ARG PYTHON_BASE_IMAGE" { print $2 }' adp/vega/vega-backend/docker/Dockerfile)"
 
 # --- bkn-backend (Go, CGO) — plain Dockerfile build ---
 ( cd adp/bkn/bkn-backend && docker build -f docker/Dockerfile \
@@ -30,14 +31,11 @@ BASE_UBUNTU=docker.m.daocloud.io/library/ubuntu:24.04      # or ubuntu:24.04
     --build-arg GOPROXY_URL="$GOPROXY_URL" --build-arg SERVER_VERSION="$TAG" \
     -t "$REG/bkn-backend:$TAG" . )
 
-# --- vega-backend (Go, CGO) — its prod stage pip-installs sqlglot (slow/blocked
-#     in CN), so build the binary then OVERLAY onto the existing base image ---
-( cd adp/vega/vega-backend
-  docker run --rm -v "$PWD/server:/go/src" -w /go/src \
-    -e GOPROXY="$GOPROXY_URL" -e CGO_ENABLED=1 -e GOFLAGS=-mod=mod "$BUILD_IMAGE" \
-    bash -c "go mod download && go build -ldflags '-s -w -X vega-backend/version.ServerVersion=$TAG' -o ./bin/vega-backend-server"
-  printf 'FROM %s/vega-backend:0.1.0\nCOPY bin/vega-backend-server /opt/vega-backend/vega-backend-server\n' "$REG" > /tmp/vega.Dockerfile
-  docker build -f /tmp/vega.Dockerfile -t "$REG/vega-backend:$TAG" server )
+# --- vega-backend (Go, CGO) — reuses the published Python base image ---
+( cd adp/vega/vega-backend && docker build -f docker/Dockerfile \
+    --build-arg BUILD_IMAGE="$BUILD_IMAGE" --build-arg PYTHON_BASE_IMAGE="$PYTHON_BASE_IMAGE" \
+    --build-arg GOPROXY_URL="$GOPROXY_URL" --build-arg SERVER_VERSION="$TAG" \
+    -t "$REG/vega-backend:$TAG" . )
 
 # --- agent-backend (agent-factory) and mf-model-api ---
 # Rebuild from their own docker/Dockerfile the same way (Go: plain build;


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Added an immutable, reusable Vega Python runtime base image.
- [x] Changed Vega backend images to inherit the Python base through `PYTHON_BASE_IMAGE`.
- [x] Updated release and local republish instructions to reuse the computed base-image hash.

---

## Why

- Related Issue: Closes #1300
- Related Feature: N/A
- Background: Each Vega backend image build installed Python and SQLGlot in its production stage, making routine builds slow and dependent on the Python package index.

---

## How

- Key implementation points:
  - The base Dockerfile pins the Ubuntu manifest digest and installs Python, Pip, and `sqlglot==30.14.0`.
  - Release CI computes a content-derived base tag, rebuilds the base only when its directory changes, and makes the backend build wait for either a successful or skipped base build.
  - The backend build always receives the computed base-image hash explicitly.
- Breaking changes (API, config, database, etc.): No API, Helm, database, or deployment contract changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not applicable; this change has no integration-test target)
- [ ] Verified in test environment (not run; requires remote CI and an environment)

Test notes:

- `make lint`
- `make test`
- Docker base and backend builds, including runtime SQLGlot import and UID/GID checks
- Workflow YAML parsing, `actionlint`, and `git diff --check`

---

## Risk & Rollback

- Potential risks: The first backend build for a new base hash requires that base image to be published first; the workflow dependency enforces this ordering.
- Rollback plan: Revert commit `40e3092fe` to restore the self-contained backend Dockerfile and prior release workflow.

---

## Additional Notes

- The base image is tagged with a deterministic `sha-<hash>`; ordinary backend changes skip Python dependency installation.
