### PR TITLE
fix(execution-factory): honor object-level authorization permission

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -72,17 +72,55 @@ func (s *safeAuthorization) OperationCheck(ctx context.Context, req *interfaces.
 	return &interfaces.AuthOperationCheckResponse{Result: ok}, nil
 }
 
-// ResourceFilter keeps the resources the accessor is allowed all the operations on.
+// ResourceFilter keeps the resources the accessor is allowed all the visibility operations on
+// and projects the requested candidate operations for each surviving resource in one bkn-safe
+// request. Do not replace this with one check per list row: list pages must remain batch PEPs.
 func (s *safeAuthorization) ResourceFilter(ctx context.Context, req *interfaces.AuthResourceFilterRequest) ([]*interfaces.AuthResourceResult, error) {
-	out := make([]*interfaces.AuthResourceResult, 0, len(req.Resources))
-	for _, r := range req.Resources {
-		ok, err := s.allowedAll(ctx, req.Accessor.ID, r.Type, r.ID, req.Operations)
-		if err != nil {
-			return nil, err
+	if req == nil || req.Accessor == nil {
+		return []*interfaces.AuthResourceResult{}, nil
+	}
+
+	type safeResourceResult struct {
+		ResourceID   string   `json:"resource_id"`
+		ResourceType string   `json:"resource_type"`
+		Operations   []string `json:"operations"`
+	}
+	var response struct {
+		Resources []safeResourceResult `json:"resources"`
+	}
+	resources := make([]map[string]string, 0, len(req.Resources))
+	for _, resource := range req.Resources {
+		if resource == nil {
+			continue
 		}
-		if ok {
-			out = append(out, &interfaces.AuthResourceResult{ID: r.ID})
+		resources = append(resources, map[string]string{"id": resource.ID, "type": resource.Type})
+	}
+	visibilityOperations := make([]string, 0, len(req.Operations))
+	for _, operation := range req.Operations {
+		visibilityOperations = append(visibilityOperations, string(operation))
+	}
+	candidateOperations := make([]string, 0, len(req.CandidateOperations))
+	for _, operation := range req.CandidateOperations {
+		candidateOperations = append(candidateOperations, string(operation))
+	}
+	if err := s.post(ctx, "/api/safe/v1/authz/resource-filter", map[string]any{
+		"accessor_id":           req.Accessor.ID,
+		"resources":             resources,
+		"visibility_operations": visibilityOperations,
+		"candidate_operations":  candidateOperations,
+	}, &response); err != nil {
+		return nil, err
+	}
+
+	out := make([]*interfaces.AuthResourceResult, 0, len(response.Resources))
+	for _, resource := range response.Resources {
+		operations := make([]interfaces.AuthOperationType, 0, len(resource.Operations))
+		for _, operation := range resource.Operations {
+			operations = append(operations, interfaces.AuthOperationType(operation))
 		}
+		out = append(out, &interfaces.AuthResourceResult{
+			ID: resource.ResourceID, Type: resource.ResourceType, Operations: operations,
+		})
 	}
 	return out, nil
 }

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -86,7 +86,7 @@ func (s *safeAuthorization) ResourceFilter(ctx context.Context, req *interfaces.
 		Operations   []string `json:"operations"`
 	}
 	var response struct {
-		Resources []safeResourceResult `json:"resources"`
+		Resources *[]safeResourceResult `json:"resources"`
 	}
 	resources := make([]map[string]string, 0, len(req.Resources))
 	for _, resource := range req.Resources {
@@ -111,9 +111,12 @@ func (s *safeAuthorization) ResourceFilter(ctx context.Context, req *interfaces.
 	}, &response); err != nil {
 		return nil, err
 	}
+	if response.Resources == nil {
+		return nil, fmt.Errorf("invalid bkn-safe resource-filter response")
+	}
 
-	out := make([]*interfaces.AuthResourceResult, 0, len(response.Resources))
-	for _, resource := range response.Resources {
+	out := make([]*interfaces.AuthResourceResult, 0, len(*response.Resources))
+	for _, resource := range *response.Resources {
 		operations := make([]interfaces.AuthOperationType, 0, len(resource.Operations))
 		for _, operation := range resource.Operations {
 			operations = append(operations, interfaces.AuthOperationType(operation))

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
@@ -107,6 +107,22 @@ func TestSafeAuthorizationResourceFilterProjectsCandidateOperations(t *testing.T
 	}
 }
 
+func TestSafeAuthorizationResourceFilterRejectsMissingResources(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	resources, err := newSafeAuthorization(srv.URL, testLogger{}).ResourceFilter(context.Background(), &interfaces.AuthResourceFilterRequest{
+		Accessor:   &interfaces.AuthAccessor{ID: "u1"},
+		Resources:  []*interfaces.AuthResource{{ID: "s1", Type: "skill"}},
+		Operations: []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+	})
+	if err == nil {
+		t.Fatalf("ResourceFilter = %+v, want an invalid response error", resources)
+	}
+}
+
 func TestSafeAuthorizationResourceList(t *testing.T) {
 	srv := fakeAuthz(t)
 	defer srv.Close()

--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe_test.go
@@ -56,7 +56,55 @@ func fakeAuthz(t *testing.T) *httptest.Server {
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"ids": ids})
 	})
+	mux.HandleFunc("/api/safe/v1/authz/resource-filter", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			AccessorID string `json:"accessor_id"`
+			Resources  []struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resources"`
+			VisibilityOperations []string `json:"visibility_operations"`
+			CandidateOperations  []string `json:"candidate_operations"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if req.AccessorID != "u1" || len(req.Resources) != 2 || req.Resources[0].Type != "skill" || req.Resources[0].ID != "s1" ||
+			len(req.VisibilityOperations) != 1 || req.VisibilityOperations[0] != "view" ||
+			len(req.CandidateOperations) != 1 || req.CandidateOperations[0] != "authorize" {
+			http.Error(w, "unexpected resource filter request", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"resources": []map[string]any{
+			{"resource_id": "s1", "resource_type": "skill", "operations": []string{"authorize"}},
+			{"resource_id": "s2", "resource_type": "skill", "operations": []string{}},
+		}})
+	})
 	return httptest.NewServer(mux)
+}
+
+func TestSafeAuthorizationResourceFilterProjectsCandidateOperations(t *testing.T) {
+	srv := fakeAuthz(t)
+	defer srv.Close()
+
+	resources, err := newSafeAuthorization(srv.URL, testLogger{}).ResourceFilter(context.Background(), &interfaces.AuthResourceFilterRequest{
+		Accessor: &interfaces.AuthAccessor{ID: "u1"},
+		Resources: []*interfaces.AuthResource{
+			{ID: "s1", Type: "skill"},
+			{ID: "s2", Type: "skill"},
+		},
+		Operations:          []interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+		CandidateOperations: []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+	})
+	if err != nil {
+		t.Fatalf("ResourceFilter: %v", err)
+	}
+	if len(resources) != 2 || resources[0].ID != "s1" || resources[0].Type != "skill" ||
+		len(resources[0].Operations) != 1 || resources[0].Operations[0] != interfaces.AuthOperationTypeAuthorize ||
+		len(resources[1].Operations) != 0 {
+		t.Fatalf("ResourceFilter = %+v, want authorize only for s1", resources)
+	}
 }
 
 func TestSafeAuthorizationResourceList(t *testing.T) {

--- a/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/drivenadapters.go
@@ -330,10 +330,11 @@ type ResourceListRequest struct {
 
 // AuthResourceFilterRequest resource filtering request.
 type AuthResourceFilterRequest struct {
-	Accessor   *AuthAccessor       `json:"accessor"`  // Visitor information.
-	Resources  []*AuthResource     `json:"resources"` // Resource list.
-	Operations []AuthOperationType `json:"operation"` // List of actions to check.
-	Method     string              `json:"method"`    // method.
+	Accessor            *AuthAccessor       `json:"accessor"`             // Visitor information.
+	Resources           []*AuthResource     `json:"resources"`            // Resource list.
+	Operations          []AuthOperationType `json:"operation"`            // Operations required for visibility.
+	CandidateOperations []AuthOperationType `json:"candidate_operations"` // Operations to project for every visible resource.
+	Method              string              `json:"method"`               // method.
 }
 
 type AuthOperation struct {
@@ -363,7 +364,9 @@ type AuthDeletePolicyRequest struct {
 
 // AuthResourceResult resource result.
 type AuthResourceResult struct {
-	ID string `json:"id"` // Unique identification ID.
+	ID         string              `json:"id"`         // Unique identification ID.
+	Type       string              `json:"type"`       // Resource type.
+	Operations []AuthOperationType `json:"operations"` // Operations held on this resource.
 }
 
 // Authorization authorization service interface.

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_auth.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_auth.go
@@ -117,6 +117,10 @@ type IAuthorizationService interface {
 
 	// ResourceFilterIDs resource filtering.
 	ResourceFilterIDs(ctx context.Context, accessor *AuthAccessor, resourceIDS []string, resourceType AuthResourceType, operations ...AuthOperationType) ([]string, error)
+	// ResourceFilterOperations returns the requested candidate operations for each resource
+	// that satisfies every visibility operation. It is the list-page projection used by
+	// clients to decide which object-level controls to render.
+	ResourceFilterOperations(ctx context.Context, accessor *AuthAccessor, resourceIDs []string, resourceType AuthResourceType, visibilityOperations []AuthOperationType, candidateOperations []AuthOperationType) (map[string][]AuthOperationType, error)
 	// ResourceListIDs resource list.
 	ResourceListIDs(ctx context.Context, accessor *AuthAccessor, resourceType AuthResourceType, operations ...AuthOperationType) ([]string, error)
 

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_mcp.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_mcp.go
@@ -101,6 +101,7 @@ type MCPServerDeleteRequest struct {
 
 type MCPServerConfigInfo struct {
 	MCPCoreConfigInfo `json:",inline"`
+	Operations        []AuthOperationType  `json:"operations,omitempty"`                        // Instance operations held by the requesting user.
 	MCPID             string               `json:"mcp_id"`                                      // MCP Server ID
 	Version           int                  `json:"version,omitempty"`                           // MCP Server version.
 	CreationType      MCPCreationType      `json:"creation_type,omitempty"`                     // Create type.

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_operator.go
@@ -88,7 +88,8 @@ type OperatorEditResp struct {
 
 // OperatorDataInfo operator data.
 type OperatorDataInfo struct {
-	Name                   string                  `json:"name"` // Operator name.
+	Operations             []AuthOperationType     `json:"operations,omitempty"` // Instance operations held by the requesting user.
+	Name                   string                  `json:"name"`                 // Operator name.
 	OperatorID             string                  `json:"operator_id" validate:"uuid"`
 	Version                string                  `json:"version" validate:"uuid"`
 	Status                 BizStatus               `json:"status" validate:"omitempty,oneof=unpublish published offline editing"` // Status.

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_skill.go
@@ -60,22 +60,23 @@ type QuerySkillListReq struct {
 
 // SkillInfo Skill details.
 type SkillInfo struct {
-	SkillID      string         `json:"skill_id"`
-	Name         string         `json:"name"`
-	Description  string         `json:"description"`
-	Version      string         `json:"version"`
-	Status       BizStatus      `json:"status"`
-	Source       string         `json:"source"`
-	Dependencies map[string]any `json:"dependencies,omitempty"`
-	ExtendInfo   map[string]any `json:"extend_info,omitempty"`
-	CreateUser   string         `json:"create_user"`
-	CreateTime   int64          `json:"create_time"`
-	UpdateUser   string         `json:"update_user"`
-	UpdateTime   int64          `json:"update_time"`
-	Category     BizCategory    `json:"category,omitempty"`
-	CategoryName string         `json:"category_name,omitempty"`
-	ReleaseUser  string         `json:"release_user,omitempty"`
-	ReleaseTime  int64          `json:"release_time,omitempty"`
+	Operations   []AuthOperationType `json:"operations,omitempty"`
+	SkillID      string              `json:"skill_id"`
+	Name         string              `json:"name"`
+	Description  string              `json:"description"`
+	Version      string              `json:"version"`
+	Status       BizStatus           `json:"status"`
+	Source       string              `json:"source"`
+	Dependencies map[string]any      `json:"dependencies,omitempty"`
+	ExtendInfo   map[string]any      `json:"extend_info,omitempty"`
+	CreateUser   string              `json:"create_user"`
+	CreateTime   int64               `json:"create_time"`
+	UpdateUser   string              `json:"update_user"`
+	UpdateTime   int64               `json:"update_time"`
+	Category     BizCategory         `json:"category,omitempty"`
+	CategoryName string              `json:"category_name,omitempty"`
+	ReleaseUser  string              `json:"release_user,omitempty"`
+	ReleaseTime  int64               `json:"release_time,omitempty"`
 }
 
 // SkillFileSummary Skill file summary.

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -166,23 +166,24 @@ type CommonPageParams struct {
 
 // ToolBoxInfo toolbox information.
 type ToolBoxInfo struct {
-	MetadataType MetadataType `json:"metadata_type" validate:"required,oneof=openapi function"` // metadata type.
-	BoxID        string       `json:"box_id"`                                                   // Toolbox ID.
-	BoxName      string       `json:"box_name"`                                                 // Toolbox name.
-	BoxDesc      string       `json:"box_desc"`                                                 // Toolbox description.
-	BoxSvcURL    string       `json:"box_svc_url"`                                              // Toolbox service address.
-	Status       BizStatus    `json:"status" validate:"oneof=unpublish published offline"`      // toolbox status.
-	CategoryType string       `json:"category_type"`                                            // Classification.
-	CategoryName string       `json:"category_name"`                                            // Category name.
-	IsInternal   bool         `json:"is_internal"`                                              // Is it an internal toolbox?.
-	Source       string       `json:"source" default:"custom" validate:"oneof=custom internal"` // Toolbox source.
-	Tools        []string     `json:"tools"`                                                    // Tool list under toolbox.
-	CreateTime   int64        `json:"create_time"`                                              // creation time.
-	UpdateTime   int64        `json:"update_time"`                                              // Update time.
-	CreateUser   string       `json:"create_user"`                                              // Create user.
-	UpdateUser   string       `json:"update_user"`                                              // Update user.
-	ReleaseUser  string       `json:"release_user,omitempty"`                                   // Posted by.
-	ReleaseTime  int64        `json:"release_time,omitempty"`                                   // Release time.
+	Operations   []AuthOperationType `json:"operations,omitempty"`                                     // Instance operations held by the requesting user.
+	MetadataType MetadataType        `json:"metadata_type" validate:"required,oneof=openapi function"` // metadata type.
+	BoxID        string              `json:"box_id"`                                                   // Toolbox ID.
+	BoxName      string              `json:"box_name"`                                                 // Toolbox name.
+	BoxDesc      string              `json:"box_desc"`                                                 // Toolbox description.
+	BoxSvcURL    string              `json:"box_svc_url"`                                              // Toolbox service address.
+	Status       BizStatus           `json:"status" validate:"oneof=unpublish published offline"`      // toolbox status.
+	CategoryType string              `json:"category_type"`                                            // Classification.
+	CategoryName string              `json:"category_name"`                                            // Category name.
+	IsInternal   bool                `json:"is_internal"`                                              // Is it an internal toolbox?.
+	Source       string              `json:"source" default:"custom" validate:"oneof=custom internal"` // Toolbox source.
+	Tools        []string            `json:"tools"`                                                    // Tool list under toolbox.
+	CreateTime   int64               `json:"create_time"`                                              // creation time.
+	UpdateTime   int64               `json:"update_time"`                                              // Update time.
+	CreateUser   string              `json:"create_user"`                                              // Create user.
+	UpdateUser   string              `json:"update_user"`                                              // Update user.
+	ReleaseUser  string              `json:"release_user,omitempty"`                                   // Posted by.
+	ReleaseTime  int64               `json:"release_time,omitempty"`                                   // Release time.
 }
 
 // QueryToolBoxListResp Gets the toolbox list and returns the results.

--- a/adp/execution-factory/operator-integration/server/logics/auth/decision.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/decision.go
@@ -209,10 +209,11 @@ func (s *authServiceImpl) ResourceFilterIDs(
 	operations ...interfaces.AuthOperationType,
 ) ([]string, error) {
 	req := &interfaces.AuthResourceFilterRequest{
-		Accessor:   accessor,
-		Resources:  []*interfaces.AuthResource{},
-		Operations: operations,
-		Method:     interfaces.AuthMethodGet,
+		Accessor:            accessor,
+		Resources:           []*interfaces.AuthResource{},
+		Operations:          operations,
+		CandidateOperations: operations,
+		Method:              interfaces.AuthMethodGet,
 	}
 
 	for _, resourceID := range resourceIDS {
@@ -231,6 +232,44 @@ func (s *authServiceImpl) ResourceFilterIDs(
 		resourceIDs = append(resourceIDs, resource.ID)
 	}
 	return resourceIDs, nil
+}
+
+// ResourceFilterOperations returns the candidate operations held on each resource that is
+// visible to the accessor. The caller supplies explicit candidates so list rendering cannot
+// accidentally infer instance permissions from a type-wide grant.
+func (s *authServiceImpl) ResourceFilterOperations(
+	ctx context.Context,
+	accessor *interfaces.AuthAccessor,
+	resourceIDs []string,
+	resourceType interfaces.AuthResourceType,
+	visibilityOperations []interfaces.AuthOperationType,
+	candidateOperations []interfaces.AuthOperationType,
+) (map[string][]interfaces.AuthOperationType, error) {
+	result := make(map[string][]interfaces.AuthOperationType, len(resourceIDs))
+	if len(resourceIDs) == 0 {
+		return result, nil
+	}
+	resources := make([]*interfaces.AuthResource, 0, len(resourceIDs))
+	for _, resourceID := range resourceIDs {
+		resources = append(resources, &interfaces.AuthResource{ID: resourceID, Type: string(resourceType)})
+	}
+	response, err := s.authorization.ResourceFilter(ctx, &interfaces.AuthResourceFilterRequest{
+		Accessor:            accessor,
+		Resources:           resources,
+		Operations:          visibilityOperations,
+		CandidateOperations: candidateOperations,
+		Method:              interfaces.AuthMethodGet,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, resource := range response {
+		if resource == nil || resource.Type != string(resourceType) {
+			continue
+		}
+		result[resource.ID] = resource.Operations
+	}
+	return result, nil
 }
 
 // ResourceListIDs Get the resource list.

--- a/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
@@ -81,3 +81,35 @@ func TestFilterViewableIDs(t *testing.T) {
 		})
 	})
 }
+
+func TestProjectAuthorizeOperations(t *testing.T) {
+	Convey("ProjectAuthorizeOperations", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		ids := []string{"a", "b"}
+
+		Convey("内部调用不投影实例权限", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			got, err := ProjectAuthorizeOperations(context.Background(), authService, "user-1", ids, interfaces.AuthResourceTypeSkill)
+			So(err, ShouldBeNil)
+			So(got, ShouldBeEmpty)
+		})
+
+		Convey("公有管理列表批量投影 authorize", func() {
+			authService := mocks.NewMockIAuthorizationService(ctrl)
+			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			authService.EXPECT().ResourceFilterOperations(
+				gomock.Any(), gomock.Any(), ids, interfaces.AuthResourceTypeSkill,
+				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+			).Return(map[string][]interfaces.AuthOperationType{
+				"a": {interfaces.AuthOperationTypeAuthorize},
+				"b": {},
+			}, nil)
+			got, err := ProjectAuthorizeOperations(publicCtx(), authService, "user-1", ids, interfaces.AuthResourceTypeSkill)
+			So(err, ShouldBeNil)
+			So(got["a"], ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
+			So(got["b"], ShouldBeEmpty)
+		})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/filter_test.go
@@ -90,23 +90,23 @@ func TestProjectAuthorizeOperations(t *testing.T) {
 
 		Convey("内部调用不投影实例权限", func() {
 			authService := mocks.NewMockIAuthorizationService(ctrl)
-			got, err := ProjectAuthorizeOperations(context.Background(), authService, "user-1", ids, interfaces.AuthResourceTypeSkill)
+			got, err := ProjectAuthorizeOperations(context.Background(), authService, nil, ids, interfaces.AuthResourceTypeSkill)
 			So(err, ShouldBeNil)
 			So(got, ShouldBeEmpty)
 		})
 
 		Convey("公有管理列表批量投影 authorize", func() {
 			authService := mocks.NewMockIAuthorizationService(ctrl)
-			authService.EXPECT().GetAccessor(gomock.Any(), "user-1").Return(&interfaces.AuthAccessor{ID: "user-1"}, nil)
+			accessor := &interfaces.AuthAccessor{ID: "user-1"}
 			authService.EXPECT().ResourceFilterOperations(
-				gomock.Any(), gomock.Any(), ids, interfaces.AuthResourceTypeSkill,
+				gomock.Any(), accessor, ids, interfaces.AuthResourceTypeSkill,
 				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
 				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
 			).Return(map[string][]interfaces.AuthOperationType{
 				"a": {interfaces.AuthOperationTypeAuthorize},
 				"b": {},
 			}, nil)
-			got, err := ProjectAuthorizeOperations(publicCtx(), authService, "user-1", ids, interfaces.AuthResourceTypeSkill)
+			got, err := ProjectAuthorizeOperations(publicCtx(), authService, accessor, ids, interfaces.AuthResourceTypeSkill)
 			So(err, ShouldBeNil)
 			So(got["a"], ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
 			So(got["b"], ShouldBeEmpty)

--- a/adp/execution-factory/operator-integration/server/logics/auth/index.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/index.go
@@ -88,6 +88,14 @@ func (n *noopAuthService) ResourceFilterIDs(ctx context.Context, accessor *inter
 	return resourceIDS, nil
 }
 
+func (n *noopAuthService) ResourceFilterOperations(ctx context.Context, accessor *interfaces.AuthAccessor, resourceIDs []string, resourceType interfaces.AuthResourceType, visibilityOperations []interfaces.AuthOperationType, candidateOperations []interfaces.AuthOperationType) (map[string][]interfaces.AuthOperationType, error) {
+	result := make(map[string][]interfaces.AuthOperationType, len(resourceIDs))
+	for _, resourceID := range resourceIDs {
+		result[resourceID] = append([]interfaces.AuthOperationType(nil), candidateOperations...)
+	}
+	return result, nil
+}
+
 func (n *noopAuthService) ResourceListIDs(ctx context.Context, accessor *interfaces.AuthAccessor, resourceType interfaces.AuthResourceType, operations ...interfaces.AuthOperationType) ([]string, error) {
 	return []string{interfaces.ResourceIDAll}, nil
 }

--- a/adp/execution-factory/operator-integration/server/logics/auth/resource_operations.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/resource_operations.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+// ProjectAuthorizeOperations obtains the per-record authorize operation for a public management
+// list. Internal callers keep their existing response contract because they do not render the
+// Studio object-grant control.
+func ProjectAuthorizeOperations(
+	ctx context.Context,
+	authorization interfaces.IAuthorizationService,
+	userID string,
+	resourceIDs []string,
+	resourceType interfaces.AuthResourceType,
+) (map[string][]interfaces.AuthOperationType, error) {
+	if !common.IsPublicAPIFromCtx(ctx) || len(resourceIDs) == 0 {
+		return map[string][]interfaces.AuthOperationType{}, nil
+	}
+	accessor, err := authorization.GetAccessor(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	return authorization.ResourceFilterOperations(
+		ctx,
+		accessor,
+		resourceIDs,
+		resourceType,
+		[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+		[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+	)
+}

--- a/adp/execution-factory/operator-integration/server/logics/auth/resource_operations.go
+++ b/adp/execution-factory/operator-integration/server/logics/auth/resource_operations.go
@@ -1,7 +1,12 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
 package auth
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
@@ -13,16 +18,15 @@ import (
 func ProjectAuthorizeOperations(
 	ctx context.Context,
 	authorization interfaces.IAuthorizationService,
-	userID string,
+	accessor *interfaces.AuthAccessor,
 	resourceIDs []string,
 	resourceType interfaces.AuthResourceType,
 ) (map[string][]interfaces.AuthOperationType, error) {
 	if !common.IsPublicAPIFromCtx(ctx) || len(resourceIDs) == 0 {
 		return map[string][]interfaces.AuthOperationType{}, nil
 	}
-	accessor, err := authorization.GetAccessor(ctx, userID)
-	if err != nil {
-		return nil, err
+	if accessor == nil {
+		return nil, fmt.Errorf("authorization accessor is required for public resource operation projection")
 	}
 	return authorization.ResourceFilterOperations(
 		ctx,

--- a/adp/execution-factory/operator-integration/server/logics/mcp/authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/authz_test.go
@@ -42,3 +42,26 @@ func TestParseSSEAuthz(t *testing.T) {
 		// The single test environment cannot be entered, so internal surface release is only guaranteed by the IsPublicAPIFromCtx judgment itself and is not asserted here.
 	})
 }
+
+func TestProjectMCPAuthorizeOperations(t *testing.T) {
+	Convey("MCP list projects authorize with the existing accessor", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		accessor := &interfaces.AuthAccessor{ID: "user-1"}
+		configs := []*interfaces.MCPServerConfigInfo{{MCPID: "mcp-1"}, {MCPID: "mcp-2"}}
+		authService.EXPECT().ResourceFilterOperations(
+			gomock.Any(), accessor, []string{"mcp-1", "mcp-2"}, interfaces.AuthResourceTypeMCP,
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+		).Return(map[string][]interfaces.AuthOperationType{
+			"mcp-1": {interfaces.AuthOperationTypeAuthorize},
+		}, nil)
+
+		err := projectMCPAuthorizeOperations(common.SetPublicAPIToCtx(context.Background(), true), authService, accessor, configs)
+
+		So(err, ShouldBeNil)
+		So(configs[0].Operations, ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
+		So(configs[1].Operations, ShouldBeEmpty)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
@@ -462,6 +462,7 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 		return configList, nil
 	}
 
+	var accessor *interfaces.AuthAccessor
 	queryBuilder := auth.NewQueryBuilder[model.MCPServerConfigDB]().
 		SetPage(req.Page, req.PageSize).SetAll(req.All).
 		SetQueryFunctions(queryTotalFunc, queryBatchFunc).
@@ -473,7 +474,6 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 			return queryBatchFunc(newCtx, pageSize, offset, cursorValue)
 		}).
 		SetAuthFilter(func(newCtx context.Context) ([]string, error) {
-			var accessor *interfaces.AuthAccessor
 			accessor, err = s.AuthService.GetAccessor(newCtx, req.UserID)
 			if err != nil {
 				return nil, err
@@ -508,7 +508,7 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 		config.UpdateUser = utils.GetValueOrDefault(userMap, config.UpdateUser, interfaces.UnknownUser)
 		config.ToolConfigs = toolConfigMap[s.genToolConfigMapKey(config.MCPID, config.Version)]
 	}
-	if err = projectMCPAuthorizeOperations(ctx, s.AuthService, req.UserID, data); err != nil {
+	if err = projectMCPAuthorizeOperations(ctx, s.AuthService, accessor, data); err != nil {
 		return nil, err
 	}
 
@@ -527,12 +527,12 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 	return
 }
 
-func projectMCPAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, configs []*interfaces.MCPServerConfigInfo) error {
+func projectMCPAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, accessor *interfaces.AuthAccessor, configs []*interfaces.MCPServerConfigInfo) error {
 	mcpIDs := make([]string, 0, len(configs))
 	for _, config := range configs {
 		mcpIDs = append(mcpIDs, config.MCPID)
 	}
-	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, mcpIDs, interfaces.AuthResourceTypeMCP)
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, accessor, mcpIDs, interfaces.AuthResourceTypeMCP)
 	if err != nil {
 		return err
 	}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/manage.go
@@ -508,6 +508,9 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 		config.UpdateUser = utils.GetValueOrDefault(userMap, config.UpdateUser, interfaces.UnknownUser)
 		config.ToolConfigs = toolConfigMap[s.genToolConfigMapKey(config.MCPID, config.Version)]
 	}
+	if err = projectMCPAuthorizeOperations(ctx, s.AuthService, req.UserID, data); err != nil {
+		return nil, err
+	}
 
 	queryResult := &ormhelper.QueryResult{
 		Total:      int64(resp.TotalCount),
@@ -522,6 +525,21 @@ func (s *mcpServiceImpl) QueryPage(ctx context.Context, req *interfaces.MCPServe
 		Data:        data,
 	}
 	return
+}
+
+func projectMCPAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, configs []*interfaces.MCPServerConfigInfo) error {
+	mcpIDs := make([]string, 0, len(configs))
+	for _, config := range configs {
+		mcpIDs = append(mcpIDs, config.MCPID)
+	}
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, mcpIDs, interfaces.AuthResourceTypeMCP)
+	if err != nil {
+		return err
+	}
+	for _, config := range configs {
+		config.Operations = operationsByID[config.MCPID]
+	}
+	return nil
 }
 
 // GetDetail Gets MCP Server details.

--- a/adp/execution-factory/operator-integration/server/logics/operator/names_authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/names_authz_test.go
@@ -73,3 +73,26 @@ func TestGetOperatorNamesByIDsAuthz(t *testing.T) {
 		})
 	})
 }
+
+func TestProjectOperatorAuthorizeOperations(t *testing.T) {
+	Convey("Operator list projects authorize with the existing accessor", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		accessor := &interfaces.AuthAccessor{ID: "user-1"}
+		operators := []*interfaces.OperatorDataInfo{{OperatorID: "op-1"}, {OperatorID: "op-2"}}
+		authService.EXPECT().ResourceFilterOperations(
+			gomock.Any(), accessor, []string{"op-1", "op-2"}, interfaces.AuthResourceTypeOperator,
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+		).Return(map[string][]interfaces.AuthOperationType{
+			"op-2": {interfaces.AuthOperationTypeAuthorize},
+		}, nil)
+
+		err := projectOperatorAuthorizeOperations(common.SetPublicAPIToCtx(context.Background(), true), authService, accessor, operators)
+
+		So(err, ShouldBeNil)
+		So(operators[0].Operations, ShouldBeEmpty)
+		So(operators[1].Operations, ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/operator/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/query.go
@@ -119,7 +119,7 @@ func (m *operatorManager) GetOperatorQueryPage(ctx context.Context, req *interfa
 		},
 	}
 	var operatorList []*model.OperatorRegisterDB
-	authResp, err := m.queryOperatorConfigList(ctx, req)
+	authResp, accessor, err := m.queryOperatorConfigList(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -175,18 +175,18 @@ func (m *operatorManager) GetOperatorQueryPage(ctx context.Context, req *interfa
 		operatorInfo.UpdateUser = utils.GetValueOrDefault(userMap, operatorInfo.UpdateUser, interfaces.UnknownUser)
 		result.Data = append(result.Data, operatorInfo)
 	}
-	if err = projectOperatorAuthorizeOperations(ctx, m.AuthService, req.UserID, result.Data); err != nil {
+	if err = projectOperatorAuthorizeOperations(ctx, m.AuthService, accessor, result.Data); err != nil {
 		return nil, err
 	}
 	return
 }
 
-func projectOperatorAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, operators []*interfaces.OperatorDataInfo) error {
+func projectOperatorAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, accessor *interfaces.AuthAccessor, operators []*interfaces.OperatorDataInfo) error {
 	operatorIDs := make([]string, 0, len(operators))
 	for _, operator := range operators {
 		operatorIDs = append(operatorIDs, operator.OperatorID)
 	}
-	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, operatorIDs, interfaces.AuthResourceTypeOperator)
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, accessor, operatorIDs, interfaces.AuthResourceTypeOperator)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func projectOperatorAuthorizeOperations(ctx context.Context, authorization inter
 }
 
 func (m *operatorManager) queryOperatorConfigList(ctx context.Context, req *interfaces.PageQueryRequest) (
-	authResp *interfaces.QueryResponse[model.OperatorRegisterDB], err error) {
+	authResp *interfaces.QueryResponse[model.OperatorRegisterDB], accessor *interfaces.AuthAccessor, err error) {
 	// Query operator list.
 	conditions := map[string]interface{}{}
 	// Convert request parameters into conditions.
@@ -289,7 +289,6 @@ func (m *operatorManager) queryOperatorConfigList(ctx context.Context, req *inte
 	if common.IsPublicAPIFromCtx(ctx) {
 		queryBuilder.SetAuthFilter(func(newCtx context.Context) ([]string, error) {
 			// Check viewing permissions.
-			var accessor *interfaces.AuthAccessor
 			accessor, err = m.AuthService.GetAccessor(newCtx, req.UserID)
 			if err != nil {
 				return nil, err

--- a/adp/execution-factory/operator-integration/server/logics/operator/query.go
+++ b/adp/execution-factory/operator-integration/server/logics/operator/query.go
@@ -175,7 +175,25 @@ func (m *operatorManager) GetOperatorQueryPage(ctx context.Context, req *interfa
 		operatorInfo.UpdateUser = utils.GetValueOrDefault(userMap, operatorInfo.UpdateUser, interfaces.UnknownUser)
 		result.Data = append(result.Data, operatorInfo)
 	}
+	if err = projectOperatorAuthorizeOperations(ctx, m.AuthService, req.UserID, result.Data); err != nil {
+		return nil, err
+	}
 	return
+}
+
+func projectOperatorAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, operators []*interfaces.OperatorDataInfo) error {
+	operatorIDs := make([]string, 0, len(operators))
+	for _, operator := range operators {
+		operatorIDs = append(operatorIDs, operator.OperatorID)
+	}
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, operatorIDs, interfaces.AuthResourceTypeOperator)
+	if err != nil {
+		return err
+	}
+	for _, operator := range operators {
+		operator.Operations = operationsByID[operator.OperatorID]
+	}
+	return nil
 }
 
 func (m *operatorManager) queryOperatorConfigList(ctx context.Context, req *interfaces.PageQueryRequest) (

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -906,8 +906,18 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 				CategoryManager: mockCategoryManager,
 				Logger:          logger.DefaultLogger(),
 			}
-			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil)
+			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil).Times(2)
 			mockAuthService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill, interfaces.AuthOperationTypeView).Return([]string{"skill-12c"}, nil)
+			mockAuthService.EXPECT().ResourceFilterOperations(
+				gomock.Any(),
+				gomock.Any(),
+				[]string{"skill-12c"},
+				interfaces.AuthResourceTypeSkill,
+				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+				[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+			).Return(map[string][]interfaces.AuthOperationType{
+				"skill-12c": {interfaces.AuthOperationTypeAuthorize},
+			}, nil)
 			mockSkillRepo.EXPECT().CountByWhereClause(gomock.Any(), gomock.Nil(), gomock.Any()).Return(int64(1), nil)
 			mockSkillRepo.EXPECT().SelectSkillListPage(gomock.Any(), gomock.Nil(), gomock.Any(), gomock.Any(), gomock.Nil()).Return([]*model.SkillRepositoryDB{
 				{SkillID: "skill-12c", Name: "visible", IsDeleted: true},
@@ -924,6 +934,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(len(resp.Data), ShouldEqual, 1)
 			So(resp.Data[0].SkillID, ShouldEqual, "skill-12c")
+			So(resp.Data[0].Operations, ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
 		})
 
 		Convey("GetSkillContent hides deleting skills", func() {

--- a/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/reader_registry_test.go
@@ -906,7 +906,7 @@ func TestSkillReaderAndRegistry(t *testing.T) {
 				CategoryManager: mockCategoryManager,
 				Logger:          logger.DefaultLogger(),
 			}
-			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil).Times(2)
+			mockAuthService.EXPECT().GetAccessor(gomock.Any(), "").Return(&interfaces.AuthAccessor{ID: "viewer"}, nil).Times(1)
 			mockAuthService.EXPECT().ResourceListIDs(gomock.Any(), gomock.Any(), interfaces.AuthResourceTypeSkill, interfaces.AuthOperationTypeView).Return([]string{"skill-12c"}, nil)
 			mockAuthService.EXPECT().ResourceFilterOperations(
 				gomock.Any(),

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -932,8 +932,26 @@ func (r *skillRegistry) QuerySkillList(ctx context.Context, req *interfaces.Quer
 	if err != nil {
 		return nil, err
 	}
+	if err = projectSkillAuthorizeOperations(ctx, r.AuthService, req.UserID, skillInfos); err != nil {
+		return nil, err
+	}
 	resp.Data = skillInfos
 	return resp, nil
+}
+
+func projectSkillAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, skills []*interfaces.SkillInfo) error {
+	skillIDs := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		skillIDs = append(skillIDs, skill.SkillID)
+	}
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, skillIDs, interfaces.AuthResourceTypeSkill)
+	if err != nil {
+		return err
+	}
+	for _, skill := range skills {
+		skill.Operations = operationsByID[skill.SkillID]
+	}
+	return nil
 }
 
 // Assemble Skill Market Summary List.

--- a/adp/execution-factory/operator-integration/server/logics/skill/registry.go
+++ b/adp/execution-factory/operator-integration/server/logics/skill/registry.go
@@ -920,7 +920,7 @@ func (r *skillRegistry) QuerySkillList(ctx context.Context, req *interfaces.Quer
 		filter["category"] = req.Category.String()
 	}
 
-	authResp, err := r.querySkillListPage(ctx, filter, req.CommonPageParams, req.UserID, interfaces.AuthOperationTypeView)
+	authResp, accessor, err := r.querySkillListPage(ctx, filter, req.CommonPageParams, req.UserID, interfaces.AuthOperationTypeView)
 	if err != nil {
 		return nil, err
 	}
@@ -932,19 +932,19 @@ func (r *skillRegistry) QuerySkillList(ctx context.Context, req *interfaces.Quer
 	if err != nil {
 		return nil, err
 	}
-	if err = projectSkillAuthorizeOperations(ctx, r.AuthService, req.UserID, skillInfos); err != nil {
+	if err = projectSkillAuthorizeOperations(ctx, r.AuthService, accessor, skillInfos); err != nil {
 		return nil, err
 	}
 	resp.Data = skillInfos
 	return resp, nil
 }
 
-func projectSkillAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, skills []*interfaces.SkillInfo) error {
+func projectSkillAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, accessor *interfaces.AuthAccessor, skills []*interfaces.SkillInfo) error {
 	skillIDs := make([]string, 0, len(skills))
 	for _, skill := range skills {
 		skillIDs = append(skillIDs, skill.SkillID)
 	}
-	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, skillIDs, interfaces.AuthResourceTypeSkill)
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, accessor, skillIDs, interfaces.AuthResourceTypeSkill)
 	if err != nil {
 		return err
 	}
@@ -1081,7 +1081,7 @@ func (r *skillRegistry) queryReleaseListPage(ctx context.Context, filter map[str
 }
 
 func (r *skillRegistry) querySkillListPage(ctx context.Context, filter map[string]interface{}, pageParamsReq interfaces.CommonPageParams, userID string, operations ...interfaces.AuthOperationType) (
-	authResp *interfaces.QueryResponse[model.SkillRepositoryDB], err error) {
+	authResp *interfaces.QueryResponse[model.SkillRepositoryDB], accessor *interfaces.AuthAccessor, err error) {
 	// Build query executor.
 	sortField := "f_update_time"
 	switch pageParamsReq.SortBy {
@@ -1153,7 +1153,6 @@ func (r *skillRegistry) querySkillListPage(ctx context.Context, filter map[strin
 		// If it is an external interface, permission check.
 		queryBuilder.SetAuthFilter(func(newCtx context.Context) ([]string, error) {
 			// Check viewing permissions.
-			var accessor *interfaces.AuthAccessor
 			accessor, err = r.AuthService.GetAccessor(newCtx, userID)
 			if err != nil {
 				return nil, err

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/names_authz_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/names_authz_test.go
@@ -73,3 +73,26 @@ func TestGetToolBoxNamesByIDsAuthz(t *testing.T) {
 		})
 	})
 }
+
+func TestProjectToolBoxAuthorizeOperations(t *testing.T) {
+	Convey("Toolbox list projects authorize with the existing accessor", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		authService := mocks.NewMockIAuthorizationService(ctrl)
+		accessor := &interfaces.AuthAccessor{ID: "user-1"}
+		toolBoxes := []*interfaces.ToolBoxInfo{{BoxID: "box-1"}, {BoxID: "box-2"}}
+		authService.EXPECT().ResourceFilterOperations(
+			gomock.Any(), accessor, []string{"box-1", "box-2"}, interfaces.AuthResourceTypeToolBox,
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeView},
+			[]interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize},
+		).Return(map[string][]interfaces.AuthOperationType{
+			"box-1": {interfaces.AuthOperationTypeAuthorize},
+		}, nil)
+
+		err := projectToolBoxAuthorizeOperations(common.SetPublicAPIToCtx(context.Background(), true), authService, accessor, toolBoxes)
+
+		So(err, ShouldBeNil)
+		So(toolBoxes[0].Operations, ShouldResemble, []interfaces.AuthOperationType{interfaces.AuthOperationTypeAuthorize})
+		So(toolBoxes[1].Operations, ShouldBeEmpty)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/release.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/release.go
@@ -332,7 +332,7 @@ func (s *ToolServiceImpl) QueryMarketToolBoxList(ctx context.Context, req *inter
 	resp = &interfaces.QueryToolBoxListResp{
 		Data: []*interfaces.ToolBoxInfo{},
 	}
-	authResp, err := s.getToolBoxListPage(ctx, filter, req.CommonPageParams, req.UserID, operations)
+	authResp, _, err := s.getToolBoxListPage(ctx, filter, req.CommonPageParams, req.UserID, operations)
 	if err != nil {
 		return
 	}
@@ -351,7 +351,7 @@ func (s *ToolServiceImpl) QueryMarketToolBoxList(ctx context.Context, req *inter
 }
 
 func (s *ToolServiceImpl) getToolBoxListPage(ctx context.Context, filter map[string]interface{}, pageParamsReq interfaces.CommonPageParams,
-	userID string, operations ...interfaces.AuthOperationType) (authResp *interfaces.QueryResponse[model.ToolboxDB], err error) {
+	userID string, operations ...interfaces.AuthOperationType) (authResp *interfaces.QueryResponse[model.ToolboxDB], accessor *interfaces.AuthAccessor, err error) {
 	sortField := sortFieldMap[pageParamsReq.SortBy]
 	sort := &ormhelper.SortParams{
 		Fields: []ormhelper.SortField{
@@ -415,7 +415,6 @@ func (s *ToolServiceImpl) getToolBoxListPage(ctx context.Context, filter map[str
 	// Determine whether it is an external interface.
 	if infracommon.IsPublicAPIFromCtx(ctx) {
 		queryBuilder.SetAuthFilter(func(newCtx context.Context) ([]string, error) {
-			var accessor *interfaces.AuthAccessor
 			accessor, err = s.AuthService.GetAccessor(newCtx, userID)
 			if err != nil {
 				return nil, err

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox.go
@@ -196,7 +196,7 @@ func (s *ToolServiceImpl) QueryToolBoxList(ctx context.Context, req *interfaces.
 	resp = &interfaces.QueryToolBoxListResp{
 		Data: []*interfaces.ToolBoxInfo{},
 	}
-	authResp, err := s.getToolBoxListPage(ctx, filter, req.CommonPageParams, req.UserID, operations)
+	authResp, accessor, err := s.getToolBoxListPage(ctx, filter, req.CommonPageParams, req.UserID, operations)
 	if err != nil {
 		return
 	}
@@ -210,19 +210,19 @@ func (s *ToolServiceImpl) QueryToolBoxList(ctx context.Context, req *interfaces.
 	if err != nil {
 		return
 	}
-	if err = projectToolBoxAuthorizeOperations(ctx, s.AuthService, req.UserID, toolBoxInfoList); err != nil {
+	if err = projectToolBoxAuthorizeOperations(ctx, s.AuthService, accessor, toolBoxInfoList); err != nil {
 		return
 	}
 	resp.Data = toolBoxInfoList
 	return
 }
 
-func projectToolBoxAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, toolBoxes []*interfaces.ToolBoxInfo) error {
+func projectToolBoxAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, accessor *interfaces.AuthAccessor, toolBoxes []*interfaces.ToolBoxInfo) error {
 	toolBoxIDs := make([]string, 0, len(toolBoxes))
 	for _, toolBox := range toolBoxes {
 		toolBoxIDs = append(toolBoxIDs, toolBox.BoxID)
 	}
-	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, toolBoxIDs, interfaces.AuthResourceTypeToolBox)
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, accessor, toolBoxIDs, interfaces.AuthResourceTypeToolBox)
 	if err != nil {
 		return err
 	}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/toolbox.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/telemetry"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/auth"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metadata"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metric"
@@ -209,8 +210,26 @@ func (s *ToolServiceImpl) QueryToolBoxList(ctx context.Context, req *interfaces.
 	if err != nil {
 		return
 	}
+	if err = projectToolBoxAuthorizeOperations(ctx, s.AuthService, req.UserID, toolBoxInfoList); err != nil {
+		return
+	}
 	resp.Data = toolBoxInfoList
 	return
+}
+
+func projectToolBoxAuthorizeOperations(ctx context.Context, authorization interfaces.IAuthorizationService, userID string, toolBoxes []*interfaces.ToolBoxInfo) error {
+	toolBoxIDs := make([]string, 0, len(toolBoxes))
+	for _, toolBox := range toolBoxes {
+		toolBoxIDs = append(toolBoxIDs, toolBox.BoxID)
+	}
+	operationsByID, err := auth.ProjectAuthorizeOperations(ctx, authorization, userID, toolBoxIDs, interfaces.AuthResourceTypeToolBox)
+	if err != nil {
+		return err
+	}
+	for _, toolBox := range toolBoxes {
+		toolBox.Operations = operationsByID[toolBox.BoxID]
+	}
+	return nil
 }
 
 // UpdateToolBoxStatus Modifies toolbox status.

--- a/adp/execution-factory/operator-integration/server/mocks/auth.go
+++ b/adp/execution-factory/operator-integration/server/mocks/auth.go
@@ -345,6 +345,21 @@ func (mr *MockIAuthorizationServiceMockRecorder) ResourceFilterIDs(ctx, accessor
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceFilterIDs", reflect.TypeOf((*MockIAuthorizationService)(nil).ResourceFilterIDs), varargs...)
 }
 
+// ResourceFilterOperations mocks base method.
+func (m *MockIAuthorizationService) ResourceFilterOperations(ctx context.Context, accessor *interfaces.AuthAccessor, resourceIDs []string, resourceType interfaces.AuthResourceType, visibilityOperations, candidateOperations []interfaces.AuthOperationType) (map[string][]interfaces.AuthOperationType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResourceFilterOperations", ctx, accessor, resourceIDs, resourceType, visibilityOperations, candidateOperations)
+	ret0, _ := ret[0].(map[string][]interfaces.AuthOperationType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResourceFilterOperations indicates an expected call of ResourceFilterOperations.
+func (mr *MockIAuthorizationServiceMockRecorder) ResourceFilterOperations(ctx, accessor, resourceIDs, resourceType, visibilityOperations, candidateOperations any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResourceFilterOperations", reflect.TypeOf((*MockIAuthorizationService)(nil).ResourceFilterOperations), ctx, accessor, resourceIDs, resourceType, visibilityOperations, candidateOperations)
+}
+
 // ResourceListIDs mocks base method.
 func (m *MockIAuthorizationService) ResourceListIDs(ctx context.Context, accessor *interfaces.AuthAccessor, resourceType interfaces.AuthResourceType, operations ...interfaces.AuthOperationType) ([]string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added per-object `authorize` operation projection to operator, toolbox, MCP, and skill management list responses.
- [x] Switched execution-factory resource filtering to bkn-safe's batched `resource-filter` contract with separate visibility and candidate operations.
- [x] Added focused authorization adapter, projection, and list-response regression tests.
- [ ] Docs/doc 1 — not applicable; no standalone documentation change is required.

---

## Why

- Related Issue: [openbkn-ai/bkn-studio#554](https://github.com/openbkn-ai/bkn-studio/issues/554)
- Related Feature: Execution Factory object-level grant management
- Background: Studio's authorization drawer already supports an object-level authorization signal, but execution-factory list responses did not expose the selected execution unit's `authorize` operation. This left users with object-level authorize permission unable to manage grants unless they also held the platform-wide grant permission.

---

## How

- Key implementation points:
  - Sends one batched bkn-safe `resource-filter` request per list, requiring `view` for visibility and projecting `authorize` as a candidate operation.
  - Adds `ResourceFilterOperations` to the authorization service and preserves resource type and operation data from Safe responses.
  - Enriches public operator, toolbox, MCP, and skill list rows with `operations`; internal list calls keep their existing response behavior.
  - Does not infer permissions from parent or type-wide resources; Safe remains the authorization source of truth and mutation endpoints remain backend-enforced.
- Breaking changes (API, config, database, etc.): No breaking changes. The response adds an optional `operations` field to existing list items. No configuration or database changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; this change is covered by mocked unit tests and the module has no configured integration target.
- [ ] Verified in test environment — not performed in this PR.

Test notes:

- `GOMODCACHE=/tmp/codex-bkn554-gomodcache make test`
- `GOMODCACHE=/tmp/codex-bkn554-gomodcache go vet ./...`
- `make lint` could not start because `golangci-lint` is not installed in the local WSL environment; CI remains the authoritative lint gate.
- An isolated module cache was used because the shared local Go cache contained a truncated `Masterminds/semver` test file.
- Regression coverage includes Safe request/response mapping, public object-level authorization projection, internal-call compatibility, and skill list response propagation.

---

## Risk & Rollback

- Potential risks: Public management list requests add one batched Safe authorization call. Safe errors are propagated instead of fabricating permissions, so an authorization dependency outage can fail the affected list request.
- Rollback plan: Revert commit `7f891b5d8` or roll back the operator-integration service image. The change is stateless and requires no data or schema rollback.

---

## Additional Notes

- Closes openbkn-ai/bkn-studio#554
- This PR implements the execution-factory/backend half of the cross-repository issue; the Studio UI consumes the new per-object `operations` field.
- Screenshots are not applicable to this backend-only change.
