### PR TITLE
feat(bkn-safe): add managed knowledge network proxy accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TPL_DIR      := $(API_DIR)/_templates
 MODULES      := bkn context-loader ontology-query vega execution-factory mf-model-manager \
                 agent-observability bkn-agent
 # 暂不发布的模块目录（YAML 保留在仓库，只是不进站点、不参与 lint）：
-#   bkn-safe      自助读取面和集群内 authz 合同都不作为通用集成合同对外
+#   bkn-safe      自助读取面及集群内 authz / managed-proxy 合同不作为通用集成合同对外
 #   observability 只有 observability.json，没有可发布的 YAML，渲染出来是空分组
 MODULES_UNPUBLISHED := bkn-safe observability
 # Unpublished modules are linted too, so service-to-service request and error

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TPL_DIR      := $(API_DIR)/_templates
 MODULES      := bkn context-loader ontology-query vega execution-factory mf-model-manager \
                 agent-observability bkn-agent
 # 暂不发布的模块目录（YAML 保留在仓库，只是不进站点、不参与 lint）：
-#   bkn-safe      自助读取面及集群内 authz / managed-proxy 合同不作为通用集成合同对外
+#   bkn-safe      Self-service reads and cluster-internal authz / managed-proxy contracts are not published as general integration APIs
 #   observability 只有 observability.json，没有可发布的 YAML，渲染出来是空分组
 MODULES_UNPUBLISHED := bkn-safe observability
 # Unpublished modules are linted too, so service-to-service request and error

--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -7,6 +7,7 @@ bkn-safe 是 OpenBKN 的认证、鉴权和用户目录服务。它配合**上游
 **文档**：
 - 领域知识网络权限调用合同：[`docs/api/knowledge-network-authorization.md`](../docs/api/knowledge-network-authorization.md)
 - 自助授权范围 OpenAPI：[`docs/api/bkn-safe/self-service.yaml`](../docs/api/bkn-safe/self-service.yaml)
+- 受管 KN 代理内部 OpenAPI：[`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
 - 全局设计文档：[bkn-docs `docs/foundry/`](https://github.com/openbkn-ai/bkn-docs/tree/main/docs/foundry)
 
 ## 三职责
@@ -98,6 +99,8 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
 - 认证（hydra 重定向到这里）：`GET/POST /login`、`GET /consent`、`GET/POST /device`
 - 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST /resource-filter`、
   `POST|DELETE /policies`、`POST /role-bindings`
+- 受管 KN 代理（ClusterIP 内部面）`/api/safe/in/v1/managed-proxy-accounts`：创建、查询、
+  禁用和归档一对一 proxy app；账号禁止登录、AppKey、普通用户管理与通用 Policy 授权
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`

--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -7,7 +7,7 @@ bkn-safe 是 OpenBKN 的认证、鉴权和用户目录服务。它配合**上游
 **文档**：
 - 领域知识网络权限调用合同：[`docs/api/knowledge-network-authorization.md`](../docs/api/knowledge-network-authorization.md)
 - 自助授权范围 OpenAPI：[`docs/api/bkn-safe/self-service.yaml`](../docs/api/bkn-safe/self-service.yaml)
-- 受管 KN 代理内部 OpenAPI：[`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
+- Managed KN proxy internal OpenAPI: [`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
 - 全局设计文档：[bkn-docs `docs/foundry/`](https://github.com/openbkn-ai/bkn-docs/tree/main/docs/foundry)
 
 ## 三职责
@@ -99,8 +99,9 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
 - 认证（hydra 重定向到这里）：`GET/POST /login`、`GET /consent`、`GET/POST /device`
 - 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST /resource-filter`、
   `POST|DELETE /policies`、`POST /role-bindings`
-- 受管 KN 代理（ClusterIP 内部面）`/api/safe/in/v1/managed-proxy-accounts`：创建、查询、
-  禁用和归档一对一 proxy app；账号禁止登录、AppKey、普通用户管理与通用 Policy 授权
+- Managed KN proxies (ClusterIP-internal surface) `/api/safe/in/v1/managed-proxy-accounts`:
+  create, get, disable, and archive one-to-one proxy apps; these accounts cannot log in, use
+  AppKeys, be managed as regular users, or receive grants through the generic Policy API
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`

--- a/bkn-safe/charts/bkn-safe/templates/networkpolicy.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/networkpolicy.yaml
@@ -2,7 +2,7 @@
 Default-deny ingress for bkn-safe, admitting only:
   - the gateway/ingress controller, for the browser- and CLI-facing routes;
   - an explicit set of in-cluster peers, for the tokenless internal APIs
-    (/authz, /directory, /api-keys/introspect).
+    (/authz, /directory, /api-keys/introspect, /in/v1/managed-proxy-accounts).
 
 These internal APIs authenticate no caller by design — their whole security
 model is "only in-cluster services can reach them", which a ClusterIP Service

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -19,7 +19,8 @@ service:
 # Only the hydra provider pages (login/consent/device) and the self-service
 # change-password endpoint are browser/CLI-facing and go through the ingress.
 # The internal APIs (/api/safe/v1/authz, /api/safe/v1/directory,
-# /api/safe/v1/internal/license) stay ClusterIP, called service-to-service — do
+# /api/safe/v1/internal/license, /api/safe/in/v1/managed-proxy-accounts) stay
+# ClusterIP, called service-to-service — do
 # NOT expose those at the gateway. The licence group is tokenless by design (its
 # boundary is the network, see networkPolicy below), so putting it behind the
 # ingress would publish the certificate and its expiry to anyone who can reach

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -152,12 +152,14 @@ func (s *APIKeyStore) Verify(ctx context.Context, plaintext string) (*VerifiedKe
 	if !owner.Enabled {
 		return nil, ErrAPIKeyInvalid
 	}
-	managed, err := managedproxy.IsManaged(ctx, s.db, owner.ID)
-	if err != nil {
-		return nil, err
-	}
-	if managed {
-		return nil, ErrAPIKeyInvalid
+	if owner.AccountType == model.AccountTypeApp {
+		managed, err := managedproxy.IsManaged(ctx, s.db, owner.ID)
+		if err != nil {
+			return nil, err
+		}
+		if managed {
+			return nil, ErrAPIKeyInvalid
+		}
 	}
 
 	// Best-effort last-used stamp; never fail verification on a write error.

--- a/bkn-safe/server/internal/auth/apikey.go
+++ b/bkn-safe/server/internal/auth/apikey.go
@@ -16,6 +16,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -71,6 +72,13 @@ type VerifiedKey struct {
 // nil = never expires. The caller has already authenticated the owner, so the key
 // can never grant more than the owner holds.
 func (s *APIKeyStore) Issue(ctx context.Context, ownerID, name string, expiresAt *time.Time) (string, *model.APIKey, error) {
+	managed, err := managedproxy.IsManaged(ctx, s.db, ownerID)
+	if err != nil {
+		return "", nil, err
+	}
+	if managed {
+		return "", nil, managedproxy.ErrManagedAccount
+	}
 	// Names are unique per owner so a user's key list is unambiguous. Checked at
 	// the app layer (not a DB unique index) because pre-existing rows may already
 	// hold duplicate names — a unique index would break AutoMigrate on them.
@@ -144,6 +152,13 @@ func (s *APIKeyStore) Verify(ctx context.Context, plaintext string) (*VerifiedKe
 	if !owner.Enabled {
 		return nil, ErrAPIKeyInvalid
 	}
+	managed, err := managedproxy.IsManaged(ctx, s.db, owner.ID)
+	if err != nil {
+		return nil, err
+	}
+	if managed {
+		return nil, ErrAPIKeyInvalid
+	}
 
 	// Best-effort last-used stamp; never fail verification on a write error.
 	now := time.Now()
@@ -210,8 +225,15 @@ func (s *APIKeyStore) Delete(ctx context.Context, id string) error {
 // This is the "I lost it / rotate on suspected leak" path — no need to recreate
 // and rename. Returns gorm.ErrRecordNotFound when the caller owns no such key.
 func (s *APIKeyStore) Regenerate(ctx context.Context, ownerID, id string) (string, *model.APIKey, error) {
+	managed, err := managedproxy.IsManaged(ctx, s.db, ownerID)
+	if err != nil {
+		return "", nil, err
+	}
+	if managed {
+		return "", nil, managedproxy.ErrManagedAccount
+	}
 	var rec model.APIKey
-	err := s.db.WithContext(ctx).First(&rec, "id = ? AND owner_user_id = ?", id, ownerID).Error
+	err = s.db.WithContext(ctx).First(&rec, "id = ? AND owner_user_id = ?", id, ownerID).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return "", nil, gorm.ErrRecordNotFound
 	}

--- a/bkn-safe/server/internal/auth/apikey_test.go
+++ b/bkn-safe/server/internal/auth/apikey_test.go
@@ -71,6 +71,24 @@ func TestIssueAndVerify(t *testing.T) {
 	}
 }
 
+func TestVerifyUserKeySkipsManagedProxyLookup(t *testing.T) {
+	s, db := newAPIKeyStore(t)
+	ctx := context.Background()
+	seedUser(t, db, "u-1", true, model.AccountTypeOther)
+	plaintext, _, err := s.Issue(ctx, "u-1", "ci-bot", nil)
+	if err != nil {
+		t.Fatalf("issue: %v", err)
+	}
+	if err := db.Migrator().DropTable(&model.ManagedProxyAccount{}); err != nil {
+		t.Fatalf("drop managed proxy table: %v", err)
+	}
+
+	v, err := s.Verify(ctx, plaintext)
+	if err != nil || v.OwnerID != "u-1" {
+		t.Fatalf("verify without managed proxy table = %+v err=%v", v, err)
+	}
+}
+
 func TestVerifyAppAccountType(t *testing.T) {
 	s, db := newAPIKeyStore(t)
 	ctx := context.Background()

--- a/bkn-safe/server/internal/auth/ldap.go
+++ b/bkn-safe/server/internal/auth/ldap.go
@@ -139,6 +139,9 @@ func (c *Chain) Verify(ctx context.Context, account, password string) (*model.Us
 		if err == nil {
 			return u, nil
 		}
+		if errors.Is(err, ErrManagedLoginDisabled) {
+			return nil, err
+		}
 		// Fall through on credential failures; surface infra errors immediately.
 		if errors.Is(err, ErrInvalidCredentials) || errors.Is(err, ErrUserDisabled) {
 			lastErr = err

--- a/bkn-safe/server/internal/auth/managedproxy_test.go
+++ b/bkn-safe/server/internal/auth/managedproxy_test.go
@@ -87,6 +87,17 @@ func TestManagedProxyCannotReceiveOrRotateCredentials(t *testing.T) {
 	if _, _, err := keys.Regenerate(t.Context(), user.ID, "missing"); !errors.Is(err, managedproxy.ErrManagedAccount) {
 		t.Fatalf("Regenerate() error = %v, want ErrManagedAccount", err)
 	}
+	keyID := randBase62(keyIDLen)
+	secret := randBase62(secretLen)
+	if err := db.Create(&model.APIKey{
+		ID: NewID(), KeyID: keyID, OwnerUserID: user.ID, Name: "injected",
+		SecretHash: hashSecret(secret), Enabled: true,
+	}).Error; err != nil {
+		t.Fatalf("inject legacy key: %v", err)
+	}
+	if _, err := keys.Verify(t.Context(), KeyPrefix+keyID+"_"+secret); !errors.Is(err, ErrAPIKeyInvalid) {
+		t.Fatalf("Verify() error = %v, want ErrAPIKeyInvalid", err)
+	}
 	if err := NewUserStore(db).ResetPassword(t.Context(), user.ID, "secret"); !errors.Is(err, managedproxy.ErrManagedAccount) {
 		t.Fatalf("ResetPassword() error = %v, want ErrManagedAccount", err)
 	}

--- a/bkn-safe/server/internal/auth/managedproxy_test.go
+++ b/bkn-safe/server/internal/auth/managedproxy_test.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func protectedProxyFixture(t *testing.T) (*gorm.DB, *model.User) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	account, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-protected",
+	})
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	var user model.User
+	if err := db.First(&user, "id = ?", account.ProxyAccountID).Error; err != nil {
+		t.Fatalf("load proxy: %v", err)
+	}
+	return db, &user
+}
+
+func TestManagedProxyCannotLoginEvenIfPasswordIsInjected(t *testing.T) {
+	db, user := protectedProxyFixture(t)
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if err := db.Model(&model.User{}).Where("id = ?", user.ID).Update("password_hash", string(hash)).Error; err != nil {
+		t.Fatalf("inject password: %v", err)
+	}
+	_, err = NewUserStore(db).Verify(t.Context(), user.Account, "secret")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("Verify() error = %v, want opaque invalid credentials", err)
+	}
+	if !errors.Is(err, ErrManagedLoginDisabled) {
+		t.Fatalf("Verify() error = %v, want managed-login sentinel", err)
+	}
+}
+
+func TestManagedProxyLoginDoesNotFallThroughAuthenticatorChain(t *testing.T) {
+	db, user := protectedProxyFixture(t)
+	called := false
+	chain := NewChain(NewUserStore(db), authenticatorFunc(func(context.Context, string, string) (*model.User, error) {
+		called = true
+		return user, nil
+	}))
+	_, err := chain.Verify(t.Context(), user.Account, "anything")
+	if !errors.Is(err, ErrManagedLoginDisabled) || called {
+		t.Fatalf("Chain.Verify() = (%v, LDAP called=%v), want terminal managed-login denial", err, called)
+	}
+}
+
+type authenticatorFunc func(context.Context, string, string) (*model.User, error)
+
+func (f authenticatorFunc) Verify(ctx context.Context, account, password string) (*model.User, error) {
+	return f(ctx, account, password)
+}
+
+func TestManagedProxyCannotReceiveOrRotateCredentials(t *testing.T) {
+	db, user := protectedProxyFixture(t)
+	keys := NewAPIKeyStore(db)
+	if _, _, err := keys.Issue(t.Context(), user.ID, "forbidden", nil); !errors.Is(err, managedproxy.ErrManagedAccount) {
+		t.Fatalf("Issue() error = %v, want ErrManagedAccount", err)
+	}
+	if _, _, err := keys.Regenerate(t.Context(), user.ID, "missing"); !errors.Is(err, managedproxy.ErrManagedAccount) {
+		t.Fatalf("Regenerate() error = %v, want ErrManagedAccount", err)
+	}
+	if err := NewUserStore(db).ResetPassword(t.Context(), user.ID, "secret"); !errors.Is(err, managedproxy.ErrManagedAccount) {
+		t.Fatalf("ResetPassword() error = %v, want ErrManagedAccount", err)
+	}
+}
+
+func TestManagedProxyCannotUseGenericUserMutationPaths(t *testing.T) {
+	db, user := protectedProxyFixture(t)
+	users := NewUserStore(db)
+	if err := users.UpdateUser(t.Context(), user.ID, map[string]any{"enabled": false}); !errors.Is(err, managedproxy.ErrManagedAccount) {
+		t.Fatalf("UpdateUser() error = %v, want ErrManagedAccount", err)
+	}
+	if err := users.DeleteUser(t.Context(), user.ID); !errors.Is(err, managedproxy.ErrManagedAccount) {
+		t.Fatalf("DeleteUser() error = %v, want ErrManagedAccount", err)
+	}
+}

--- a/bkn-safe/server/internal/auth/userstore.go
+++ b/bkn-safe/server/internal/auth/userstore.go
@@ -12,11 +12,13 @@ package auth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -43,6 +45,12 @@ func NewInitialPassword() string {
 // ErrInvalidCredentials is returned when account/password verification fails.
 // It is deliberately opaque (no "user not found" vs "wrong password" leak).
 var ErrInvalidCredentials = errors.New("invalid account or password")
+
+// ErrManagedLoginDisabled is intentionally wrapped in ErrInvalidCredentials so
+// public login responses remain opaque. The distinct sentinel prevents an
+// authenticator chain from falling through to LDAP for a protected local proxy
+// account that happens to share the same account string.
+var ErrManagedLoginDisabled = fmt.Errorf("%w: managed account login disabled", ErrInvalidCredentials)
 
 // ErrUserDisabled is returned when the account exists but is disabled.
 var ErrUserDisabled = errors.New("user disabled")
@@ -78,6 +86,13 @@ func (s *UserStore) Verify(ctx context.Context, account, password string) (*mode
 	if err != nil {
 		return nil, err
 	}
+	managed, err := managedproxy.IsManaged(ctx, s.db, u.ID)
+	if err != nil {
+		return nil, err
+	}
+	if managed {
+		return nil, ErrManagedLoginDisabled
+	}
 	if u.PasswordHash == "" {
 		// No local password (e.g. an LDAP/app identity) — not a local login.
 		return nil, ErrInvalidCredentials
@@ -109,6 +124,9 @@ func (s *UserStore) CreateLocalUser(ctx context.Context, u *model.User, password
 // enabled/account_type — NOT account or password, which have their own paths).
 // Returns gorm.ErrRecordNotFound when no row matches.
 func (s *UserStore) UpdateUser(ctx context.Context, id string, fields map[string]any) error {
+	if err := rejectManagedMutation(ctx, s.db, id); err != nil {
+		return err
+	}
 	res := s.db.WithContext(ctx).Model(&model.User{}).Where("id = ?", id).Updates(fields)
 	if res.Error != nil {
 		return res.Error
@@ -124,6 +142,9 @@ func (s *UserStore) UpdateUser(ctx context.Context, id string, fields map[string
 // caller's job (it holds the enforcer). Returns gorm.ErrRecordNotFound when the
 // user doesn't exist.
 func (s *UserStore) DeleteUser(ctx context.Context, id string) error {
+	if err := rejectManagedMutation(ctx, s.db, id); err != nil {
+		return err
+	}
 	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		res := tx.Where("id = ?", id).Delete(&model.User{})
 		if res.Error != nil {
@@ -166,6 +187,9 @@ func (s *UserStore) ChangePassword(ctx context.Context, account, oldPassword, ne
 // their next login. Contrast SetPassword (self-service / forced-change
 // completion), which clears the flag.
 func (s *UserStore) ResetPassword(ctx context.Context, userID, password string) error {
+	if err := rejectManagedMutation(ctx, s.db, userID); err != nil {
+		return err
+	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return err
@@ -178,6 +202,9 @@ func (s *UserStore) ResetPassword(ctx context.Context, userID, password string) 
 // SetPassword updates a local user's password and clears MustChangePassword
 // (a successful change always satisfies a forced-change requirement).
 func (s *UserStore) SetPassword(ctx context.Context, userID, password string) error {
+	if err := rejectManagedMutation(ctx, s.db, userID); err != nil {
+		return err
+	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return err
@@ -185,4 +212,15 @@ func (s *UserStore) SetPassword(ctx context.Context, userID, password string) er
 	return s.db.WithContext(ctx).Model(&model.User{}).
 		Where("id = ?", userID).
 		Updates(map[string]any{"password_hash": string(hash), "must_change_password": false}).Error
+}
+
+func rejectManagedMutation(ctx context.Context, db *gorm.DB, userID string) error {
+	managed, err := managedproxy.IsManaged(ctx, db, userID)
+	if err != nil {
+		return err
+	}
+	if managed {
+		return managedproxy.ErrManagedAccount
+	}
+	return nil
 }

--- a/bkn-safe/server/internal/directory/departments_admin_list.go
+++ b/bkn-safe/server/internal/directory/departments_admin_list.go
@@ -59,6 +59,7 @@ func (s *Service) memberCounts(ctx context.Context, deptIDs []string) (map[strin
 	if err := s.db.WithContext(ctx).Model(&model.UserDepartment{}).
 		Select("department_id, COUNT(*) AS count").
 		Where("department_id IN ?", deptIDs).
+		Where(managedProxyMembershipFilter("user_departments.user_id")).
 		Group("department_id").
 		Scan(&rows).Error; err != nil {
 		return nil, err
@@ -108,6 +109,7 @@ func (s *Service) subtreeMemberCounts(ctx context.Context, deptIDs []string) (ma
 	if err := s.db.WithContext(ctx).Model(&model.UserDepartment{}).
 		Select("user_id, department_id").
 		Where("department_id IN ?", allDeptIDs).
+		Where(managedProxyMembershipFilter("user_departments.user_id")).
 		Scan(&rows).Error; err != nil {
 		return nil, err
 	}

--- a/bkn-safe/server/internal/directory/directory.go
+++ b/bkn-safe/server/internal/directory/directory.go
@@ -66,7 +66,8 @@ type UserDetail struct {
 // GetUser returns a user's detail, or gorm.ErrRecordNotFound.
 func (s *Service) GetUser(ctx context.Context, id string) (*UserDetail, error) {
 	var u model.User
-	if err := s.db.WithContext(ctx).First(&u, "id = ?", id).Error; err != nil {
+	if err := withoutManagedProxyAccounts(s.db.WithContext(ctx).Model(&model.User{})).
+		Where("id = ?", id).First(&u).Error; err != nil {
 		return nil, err
 	}
 	d := &UserDetail{
@@ -91,7 +92,7 @@ func (s *Service) GetUser(ctx context.Context, id string) (*UserDetail, error) {
 // ResolveUserNames maps user ids to {id,name}. Unknown ids are omitted (the
 // clean contract returns what it finds; callers handle gaps).
 func (s *Service) ResolveUserNames(ctx context.Context, ids []string) ([]NamedRef, error) {
-	return s.resolveNames(ctx, &model.User{}, ids)
+	return s.resolveUserNames(ctx, ids)
 }
 
 // ResolveDepartmentNames maps department ids to {id,name}.
@@ -107,13 +108,25 @@ func (s *Service) ResolveGroupNames(ctx context.Context, ids []string) ([]NamedR
 // ResolveAppNames maps application-account ids to {id,name}. App accounts are
 // User rows (account_type=app), so resolution is a plain users-table lookup.
 func (s *Service) ResolveAppNames(ctx context.Context, ids []string) ([]NamedRef, error) {
-	return s.resolveNames(ctx, &model.User{}, ids)
+	return s.resolveUserNames(ctx, ids)
 }
 
 // ResolveContactorNames maps contactor ids to {id,name} (User rows,
 // account_type=contactor).
 func (s *Service) ResolveContactorNames(ctx context.Context, ids []string) ([]NamedRef, error) {
-	return s.resolveNames(ctx, &model.User{}, ids)
+	return s.resolveUserNames(ctx, ids)
+}
+
+func (s *Service) resolveUserNames(ctx context.Context, ids []string) ([]NamedRef, error) {
+	out := make([]NamedRef, 0, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	if err := withoutManagedProxyAccounts(s.db.WithContext(ctx).Model(&model.User{})).
+		Select("id", "name").Where("id IN ?", ids).Scan(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // resolveNames is the shared id->name lookup for any model with id+name columns.
@@ -143,7 +156,10 @@ func (s *Service) ListDepartments(ctx context.Context, parentID string) ([]model
 func (s *Service) FindUserByAccount(ctx context.Context, account string) (*UserSummary, error) {
 	var u UserSummary
 	if err := s.db.WithContext(ctx).Model(&model.User{}).
-		Select(userSummaryCols).Where("account = ?", account).First(&u).Error; err != nil {
+		Select(userSummaryCols).
+		Where("account = ?", account).
+		Where("NOT EXISTS (SELECT 1 FROM managed_proxy_accounts mpa WHERE mpa.proxy_account_id = users.id)").
+		First(&u).Error; err != nil {
 		return nil, err
 	}
 	return &u, nil
@@ -174,7 +190,7 @@ func (s *Service) DepartmentMembers(ctx context.Context, deptID string) ([]UserS
 	if len(ids) == 0 {
 		return out, nil
 	}
-	if err := s.db.WithContext(ctx).Model(&model.User{}).
+	if err := withoutManagedProxyAccounts(s.db.WithContext(ctx).Model(&model.User{})).
 		Select(userSummaryCols).Where("id IN ?", ids).Order("account").Scan(&out).Error; err != nil {
 		return nil, err
 	}
@@ -220,6 +236,9 @@ func (s *Service) RemoveDepartmentMembers(ctx context.Context, deptID string, us
 	if len(ids) == 0 {
 		return nil
 	}
+	if err := s.rejectManagedUserIDs(ctx, ids); err != nil {
+		return err
+	}
 	return s.db.WithContext(ctx).
 		Where("department_id = ? AND user_id IN ?", deptID, ids).
 		Delete(&model.UserDepartment{}).Error
@@ -242,7 +261,9 @@ func (s *Service) requireDepartment(ctx context.Context, id string) error {
 func (s *Service) requireUsersExist(ctx context.Context, ids []string) error {
 	var found []string
 	if err := s.db.WithContext(ctx).Model(&model.User{}).
-		Where("id IN ?", ids).Pluck("id", &found).Error; err != nil {
+		Where("id IN ?", ids).
+		Where("NOT EXISTS (SELECT 1 FROM managed_proxy_accounts mpa WHERE mpa.proxy_account_id = users.id)").
+		Pluck("id", &found).Error; err != nil {
 		return err
 	}
 	if len(found) == len(ids) {
@@ -308,7 +329,10 @@ func (s *Service) SetUserDepartments(ctx context.Context, userID string, deptIDs
 // requireUser returns gorm.ErrRecordNotFound when no user has the id.
 func (s *Service) requireUser(ctx context.Context, id string) error {
 	var n int64
-	if err := s.db.WithContext(ctx).Model(&model.User{}).Where("id = ?", id).Count(&n).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(&model.User{}).
+		Where("id = ?", id).
+		Where("NOT EXISTS (SELECT 1 FROM managed_proxy_accounts mpa WHERE mpa.proxy_account_id = users.id)").
+		Count(&n).Error; err != nil {
 		return err
 	}
 	if n == 0 {
@@ -395,7 +419,8 @@ func (s *Service) DeleteDepartment(ctx context.Context, id string) error {
 // GroupMembers returns the member user ids of a group.
 func (s *Service) GroupMembers(ctx context.Context, groupID string) ([]string, error) {
 	var ms []model.GroupMember
-	if err := s.db.WithContext(ctx).Where("group_id = ?", groupID).Find(&ms).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("group_id = ?", groupID).
+		Where(managedProxyMembershipFilter("group_members.member_id")).Find(&ms).Error; err != nil {
 		return nil, err
 	}
 	ids := make([]string, 0, len(ms))
@@ -415,6 +440,7 @@ func (s *Service) SearchOrg(ctx context.Context, userIDs, scopeDeptIDs []string)
 	var uds []model.UserDepartment
 	if err := s.db.WithContext(ctx).
 		Where("user_id IN ? AND department_id IN ?", userIDs, scopeDeptIDs).
+		Where(managedProxyMembershipFilter("user_departments.user_id")).
 		Find(&uds).Error; err != nil {
 		return nil, err
 	}

--- a/bkn-safe/server/internal/directory/hierarchy.go
+++ b/bkn-safe/server/internal/directory/hierarchy.go
@@ -84,7 +84,8 @@ func (s *Service) deptChain(ctx context.Context, deptID string) ([]DeptRef, erro
 // userDirectDeptIDs returns the departments a user is directly assigned to.
 func (s *Service) userDirectDeptIDs(ctx context.Context, userID string) ([]string, error) {
 	var uds []model.UserDepartment
-	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).Find(&uds).Error; err != nil {
+	if err := s.db.WithContext(ctx).Where("user_id = ?", userID).
+		Where(managedProxyMembershipFilter("user_departments.user_id")).Find(&uds).Error; err != nil {
 		return nil, err
 	}
 	ids := make([]string, 0, len(uds))
@@ -162,7 +163,9 @@ func (s *Service) DepartmentInfos(ctx context.Context, ids []string) ([]DeptInfo
 // departments (by member_type).
 func (s *Service) GroupMembersSplit(ctx context.Context, groupID string) (userIDs, deptIDs []string, err error) {
 	var ms []model.GroupMember
-	if err = s.db.WithContext(ctx).Where("group_id = ?", groupID).Find(&ms).Error; err != nil {
+	if err = s.db.WithContext(ctx).Where("group_id = ?", groupID).
+		Where("member_type = ? OR "+managedProxyMembershipFilter("group_members.member_id"), "department").
+		Find(&ms).Error; err != nil {
 		return nil, nil, err
 	}
 	userIDs, deptIDs = []string{}, []string{}
@@ -234,7 +237,8 @@ func (s *Service) UsersDetail(ctx context.Context, ids []string) ([]UserFull, er
 	out := make([]UserFull, 0, len(ids))
 	for _, id := range ids {
 		var u model.User
-		err := s.db.WithContext(ctx).First(&u, "id = ?", id).Error
+		err := withoutManagedProxyAccounts(s.db.WithContext(ctx).Model(&model.User{})).
+			Where("id = ?", id).First(&u).Error
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			continue
 		}

--- a/bkn-safe/server/internal/directory/managedproxy.go
+++ b/bkn-safe/server/internal/directory/managedproxy.go
@@ -1,0 +1,45 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package directory
+
+import (
+	"context"
+	"fmt"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// withoutManagedProxyAccounts keeps system-owned proxy identities out of every
+// generic user-directory projection. Callers that need proxy lifecycle data use
+// the dedicated internal managed-proxy API instead.
+func withoutManagedProxyAccounts(db *gorm.DB) *gorm.DB {
+	return db.Where(
+		"NOT EXISTS (SELECT 1 FROM managed_proxy_accounts mpa WHERE mpa.proxy_account_id = users.id)",
+	)
+}
+
+func managedProxyMembershipFilter(userIDColumn string) string {
+	return "NOT EXISTS (SELECT 1 FROM managed_proxy_accounts mpa WHERE mpa.proxy_account_id = " + userIDColumn + ")"
+}
+
+// rejectManagedUserIDs prevents generic membership-removal paths from mutating
+// a proxy identity while preserving their existing idempotency for unknown
+// ordinary user ids.
+func (s *Service) rejectManagedUserIDs(ctx context.Context, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&model.ManagedProxyAccount{}).
+		Where("proxy_account_id IN ?", ids).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: managed proxy accounts are not directory users", ErrUnknownUser)
+	}
+	return nil
+}

--- a/bkn-safe/server/internal/directory/users_admin_list.go
+++ b/bkn-safe/server/internal/directory/users_admin_list.go
@@ -64,7 +64,7 @@ func (s *Service) ListUsers(ctx context.Context, filter UserListFilter) ([]UserS
 		offset = 0
 	}
 
-	q := s.db.WithContext(ctx).Model(&model.User{})
+	q := withoutManagedProxyAccounts(s.db.WithContext(ctx).Model(&model.User{}))
 	if filter.Search != "" {
 		like := "%" + filter.Search + "%"
 		q = q.Where(

--- a/bkn-safe/server/internal/directory/users_admin_list_test.go
+++ b/bkn-safe/server/internal/directory/users_admin_list_test.go
@@ -6,9 +6,13 @@ package directory
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"gorm.io/gorm"
+
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -56,6 +60,111 @@ func TestListUsersFiltersAndEnrichment(t *testing.T) {
 	}
 	if total != 1 || byRole[0].ID != "u1" {
 		t.Fatalf("role filter: total=%d user=%s", total, byRole[0].ID)
+	}
+}
+
+func TestListUsersHidesManagedProxyAccounts(t *testing.T) {
+	s, db := newSvc(t)
+	if err := db.Create(&model.User{ID: "u-visible", Account: "visible", Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-hidden",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	users, total, err := s.ListUsers(t.Context(), UserListFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(users) != 1 || users[0].ID != "u-visible" {
+		t.Fatalf("ListUsers() = total %d, users %+v; proxy %q must stay hidden", total, users, proxy.ProxyAccountID)
+	}
+	if _, err := s.GetUser(t.Context(), proxy.ProxyAccountID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("GetUser(proxy) error = %v, want not found", err)
+	}
+	if err := s.SetUserDepartments(t.Context(), proxy.ProxyAccountID, nil); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("SetUserDepartments(proxy) error = %v, want not found", err)
+	}
+}
+
+func TestManagedProxyIsHiddenFromDirectoryMembershipSurfaces(t *testing.T) {
+	s, db := newSvc(t)
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-hidden-membership",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Department{ID: "d-proxy", Name: "Hidden"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Group{ID: "g-proxy", Name: "Hidden"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Simulate legacy/corrupt memberships created before the managed-account
+	// guards existed. Read paths still must not expose the proxy.
+	if err := db.Create(&model.UserDepartment{UserID: proxy.ProxyAccountID, DepartmentID: "d-proxy"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.GroupMember{
+		GroupID: "g-proxy", MemberID: proxy.ProxyAccountID, MemberType: "user",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	for name, resolve := range map[string]func(context.Context, []string) ([]NamedRef, error){
+		"user names":      s.ResolveUserNames,
+		"app names":       s.ResolveAppNames,
+		"contactor names": s.ResolveContactorNames,
+	} {
+		t.Run(name, func(t *testing.T) {
+			refs, err := resolve(t.Context(), []string{proxy.ProxyAccountID})
+			if err != nil || len(refs) != 0 {
+				t.Fatalf("resolve proxy = (%+v, %v), want empty", refs, err)
+			}
+		})
+	}
+	if user, err := s.FindUserByAccount(t.Context(), "bkn-proxy-"+proxy.ProxyAccountID); !errors.Is(err, gorm.ErrRecordNotFound) || user != nil {
+		t.Fatalf("FindUserByAccount(proxy) = (%+v, %v), want not found", user, err)
+	}
+	if members, err := s.DepartmentMembers(t.Context(), "d-proxy"); err != nil || len(members) != 0 {
+		t.Fatalf("DepartmentMembers() = (%+v, %v), want empty", members, err)
+	}
+	if members, err := s.GroupMembers(t.Context(), "g-proxy"); err != nil || len(members) != 0 {
+		t.Fatalf("GroupMembers() = (%+v, %v), want empty", members, err)
+	}
+	if users, _, err := s.GroupMembersSplit(t.Context(), "g-proxy"); err != nil || len(users) != 0 {
+		t.Fatalf("GroupMembersSplit() = (%+v, %v), want no users", users, err)
+	}
+	if ids, err := s.UserDeptIDs(t.Context(), proxy.ProxyAccountID); err != nil || len(ids) != 0 {
+		t.Fatalf("UserDeptIDs(proxy) = (%+v, %v), want empty", ids, err)
+	}
+	if users, err := s.UsersDetail(t.Context(), []string{proxy.ProxyAccountID}); err != nil || len(users) != 0 {
+		t.Fatalf("UsersDetail(proxy) = (%+v, %v), want empty", users, err)
+	}
+	if users, _, err := s.SearchOrgFull(t.Context(), []string{proxy.ProxyAccountID}, nil, []string{"d-proxy"}); err != nil || len(users) != 0 {
+		t.Fatalf("SearchOrgFull(proxy) = (%+v, %v), want empty", users, err)
+	}
+	deps, _, err := s.ListAllDepartments(t.Context(), "", 0, 10)
+	if err != nil || len(deps) != 1 || deps[0].MemberCount != 0 || deps[0].SubtreeMemberCount != 0 {
+		t.Fatalf("department counts expose proxy membership: (%+v, %v)", deps, err)
+	}
+
+	if err := s.RemoveDepartmentMembers(t.Context(), "d-proxy", []string{proxy.ProxyAccountID}); !errors.Is(err, ErrUnknownUser) {
+		t.Fatalf("RemoveDepartmentMembers(proxy) error = %v, want ErrUnknownUser", err)
+	}
+	var count int64
+	if err := db.Model(&model.UserDepartment{}).
+		Where("user_id = ? AND department_id = ?", proxy.ProxyAccountID, "d-proxy").Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("generic removal changed proxy membership, rows = %d", count)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/apikey.go
+++ b/bkn-safe/server/internal/httpapi/apikey.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -49,6 +50,10 @@ func registerMeAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
 		plaintext, rec, err := keys.Issue(c.Request.Context(), owner, req.Name, exp)
 		if errors.Is(err, auth.ErrAPIKeyNameTaken) {
 			replyPublicError(c, http.StatusConflict)
+			return
+		}
+		if errors.Is(err, managedproxy.ErrManagedAccount) {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		if err != nil {
@@ -97,6 +102,10 @@ func registerMeAPIKeys(g *gin.RouterGroup, keys *auth.APIKeyStore) {
 		plaintext, rec, err := keys.Regenerate(c.Request.Context(), owner, c.Param("id"))
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			replyPublicError(c, http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, managedproxy.ErrManagedAccount) {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		if err != nil {

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -226,6 +227,15 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			Operations []string    `json:"operations" binding:"required"`
 		}
 		if !bind(c, &req) {
+			return
+		}
+		managed, err := managedproxy.IsManaged(c.Request.Context(), db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if managed {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		// This route is tokenless by design (service-to-service, ClusterIP), so
@@ -465,6 +475,15 @@ func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			RoleID     string `json:"role_id" binding:"required"`
 		}
 		if !bind(c, &req) {
+			return
+		}
+		managed, err := managedproxy.IsManaged(c.Request.Context(), db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if managed {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		// Unbinding is blocked for the same reason binding is: with no API path
@@ -774,7 +793,18 @@ func splitObject(o string) (rtype, rid string) {
 // department or group id.
 func accessorExists(c *gin.Context, db *gorm.DB, id string) (bool, error) {
 	ctx := c.Request.Context()
-	for _, m := range []any{&model.User{}, &model.Department{}, &model.Group{}} {
+	var userCount int64
+	if err := db.WithContext(ctx).Model(&model.User{}).Where("id = ?", id).Count(&userCount).Error; err != nil {
+		return false, err
+	}
+	if userCount > 0 {
+		managed, err := managedproxy.IsManaged(ctx, db, id)
+		if err != nil {
+			return false, err
+		}
+		return !managed, nil
+	}
+	for _, m := range []any{&model.Department{}, &model.Group{}} {
 		var n int64
 		if err := db.WithContext(ctx).Model(m).Where("id = ?", id).Count(&n).Error; err != nil {
 			return false, err

--- a/bkn-safe/server/internal/httpapi/directory.go
+++ b/bkn-safe/server/internal/httpapi/directory.go
@@ -592,6 +592,10 @@ func registerDeptAdmin(g *gin.RouterGroup, dir *directory.Service, e *authz.Enfo
 			replyPublicError(c, http.StatusNotFound)
 			return
 		}
+		if errors.Is(err, directory.ErrUnknownUser) {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
 		if err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/managedproxy.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy.go
@@ -1,0 +1,70 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+)
+
+// registerManagedProxyAccounts mounts the ClusterIP-only control-plane API.
+// The route is intentionally separate from public /me and /admin surfaces: its
+// caller is the trusted BKN workload, and network policy is the trust boundary.
+func registerManagedProxyAccounts(r *gin.Engine, service *managedproxy.Service) {
+	group := r.Group("/api/safe/in/v1/managed-proxy-accounts")
+
+	group.POST("", func(c *gin.Context) {
+		var req managedproxy.CreateRequest
+		if !bind(c, &req) {
+			return
+		}
+		account, created, err := service.Create(c.Request.Context(), req)
+		if errors.Is(err, managedproxy.ErrInvalidManagedResource) {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		status := http.StatusOK
+		if created {
+			status = http.StatusCreated
+		}
+		c.JSON(status, account)
+	})
+
+	group.GET("/:id", func(c *gin.Context) {
+		account, err := service.Get(c.Request.Context(), c.Param("id"))
+		writeManagedProxyResult(c, account, err)
+	})
+
+	group.POST("/:id/disable", func(c *gin.Context) {
+		account, err := service.Disable(c.Request.Context(), c.Param("id"))
+		writeManagedProxyResult(c, account, err)
+	})
+
+	group.POST("/:id/archive", func(c *gin.Context) {
+		account, err := service.Archive(c.Request.Context(), c.Param("id"))
+		writeManagedProxyResult(c, account, err)
+	})
+}
+
+func writeManagedProxyResult(c *gin.Context, account *managedproxy.Account, err error) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		replyPublicError(c, http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		serverError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, account)
+}

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -1,0 +1,214 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestManagedProxyAccountLifecycleAPI(t *testing.T) {
+	r, _, _ := newTestServer(t)
+	body := map[string]any{
+		"managed_resource_type": managedproxy.ResourceKnowledgeNetwork,
+		"managed_resource_id":   "kn-api",
+		"name":                  "API proxy",
+	}
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d body=%s", w.Code, w.Body.String())
+	}
+	var account managedproxy.Account
+	if err := json.Unmarshal(w.Body.Bytes(), &account); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if account.ProxyAccountID == "" || account.LoginEnabled || account.CredentialIssuanceEnabled {
+		t.Fatalf("create response = %+v", account)
+	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay create = %d body=%s", w.Code, w.Body.String())
+	}
+	var replay managedproxy.Account
+	_ = json.Unmarshal(w.Body.Bytes(), &replay)
+	if replay.ProxyAccountID != account.ProxyAccountID {
+		t.Fatalf("replay id = %q, want %q", replay.ProxyAccountID, account.ProxyAccountID)
+	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts/"+account.ProxyAccountID+"/disable", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disable = %d body=%s", w.Code, w.Body.String())
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &account)
+	if account.Enabled || account.LifecycleStatus != managedproxy.StatusDisabling {
+		t.Fatalf("disabled response = %+v", account)
+	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts/"+account.ProxyAccountID+"/archive", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("archive = %d body=%s", w.Code, w.Body.String())
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &account)
+	if account.Enabled || account.LifecycleStatus != managedproxy.StatusArchived {
+		t.Fatalf("archived response = %+v", account)
+	}
+}
+
+func TestManagedProxyStatusControlsAuthorizationDecisions(t *testing.T) {
+	r, enforcer, _ := newTestServer(t)
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", map[string]any{
+		"managed_resource_type": managedproxy.ResourceKnowledgeNetwork,
+		"managed_resource_id":   "kn-pep",
+	})
+	var account managedproxy.Account
+	_ = json.Unmarshal(w.Body.Bytes(), &account)
+	if err := enforcer.GrantObjectPermission(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	check := map[string]any{
+		"accessor_id": account.ProxyAccountID,
+		"resource":    map[string]any{"type": "resource", "id": "r-1"},
+		"operation":   "query_data",
+	}
+	w = do(t, r, http.MethodPost, "/api/safe/v1/authz/check", check)
+	var decision struct {
+		Allowed bool `json:"allowed"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &decision)
+	if !decision.Allowed {
+		t.Fatalf("active proxy decision = %s", w.Body.String())
+	}
+
+	do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts/"+account.ProxyAccountID+"/disable", nil)
+	w = do(t, r, http.MethodPost, "/api/safe/v1/authz/check", check)
+	_ = json.Unmarshal(w.Body.Bytes(), &decision)
+	if decision.Allowed {
+		t.Fatalf("disabled proxy remained allowed: %s", w.Body.String())
+	}
+}
+
+func TestManagedProxyAPIRejectsUnsupportedOwnerType(t *testing.T) {
+	r, _, _ := newTestServer(t)
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", map[string]any{
+		"managed_resource_type": "tool_box",
+		"managed_resource_id":   "box-1",
+	})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("create unsupported = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestGenericPolicyEndpointCannotGrantManagedProxy(t *testing.T) {
+	r, _, _ := newTestServer(t)
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", map[string]any{
+		"managed_resource_type": managedproxy.ResourceKnowledgeNetwork,
+		"managed_resource_id":   "kn-policy",
+	})
+	var account managedproxy.Account
+	_ = json.Unmarshal(w.Body.Bytes(), &account)
+
+	w = do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", map[string]any{
+		"accessor_id": account.ProxyAccountID,
+		"resource":    map[string]any{"type": "resource", "id": "r-1"},
+		"operations":  []string{"query_data"},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("generic proxy grant = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestManagedProxyIsNotAGenericGranteeOrRoleSubject(t *testing.T) {
+	_, _, db := newTestServer(t)
+	account, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-subject",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	if ok, err := isUserAccessor(c, db, account.ProxyAccountID); err != nil || ok {
+		t.Fatalf("isUserAccessor(proxy) = (%v, %v), want false", ok, err)
+	}
+	if ok, err := accessorExists(c, db, account.ProxyAccountID); err != nil || ok {
+		t.Fatalf("accessorExists(proxy) = (%v, %v), want false", ok, err)
+	}
+}
+
+func TestGenericRevokeAndRoleUnbindCannotMutateManagedProxy(t *testing.T) {
+	r, enforcer, db, _ := newAdminServer(t)
+	account, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-protected-writes",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "resource", "query_data")
+	if err := enforcer.GrantObjectPermission(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Role{ID: "proxy-role", Name: "proxy-role", Source: model.RoleSourceCustom}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.AssignRole(account.ProxyAccountID, "proxy-role"); err != nil {
+		t.Fatal(err)
+	}
+
+	w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{
+		"accessor_id": account.ProxyAccountID,
+		"resource":    gin.H{"type": "resource", "id": "r-1"},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("generic revoke = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	allowed, err := enforcer.Check(account.ProxyAccountID, "resource", "r-1", "query_data")
+	if err != nil || !allowed {
+		t.Fatalf("generic revoke changed proxy permission: allowed=%v err=%v", allowed, err)
+	}
+
+	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/role-bindings", gin.H{
+		"accessor_id": account.ProxyAccountID,
+		"role_id":     "proxy-role",
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("generic role unbind = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	roles, err := enforcer.RolesForAccessor(account.ProxyAccountID)
+	if err != nil || len(roles) != 1 || roles[0] != "proxy-role" {
+		t.Fatalf("generic unbind changed proxy roles: roles=%v err=%v", roles, err)
+	}
+}
+
+func TestManagedProxyCannotUseSelfServiceCredentialEndpoints(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	account, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-self-credentials",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/api-keys", gin.H{
+		"name": "forbidden",
+	}, account.ProxyAccountID)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("managed proxy issue key = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+	w = tokReq(t, r, http.MethodPost, "/api/safe/v1/me/api-keys/missing/regenerate", nil, account.ProxyAccountID)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("managed proxy regenerate key = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+}

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -127,8 +127,8 @@ func TestGenericPolicyEndpointCannotGrantManagedProxy(t *testing.T) {
 	}
 }
 
-func TestManagedProxyIsNotAGenericGranteeOrRoleSubject(t *testing.T) {
-	_, _, db := newTestServer(t)
+func TestManagedProxyIsProtectedFromGenericGrantAndRoleBinding(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
 	account, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
 		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
 		ManagedResourceID:   "kn-subject",
@@ -136,10 +136,20 @@ func TestManagedProxyIsNotAGenericGranteeOrRoleSubject(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	seedCatalogOps(t, db, "resource", "query_data")
+	w := adminReq(t, r, http.MethodPost, objectGrantsPath, gin.H{
+		"accessor_id": account.ProxyAccountID,
+		"resource":    gin.H{"type": "resource", "id": "r-1"},
+		"operations":  []string{"query_data"},
+	})
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("generic grant = %d body=%s, want 403", w.Code, w.Body.String())
+	}
+
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
 	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
-	if ok, err := isUserAccessor(c, db, account.ProxyAccountID); err != nil || ok {
-		t.Fatalf("isUserAccessor(proxy) = (%v, %v), want false", ok, err)
+	if ok, err := isUserAccessor(c, db, account.ProxyAccountID); err != nil || !ok {
+		t.Fatalf("isUserAccessor(proxy) = (%v, %v), want true", ok, err)
 	}
 	if ok, err := accessorExists(c, db, account.ProxyAccountID); err != nil || ok {
 		t.Fatalf("accessorExists(proxy) = (%v, %v), want false", ok, err)

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -516,13 +516,6 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 // isUserAccessor reports whether id is a known user row (real user or app
 // account; both are model.User distinguished by account_type).
 func isUserAccessor(c *gin.Context, db *gorm.DB, id string) (bool, error) {
-	managed, err := managedproxy.IsManaged(c.Request.Context(), db, id)
-	if err != nil {
-		return false, err
-	}
-	if managed {
-		return false, nil
-	}
 	var n int64
 	if err := db.WithContext(c.Request.Context()).Model(&model.User{}).
 		Where("id = ? AND enabled = ?", id, true).Count(&n).Error; err != nil {
@@ -722,6 +715,15 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}
+		managed, err := managedproxy.IsManaged(c.Request.Context(), db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if managed {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
 		// Administrator, or the object's own owner delegating it. Resolved here
 		// rather than in middleware because the owner branch is a question about
 		// the object named in the BODY, which middleware cannot see.
@@ -734,7 +736,7 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		}
 		// Grantee must be a user (apps are user rows too). Departments/groups are
 		// rejected: their grants never match at enforce time.
-		ok, err := isUserAccessor(c, db, req.AccessorID)
+		ok, err = isUserAccessor(c, db, req.AccessorID)
 		if err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -515,6 +516,13 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 // isUserAccessor reports whether id is a known user row (real user or app
 // account; both are model.User distinguished by account_type).
 func isUserAccessor(c *gin.Context, db *gorm.DB, id string) (bool, error) {
+	managed, err := managedproxy.IsManaged(c.Request.Context(), db, id)
+	if err != nil {
+		return false, err
+	}
+	if managed {
+		return false, nil
+	}
 	var n int64
 	if err := db.WithContext(c.Request.Context()).Model(&model.User{}).
 		Where("id = ? AND enabled = ?", id, true).Count(&n).Error; err != nil {
@@ -789,7 +797,6 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 
 func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
-
 		var req struct {
 			AccessorID string      `json:"accessor_id" binding:"required"`
 			Resource   resourceRef `json:"resource" binding:"required"`
@@ -799,6 +806,15 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		}
 		if !isConcreteResourceID(req.Resource.ID) {
 			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		managed, err := managedproxy.IsManaged(c.Request.Context(), db, req.AccessorID)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if managed {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		// Revoking on an object is the mirror of granting on it: whoever can open

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 )
 
 // Deps are the collaborators the HTTP layer needs.
@@ -80,6 +81,7 @@ func New(deps Deps) *gin.Engine {
 	if deps.DB != nil {
 		apiKeys = auth.NewAPIKeyStore(deps.DB)
 		registerAPIKeyVerify(r, apiKeys)
+		registerManagedProxyAccounts(r, managedproxy.New(deps.DB))
 	}
 
 	// hydra login/consent/device provider pages.

--- a/bkn-safe/server/internal/httpapi/useradmin.go
+++ b/bkn-safe/server/internal/httpapi/useradmin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/seed"
 )
@@ -108,7 +109,10 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}
-		if err := users.ResetPassword(c.Request.Context(), c.Param("id"), req.Password); err != nil {
+		if err := users.ResetPassword(c.Request.Context(), c.Param("id"), req.Password); errors.Is(err, managedproxy.ErrManagedAccount) {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		} else if err != nil {
 			serverError(c, err)
 			return
 		}
@@ -185,6 +189,10 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 		}
 		if len(fields) > 0 {
 			err := users.UpdateUser(ctx, id, fields)
+			if errors.Is(err, managedproxy.ErrManagedAccount) {
+				replyPublicError(c, http.StatusForbidden)
+				return
+			}
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				replyPublicError(c, http.StatusNotFound)
 				return
@@ -219,6 +227,10 @@ func registerUserAdmin(g *gin.RouterGroup, users *auth.UserStore, e *authz.Enfor
 			return
 		}
 		err := users.DeleteUser(c.Request.Context(), id)
+		if errors.Is(err, managedproxy.ErrManagedAccount) {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			replyPublicError(c, http.StatusNotFound)
 			return

--- a/bkn-safe/server/internal/managedproxy/service.go
+++ b/bkn-safe/server/internal/managedproxy/service.go
@@ -1,0 +1,238 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package managedproxy owns the lifecycle of app identities that represent a
+// knowledge network when downstream services enforce resource permissions.
+package managedproxy
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+const (
+	ManagerBKN               = "bkn"
+	ResourceKnowledgeNetwork = "knowledge_network"
+
+	StatusActive    = "active"
+	StatusDisabling = "disabling"
+	StatusArchived  = "archived"
+)
+
+var (
+	ErrInvalidManagedResource = errors.New("invalid managed resource")
+	ErrManagedAccount         = errors.New("managed proxy account is protected")
+	ErrInconsistentAccount    = errors.New("managed proxy account is inconsistent")
+)
+
+// Account is the lifecycle view returned to the BKN control plane. The two
+// capability flags are invariants, not mutable account settings.
+type Account struct {
+	ProxyAccountID            string `json:"proxy_account_id"`
+	AccountType               string `json:"account_type"`
+	Name                      string `json:"name"`
+	ManagedBy                 string `json:"managed_by"`
+	ManagedResourceType       string `json:"managed_resource_type"`
+	ManagedResourceID         string `json:"managed_resource_id"`
+	LifecycleStatus           string `json:"lifecycle_status"`
+	Enabled                   bool   `json:"enabled"`
+	LoginEnabled              bool   `json:"login_enabled"`
+	CredentialIssuanceEnabled bool   `json:"credential_issuance_enabled"`
+	Version                   uint64 `json:"version"`
+}
+
+// CreateRequest identifies the environment-local resource that owns the app.
+// ManagedBy is deliberately absent: this endpoint is BKN-specific and clients
+// cannot turn it into a generic managed-account issuer.
+type CreateRequest struct {
+	ManagedResourceType string `json:"managed_resource_type"`
+	ManagedResourceID   string `json:"managed_resource_id"`
+	Name                string `json:"name"`
+}
+
+// Service persists managed identities and their one-to-one ownership mapping.
+type Service struct {
+	db *gorm.DB
+}
+
+func New(db *gorm.DB) *Service { return &Service{db: db} }
+
+// Create provisions the unique active proxy for a KN. Replaying the same
+// request is idempotent and returns created=false with the existing identity.
+func (s *Service) Create(ctx context.Context, req CreateRequest) (*Account, bool, error) {
+	req.ManagedResourceType = strings.TrimSpace(req.ManagedResourceType)
+	req.ManagedResourceID = strings.TrimSpace(req.ManagedResourceID)
+	req.Name = strings.TrimSpace(req.Name)
+	if req.ManagedResourceType != ResourceKnowledgeNetwork || req.ManagedResourceID == "" ||
+		len(req.ManagedResourceID) > 128 || len(req.Name) > 255 {
+		return nil, false, ErrInvalidManagedResource
+	}
+
+	if existing, err := s.getByManagedResource(ctx, req.ManagedResourceType, req.ManagedResourceID); err == nil {
+		return existing, false, nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, false, err
+	}
+
+	proxyID, err := newID()
+	if err != nil {
+		return nil, false, fmt.Errorf("generate managed proxy id: %w", err)
+	}
+	if req.Name == "" {
+		req.Name = "BKN proxy " + req.ManagedResourceID
+		if len(req.Name) > 255 {
+			req.Name = req.Name[:255]
+		}
+	}
+	user := model.User{
+		ID: proxyID, Account: "bkn-proxy-" + proxyID, Name: req.Name,
+		Enabled: true, Source: model.SourceLocal, AccountType: model.AccountTypeApp,
+		PasswordHash: "", MustChangePassword: false,
+	}
+	mapping := model.ManagedProxyAccount{
+		ProxyAccountID: proxyID, ManagedBy: ManagerBKN,
+		ManagedResourceType: req.ManagedResourceType, ManagedResourceID: req.ManagedResourceID,
+		LifecycleStatus: StatusActive, Version: 1,
+	}
+	err = s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Let the composite database key arbitrate concurrent creates. The
+		// mapping is inserted first inside the transaction so a losing request
+		// never creates an orphan User row.
+		if err := tx.Create(&mapping).Error; err != nil {
+			return err
+		}
+		return tx.Create(&user).Error
+	})
+	if err == nil {
+		return render(user, mapping), true, nil
+	}
+
+	// A concurrent request can win the unique mapping key after our first read.
+	// Its transaction has committed before the conflicting insert returns, so
+	// resolve the authoritative identity instead of surfacing a conflict.
+	existing, readErr := s.getByManagedResource(ctx, req.ManagedResourceType, req.ManagedResourceID)
+	if readErr == nil {
+		return existing, false, nil
+	}
+	return nil, false, fmt.Errorf("create managed proxy: %w", err)
+}
+
+func (s *Service) Get(ctx context.Context, proxyAccountID string) (*Account, error) {
+	return s.get(ctx, "proxy_account_id = ?", strings.TrimSpace(proxyAccountID))
+}
+
+func (s *Service) getByManagedResource(ctx context.Context, resourceType, resourceID string) (*Account, error) {
+	return s.get(ctx, "managed_by = ? AND managed_resource_type = ? AND managed_resource_id = ?",
+		ManagerBKN, resourceType, resourceID)
+}
+
+func (s *Service) get(ctx context.Context, query string, args ...any) (*Account, error) {
+	var mapping model.ManagedProxyAccount
+	if err := s.db.WithContext(ctx).Where(query, args...).First(&mapping).Error; err != nil {
+		return nil, err
+	}
+	var user model.User
+	if err := s.db.WithContext(ctx).First(&user, "id = ?", mapping.ProxyAccountID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrInconsistentAccount
+		}
+		return nil, err
+	}
+	if user.AccountType != model.AccountTypeApp || user.PasswordHash != "" ||
+		mapping.ManagedBy != ManagerBKN || mapping.ManagedResourceType != ResourceKnowledgeNetwork {
+		return nil, ErrInconsistentAccount
+	}
+	statusActive := mapping.LifecycleStatus == StatusActive
+	if (!statusActive && mapping.LifecycleStatus != StatusDisabling && mapping.LifecycleStatus != StatusArchived) ||
+		user.Enabled != statusActive {
+		return nil, ErrInconsistentAccount
+	}
+	return render(user, mapping), nil
+}
+
+// Disable is idempotent and immediately makes the account fail the existing
+// active-account guard used by every authorization decision endpoint.
+func (s *Service) Disable(ctx context.Context, proxyAccountID string) (*Account, error) {
+	return s.transition(ctx, proxyAccountID, StatusDisabling)
+}
+
+// Archive permanently keeps the identity disabled while preserving the row for
+// historical audit joins.
+func (s *Service) Archive(ctx context.Context, proxyAccountID string) (*Account, error) {
+	return s.transition(ctx, proxyAccountID, StatusArchived)
+}
+
+func (s *Service) transition(ctx context.Context, proxyAccountID, target string) (*Account, error) {
+	proxyAccountID = strings.TrimSpace(proxyAccountID)
+	if proxyAccountID == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var mapping model.ManagedProxyAccount
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&mapping, "proxy_account_id = ?", proxyAccountID).Error; err != nil {
+			return err
+		}
+		var user model.User
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&user, "id = ?", proxyAccountID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrInconsistentAccount
+			}
+			return err
+		}
+		if user.AccountType != model.AccountTypeApp || user.PasswordHash != "" {
+			return ErrInconsistentAccount
+		}
+		if user.Enabled {
+			if err := tx.Model(&user).Update("enabled", false).Error; err != nil {
+				return err
+			}
+		}
+		if mapping.LifecycleStatus == StatusArchived || mapping.LifecycleStatus == target {
+			return nil
+		}
+		return tx.Model(&mapping).Updates(map[string]any{
+			"lifecycle_status": target,
+			"version":          gorm.Expr("version + ?", 1),
+		}).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.Get(ctx, proxyAccountID)
+}
+
+// IsManaged reports whether an identity is protected by the managed lifecycle.
+func IsManaged(ctx context.Context, db *gorm.DB, accountID string) (bool, error) {
+	var count int64
+	err := db.WithContext(ctx).Model(&model.ManagedProxyAccount{}).
+		Where("proxy_account_id = ?", accountID).Count(&count).Error
+	return count > 0, err
+}
+
+func render(user model.User, mapping model.ManagedProxyAccount) *Account {
+	return &Account{
+		ProxyAccountID: user.ID, AccountType: string(user.AccountType), Name: user.Name,
+		ManagedBy: mapping.ManagedBy, ManagedResourceType: mapping.ManagedResourceType,
+		ManagedResourceID: mapping.ManagedResourceID, LifecycleStatus: mapping.LifecycleStatus,
+		Enabled: user.Enabled, LoginEnabled: false, CredentialIssuanceEnabled: false,
+		Version: mapping.Version,
+	}
+}
+
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/bkn-safe/server/internal/managedproxy/service_test.go
+++ b/bkn-safe/server/internal/managedproxy/service_test.go
@@ -1,0 +1,258 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package managedproxy_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func managedProxyTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestCreateIsIdempotentAndBuildsNonCredentialedApp(t *testing.T) {
+	db := managedProxyTestDB(t)
+	service := managedproxy.New(db)
+	req := managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-1",
+		Name:                "Supply chain proxy",
+	}
+
+	first, created, err := service.Create(t.Context(), req)
+	if err != nil || !created {
+		t.Fatalf("first Create() = (%+v, %v, %v), want created", first, created, err)
+	}
+	second, created, err := service.Create(t.Context(), req)
+	if err != nil || created {
+		t.Fatalf("replayed Create() = (%+v, %v, %v), want existing", second, created, err)
+	}
+	if second.ProxyAccountID != first.ProxyAccountID {
+		t.Fatalf("replay proxy id = %q, want %q", second.ProxyAccountID, first.ProxyAccountID)
+	}
+	if first.AccountType != string(model.AccountTypeApp) || first.ManagedBy != managedproxy.ManagerBKN ||
+		first.LoginEnabled || first.CredentialIssuanceEnabled || !first.Enabled || first.Version != 1 {
+		t.Fatalf("unexpected proxy contract: %+v", first)
+	}
+
+	var user model.User
+	if err := db.First(&user, "id = ?", first.ProxyAccountID).Error; err != nil {
+		t.Fatalf("load proxy user: %v", err)
+	}
+	if user.PasswordHash != "" || user.MustChangePassword || user.AccountType != model.AccountTypeApp {
+		t.Fatalf("proxy user can carry credentials: %+v", user)
+	}
+	var mappings int64
+	if err := db.Model(&model.ManagedProxyAccount{}).Count(&mappings).Error; err != nil {
+		t.Fatalf("count mappings: %v", err)
+	}
+	if mappings != 1 {
+		t.Fatalf("mapping count = %d, want 1", mappings)
+	}
+}
+
+func TestConcurrentCreateReturnsOneProxyWithoutOrphanAccounts(t *testing.T) {
+	db := managedProxyTestDB(t)
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Keep the in-memory SQLite database on one connection. The calls still
+	// enter the service concurrently; production databases additionally use the
+	// composite unique key when requests reach the database simultaneously.
+	sqlDB.SetMaxOpenConns(1)
+	service := managedproxy.New(db)
+	req := managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-concurrent",
+	}
+
+	const callers = 16
+	results := make(chan *managedproxy.Account, callers)
+	errs := make(chan error, callers)
+	created := make(chan bool, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			account, wasCreated, err := service.Create(t.Context(), req)
+			results <- account
+			created <- wasCreated
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	close(created)
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Create() error = %v", err)
+		}
+	}
+	createdCount := 0
+	for value := range created {
+		if value {
+			createdCount++
+		}
+	}
+	if createdCount != 1 {
+		t.Fatalf("created responses = %d, want 1", createdCount)
+	}
+	proxyID := ""
+	for account := range results {
+		if account == nil {
+			t.Fatal("concurrent Create() returned nil account")
+		}
+		if proxyID == "" {
+			proxyID = account.ProxyAccountID
+		}
+		if account.ProxyAccountID != proxyID {
+			t.Fatalf("concurrent proxy id = %q, want %q", account.ProxyAccountID, proxyID)
+		}
+	}
+	var users, mappings int64
+	if err := db.Model(&model.User{}).Where("account LIKE ?", "bkn-proxy-%").Count(&users).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&model.ManagedProxyAccount{}).Count(&mappings).Error; err != nil {
+		t.Fatal(err)
+	}
+	if users != 1 || mappings != 1 {
+		t.Fatalf("concurrent create left users=%d mappings=%d, want 1/1", users, mappings)
+	}
+}
+
+func TestCreateRejectsArbitraryManagedResource(t *testing.T) {
+	service := managedproxy.New(managedProxyTestDB(t))
+	_, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: "tool_box",
+		ManagedResourceID:   "box-1",
+	})
+	if !errors.Is(err, managedproxy.ErrInvalidManagedResource) {
+		t.Fatalf("Create() error = %v, want ErrInvalidManagedResource", err)
+	}
+}
+
+func TestDisableAndArchiveAreIdempotent(t *testing.T) {
+	service := managedproxy.New(managedProxyTestDB(t))
+	created, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-lifecycle",
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+
+	disabled, err := service.Disable(t.Context(), created.ProxyAccountID)
+	if err != nil {
+		t.Fatalf("Disable(): %v", err)
+	}
+	if disabled.Enabled || disabled.LifecycleStatus != managedproxy.StatusDisabling || disabled.Version != 2 {
+		t.Fatalf("disabled = %+v", disabled)
+	}
+	disabledAgain, err := service.Disable(t.Context(), created.ProxyAccountID)
+	if err != nil || disabledAgain.Version != 2 {
+		t.Fatalf("replayed Disable() = (%+v, %v), want version 2", disabledAgain, err)
+	}
+
+	archived, err := service.Archive(t.Context(), created.ProxyAccountID)
+	if err != nil {
+		t.Fatalf("Archive(): %v", err)
+	}
+	if archived.Enabled || archived.LifecycleStatus != managedproxy.StatusArchived || archived.Version != 3 {
+		t.Fatalf("archived = %+v", archived)
+	}
+	archivedAgain, err := service.Archive(t.Context(), created.ProxyAccountID)
+	if err != nil || archivedAgain.Version != 3 {
+		t.Fatalf("replayed Archive() = (%+v, %v), want version 3", archivedAgain, err)
+	}
+}
+
+func TestGetFailsClosedForCredentialedManagedIdentity(t *testing.T) {
+	db := managedProxyTestDB(t)
+	service := managedproxy.New(db)
+	account, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-corrupt",
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	if err := db.Model(&model.User{}).Where("id = ?", account.ProxyAccountID).
+		Update("password_hash", "unexpected").Error; err != nil {
+		t.Fatalf("corrupt user: %v", err)
+	}
+	_, err = service.Get(t.Context(), account.ProxyAccountID)
+	if !errors.Is(err, managedproxy.ErrInconsistentAccount) {
+		t.Fatalf("Get() error = %v, want ErrInconsistentAccount", err)
+	}
+}
+
+func TestGetFailsClosedForLifecycleAccountStateMismatch(t *testing.T) {
+	db := managedProxyTestDB(t)
+	service := managedproxy.New(db)
+	account, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-state-mismatch",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&model.ManagedProxyAccount{}).Where("proxy_account_id = ?", account.ProxyAccountID).
+		Update("lifecycle_status", managedproxy.StatusArchived).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Get(t.Context(), account.ProxyAccountID); !errors.Is(err, managedproxy.ErrInconsistentAccount) {
+		t.Fatalf("Get() error = %v, want ErrInconsistentAccount", err)
+	}
+}
+
+func TestDisableFailsClosedWithoutAdvancingMappingWhenUserIsMissing(t *testing.T) {
+	db := managedProxyTestDB(t)
+	service := managedproxy.New(db)
+	account, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-missing-user",
+	})
+	if err != nil {
+		t.Fatalf("Create(): %v", err)
+	}
+	if err := db.Where("id = ?", account.ProxyAccountID).Delete(&model.User{}).Error; err != nil {
+		t.Fatalf("delete proxy user: %v", err)
+	}
+	if _, err := service.Disable(t.Context(), account.ProxyAccountID); !errors.Is(err, managedproxy.ErrInconsistentAccount) {
+		t.Fatalf("Disable() error = %v, want ErrInconsistentAccount", err)
+	}
+	var mapping model.ManagedProxyAccount
+	if err := db.First(&mapping, "proxy_account_id = ?", account.ProxyAccountID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if mapping.LifecycleStatus != managedproxy.StatusActive || mapping.Version != 1 {
+		t.Fatalf("failed transition mutated mapping: %+v", mapping)
+	}
+}

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -52,6 +52,26 @@ type User struct {
 	UpdatedAt          time.Time
 }
 
+// ManagedProxyAccount marks an app identity whose lifecycle is owned by one
+// platform resource rather than by a human administrator. The identity itself
+// remains a User row so the existing Casbin subject and account-status checks
+// keep working; this companion row is the protection boundary that keeps the
+// account out of normal login, credential, directory-membership and generic
+// grant-management paths.
+//
+// The three managed-resource columns are unique together: retrying KN creation
+// resolves the same proxy instead of creating another enabled app identity.
+type ManagedProxyAccount struct {
+	ProxyAccountID      string `gorm:"primaryKey;size:64"`
+	ManagedBy           string `gorm:"size:32;uniqueIndex:uidx_managed_proxy_resource,priority:1"`
+	ManagedResourceType string `gorm:"size:64;uniqueIndex:uidx_managed_proxy_resource,priority:2"`
+	ManagedResourceID   string `gorm:"size:128;uniqueIndex:uidx_managed_proxy_resource,priority:3"`
+	LifecycleStatus     string `gorm:"size:16;index"`
+	Version             uint64
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
 // Role source values. system|business roles are SEEDED built-ins (their UUIDs
 // are hardcoded in DA/flow-automation, such as application, data, and AI administrators) and are
 // immutable via the API — they may only be changed by editing the seed files.
@@ -265,5 +285,6 @@ func AllModels() []any {
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
 		&AuditLog{}, &AccessLog{}, &APIKey{}, &License{}, &ResourceParent{},
+		&ManagedProxyAccount{},
 	}
 }

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -37,7 +37,7 @@ These directories remain in the repository but are not published on the site. Th
 
 | Directory | Reason |
 | --- | --- |
-| [`bkn-safe/`](bkn-safe/) | Contains the self-service read surface and a cluster-internal authorization contract. Both are linted but are not published as general external integration APIs |
+| [`bkn-safe/`](bkn-safe/) | Contains the self-service read surface plus cluster-internal authorization and managed-proxy contracts. They are linted but are not published as general external integration APIs |
 | [`observability/`](observability/) | Contains only `observability.json`; it has no publishable YAML and would render as an empty group |
 
 > Every new module directory must be registered in either `MODULES` or `MODULES_UNPUBLISHED`. The `make api-docs-*` targets fail otherwise, preventing documentation from being added silently without appearing on the site.

--- a/docs/api/bkn-safe/managed-proxy.yaml
+++ b/docs/api/bkn-safe/managed-proxy.yaml
@@ -4,16 +4,18 @@
 
 openapi: 3.0.3
 info:
-  title: BKN Safe 受管知识网络代理账号 API
+  title: BKN Safe Managed Knowledge Network Proxy Account API
   version: 0.1.5
   description: |
-    供受信任 BKN workload 创建和管理知识网络的一对一代理 app 身份。
-    本接口只存在于 ClusterIP 内部面，不经 Ingress 暴露；调用方不能指定
-    `managed_by`、账号 ID、账号类型、登录能力或凭据签发能力。
+    Creates and manages a one-to-one proxy app identity for a knowledge network on behalf of
+    trusted BKN workloads. This API is available only on the internal ClusterIP surface and is
+    not exposed through Ingress. Callers cannot specify `managed_by`, the account ID, the account
+    type, login capability, or credential-issuance capability.
 
-    同一知识网络的重复创建是幂等的：首次返回 201，重放返回 200，并复用
-    原 proxy account。禁用和归档同样幂等。proxy account 不进入 Studio 用户
-    列表，不能登录、重置密码、签发 AppKey、绑定角色或通过通用 Policy 接口授权。
+    Repeated creation for the same knowledge network is idempotent: the first request returns
+    201, while replays return 200 and reuse the original proxy account. Disable and archive are
+    also idempotent. Proxy accounts are hidden from Studio user lists and cannot log in, reset a
+    password, issue AppKeys, bind roles, or receive grants through the generic Policy API.
 servers:
   - url: /api/safe/in/v1
 security: []
@@ -22,7 +24,7 @@ paths:
     post:
       tags: [Managed proxy accounts]
       operationId: createManagedProxyAccount
-      summary: 创建或解析知识网络的受管代理账号
+      summary: Create or resolve a managed proxy account for a knowledge network
       requestBody:
         required: true
         content:
@@ -31,13 +33,13 @@ paths:
               $ref: '#/components/schemas/CreateManagedProxyAccountRequest'
       responses:
         '201':
-          description: 已创建新的代理账号
+          description: A new proxy account was created
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ManagedProxyAccount'
         '200':
-          description: 相同知识网络已经存在代理账号，返回原账号
+          description: A proxy account already exists for the knowledge network; the existing account is returned
           content:
             application/json:
               schema:
@@ -52,10 +54,10 @@ paths:
     get:
       tags: [Managed proxy accounts]
       operationId: getManagedProxyAccount
-      summary: 查询受管代理账号
+      summary: Get a managed proxy account
       responses:
         '200':
-          description: 代理账号及其当前生命周期状态
+          description: The proxy account and its current lifecycle status
           content:
             application/json:
               schema:
@@ -70,12 +72,13 @@ paths:
     post:
       tags: [Managed proxy accounts]
       operationId: disableManagedProxyAccount
-      summary: 禁用受管代理账号
+      summary: Disable a managed proxy account
       description: |
-        立即令账号无法通过现有 active-account 判定。重复调用不增加版本号。
+        Immediately prevents the account from passing the existing active-account check.
+        Repeated calls do not increment the version.
       responses:
         '200':
-          description: 已禁用；账号进入 disabling 状态
+          description: The account was disabled and is now in the disabling state
           content:
             application/json:
               schema:
@@ -90,12 +93,13 @@ paths:
     post:
       tags: [Managed proxy accounts]
       operationId: archiveManagedProxyAccount
-      summary: 归档受管代理账号
+      summary: Archive a managed proxy account
       description: |
-        保留身份记录供历史审计关联，并保证账号保持 disabled。重复调用不增加版本号。
+        Preserves the identity record for historical audit correlation and keeps the account
+        disabled. Repeated calls do not increment the version.
       responses:
         '200':
-          description: 已归档
+          description: The account was archived
           content:
             application/json:
               schema:
@@ -110,25 +114,25 @@ components:
       name: id
       in: path
       required: true
-      description: 环境内系统生成的 proxy account ID。
+      description: The system-generated proxy account ID within this environment.
       schema:
         type: string
         maxLength: 64
   responses:
     BadRequest:
-      description: 请求体缺失、类型错误或试图管理非知识网络资源
+      description: The request body is missing or invalid, or the resource is not a knowledge network
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     NotFound:
-      description: 代理账号不存在
+      description: The proxy account does not exist
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     InternalError:
-      description: 数据库失败或代理映射与账号记录不一致
+      description: A database failure occurred, or the proxy mapping and account record are inconsistent
       content:
         application/json:
           schema:
@@ -146,11 +150,11 @@ components:
           type: string
           minLength: 1
           maxLength: 128
-          description: 知识网络 ID；同一环境内只能绑定一个 proxy account。
+          description: Knowledge network ID; only one proxy account can be bound within an environment.
         name:
           type: string
           maxLength: 255
-          description: 可选展示名；不作为账号 ID、登录名或幂等键。
+          description: Optional display name; it is not used as the account ID, login name, or idempotency key.
     ManagedProxyAccount:
       type: object
       additionalProperties: false

--- a/docs/api/bkn-safe/managed-proxy.yaml
+++ b/docs/api/bkn-safe/managed-proxy.yaml
@@ -1,0 +1,199 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+info:
+  title: BKN Safe 受管知识网络代理账号 API
+  version: 0.1.5
+  description: |
+    供受信任 BKN workload 创建和管理知识网络的一对一代理 app 身份。
+    本接口只存在于 ClusterIP 内部面，不经 Ingress 暴露；调用方不能指定
+    `managed_by`、账号 ID、账号类型、登录能力或凭据签发能力。
+
+    同一知识网络的重复创建是幂等的：首次返回 201，重放返回 200，并复用
+    原 proxy account。禁用和归档同样幂等。proxy account 不进入 Studio 用户
+    列表，不能登录、重置密码、签发 AppKey、绑定角色或通过通用 Policy 接口授权。
+servers:
+  - url: /api/safe/in/v1
+security: []
+paths:
+  /managed-proxy-accounts:
+    post:
+      tags: [Managed proxy accounts]
+      operationId: createManagedProxyAccount
+      summary: 创建或解析知识网络的受管代理账号
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateManagedProxyAccountRequest'
+      responses:
+        '201':
+          description: 已创建新的代理账号
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '200':
+          description: 相同知识网络已经存在代理账号，返回原账号
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /managed-proxy-accounts/{id}:
+    parameters:
+      - $ref: '#/components/parameters/ProxyAccountID'
+    get:
+      tags: [Managed proxy accounts]
+      operationId: getManagedProxyAccount
+      summary: 查询受管代理账号
+      responses:
+        '200':
+          description: 代理账号及其当前生命周期状态
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /managed-proxy-accounts/{id}/disable:
+    parameters:
+      - $ref: '#/components/parameters/ProxyAccountID'
+    post:
+      tags: [Managed proxy accounts]
+      operationId: disableManagedProxyAccount
+      summary: 禁用受管代理账号
+      description: |
+        立即令账号无法通过现有 active-account 判定。重复调用不增加版本号。
+      responses:
+        '200':
+          description: 已禁用；账号进入 disabling 状态
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /managed-proxy-accounts/{id}/archive:
+    parameters:
+      - $ref: '#/components/parameters/ProxyAccountID'
+    post:
+      tags: [Managed proxy accounts]
+      operationId: archiveManagedProxyAccount
+      summary: 归档受管代理账号
+      description: |
+        保留身份记录供历史审计关联，并保证账号保持 disabled。重复调用不增加版本号。
+      responses:
+        '200':
+          description: 已归档
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  parameters:
+    ProxyAccountID:
+      name: id
+      in: path
+      required: true
+      description: 环境内系统生成的 proxy account ID。
+      schema:
+        type: string
+        maxLength: 64
+  responses:
+    BadRequest:
+      description: 请求体缺失、类型错误或试图管理非知识网络资源
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    NotFound:
+      description: 代理账号不存在
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    InternalError:
+      description: 数据库失败或代理映射与账号记录不一致
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+  schemas:
+    CreateManagedProxyAccountRequest:
+      type: object
+      additionalProperties: false
+      required: [managed_resource_type, managed_resource_id]
+      properties:
+        managed_resource_type:
+          type: string
+          enum: [knowledge_network]
+        managed_resource_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: 知识网络 ID；同一环境内只能绑定一个 proxy account。
+        name:
+          type: string
+          maxLength: 255
+          description: 可选展示名；不作为账号 ID、登录名或幂等键。
+    ManagedProxyAccount:
+      type: object
+      additionalProperties: false
+      required:
+        - proxy_account_id
+        - account_type
+        - name
+        - managed_by
+        - managed_resource_type
+        - managed_resource_id
+        - lifecycle_status
+        - enabled
+        - login_enabled
+        - credential_issuance_enabled
+        - version
+      properties:
+        proxy_account_id:
+          type: string
+        account_type:
+          type: string
+          enum: [app]
+        name:
+          type: string
+        managed_by:
+          type: string
+          enum: [bkn]
+        managed_resource_type:
+          type: string
+          enum: [knowledge_network]
+        managed_resource_id:
+          type: string
+        lifecycle_status:
+          type: string
+          enum: [active, disabling, archived]
+        enabled:
+          type: boolean
+        login_enabled:
+          type: boolean
+          enum: [false]
+        credential_issuance_enabled:
+          type: boolean
+          enum: [false]
+        version:
+          type: integer
+          format: int64
+          minimum: 1


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add an idempotent managed proxy account lifecycle for knowledge networks, including create, query, disable, and archive operations.
- [x] Isolate managed proxy identities from login, API key issuance, generic directory mutation, and generic authorization grant paths.
- [x] Add focused regression coverage and document the internal ClusterIP-only OpenAPI contract and network boundary.

---

## Why

- Related Issue: Closes #1304 ([Issue #1304](https://github.com/openbkn-ai/bkn-foundry/issues/1304))
- Related Feature: [Knowledge network proxy identity epic #805](https://github.com/openbkn-ai/bkn-foundry/issues/805)
- Background: Each knowledge network needs a stable, auditable app identity that is managed exclusively by BKN and cannot obtain interactive or reusable credentials. This is the first implementation slice under #805.

---

## How

- Key implementation points: Introduces a `ManagedProxyAccount` mapping with a composite uniqueness constraint, transactional and retry-safe creation, lifecycle invariant checks, and fail-closed protection across authentication, directory, API key, policy, object grant, role binding, and PEP paths. Internal HTTP handlers expose lifecycle operations under `/api/safe/in/v1/managed-proxy-accounts`.
- Breaking changes (API, config, database, etc.): Adds the `managed_proxy_accounts` table through the existing application AutoMigrate path and adds an internal API surface. There are no public API removals or configuration-default changes. No shared or production database migration was executed as part of this work.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; focused package tests cover this isolated slice and CI owns the full suite.
- [ ] Verified in test environment — no deployment or shared-environment migration was performed.

Test notes:

- `go build ./...`
- `go test ./internal/managedproxy ./internal/auth ./internal/directory ./internal/httpapi`
- `go test ./internal/managedproxy ./internal/httpapi`
- `npx @redocly/cli lint --config .redocly.yaml docs/api/bkn-safe/managed-proxy.yaml`
- `git diff --check`
- The full `go test ./...` suite was intentionally left to CI under the repository's local resource-safety policy.

---

## Risk & Rollback

- Potential risks: AutoMigrate creates a new table and composite index at application startup. The tokenless internal endpoints depend on the documented ClusterIP and NetworkPolicy boundary. Knowledge-network callers remain a follow-up under #1306, and proxy-specific authorization grant sources remain a follow-up under #1305.
- Rollback plan: Revert this PR before rollout, or disable callers and revert the application code after rollout. Preserve the new table and identity rows for audit instead of dropping data automatically; any destructive schema rollback requires a separately reviewed and owner-confirmed plan.

---

## Additional Notes

- No UI changes or screenshots are applicable.
- The managed proxy route is intentionally not exposed through ingress; deployment must explicitly allow only the required in-cluster callers in NetworkPolicy.
- This PR closes only #1304. Epic #805 remains open for the remaining implementation slices.
