### PR TITLE
feat(bkn-safe): materialize proxy grants with provenance

### DIFF
--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -7,7 +7,8 @@ bkn-safe 是 OpenBKN 的认证、鉴权和用户目录服务。它配合**上游
 **文档**：
 - 领域知识网络权限调用合同：[`docs/api/knowledge-network-authorization.md`](../docs/api/knowledge-network-authorization.md)
 - 自助授权范围 OpenAPI：[`docs/api/bkn-safe/self-service.yaml`](../docs/api/bkn-safe/self-service.yaml)
-- Managed KN proxy internal OpenAPI: [`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
+- 受管 KN 代理内部 OpenAPI：[`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
+- 代理授权来源内部 OpenAPI：[`docs/api/bkn-safe/proxy-grants.yaml`](../docs/api/bkn-safe/proxy-grants.yaml)
 - 全局设计文档：[bkn-docs `docs/foundry/`](https://github.com/openbkn-ai/bkn-docs/tree/main/docs/foundry)
 
 ## 三职责
@@ -99,9 +100,10 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
 - 认证（hydra 重定向到这里）：`GET/POST /login`、`GET /consent`、`GET/POST /device`
 - 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST /resource-filter`、
   `POST|DELETE /policies`、`POST /role-bindings`
-- Managed KN proxies (ClusterIP-internal surface) `/api/safe/in/v1/managed-proxy-accounts`:
-  create, get, disable, and archive one-to-one proxy apps; these accounts cannot log in, use
-  AppKeys, be managed as regular users, or receive grants through the generic Policy API
+- 受管 KN 代理（ClusterIP 内部面）`/api/safe/in/v1/managed-proxy-accounts`：创建、查询、
+  禁用和归档一对一 proxy app；账号禁止登录、AppKey、普通用户管理与通用 Policy 授权
+- 代理授权来源（ClusterIP 内部面）`/api/safe/in/v1/proxy-grant-sources`：来源增删、
+  授权预检、最新模型全量同步和 Casbin Allow 对账；来源账本与 Policy 在单一事务内更新
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`

--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -7,8 +7,8 @@ bkn-safe 是 OpenBKN 的认证、鉴权和用户目录服务。它配合**上游
 **文档**：
 - 领域知识网络权限调用合同：[`docs/api/knowledge-network-authorization.md`](../docs/api/knowledge-network-authorization.md)
 - 自助授权范围 OpenAPI：[`docs/api/bkn-safe/self-service.yaml`](../docs/api/bkn-safe/self-service.yaml)
-- 受管 KN 代理内部 OpenAPI：[`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
-- 代理授权来源内部 OpenAPI：[`docs/api/bkn-safe/proxy-grants.yaml`](../docs/api/bkn-safe/proxy-grants.yaml)
+- Managed KN proxy internal OpenAPI: [`docs/api/bkn-safe/managed-proxy.yaml`](../docs/api/bkn-safe/managed-proxy.yaml)
+- Proxy grant source internal OpenAPI: [`docs/api/bkn-safe/proxy-grants.yaml`](../docs/api/bkn-safe/proxy-grants.yaml)
 - 全局设计文档：[bkn-docs `docs/foundry/`](https://github.com/openbkn-ai/bkn-docs/tree/main/docs/foundry)
 
 ## 三职责
@@ -100,10 +100,12 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
 - 认证（hydra 重定向到这里）：`GET/POST /login`、`GET /consent`、`GET/POST /device`
 - 鉴权 `/api/safe/v1/authz`：`POST /check`、`POST /operations`、`POST /resource-filter`、
   `POST|DELETE /policies`、`POST /role-bindings`
-- 受管 KN 代理（ClusterIP 内部面）`/api/safe/in/v1/managed-proxy-accounts`：创建、查询、
-  禁用和归档一对一 proxy app；账号禁止登录、AppKey、普通用户管理与通用 Policy 授权
-- 代理授权来源（ClusterIP 内部面）`/api/safe/in/v1/proxy-grant-sources`：来源增删、
-  授权预检、最新模型全量同步和 Casbin Allow 对账；来源账本与 Policy 在单一事务内更新
+- Managed KN proxies (ClusterIP-internal surface) `/api/safe/in/v1/managed-proxy-accounts`:
+  create, get, disable, and archive one-to-one proxy apps; these accounts cannot log in, use
+  AppKeys, be managed as regular users, or receive grants through the generic Policy API
+- Proxy grant sources (ClusterIP-internal surface) `/api/safe/in/v1/proxy-grant-sources`:
+  create and revoke sources, preflight authorization, synchronize the complete published-model
+  source set, and reconcile Casbin Allow policies; the source ledger and policies update atomically
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`

--- a/bkn-safe/charts/bkn-safe/templates/deployment.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- /* Casbin policies are cached in process. Until a cross-pod watcher is
+added, multiple replicas can make authorization decisions from different
+policy versions. Keep the supported deployment shape explicit. */}}
+{{- if ne (int .Values.replicaCount) 1 }}
+{{- fail (printf "bkn-safe currently supports only one replica; replicaCount must be 1, got %v" .Values.replicaCount) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -1,3 +1,6 @@
+# Casbin policy state is cached in process. Keep one replica until a cross-pod
+# policy watcher/version refresh is implemented; the deployment template
+# rejects overrides so authorization decisions cannot diverge between Pods.
 replicaCount: 1
 # Namespace follows the Helm release (-n) — templates use .Release.Namespace, so
 # bkn-safe installs into the same namespace as the rest of BKN Foundry (openbkn).
@@ -19,7 +22,8 @@ service:
 # Only the hydra provider pages (login/consent/device) and the self-service
 # change-password endpoint are browser/CLI-facing and go through the ingress.
 # The internal APIs (/api/safe/v1/authz, /api/safe/v1/directory,
-# /api/safe/v1/internal/license, /api/safe/in/v1/managed-proxy-accounts) stay
+# /api/safe/v1/internal/license, /api/safe/in/v1/managed-proxy-accounts and
+# /api/safe/in/v1/proxy-grant-sources) stay
 # ClusterIP, called service-to-service — do
 # NOT expose those at the gateway. The licence group is tokenless by design (its
 # boundary is the network, see networkPolicy below), so putting it behind the

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -16,13 +16,17 @@
 package authz
 
 import (
+	"errors"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
 	gormadapter "github.com/casbin/gorm-adapter/v3"
 	"gorm.io/gorm"
+
+	safemodel "github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // modelConf is the RBAC + resource-instance Casbin model.
@@ -62,14 +66,23 @@ const PublicAccessorID = "00000000-0000-0000-0000-000000000000"
 // the matched object (used for the super-admin "do everything" grant).
 const ActAll = "*"
 
+// ErrManagedProxyPolicies tells a resource-deletion caller to remove the
+// corresponding proxy-grant sources before performing generic policy cleanup.
+var ErrManagedProxyPolicies = errors.New("resource still has managed proxy policies")
+
 // Enforcer wraps a Casbin enforcer with the bkn-safe object convention.
 type Enforcer struct {
-	e *casbin.Enforcer
+	e casbin.IEnforcer
 	// db reads the resource hierarchy (which catalog a table belongs to) that
 	// casbin cannot express: policies are keyed by an opaque "type:id", so
 	// inheritance is resolved around the matcher, not inside it. Nil disables
 	// inheritance entirely, which is the pre-#800 behaviour.
 	db *gorm.DB
+	// transactionMu serializes every policy write and must be acquired before
+	// reading the adapter pointer. The gorm adapter temporarily replaces that
+	// pointer while a transaction is in flight, so adapter-local locking alone
+	// is too late for concurrent callers.
+	transactionMu sync.Mutex
 }
 
 // New builds an Enforcer using a GORM-backed policy store on the given db.
@@ -82,7 +95,7 @@ func New(db *gorm.DB) (*Enforcer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse casbin model: %w", err)
 	}
-	e, err := casbin.NewEnforcer(m, adapter)
+	e, err := casbin.NewSyncedEnforcer(m, adapter)
 	if err != nil {
 		return nil, fmt.Errorf("new enforcer: %w", err)
 	}
@@ -148,6 +161,8 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 // GrantRolePermission grants a role an op over a resource-type instance pattern
 // (id may be "*" for the whole type). Idempotent.
 func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.AddPolicy(roleID, obj(resourceType, idPattern), op)
 	return err
 }
@@ -155,6 +170,8 @@ func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op stri
 // RevokeRolePermission removes a role's op over a resource-type instance
 // pattern (the inverse of GrantRolePermission). Idempotent.
 func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.RemovePolicy(roleID, obj(resourceType, idPattern), op)
 	return err
 }
@@ -163,6 +180,8 @@ func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op str
 // (e.g. "agent:*" or "*" for everything); act may be ActAll ("*"). Used by the
 // seed for the super-admin wildcard. Idempotent.
 func (en *Enforcer) Grant(sub, obj, act string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.AddPolicy(sub, obj, act)
 	return err
 }
@@ -170,12 +189,16 @@ func (en *Enforcer) Grant(sub, obj, act string) error {
 // GrantObjectPermission grants an accessor an op over one concrete resource
 // instance (the CreateResources pattern). Idempotent.
 func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, op string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op)
 	return err
 }
 
 // RevokeObjectPermission removes a concrete per-object grant.
 func (en *Enforcer) RevokeObjectPermission(accessorID, resourceType, resourceID, op string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.RemovePolicy(accessorID, obj(resourceType, resourceID), op)
 	return err
 }
@@ -189,6 +212,8 @@ func (en *Enforcer) CanAdmin(accessorID string) (bool, error) {
 
 // AssignRole binds an accessor (user/app) to a role. Idempotent.
 func (en *Enforcer) AssignRole(accessorID, roleID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.AddGroupingPolicy(accessorID, roleID)
 	return err
 }
@@ -196,6 +221,8 @@ func (en *Enforcer) AssignRole(accessorID, roleID string) error {
 // RemoveRole unbinds an accessor from a role (the inverse of AssignRole).
 // Idempotent: removing a binding that isn't there is a no-op.
 func (en *Enforcer) RemoveRole(accessorID, roleID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.RemoveGroupingPolicy(accessorID, roleID)
 	return err
 }
@@ -444,6 +471,8 @@ func hasOp(ops []string, want string) bool {
 // (grouping g-lines with role=roleID) and its own permission grants (p-lines
 // with sub=roleID). Called when a custom role is deleted. Idempotent.
 func (en *Enforcer) RemoveRoleCompletely(roleID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	if _, err := en.e.RemoveFilteredGroupingPolicy(1, roleID); err != nil {
 		return err
 	}
@@ -462,6 +491,8 @@ func (en *Enforcer) RemoveRoleCompletely(roleID string) error {
 // This is the migration for those, and it is idempotent: once no row holds the
 // old spelling, it does nothing.
 func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, error) {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	rows, err := en.e.GetFilteredPolicy(2, oldOp)
 	if err != nil {
 		return 0, err
@@ -510,6 +541,8 @@ type BackfilledGrant struct {
 // Idempotent: once every holder row carries the implied operation it adds
 // nothing, at the cost of one filtered read per declared implication per start.
 func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp string) ([]BackfilledGrant, error) {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	rows, err := en.e.GetFilteredPolicy(2, holderOp)
 	if err != nil {
 		return nil, err
@@ -543,6 +576,8 @@ func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp s
 // member bindings. Seed uses this before re-applying the built-in permission
 // matrix so removed grants do not linger across upgrades.
 func (en *Enforcer) RemoveRolePermissions(roleID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	_, err := en.e.RemoveFilteredPolicy(0, roleID)
 	return err
 }
@@ -552,6 +587,8 @@ func (en *Enforcer) RemoveRolePermissions(roleID string) error {
 // directly to it (p-lines with sub=accessor). Called when a user is deleted so
 // no orphaned grants linger. Idempotent.
 func (en *Enforcer) RemoveAccessor(accessorID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
 	if _, err := en.e.RemoveFilteredGroupingPolicy(0, accessorID); err != nil {
 		return err
 	}
@@ -559,9 +596,24 @@ func (en *Enforcer) RemoveAccessor(accessorID string) error {
 	return err
 }
 
-// RemoveResourcePolicies drops every policy targeting a concrete resource
-// instance (used when a resource is deleted).
+// RemoveResourcePolicies drops policies targeting a concrete resource instance
+// after ensuring no managed proxy policy remains. Proxy policies belong
+// exclusively to proxy-grant sources, and the KN deletion flow must remove
+// those sources before generic resource policy cleanup.
 func (en *Enforcer) RemoveResourcePolicies(resourceType, resourceID string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	if en.db != nil {
+		var activeSources int64
+		if err := en.db.Model(&safemodel.ProxyGrantSource{}).
+			Where("resource_type = ? AND resource_id = ? AND lifecycle_status = ?", resourceType, resourceID, "active").
+			Count(&activeSources).Error; err != nil {
+			return err
+		}
+		if activeSources > 0 {
+			return ErrManagedProxyPolicies
+		}
+	}
 	_, err := en.e.RemoveFilteredPolicy(1, obj(resourceType, resourceID))
 	return err
 }
@@ -733,7 +785,9 @@ func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string
 // one per op. The "edit a grant" write behind the admin object-grant page
 // (POST /policies only adds, never prunes). Passing no ops clears the grant.
 func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID string, ops []string) error {
-	if _, err := en.RemoveAccessorResourcePolicies(accessorID, resourceType, resourceID); err != nil {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	if _, err := en.removeAccessorResourcePolicies(accessorID, resourceType, resourceID); err != nil {
 		return err
 	}
 	for _, op := range ops {
@@ -755,6 +809,12 @@ func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID st
 // either way — but the audit trail needs the distinction: "revoked 3 ops" and
 // "matched nothing" are different administrative facts.
 func (en *Enforcer) RemoveAccessorResourcePolicies(accessorID, resourceType, resourceID string) (int, error) {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	return en.removeAccessorResourcePolicies(accessorID, resourceType, resourceID)
+}
+
+func (en *Enforcer) removeAccessorResourcePolicies(accessorID, resourceType, resourceID string) (int, error) {
 	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID))
 	if err != nil {
 		return 0, err

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -5,12 +5,14 @@
 package authz
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 // newTestEnforcer builds an Enforcer over an in-memory sqlite DB carrying the
@@ -129,20 +131,42 @@ func TestAllowedOps(t *testing.T) {
 	}
 }
 
-// TestRemoveResourcePolicies drops all grants on a concrete instance.
+// TestRemoveResourcePolicies requires source-ledger cleanup before it drops
+// grants on a concrete instance.
 func TestRemoveResourcePolicies(t *testing.T) {
-	e := newTestEnforcer(t)
+	e, db := newTestEnforcerDB(t)
 	const user = "u-1"
 	mustNoErr(t, e.GrantObjectPermission(user, "pipeline", "p1", "read"))
 	mustNoErr(t, e.GrantObjectPermission(user, "pipeline", "p1", "update"))
+	const proxy = "proxy-1"
+	source := model.ProxyGrantSource{
+		ID: "source-1", ProxyAccountID: proxy, ResourceType: "pipeline", ResourceID: "p1",
+		Operation: "read", SourceType: "manual", SourceID: "binding-1", LifecycleStatus: "active",
+	}
+	if err := db.Create(&source).Error; err != nil {
+		t.Fatal(err)
+	}
+	mustNoErr(t, e.GrantObjectPermission(proxy, "pipeline", "p1", "read"))
 
 	ok, _ := e.Check(user, "pipeline", "p1", "read")
 	if !ok {
 		t.Fatal("expected read before removal")
 	}
+	if err := e.RemoveResourcePolicies("pipeline", "p1"); !errors.Is(err, ErrManagedProxyPolicies) {
+		t.Fatalf("RemoveResourcePolicies() error = %v, want managed proxy conflict", err)
+	}
+	if ok, _ := e.Check(user, "pipeline", "p1", "read"); !ok {
+		t.Error("ordinary policy changed despite managed proxy conflict")
+	}
+	if err := db.Model(&source).Update("lifecycle_status", "revoked").Error; err != nil {
+		t.Fatal(err)
+	}
 	mustNoErr(t, e.RemoveResourcePolicies("pipeline", "p1"))
 	if ok, _ := e.Check(user, "pipeline", "p1", "read"); ok {
 		t.Error("read still allowed after RemoveResourcePolicies")
+	}
+	if ok, _ := e.Check(proxy, "pipeline", "p1", "read"); ok {
+		t.Error("unsourced proxy policy still allowed after RemoveResourcePolicies")
 	}
 }
 

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/casbin/casbin/v2"
+	casbinmodel "github.com/casbin/casbin/v2/model"
+	gormadapter "github.com/casbin/gorm-adapter/v3"
+	"gorm.io/gorm"
+)
+
+// ErrPolicyReloadAfterCommit means the database transaction committed but the
+// live authorization cache could not be refreshed. Mutation callers receive an
+// error and may retry, but must not audit the committed write as denied.
+var ErrPolicyReloadAfterCommit = errors.New("reload committed casbin policy")
+
+// PolicyTransaction is a Casbin transaction and its underlying GORM
+// transaction. Domain services can persist provenance rows through DB while
+// changing the matching policy through the methods below; the adapter commits
+// or rolls both back together and reloads the live in-memory policy.
+type PolicyTransaction struct {
+	db       *gorm.DB
+	enforcer *Enforcer
+}
+
+func (tx *PolicyTransaction) DB() *gorm.DB { return tx.db }
+
+func (tx *PolicyTransaction) Check(accessorID, resourceType, resourceID, operation string) (bool, error) {
+	return tx.enforcer.Check(accessorID, resourceType, resourceID, operation)
+}
+
+func (tx *PolicyTransaction) HasObjectPermission(accessorID, resourceType, resourceID, operation string) (bool, error) {
+	return tx.enforcer.e.HasPolicy(accessorID, obj(resourceType, resourceID), operation)
+}
+
+func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
+	_, err := tx.enforcer.e.AddPolicy(accessorID, obj(resourceType, resourceID), operation)
+	return err
+}
+
+func (tx *PolicyTransaction) RevokeObjectPermission(accessorID, resourceType, resourceID, operation string) error {
+	_, err := tx.enforcer.e.RemovePolicy(accessorID, obj(resourceType, resourceID), operation)
+	return err
+}
+
+// Transaction runs fn inside the gorm-adapter transaction used by Casbin. The
+// adapter temporarily points the callback enforcer at the transaction-bound DB;
+// deriving tx.db from that adapter is what gives relational rows and policy rows
+// one commit boundary.
+func (en *Enforcer) Transaction(ctx context.Context, fn func(*PolicyTransaction) error) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+
+	adapter, ok := en.e.GetAdapter().(*gormadapter.Adapter)
+	if !ok {
+		return fmt.Errorf("authz adapter does not support gorm transactions")
+	}
+	// Do not let the adapter swap the live enforcer onto its transaction-bound
+	// DB: AddPolicy mutates the in-memory model before commit, which would expose
+	// an uncommitted allow to concurrent authorization checks. A short-lived
+	// enforcer owns the transactional model; the live model reloads only after a
+	// successful commit.
+	m, err := casbinmodel.NewModelFromString(modelConf)
+	if err != nil {
+		return fmt.Errorf("parse transactional casbin model: %w", err)
+	}
+	transactionEnforcer, err := casbin.NewEnforcer(m, adapter)
+	if err != nil {
+		return fmt.Errorf("create transactional casbin enforcer: %w", err)
+	}
+	err = adapter.Transaction(transactionEnforcer, func(txEnforcer casbin.IEnforcer) error {
+		base, ok := txEnforcer.(*casbin.Enforcer)
+		if !ok {
+			return fmt.Errorf("unexpected transactional enforcer type %T", txEnforcer)
+		}
+		txAdapter, ok := txEnforcer.GetAdapter().(*gormadapter.Adapter)
+		if !ok {
+			return fmt.Errorf("unexpected transactional adapter type %T", txEnforcer.GetAdapter())
+		}
+		// GetDb inherits a permanent casbin_rule table scope. Start from the
+		// application's clean GORM handle, then attach the adapter transaction's
+		// connection pool so domain models resolve their own table names while
+		// still sharing the exact same commit boundary.
+		txDB := en.db.Session(&gorm.Session{NewDB: true, Context: ctx})
+		txDB.Statement.ConnPool = txAdapter.GetDb().Statement.ConnPool
+		return fn(&PolicyTransaction{
+			db:       txDB,
+			enforcer: &Enforcer{e: base, db: txDB},
+		})
+	})
+	if err != nil {
+		return err
+	}
+	if err := en.e.LoadPolicy(); err != nil {
+		return fmt.Errorf("%w: %v", ErrPolicyReloadAfterCommit, err)
+	}
+	return nil
+}

--- a/bkn-safe/server/internal/authz/transaction_test.go
+++ b/bkn-safe/server/internal/authz/transaction_test.go
@@ -1,0 +1,72 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"testing"
+	"time"
+)
+
+func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
+	e := newTestEnforcer(t)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	transactionDone := make(chan error, 1)
+	go func() {
+		transactionDone <- e.Transaction(t.Context(), func(tx *PolicyTransaction) error {
+			if err := tx.GrantObjectPermission("proxy", "resource", "r-1", "query_data"); err != nil {
+				return err
+			}
+			close(entered)
+			<-release
+			return nil
+		})
+	}()
+	<-entered
+	allowed, err := e.e.HasPolicy("proxy", obj("resource", "r-1"), "query_data")
+	if err != nil || allowed {
+		t.Fatalf("uncommitted policy was visible: allowed=%v err=%v", allowed, err)
+	}
+
+	ordinaryWriteDone := make(chan error, 1)
+	go func() {
+		ordinaryWriteDone <- e.GrantObjectPermission("user", "resource", "r-2", "view_detail")
+	}()
+	select {
+	case err := <-ordinaryWriteDone:
+		t.Fatalf("ordinary write escaped active policy transaction: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	if err := waitForTestResult(t, transactionDone); err != nil {
+		t.Fatalf("Transaction() error = %v", err)
+	}
+	if err := waitForTestResult(t, ordinaryWriteDone); err != nil {
+		t.Fatalf("GrantObjectPermission() error = %v", err)
+	}
+	for _, check := range []struct {
+		accessor, resource, operation string
+	}{
+		{"proxy", "r-1", "query_data"},
+		{"user", "r-2", "view_detail"},
+	} {
+		allowed, err := e.e.HasPolicy(check.accessor, obj("resource", check.resource), check.operation)
+		if err != nil || !allowed {
+			t.Fatalf("Check(%q, %q, %q) = %v, %v", check.accessor, check.resource, check.operation, allowed, err)
+		}
+	}
+}
+
+func waitForTestResult(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for concurrent policy write")
+		return nil
+	}
+}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -285,6 +285,10 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 		}
 		auditPolicyWriteShape(c, db, "DELETE", "", req.Resource, nil)
 		if err := e.RemoveResourcePolicies(req.Resource.Type, req.Resource.ID); err != nil {
+			if errors.Is(err, authz.ErrManagedProxyPolicies) {
+				replyPublicError(c, http.StatusConflict)
+				return
+			}
 			serverError(c, err)
 			return
 		}

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -109,7 +109,7 @@ func TestManagedProxyAPIRejectsUnsupportedOwnerType(t *testing.T) {
 }
 
 func TestGenericPolicyEndpointCannotGrantManagedProxy(t *testing.T) {
-	r, _, _ := newTestServer(t)
+	r, enforcer, db := newTestServer(t)
 	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", map[string]any{
 		"managed_resource_type": managedproxy.ResourceKnowledgeNetwork,
 		"managed_resource_id":   "kn-policy",
@@ -124,6 +124,24 @@ func TestGenericPolicyEndpointCannotGrantManagedProxy(t *testing.T) {
 	})
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("generic proxy grant = %d body=%s", w.Code, w.Body.String())
+	}
+	if err := enforcer.GrantObjectPermission(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ProxyGrantSource{
+		ID: "source-policy", ProxyAccountID: account.ProxyAccountID, ResourceType: "resource", ResourceID: "r-1",
+		Operation: "query_data", SourceType: "manual", SourceID: "binding-policy", LifecycleStatus: "active",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	w = do(t, r, http.MethodDelete, "/api/safe/v1/authz/policies", map[string]any{
+		"resource": map[string]any{"type": "resource", "id": "r-1"},
+	})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("generic resource cleanup = %d body=%s, want 409", w.Code, w.Body.String())
+	}
+	if allowed, err := enforcer.Check(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil || !allowed {
+		t.Fatalf("generic resource cleanup changed proxy permission: allowed=%v err=%v", allowed, err)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/proxygrant.go
+++ b/bkn-safe/server/internal/httpapi/proxygrant.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/proxygrant"
+)
+
+// registerProxyGrantSources mounts the ClusterIP-only provenance and policy
+// synchronization surface used by the BKN publishing coordinator.
+func registerProxyGrantSources(r *gin.Engine, service *proxygrant.Service) {
+	group := r.Group("/api/safe/in/v1/proxy-grant-sources")
+
+	group.POST("", func(c *gin.Context) {
+		var req proxygrant.GrantRequest
+		if !bind(c, &req) {
+			return
+		}
+		source, changed, err := service.Grant(c.Request.Context(), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		status := http.StatusOK
+		if changed {
+			status = http.StatusCreated
+		}
+		c.JSON(status, source)
+	})
+
+	group.DELETE("/:id", func(c *gin.Context) {
+		var req proxygrant.RevokeRequest
+		if !bind(c, &req) {
+			return
+		}
+		source, _, err := service.Revoke(c.Request.Context(), c.Param("id"), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		c.JSON(http.StatusOK, source)
+	})
+
+	group.POST("/check", func(c *gin.Context) {
+		var req proxygrant.GrantRequest
+		if !bind(c, &req) {
+			return
+		}
+		result, err := service.Check(c.Request.Context(), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		c.JSON(http.StatusOK, result)
+	})
+
+	group.POST("/sync", func(c *gin.Context) {
+		var req proxygrant.SyncRequest
+		if !bind(c, &req) {
+			return
+		}
+		result, err := service.Sync(c.Request.Context(), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		c.JSON(http.StatusOK, result)
+	})
+
+	group.POST("/reconcile", func(c *gin.Context) {
+		var req proxygrant.ReconcileRequest
+		if !bind(c, &req) {
+			return
+		}
+		result, err := service.Reconcile(c.Request.Context(), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		c.JSON(http.StatusOK, result)
+	})
+}
+
+// writeProxyGrantError writes err and reports whether the caller must stop.
+func writeProxyGrantError(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	switch {
+	case errors.Is(err, proxygrant.ErrInvalidRequest):
+		replyPublicError(c, http.StatusBadRequest)
+	case errors.Is(err, proxygrant.ErrForbidden):
+		replyPublicError(c, http.StatusForbidden)
+	case errors.Is(err, proxygrant.ErrNotFound):
+		replyPublicError(c, http.StatusNotFound)
+	case errors.Is(err, proxygrant.ErrProxyInactive):
+		replyPublicError(c, http.StatusConflict)
+	default:
+		serverError(c, err)
+	}
+	return true
+}

--- a/bkn-safe/server/internal/httpapi/proxygrant_test.go
+++ b/bkn-safe/server/internal/httpapi/proxygrant_test.go
@@ -1,0 +1,162 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/proxygrant"
+)
+
+func TestProxyGrantSourceLifecycleAPI(t *testing.T) {
+	r, enforcer, db := newTestServer(t)
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-api-grant",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEnabledUser(t, db, "grantor-api")
+	seedCatalogOps(t, db, "resource", "authorize", "query_data")
+	if err := enforcer.GrantObjectPermission("grantor-api", "resource", "r-api", "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("grantor-api", "resource", "r-api", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	body := map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"grantor_id":       "grantor-api",
+		"source": map[string]any{
+			"resource_type": "resource", "resource_id": "r-api", "operation": "query_data",
+			"source_type": "kn_proxy_binding", "source_id": "source-api", "kn_id": "kn-api-grant",
+			"binding_type": "object_type", "binding_id": "ot-api",
+		},
+	}
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create = %d body=%s", w.Code, w.Body.String())
+	}
+	var source model.ProxyGrantSource
+	if err := json.Unmarshal(w.Body.Bytes(), &source); err != nil {
+		t.Fatal(err)
+	}
+	if source.ID == "" || source.GrantedBy != "grantor-api" || source.LifecycleStatus != proxygrant.StatusActive {
+		t.Fatalf("source = %+v", source)
+	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay = %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = do(t, r, http.MethodDelete, "/api/safe/in/v1/proxy-grant-sources/"+source.ID, map[string]any{"grantor_id": "grantor-api"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("revoke = %d body=%s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &source); err != nil {
+		t.Fatal(err)
+	}
+	if source.LifecycleStatus != proxygrant.StatusRevoked || source.RevokedAt == nil {
+		t.Fatalf("revoked source = %+v", source)
+	}
+	allowed, err := enforcer.Check(proxy.ProxyAccountID, "resource", "r-api", "query_data")
+	if err != nil || allowed {
+		t.Fatalf("policy after revoke: allowed=%v err=%v", allowed, err)
+	}
+}
+
+func TestProxyGrantAPIRejectsUnauthorizedGrantorAndWildcardTarget(t *testing.T) {
+	r, _, db := newTestServer(t)
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-api-deny",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEnabledUser(t, db, "grantor-denied")
+	seedCatalogOps(t, db, "resource", "query_data")
+	body := map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"grantor_id":       "grantor-denied",
+		"source": map[string]any{
+			"resource_type": "resource", "resource_id": "r-denied", "operation": "query_data",
+			"source_id": "source-denied", "kn_id": "kn-api-deny",
+			"binding_type": "object_type", "binding_id": "ot-denied",
+		},
+	}
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources", body)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("unauthorized grant = %d body=%s", w.Code, w.Body.String())
+	}
+
+	source := body["source"].(map[string]any)
+	source["resource_id"] = "*"
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("wildcard grant = %d body=%s", w.Code, w.Body.String())
+	}
+
+	var count int64
+	if err := db.Model(&model.ProxyGrantSource{}).Count(&count).Error; err != nil || count != 0 {
+		t.Fatalf("source count = %d err=%v", count, err)
+	}
+}
+
+func TestProxyGrantCheckAndReconcileAPI(t *testing.T) {
+	r, enforcer, db := newTestServer(t)
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-api-check",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEnabledUser(t, db, "grantor-check")
+	seedCatalogOps(t, db, "resource", "authorize", "view_detail")
+	if err := enforcer.GrantObjectPermission("grantor-check", "resource", "r-check", "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("grantor-check", "resource", "r-check", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	body := map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"grantor_id":       "grantor-check",
+		"source": map[string]any{
+			"resource_type": "resource", "resource_id": "r-check", "operation": "view_detail",
+			"source_id": "source-check", "kn_id": "kn-api-check",
+			"binding_type": "object_type", "binding_id": "ot-check",
+		},
+	}
+	w := do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources/check", body)
+	if w.Code != http.StatusOK || !jsonBool(t, w.Body.Bytes(), "allowed") {
+		t.Fatalf("check = %d body=%s", w.Code, w.Body.String())
+	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources/reconcile", map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"requested_by":     "system:reconcile",
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("reconcile = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func jsonBool(t *testing.T, body []byte, field string) bool {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(body, &value); err != nil {
+		t.Fatal(err)
+	}
+	result, _ := value[field].(bool)
+	return result
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/proxygrant"
 )
 
 // Deps are the collaborators the HTTP layer needs.
@@ -82,6 +83,9 @@ func New(deps Deps) *gin.Engine {
 		apiKeys = auth.NewAPIKeyStore(deps.DB)
 		registerAPIKeyVerify(r, apiKeys)
 		registerManagedProxyAccounts(r, managedproxy.New(deps.DB))
+		if deps.Enforcer != nil {
+			registerProxyGrantSources(r, proxygrant.New(deps.DB, deps.Enforcer))
+		}
 	}
 
 	// hydra login/consent/device provider pages.

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -72,6 +72,70 @@ type ManagedProxyAccount struct {
 	UpdatedAt           time.Time
 }
 
+// ProxyGrantSource is the durable provenance ledger for one direct permission
+// required by a managed BKN proxy. A binding may require several permissions,
+// and several bindings may require the same permission, so the source identity
+// and permission tuple form the idempotency key. Revoked rows are retained for
+// audit and may be reactivated by a later full synchronization.
+type ProxyGrantSource struct {
+	ID              string     `json:"id" gorm:"primaryKey;size:64"`
+	ProxyAccountID  string     `json:"proxy_account_id" gorm:"size:64;uniqueIndex:uidx_proxy_grant_source,priority:1;index:idx_proxy_grant_tuple,priority:1"`
+	ResourceType    string     `json:"resource_type" gorm:"size:64;uniqueIndex:uidx_proxy_grant_source,priority:2;index:idx_proxy_grant_tuple,priority:2"`
+	ResourceID      string     `json:"resource_id" gorm:"size:128;uniqueIndex:uidx_proxy_grant_source,priority:3;index:idx_proxy_grant_tuple,priority:3"`
+	Operation       string     `json:"operation" gorm:"size:64;uniqueIndex:uidx_proxy_grant_source,priority:4;index:idx_proxy_grant_tuple,priority:4"`
+	SourceType      string     `json:"source_type" gorm:"size:32;uniqueIndex:uidx_proxy_grant_source,priority:5;index"`
+	SourceID        string     `json:"source_id" gorm:"size:128;uniqueIndex:uidx_proxy_grant_source,priority:6;index"`
+	KNID            string     `json:"kn_id" gorm:"size:128;index"`
+	BindingType     string     `json:"binding_type" gorm:"size:64"`
+	BindingID       string     `json:"binding_id" gorm:"size:128"`
+	GrantedBy       string     `json:"granted_by" gorm:"size:64;index"`
+	LifecycleStatus string     `json:"lifecycle_status" gorm:"size:16;index"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	RevokedAt       *time.Time `json:"revoked_at,omitempty" gorm:"index"`
+}
+
+// TableName keeps the schema name frozen to the singular name used by the
+// cross-service design contract.
+func (ProxyGrantSource) TableName() string { return "proxy_grant_source" }
+
+// ProxyGrantPolicy records whether the source service owns the concrete
+// Casbin row for a permission tuple. If the row already existed when the first
+// source arrived, PolicyOwned is false and removing the last source preserves
+// that manual/legacy Allow.
+type ProxyGrantPolicy struct {
+	ProxyAccountID string `gorm:"primaryKey;size:64"`
+	ResourceType   string `gorm:"primaryKey;size:64"`
+	ResourceID     string `gorm:"primaryKey;size:128"`
+	Operation      string `gorm:"primaryKey;size:64"`
+	PolicyOwned    bool   `gorm:"not null"`
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+}
+
+func (ProxyGrantPolicy) TableName() string { return "proxy_grant_policy" }
+
+// ProxyGrantAuditLog records both successful and denied proxy-grant decisions.
+// It is deliberately separate from the browser/admin audit log: this internal
+// surface receives a trusted grantor identity in the request rather than an
+// OAuth token resolved by HTTP middleware.
+type ProxyGrantAuditLog struct {
+	ID             string    `json:"id" gorm:"primaryKey;size:64"`
+	Action         string    `json:"action" gorm:"size:32;index"`
+	Decision       string    `json:"decision" gorm:"size:16;index"`
+	Reason         string    `json:"reason" gorm:"size:255"`
+	GrantorID      string    `json:"grantor_id" gorm:"size:64;index"`
+	ProxyAccountID string    `json:"proxy_account_id" gorm:"size:64;index"`
+	ResourceType   string    `json:"resource_type" gorm:"size:64"`
+	ResourceID     string    `json:"resource_id" gorm:"size:128"`
+	Operation      string    `json:"operation" gorm:"size:64"`
+	SourceType     string    `json:"source_type" gorm:"size:32"`
+	SourceID       string    `json:"source_id" gorm:"size:128"`
+	CreatedAt      time.Time `json:"created_at" gorm:"index"`
+}
+
+func (ProxyGrantAuditLog) TableName() string { return "proxy_grant_audit_log" }
+
 // Role source values. system|business roles are SEEDED built-ins (their UUIDs
 // are hardcoded in DA/flow-automation, such as application, data, and AI administrators) and are
 // immutable via the API — they may only be changed by editing the seed files.
@@ -285,6 +349,7 @@ func AllModels() []any {
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
 		&AuditLog{}, &AccessLog{}, &APIKey{}, &License{}, &ResourceParent{},
-		&ManagedProxyAccount{},
+		&ManagedProxyAccount{}, &ProxyGrantSource{}, &ProxyGrantPolicy{},
+		&ProxyGrantAuditLog{},
 	}
 }

--- a/bkn-safe/server/internal/proxygrant/service.go
+++ b/bkn-safe/server/internal/proxygrant/service.go
@@ -1,0 +1,817 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package proxygrant owns the provenance ledger and Casbin materialization for
+// permissions held by managed BKN proxy accounts.
+package proxygrant
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	gormadapter "github.com/casbin/gorm-adapter/v3"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+const (
+	SourceTypeKNProxyBinding = "kn_proxy_binding"
+	SourceTypeManual         = "manual"
+	SourceTypeAdmin          = "admin"
+	StatusActive             = "active"
+	StatusRevoked            = "revoked"
+)
+
+var (
+	ErrInvalidRequest = errors.New("invalid proxy grant request")
+	ErrForbidden      = errors.New("proxy grant is forbidden")
+	ErrNotFound       = errors.New("proxy grant source not found")
+	ErrProxyInactive  = errors.New("managed proxy is not active")
+)
+
+// SourceSpec is one published-model binding's need for one concrete operation.
+type SourceSpec struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+	Operation    string `json:"operation"`
+	SourceType   string `json:"source_type"`
+	SourceID     string `json:"source_id"`
+	KNID         string `json:"kn_id"`
+	BindingType  string `json:"binding_type"`
+	BindingID    string `json:"binding_id"`
+}
+
+type GrantRequest struct {
+	ProxyAccountID string     `json:"proxy_account_id"`
+	GrantorID      string     `json:"grantor_id"`
+	Source         SourceSpec `json:"source"`
+}
+
+type RevokeRequest struct {
+	GrantorID string `json:"grantor_id"`
+}
+
+type SyncRequest struct {
+	ProxyAccountID string       `json:"proxy_account_id"`
+	GrantorID      string       `json:"grantor_id"`
+	Sources        []SourceSpec `json:"sources"`
+}
+
+type ReconcileRequest struct {
+	ProxyAccountID string `json:"proxy_account_id"`
+	RequestedBy    string `json:"requested_by"`
+}
+
+type CheckResult struct {
+	Allowed bool   `json:"allowed"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+type SyncResult struct {
+	Added     int                      `json:"added"`
+	Revoked   int                      `json:"revoked"`
+	Unchanged int                      `json:"unchanged"`
+	Sources   []model.ProxyGrantSource `json:"sources"`
+}
+
+type ReconcileResult struct {
+	PoliciesRestored  int `json:"policies_restored"`
+	PoliciesRemoved   int `json:"policies_removed"`
+	MarkersCreated    int `json:"markers_created"`
+	MarkersRemoved    int `json:"markers_removed"`
+	UntrackedPolicies int `json:"untracked_policies"`
+}
+
+type Service struct {
+	db       *gorm.DB
+	enforcer *authz.Enforcer
+}
+
+func New(db *gorm.DB, enforcer *authz.Enforcer) *Service {
+	return &Service{db: db, enforcer: enforcer}
+}
+
+// Grant adds or reactivates one source. Replaying the same source tuple is a
+// successful no-op. The source, materialization marker, audit row and Casbin
+// policy share the adapter's database transaction.
+func (s *Service) Grant(ctx context.Context, req GrantRequest) (*model.ProxyGrantSource, bool, error) {
+	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
+	req.GrantorID = strings.TrimSpace(req.GrantorID)
+	spec, err := normalizeSpec(req.Source)
+	if err != nil || req.ProxyAccountID == "" || req.GrantorID == "" ||
+		len(req.ProxyAccountID) > 64 || len(req.GrantorID) > 64 {
+		return nil, false, ErrInvalidRequest
+	}
+	req.Source = spec
+
+	var result model.ProxyGrantSource
+	var changed bool
+	err = s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		if err := validateProxy(tx.DB(), req.ProxyAccountID, spec.KNID, true); err != nil {
+			return err
+		}
+		if err := validateAuthority(tx, req.GrantorID, spec); err != nil {
+			return err
+		}
+		row, created, err := grantInTransaction(tx, req.ProxyAccountID, req.GrantorID, spec)
+		if err != nil {
+			return err
+		}
+		result, changed = row, created
+		reason := "created"
+		if !created {
+			reason = "idempotent replay"
+		}
+		return recordAudit(tx.DB(), "grant", "allow", reason, req.GrantorID, req.ProxyAccountID, spec)
+	})
+	if err != nil {
+		if !errors.Is(err, authz.ErrPolicyReloadAfterCommit) {
+			s.recordDenied(ctx, "grant", req.GrantorID, req.ProxyAccountID, spec, err)
+		}
+		return nil, false, err
+	}
+	return &result, changed, nil
+}
+
+// Revoke retires one source row. The corresponding direct policy is removed
+// only when this was the final active source and the ledger owns that policy.
+func (s *Service) Revoke(ctx context.Context, id string, req RevokeRequest) (*model.ProxyGrantSource, bool, error) {
+	id = strings.TrimSpace(id)
+	req.GrantorID = strings.TrimSpace(req.GrantorID)
+	if id == "" || req.GrantorID == "" || len(id) > 64 || len(req.GrantorID) > 64 {
+		return nil, false, ErrInvalidRequest
+	}
+	var result model.ProxyGrantSource
+	var changed bool
+	err := s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		// Resolve the immutable proxy id first, then lock the proxy mapping before
+		// locking the source. Grant, sync, revoke and reconcile all use this order,
+		// so separate bkn-safe replicas serialize mutations for the same proxy.
+		var identified model.ProxyGrantSource
+		if err := tx.DB().Select("proxy_account_id").First(&identified, "id = ?", id).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if _, err := loadProxy(tx.DB(), identified.ProxyAccountID); err != nil {
+			return err
+		}
+		if err := validateGrantorIdentity(tx.DB(), req.GrantorID); err != nil {
+			return err
+		}
+		row, revoked, err := revokeByID(tx, id)
+		if err != nil {
+			return err
+		}
+		result, changed = row, revoked
+		spec := specFromModel(row)
+		reason := "revoked"
+		if !revoked {
+			reason = "idempotent replay"
+		}
+		return recordAudit(tx.DB(), "revoke", "allow", reason, req.GrantorID, row.ProxyAccountID, spec)
+	})
+	if err != nil {
+		if !errors.Is(err, authz.ErrPolicyReloadAfterCommit) {
+			var source model.ProxyGrantSource
+			_ = s.db.WithContext(ctx).First(&source, "id = ?", id).Error
+			s.recordDenied(ctx, "revoke", req.GrantorID, source.ProxyAccountID, specFromModel(source), err)
+		}
+		return nil, false, err
+	}
+	return &result, changed, nil
+}
+
+// Check verifies whether the named grantor may create a source without
+// changing policy state. Denials are returned as a normal decision payload and
+// are persisted in the proxy-grant audit log.
+func (s *Service) Check(ctx context.Context, req GrantRequest) (CheckResult, error) {
+	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
+	req.GrantorID = strings.TrimSpace(req.GrantorID)
+	spec, err := normalizeSpec(req.Source)
+	if err != nil || req.ProxyAccountID == "" || req.GrantorID == "" ||
+		len(req.ProxyAccountID) > 64 || len(req.GrantorID) > 64 {
+		return CheckResult{}, ErrInvalidRequest
+	}
+	result := CheckResult{Allowed: true}
+	err = s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		decision := "allow"
+		reason := "grantor holds authorize and requested operation"
+		decisionErr := validateProxy(tx.DB(), req.ProxyAccountID, spec.KNID, true)
+		if decisionErr == nil {
+			decisionErr = validateAuthority(tx, req.GrantorID, spec)
+		}
+		if decisionErr != nil {
+			if !errors.Is(decisionErr, ErrForbidden) && !errors.Is(decisionErr, ErrProxyInactive) &&
+				!errors.Is(decisionErr, ErrNotFound) {
+				return decisionErr
+			}
+			decision = "deny"
+			reason = decisionErr.Error()
+			result = CheckResult{Allowed: false, Reason: reason}
+		}
+		if auditErr := recordAudit(tx.DB(), "check", decision, reason, req.GrantorID, req.ProxyAccountID, spec); auditErr != nil {
+			return auditErr
+		}
+		return nil
+	})
+	if err != nil {
+		return CheckResult{}, err
+	}
+	return result, nil
+}
+
+// Sync replaces the active KN binding source set for one proxy with the latest
+// published-model set. All additions are authorized before any row changes, so
+// one unauthorized target rejects the complete synchronization.
+func (s *Service) Sync(ctx context.Context, req SyncRequest) (SyncResult, error) {
+	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
+	req.GrantorID = strings.TrimSpace(req.GrantorID)
+	if req.ProxyAccountID == "" || req.GrantorID == "" ||
+		len(req.ProxyAccountID) > 64 || len(req.GrantorID) > 64 {
+		return SyncResult{}, ErrInvalidRequest
+	}
+	desired := make(map[sourceKey]SourceSpec, len(req.Sources))
+	for _, raw := range req.Sources {
+		spec, err := normalizeSpec(raw)
+		if err != nil {
+			return SyncResult{}, err
+		}
+		if spec.SourceType != SourceTypeKNProxyBinding {
+			return SyncResult{}, ErrInvalidRequest
+		}
+		key := keyForSpec(spec)
+		if previous, exists := desired[key]; exists && !sameBinding(previous, spec) {
+			return SyncResult{}, ErrInvalidRequest
+		}
+		desired[key] = spec
+	}
+
+	var result SyncResult
+	err := s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		mapping, err := loadProxy(tx.DB(), req.ProxyAccountID)
+		if err != nil {
+			return err
+		}
+		if err := validateGrantorIdentity(tx.DB(), req.GrantorID); err != nil {
+			return err
+		}
+		for _, spec := range desired {
+			if spec.KNID != mapping.ManagedResourceID {
+				return ErrForbidden
+			}
+		}
+
+		var rows []model.ProxyGrantSource
+		if err := tx.DB().Where("proxy_account_id = ? AND source_type = ?", req.ProxyAccountID, SourceTypeKNProxyBinding).
+			Find(&rows).Error; err != nil {
+			return err
+		}
+		current := make(map[sourceKey]model.ProxyGrantSource, len(rows))
+		for _, row := range rows {
+			current[keyForModel(row)] = row
+		}
+
+		// Preflight every addition before applying any mutation.
+		for key, spec := range desired {
+			if row, ok := current[key]; ok && row.LifecycleStatus == StatusActive {
+				if !sameBinding(specFromModel(row), spec) {
+					return ErrInvalidRequest
+				}
+				continue
+			}
+			if mapping.LifecycleStatus != managedproxy.StatusActive {
+				return ErrProxyInactive
+			}
+			if err := validateAuthority(tx, req.GrantorID, spec); err != nil {
+				return err
+			}
+		}
+
+		for key, spec := range desired {
+			if row, ok := current[key]; ok && row.LifecycleStatus == StatusActive {
+				result.Unchanged++
+				continue
+			}
+			row, changed, err := grantInTransaction(tx, req.ProxyAccountID, req.GrantorID, spec)
+			if err != nil {
+				return err
+			}
+			if changed {
+				result.Added++
+			}
+			if err := recordAudit(tx.DB(), "sync_grant", "allow", "synchronized", req.GrantorID, req.ProxyAccountID, specFromModel(row)); err != nil {
+				return err
+			}
+		}
+		for key, row := range current {
+			if row.LifecycleStatus != StatusActive {
+				continue
+			}
+			if _, keep := desired[key]; keep {
+				continue
+			}
+			revoked, changed, err := revokeByID(tx, row.ID)
+			if err != nil {
+				return err
+			}
+			if changed {
+				result.Revoked++
+			}
+			if err := recordAudit(tx.DB(), "sync_revoke", "allow", "absent from full source set", req.GrantorID, req.ProxyAccountID, specFromModel(revoked)); err != nil {
+				return err
+			}
+		}
+		return tx.DB().Where("proxy_account_id = ? AND source_type = ? AND lifecycle_status = ?",
+			req.ProxyAccountID, SourceTypeKNProxyBinding, StatusActive).
+			Order("source_id, resource_type, resource_id, operation").Find(&result.Sources).Error
+	})
+	if err != nil {
+		if !errors.Is(err, authz.ErrPolicyReloadAfterCommit) {
+			if len(desired) == 0 {
+				s.recordDenied(ctx, "sync", req.GrantorID, req.ProxyAccountID, SourceSpec{}, err)
+			}
+			for _, spec := range desired {
+				s.recordDenied(ctx, "sync", req.GrantorID, req.ProxyAccountID, spec, err)
+			}
+		}
+		return SyncResult{}, err
+	}
+	return result, nil
+}
+
+// Reconcile repairs missing policy rows from active source records and removes
+// stale policy rows that are still explicitly owned by a materialization marker.
+// Untracked rows are reported but preserved because they may be legacy/manual.
+func (s *Service) Reconcile(ctx context.Context, req ReconcileRequest) (ReconcileResult, error) {
+	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
+	req.RequestedBy = strings.TrimSpace(req.RequestedBy)
+	if req.RequestedBy == "" || len(req.ProxyAccountID) > 64 || len(req.RequestedBy) > 64 {
+		return ReconcileResult{}, ErrInvalidRequest
+	}
+	var result ReconcileResult
+	err := s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		proxyIDs, err := reconcileProxyIDs(tx.DB(), req.ProxyAccountID)
+		if err != nil {
+			return err
+		}
+		for _, proxyID := range proxyIDs {
+			if _, err := loadProxy(tx.DB(), proxyID); err != nil {
+				return err
+			}
+			if err := reconcileProxy(tx, proxyID, req.RequestedBy, &result); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return result, err
+}
+
+type sourceKey struct {
+	ResourceType string
+	ResourceID   string
+	Operation    string
+	SourceType   string
+	SourceID     string
+}
+
+type permissionKey struct {
+	ProxyAccountID string
+	ResourceType   string
+	ResourceID     string
+	Operation      string
+}
+
+func normalizeSpec(spec SourceSpec) (SourceSpec, error) {
+	spec.ResourceType = strings.TrimSpace(spec.ResourceType)
+	spec.ResourceID = strings.TrimSpace(spec.ResourceID)
+	spec.Operation = strings.TrimSpace(spec.Operation)
+	spec.SourceType = strings.TrimSpace(spec.SourceType)
+	spec.SourceID = strings.TrimSpace(spec.SourceID)
+	spec.KNID = strings.TrimSpace(spec.KNID)
+	spec.BindingType = strings.TrimSpace(spec.BindingType)
+	spec.BindingID = strings.TrimSpace(spec.BindingID)
+	if spec.SourceType == "" {
+		spec.SourceType = SourceTypeKNProxyBinding
+	}
+	validSourceType := spec.SourceType == SourceTypeKNProxyBinding || spec.SourceType == SourceTypeManual || spec.SourceType == SourceTypeAdmin
+	if !validSourceType || spec.SourceID == "" || spec.KNID == "" ||
+		spec.BindingType == "" || spec.BindingID == "" || spec.ResourceID == "" ||
+		strings.Contains(spec.ResourceType, ":") || strings.Contains(spec.ResourceType, "*") ||
+		strings.Contains(spec.ResourceID, "*") || strings.Contains(spec.Operation, "*") ||
+		len(spec.ResourceType) > 64 || len(spec.ResourceID) > 128 || len(spec.Operation) > 64 ||
+		len(spec.SourceID) > 128 || len(spec.KNID) > 128 || len(spec.BindingType) > 64 || len(spec.BindingID) > 128 {
+		return SourceSpec{}, ErrInvalidRequest
+	}
+	allowed := map[string]map[string]bool{
+		"resource": {"view_detail": true, "query_data": true},
+		"tool_box": {"execute": true},
+		"mcp":      {"execute": true},
+	}
+	if !allowed[spec.ResourceType][spec.Operation] {
+		return SourceSpec{}, ErrInvalidRequest
+	}
+	return spec, nil
+}
+
+func validateProxy(db *gorm.DB, proxyID, knID string, requireActive bool) error {
+	mapping, err := loadProxy(db, proxyID)
+	if err != nil {
+		return err
+	}
+	if mapping.ManagedResourceID != knID {
+		return ErrForbidden
+	}
+	if requireActive && mapping.LifecycleStatus != managedproxy.StatusActive {
+		return ErrProxyInactive
+	}
+	return nil
+}
+
+func loadProxy(db *gorm.DB, proxyID string) (model.ManagedProxyAccount, error) {
+	var mapping model.ManagedProxyAccount
+	if err := db.Clauses(clause.Locking{Strength: "UPDATE"}).First(&mapping, "proxy_account_id = ?", proxyID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return mapping, ErrNotFound
+		}
+		return mapping, err
+	}
+	var user model.User
+	if err := db.Clauses(clause.Locking{Strength: "UPDATE"}).First(&user, "id = ?", proxyID).Error; err != nil {
+		return mapping, err
+	}
+	if mapping.ManagedBy != managedproxy.ManagerBKN || mapping.ManagedResourceType != managedproxy.ResourceKnowledgeNetwork ||
+		user.AccountType != model.AccountTypeApp || user.PasswordHash != "" {
+		return mapping, managedproxy.ErrInconsistentAccount
+	}
+	active := mapping.LifecycleStatus == managedproxy.StatusActive
+	validStatus := active || mapping.LifecycleStatus == managedproxy.StatusDisabling ||
+		mapping.LifecycleStatus == managedproxy.StatusArchived
+	if !validStatus || user.Enabled != active {
+		return mapping, managedproxy.ErrInconsistentAccount
+	}
+	return mapping, nil
+}
+
+func validateAuthority(tx *authz.PolicyTransaction, grantorID string, spec SourceSpec) error {
+	if err := validateGrantorIdentity(tx.DB(), grantorID); err != nil {
+		return err
+	}
+	var registered int64
+	if err := tx.DB().Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", spec.ResourceType, spec.Operation).Count(&registered).Error; err != nil {
+		return err
+	}
+	if registered == 0 {
+		return ErrInvalidRequest
+	}
+	authorize, err := tx.Check(grantorID, spec.ResourceType, spec.ResourceID, "authorize")
+	if err != nil {
+		return err
+	}
+	operation, err := tx.Check(grantorID, spec.ResourceType, spec.ResourceID, spec.Operation)
+	if err != nil {
+		return err
+	}
+	if !authorize || !operation {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func validateGrantorIdentity(db *gorm.DB, grantorID string) error {
+	var grantor model.User
+	if err := db.First(&grantor, "id = ? AND enabled = ?", grantorID, true).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrForbidden
+		}
+		return err
+	}
+	var managed int64
+	if err := db.Model(&model.ManagedProxyAccount{}).Where("proxy_account_id = ?", grantorID).Count(&managed).Error; err != nil {
+		return err
+	}
+	if managed > 0 {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func grantInTransaction(tx *authz.PolicyTransaction, proxyID, grantorID string, spec SourceSpec) (model.ProxyGrantSource, bool, error) {
+	var row model.ProxyGrantSource
+	err := tx.DB().Where(
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ? AND source_type = ? AND source_id = ?",
+		proxyID, spec.ResourceType, spec.ResourceID, spec.Operation, spec.SourceType, spec.SourceID,
+	).First(&row).Error
+	if err == nil && !sameBinding(specFromModel(row), spec) {
+		return row, false, ErrInvalidRequest
+	}
+	changed := false
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		id, err := newID()
+		if err != nil {
+			return row, false, fmt.Errorf("generate proxy grant source id: %w", err)
+		}
+		row = model.ProxyGrantSource{
+			ID: id, ProxyAccountID: proxyID, ResourceType: spec.ResourceType,
+			ResourceID: spec.ResourceID, Operation: spec.Operation, SourceType: spec.SourceType,
+			SourceID: spec.SourceID, KNID: spec.KNID, BindingType: spec.BindingType,
+			BindingID: spec.BindingID, GrantedBy: grantorID, LifecycleStatus: StatusActive,
+		}
+		if err := tx.DB().Create(&row).Error; err != nil {
+			return row, false, err
+		}
+		changed = true
+	case err != nil:
+		return row, false, err
+	case row.LifecycleStatus == StatusRevoked:
+		if err := tx.DB().Model(&row).Updates(map[string]any{
+			"kn_id": spec.KNID, "binding_type": spec.BindingType, "binding_id": spec.BindingID,
+			"granted_by": grantorID, "lifecycle_status": StatusActive, "revoked_at": nil,
+		}).Error; err != nil {
+			return row, false, err
+		}
+		row.KNID, row.BindingType, row.BindingID = spec.KNID, spec.BindingType, spec.BindingID
+		row.GrantedBy, row.LifecycleStatus, row.RevokedAt = grantorID, StatusActive, nil
+		changed = true
+	case row.LifecycleStatus != StatusActive:
+		return row, false, ErrInvalidRequest
+	}
+	if err := ensureMaterialized(tx, proxyID, spec); err != nil {
+		return row, false, err
+	}
+	return row, changed, nil
+}
+
+func ensureMaterialized(tx *authz.PolicyTransaction, proxyID string, spec SourceSpec) error {
+	var marker model.ProxyGrantPolicy
+	err := tx.DB().First(&marker,
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ?",
+		proxyID, spec.ResourceType, spec.ResourceID, spec.Operation).Error
+	hasPolicy, policyErr := tx.HasObjectPermission(proxyID, spec.ResourceType, spec.ResourceID, spec.Operation)
+	if policyErr != nil {
+		return policyErr
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		marker = model.ProxyGrantPolicy{
+			ProxyAccountID: proxyID, ResourceType: spec.ResourceType, ResourceID: spec.ResourceID,
+			Operation: spec.Operation, PolicyOwned: !hasPolicy,
+		}
+		if err := tx.DB().Create(&marker).Error; err != nil {
+			return err
+		}
+		if !hasPolicy {
+			return tx.GrantObjectPermission(proxyID, spec.ResourceType, spec.ResourceID, spec.Operation)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if hasPolicy {
+		return nil
+	}
+	if err := tx.GrantObjectPermission(proxyID, spec.ResourceType, spec.ResourceID, spec.Operation); err != nil {
+		return err
+	}
+	return tx.DB().Model(&marker).Update("policy_owned", true).Error
+}
+
+func revokeByID(tx *authz.PolicyTransaction, id string) (model.ProxyGrantSource, bool, error) {
+	var row model.ProxyGrantSource
+	if err := tx.DB().Clauses(clause.Locking{Strength: "UPDATE"}).First(&row, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return row, false, ErrNotFound
+		}
+		return row, false, err
+	}
+	if row.LifecycleStatus == StatusRevoked {
+		return row, false, nil
+	}
+	now := time.Now().UTC()
+	if err := tx.DB().Model(&row).Updates(map[string]any{
+		"lifecycle_status": StatusRevoked,
+		"revoked_at":       &now,
+	}).Error; err != nil {
+		return row, false, err
+	}
+	row.LifecycleStatus, row.RevokedAt = StatusRevoked, &now
+
+	var active int64
+	if err := tx.DB().Model(&model.ProxyGrantSource{}).Where(
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ? AND lifecycle_status = ?",
+		row.ProxyAccountID, row.ResourceType, row.ResourceID, row.Operation, StatusActive,
+	).Count(&active).Error; err != nil {
+		return row, false, err
+	}
+	if active > 0 {
+		return row, true, nil
+	}
+	var marker model.ProxyGrantPolicy
+	err := tx.DB().First(&marker,
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ?",
+		row.ProxyAccountID, row.ResourceType, row.ResourceID, row.Operation).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return row, true, nil
+	}
+	if err != nil {
+		return row, false, err
+	}
+	if marker.PolicyOwned {
+		if err := tx.RevokeObjectPermission(row.ProxyAccountID, row.ResourceType, row.ResourceID, row.Operation); err != nil {
+			return row, false, err
+		}
+	}
+	if err := tx.DB().Delete(&marker).Error; err != nil {
+		return row, false, err
+	}
+	return row, true, nil
+}
+
+func reconcileProxy(tx *authz.PolicyTransaction, proxyID, requestedBy string, result *ReconcileResult) error {
+	var active []model.ProxyGrantSource
+	if err := tx.DB().Where("proxy_account_id = ? AND lifecycle_status = ?", proxyID, StatusActive).Find(&active).Error; err != nil {
+		return err
+	}
+	activeByPermission := make(map[permissionKey]model.ProxyGrantSource, len(active))
+	for _, source := range active {
+		key := permissionForModel(source)
+		if _, exists := activeByPermission[key]; !exists {
+			activeByPermission[key] = source
+		}
+	}
+	for key, source := range activeByPermission {
+		var marker model.ProxyGrantPolicy
+		err := tx.DB().First(&marker,
+			"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ?",
+			key.ProxyAccountID, key.ResourceType, key.ResourceID, key.Operation).Error
+		has, policyErr := tx.HasObjectPermission(key.ProxyAccountID, key.ResourceType, key.ResourceID, key.Operation)
+		if policyErr != nil {
+			return policyErr
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			marker = model.ProxyGrantPolicy{
+				ProxyAccountID: key.ProxyAccountID, ResourceType: key.ResourceType,
+				ResourceID: key.ResourceID, Operation: key.Operation, PolicyOwned: !has,
+			}
+			if err := tx.DB().Create(&marker).Error; err != nil {
+				return err
+			}
+			result.MarkersCreated++
+		} else if err != nil {
+			return err
+		}
+		if !has {
+			if err := tx.GrantObjectPermission(key.ProxyAccountID, key.ResourceType, key.ResourceID, key.Operation); err != nil {
+				return err
+			}
+			if !marker.PolicyOwned {
+				if err := tx.DB().Model(&marker).Update("policy_owned", true).Error; err != nil {
+					return err
+				}
+			}
+			result.PoliciesRestored++
+			if err := recordAudit(tx.DB(), "reconcile_restore", "allow", "active source had no policy", requestedBy, proxyID, specFromModel(source)); err != nil {
+				return err
+			}
+		}
+	}
+
+	var markers []model.ProxyGrantPolicy
+	if err := tx.DB().Where("proxy_account_id = ?", proxyID).Find(&markers).Error; err != nil {
+		return err
+	}
+	for _, marker := range markers {
+		key := permissionKey{marker.ProxyAccountID, marker.ResourceType, marker.ResourceID, marker.Operation}
+		if _, exists := activeByPermission[key]; exists {
+			continue
+		}
+		has, err := tx.HasObjectPermission(marker.ProxyAccountID, marker.ResourceType, marker.ResourceID, marker.Operation)
+		if err != nil {
+			return err
+		}
+		if marker.PolicyOwned && has {
+			if err := tx.RevokeObjectPermission(marker.ProxyAccountID, marker.ResourceType, marker.ResourceID, marker.Operation); err != nil {
+				return err
+			}
+			result.PoliciesRemoved++
+			if err := recordAudit(tx.DB(), "reconcile_remove", "allow", "owned policy had no active source", requestedBy, proxyID, SourceSpec{
+				ResourceType: marker.ResourceType, ResourceID: marker.ResourceID, Operation: marker.Operation,
+			}); err != nil {
+				return err
+			}
+		}
+		if err := tx.DB().Delete(&marker).Error; err != nil {
+			return err
+		}
+		result.MarkersRemoved++
+	}
+
+	var rules []gormadapter.CasbinRule
+	if err := tx.DB().Where("ptype = ? AND v0 = ?", "p", proxyID).Find(&rules).Error; err != nil {
+		return err
+	}
+	for _, rule := range rules {
+		rtype, rid, ok := strings.Cut(rule.V1, ":")
+		if !ok {
+			continue
+		}
+		key := permissionKey{proxyID, rtype, rid, rule.V2}
+		if _, sourced := activeByPermission[key]; sourced {
+			continue
+		}
+		var markerCount int64
+		if err := tx.DB().Model(&model.ProxyGrantPolicy{}).Where(
+			"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ?",
+			proxyID, rtype, rid, rule.V2).Count(&markerCount).Error; err != nil {
+			return err
+		}
+		if markerCount == 0 {
+			result.UntrackedPolicies++
+		}
+	}
+	return nil
+}
+
+func reconcileProxyIDs(db *gorm.DB, only string) ([]string, error) {
+	if only != "" {
+		var count int64
+		if err := db.Model(&model.ManagedProxyAccount{}).Where("proxy_account_id = ?", only).Count(&count).Error; err != nil {
+			return nil, err
+		}
+		if count == 0 {
+			return nil, ErrNotFound
+		}
+		return []string{only}, nil
+	}
+	var ids []string
+	err := db.Model(&model.ManagedProxyAccount{}).Order("proxy_account_id").Pluck("proxy_account_id", &ids).Error
+	return ids, err
+}
+
+func recordAudit(db *gorm.DB, action, decision, reason, grantorID, proxyID string, spec SourceSpec) error {
+	if len(reason) > 255 {
+		reason = reason[:255]
+	}
+	id, err := newID()
+	if err != nil {
+		return fmt.Errorf("generate proxy grant audit id: %w", err)
+	}
+	return db.Create(&model.ProxyGrantAuditLog{
+		ID: id, Action: action, Decision: decision, Reason: reason, GrantorID: grantorID,
+		ProxyAccountID: proxyID, ResourceType: spec.ResourceType, ResourceID: spec.ResourceID,
+		Operation: spec.Operation, SourceType: spec.SourceType, SourceID: spec.SourceID,
+	}).Error
+}
+
+func (s *Service) recordDenied(ctx context.Context, action, grantorID, proxyID string, spec SourceSpec, decisionErr error) {
+	if err := recordAudit(s.db.WithContext(ctx), action, "deny", decisionErr.Error(), grantorID, proxyID, spec); err != nil {
+		slog.ErrorContext(ctx, "failed to persist proxy grant denial audit", "action", action, "error", err)
+	}
+}
+
+func keyForSpec(spec SourceSpec) sourceKey {
+	return sourceKey{spec.ResourceType, spec.ResourceID, spec.Operation, spec.SourceType, spec.SourceID}
+}
+
+func keyForModel(row model.ProxyGrantSource) sourceKey {
+	return sourceKey{row.ResourceType, row.ResourceID, row.Operation, row.SourceType, row.SourceID}
+}
+
+func sameBinding(left, right SourceSpec) bool {
+	return left.KNID == right.KNID && left.BindingType == right.BindingType && left.BindingID == right.BindingID
+}
+
+func permissionForModel(row model.ProxyGrantSource) permissionKey {
+	return permissionKey{row.ProxyAccountID, row.ResourceType, row.ResourceID, row.Operation}
+}
+
+func specFromModel(row model.ProxyGrantSource) SourceSpec {
+	return SourceSpec{
+		ResourceType: row.ResourceType, ResourceID: row.ResourceID, Operation: row.Operation,
+		SourceType: row.SourceType, SourceID: row.SourceID, KNID: row.KNID,
+		BindingType: row.BindingType, BindingID: row.BindingID,
+	}
+}
+
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/bkn-safe/server/internal/proxygrant/service_test.go
+++ b/bkn-safe/server/internal/proxygrant/service_test.go
@@ -1,0 +1,459 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package proxygrant_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/proxygrant"
+)
+
+type fixture struct {
+	db       *gorm.DB
+	enforcer *authz.Enforcer
+	service  *proxygrant.Service
+	proxyID  string
+	grantor  string
+}
+
+func newFixture(t *testing.T) fixture {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	enforcer, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	const grantor = "grantor-1"
+	if err := db.Create(&model.User{ID: grantor, Account: grantor, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ResourceType{ID: "resource", Name: "Resource"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []string{"authorize", "view_detail", "query_data"} {
+		if err := db.Create(&model.Operation{ResourceTypeID: "resource", ID: operation, Name: operation}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	return fixture{
+		db: db, enforcer: enforcer, service: proxygrant.New(db, enforcer),
+		proxyID: proxy.ProxyAccountID, grantor: grantor,
+	}
+}
+
+func (f fixture) authorize(t *testing.T, resourceID string, operations ...string) {
+	t.Helper()
+	if err := f.enforcer.GrantObjectPermission(f.grantor, "resource", resourceID, "authorize"); err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range operations {
+		if err := f.enforcer.GrantObjectPermission(f.grantor, "resource", resourceID, operation); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (f fixture) request(sourceID, bindingID, resourceID string) proxygrant.GrantRequest {
+	return proxygrant.GrantRequest{
+		ProxyAccountID: f.proxyID,
+		GrantorID:      f.grantor,
+		Source: proxygrant.SourceSpec{
+			ResourceType: "resource", ResourceID: resourceID, Operation: "query_data",
+			SourceType: proxygrant.SourceTypeKNProxyBinding, SourceID: sourceID,
+			KNID: "kn-1", BindingType: "object_type", BindingID: bindingID,
+		},
+	}
+}
+
+func TestGrantIsIdempotentAndLastSourceRevokesOwnedPolicy(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+
+	first, changed, err := f.service.Grant(t.Context(), f.request("source-1", "ot-1", "r-1"))
+	if err != nil || !changed {
+		t.Fatalf("first Grant() = (%+v, %v, %v)", first, changed, err)
+	}
+	replay, changed, err := f.service.Grant(t.Context(), f.request("source-1", "ot-1", "r-1"))
+	if err != nil || changed || replay.ID != first.ID {
+		t.Fatalf("replayed Grant() = (%+v, %v, %v), first=%+v", replay, changed, err, first)
+	}
+	second, changed, err := f.service.Grant(t.Context(), f.request("source-2", "ot-2", "r-1"))
+	if err != nil || !changed {
+		t.Fatalf("second Grant() = (%+v, %v, %v)", second, changed, err)
+	}
+	assertAllowed(t, f, true)
+
+	if _, changed, err := f.service.Revoke(t.Context(), first.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil || !changed {
+		t.Fatalf("revoke first = (%v, %v)", changed, err)
+	}
+	assertAllowed(t, f, true)
+	if _, changed, err := f.service.Revoke(t.Context(), second.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil || !changed {
+		t.Fatalf("revoke second = (%v, %v)", changed, err)
+	}
+	assertAllowed(t, f, false)
+
+	var audits []model.ProxyGrantAuditLog
+	if err := f.db.Order("created_at").Find(&audits).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(audits) != 5 || audits[0].GrantorID != f.grantor || audits[0].ProxyAccountID != f.proxyID ||
+		audits[0].ResourceID != "r-1" || audits[0].Operation != "query_data" || audits[0].Decision != "allow" {
+		t.Fatalf("audit rows = %+v", audits)
+	}
+}
+
+func TestSourceIdentityCollisionIsRejected(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	original := f.request("source-1", "ot-1", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), original); err != nil {
+		t.Fatal(err)
+	}
+	collision := f.request("source-1", "ot-other", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), collision); !errors.Is(err, proxygrant.ErrInvalidRequest) {
+		t.Fatalf("colliding Grant() error = %v, want invalid request", err)
+	}
+	if _, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor,
+		Sources: []proxygrant.SourceSpec{original.Source, collision.Source},
+	}); !errors.Is(err, proxygrant.ErrInvalidRequest) {
+		t.Fatalf("colliding Sync() error = %v, want invalid request", err)
+	}
+	if _, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor,
+		Sources: []proxygrant.SourceSpec{collision.Source},
+	}); !errors.Is(err, proxygrant.ErrInvalidRequest) {
+		t.Fatalf("existing-source collision Sync() error = %v, want invalid request", err)
+	}
+	var sources []model.ProxyGrantSource
+	if err := f.db.Find(&sources).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 1 || sources[0].BindingID != "ot-1" {
+		t.Fatalf("sources after collision = %+v", sources)
+	}
+}
+
+func TestRevokingLastSourcePreservesPreexistingManualPolicy(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	if err := f.enforcer.GrantObjectPermission(f.proxyID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	source, _, err := f.service.Grant(t.Context(), f.request("source-manual", "ot-manual", "r-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Revoke(t.Context(), source.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+	var markers int64
+	if err := f.db.Model(&model.ProxyGrantPolicy{}).Count(&markers).Error; err != nil || markers != 0 {
+		t.Fatalf("markers = %d err=%v, want 0", markers, err)
+	}
+}
+
+func TestRevokingBindingPreservesActiveManualSource(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	binding, _, err := f.service.Grant(t.Context(), f.request("source-binding", "ot-binding", "r-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manualRequest := f.request("source-manual", "manual-ticket", "r-1")
+	manualRequest.Source.SourceType = proxygrant.SourceTypeManual
+	manualRequest.Source.BindingType = "manual"
+	manual, _, err := f.service.Grant(t.Context(), manualRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Revoke(t.Context(), binding.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+	if _, _, err := f.service.Revoke(t.Context(), manual.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestFullBindingSyncPreservesManualSource(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	binding := f.request("source-binding", "ot-binding", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), binding); err != nil {
+		t.Fatal(err)
+	}
+	manualRequest := f.request("source-manual", "manual-ticket", "r-1")
+	manualRequest.Source.SourceType = proxygrant.SourceTypeManual
+	manualRequest.Source.BindingType = "manual"
+	manual, _, err := f.service.Grant(t.Context(), manualRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor,
+	})
+	if err != nil || result.Revoked != 1 || len(result.Sources) != 0 {
+		t.Fatalf("empty binding Sync() = (%+v, %v)", result, err)
+	}
+	assertAllowed(t, f, true)
+	var source model.ProxyGrantSource
+	if err := f.db.First(&source, "id = ?", manual.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if source.LifecycleStatus != proxygrant.StatusActive {
+		t.Fatalf("manual source status = %q, want active", source.LifecycleStatus)
+	}
+}
+
+func TestDisabledProxyAllowsCleanupButRejectsNewSource(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-1", "ot-1", "r-1")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := managedproxy.New(f.db).Disable(t.Context(), f.proxyID); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor,
+	})
+	if err != nil || cleanup.Revoked != 1 {
+		t.Fatalf("disabled proxy cleanup Sync() = (%+v, %v)", cleanup, err)
+	}
+	assertAllowed(t, f, false)
+
+	_, err = f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor,
+		Sources: []proxygrant.SourceSpec{f.request("source-2", "ot-2", "r-1").Source},
+	})
+	if !errors.Is(err, proxygrant.ErrProxyInactive) {
+		t.Fatalf("disabled proxy addition error = %v, want proxy inactive", err)
+	}
+}
+
+func TestSyncPreflightRejectsWholeSetOnUnauthorizedTarget(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	good := f.request("source-good", "ot-good", "r-1").Source
+	bad := f.request("source-bad", "ot-bad", "r-2").Source
+
+	_, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor, Sources: []proxygrant.SourceSpec{good, bad},
+	})
+	if !errors.Is(err, proxygrant.ErrForbidden) {
+		t.Fatalf("Sync() error = %v, want forbidden", err)
+	}
+	var sources, markers int64
+	if err := f.db.Model(&model.ProxyGrantSource{}).Count(&sources).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Model(&model.ProxyGrantPolicy{}).Count(&markers).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sources != 0 || markers != 0 {
+		t.Fatalf("failed sync left sources=%d markers=%d", sources, markers)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestAuditFailureRollsBackSourceAndPolicy(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	if err := f.db.Migrator().DropTable(&model.ProxyGrantAuditLog{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-rollback", "ot-rollback", "r-1")); err == nil {
+		t.Fatal("Grant() succeeded with missing audit table")
+	}
+	var sources int64
+	if err := f.db.Model(&model.ProxyGrantSource{}).Count(&sources).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sources != 0 {
+		t.Fatalf("failed transaction left %d sources", sources)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestFullSyncAndReconcileAreIdempotent(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	one := f.request("source-1", "ot-1", "r-1").Source
+	two := f.request("source-2", "ot-2", "r-1").Source
+
+	first, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor, Sources: []proxygrant.SourceSpec{one, two},
+	})
+	if err != nil || first.Added != 2 || len(first.Sources) != 2 {
+		t.Fatalf("first Sync() = (%+v, %v)", first, err)
+	}
+	replay, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor, Sources: []proxygrant.SourceSpec{one, two},
+	})
+	if err != nil || replay.Added != 0 || replay.Revoked != 0 || replay.Unchanged != 2 {
+		t.Fatalf("replayed Sync() = (%+v, %v)", replay, err)
+	}
+
+	if err := f.enforcer.RevokeObjectPermission(f.proxyID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := f.service.Reconcile(t.Context(), proxygrant.ReconcileRequest{ProxyAccountID: f.proxyID, RequestedBy: "system:reconcile"})
+	if err != nil || repaired.PoliciesRestored != 1 {
+		t.Fatalf("restore Reconcile() = (%+v, %v)", repaired, err)
+	}
+	assertAllowed(t, f, true)
+
+	empty, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{ProxyAccountID: f.proxyID, GrantorID: f.grantor})
+	if err != nil || empty.Revoked != 2 || len(empty.Sources) != 0 {
+		t.Fatalf("empty Sync() = (%+v, %v)", empty, err)
+	}
+	assertAllowed(t, f, false)
+	replayEmpty, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{ProxyAccountID: f.proxyID, GrantorID: f.grantor})
+	if err != nil || replayEmpty.Added != 0 || replayEmpty.Revoked != 0 {
+		t.Fatalf("replayed empty Sync() = (%+v, %v)", replayEmpty, err)
+	}
+}
+
+func TestConcurrentGrantReplayCreatesOneSourceAndPolicy(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	sqlDB, err := f.db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+
+	const callers = 12
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	ids := make(chan string, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			source, _, err := f.service.Grant(t.Context(), f.request("source-concurrent", "ot-concurrent", "r-1"))
+			errs <- err
+			if source != nil {
+				ids <- source.ID
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	close(ids)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Grant() error = %v", err)
+		}
+	}
+	unique := map[string]bool{}
+	for id := range ids {
+		unique[id] = true
+	}
+	if len(unique) != 1 {
+		t.Fatalf("source ids = %v, want one", unique)
+	}
+	var sources, policies int64
+	if err := f.db.Model(&model.ProxyGrantSource{}).Count(&sources).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Model(&gormadapterRule{}).Where("ptype = ? AND v0 = ? AND v1 = ? AND v2 = ?",
+		"p", f.proxyID, "resource:r-1", "query_data").Count(&policies).Error; err != nil {
+		t.Fatal(err)
+	}
+	if sources != 1 || policies != 1 {
+		t.Fatalf("concurrent replay left sources=%d policies=%d", sources, policies)
+	}
+}
+
+func TestCheckDenialIsAuditedWithoutMutation(t *testing.T) {
+	f := newFixture(t)
+	result, err := f.service.Check(t.Context(), f.request("source-check", "ot-check", "r-1"))
+	if err != nil || result.Allowed || result.Reason == "" {
+		t.Fatalf("Check() = (%+v, %v)", result, err)
+	}
+	var audit model.ProxyGrantAuditLog
+	if err := f.db.Last(&audit).Error; err != nil {
+		t.Fatal(err)
+	}
+	if audit.Decision != "deny" || audit.GrantorID != f.grantor || audit.ProxyAccountID != f.proxyID {
+		t.Fatalf("audit = %+v", audit)
+	}
+}
+
+func TestRevokeAndEmptySyncDenialsAreAudited(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1", "query_data")
+	source, _, err := f.service.Grant(t.Context(), f.request("source-audit", "ot-audit", "r-1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Revoke(t.Context(), source.ID, proxygrant.RevokeRequest{GrantorID: "missing-grantor"}); !errors.Is(err, proxygrant.ErrForbidden) {
+		t.Fatalf("denied Revoke() error = %v, want forbidden", err)
+	}
+	if _, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: "missing-grantor",
+	}); !errors.Is(err, proxygrant.ErrForbidden) {
+		t.Fatalf("denied empty Sync() error = %v, want forbidden", err)
+	}
+	var audits []model.ProxyGrantAuditLog
+	if err := f.db.Where("decision = ?", "deny").Order("action").Find(&audits).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(audits) != 2 || audits[0].Action != "revoke" || audits[1].Action != "sync" ||
+		audits[0].SourceID != "source-audit" {
+		t.Fatalf("denial audits = %+v", audits)
+	}
+}
+
+func assertAllowed(t *testing.T, f fixture, want bool) {
+	t.Helper()
+	allowed, err := f.enforcer.Check(f.proxyID, "resource", "r-1", "query_data")
+	if err != nil || allowed != want {
+		t.Fatalf("proxy allowed = %v err=%v, want %v", allowed, err, want)
+	}
+}
+
+// gormadapterRule mirrors the public adapter table without importing adapter
+// internals into test assertions.
+type gormadapterRule struct {
+	ID    uint `gorm:"primaryKey"`
+	Ptype string
+	V0    string
+	V1    string
+	V2    string
+}
+
+func (gormadapterRule) TableName() string { return "casbin_rule" }

--- a/docs/api/bkn-safe/authorization.yaml
+++ b/docs/api/bkn-safe/authorization.yaml
@@ -184,6 +184,10 @@ paths:
     delete:
       operationId: deleteResourcePolicies
       summary: Delete all policies for one concrete resource
+      description: |
+        Deletes ordinary direct policies for the resource. If the resource still
+        has policies managed by proxy grant sources, the request fails with `409`;
+        callers must revoke or synchronize those sources before retrying cleanup.
       requestBody:
         required: true
         content:
@@ -198,6 +202,8 @@ paths:
         '204': {description: Policies deleted or already absent}
         '400':
           $ref: '#/components/responses/BadRequest'
+        '409':
+          $ref: '#/components/responses/ManagedProxyPoliciesRemain'
         '500':
           $ref: '#/components/responses/InternalError'
     get:
@@ -337,6 +343,12 @@ components:
             $ref: '#/components/schemas/BknSafeError'
     AuthorizationUnavailable:
       description: Account state cannot be read; no permission is granted.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BknSafeError'
+    ManagedProxyPoliciesRemain:
+      description: Managed proxy grant sources must be removed before generic resource policy cleanup.
       content:
         application/json:
           schema:

--- a/docs/api/bkn-safe/proxy-grants.yaml
+++ b/docs/api/bkn-safe/proxy-grants.yaml
@@ -1,0 +1,413 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+info:
+  title: BKN Safe 代理授权来源 API
+  version: 0.1.5
+  description: |
+    供受信任 BKN workload 维护受管代理账号的底层最小权限来源。本接口只存在于
+    ClusterIP 内部面，不经 Ingress 暴露。
+
+    来源记录、物化标记、授权审计和 Casbin Allow 在同一个数据库事务内更新。同一
+    来源重复写入幂等；多个来源可共享一条 Allow；只有最后一个有效来源撤销且该 Allow
+    由来源服务创建时才删除。来源建立前已存在的人工或历史 Allow 会保留并在 reconcile
+    结果中报告为未追踪策略。
+servers:
+  - url: /api/safe/in/v1
+security: []
+paths:
+  /proxy-grant-sources:
+    post:
+      tags: [Proxy grant sources]
+      operationId: createProxyGrantSource
+      summary: 新增或恢复一个代理授权来源
+      description: |
+        grantor 必须是 enabled 的非受管账号，并同时持有目标 authorize 和准备授出的
+        operation。首次创建返回 201；相同来源重放返回 200。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantRequest'
+      responses:
+        '201':
+          description: 来源已创建，必要时同时创建 Casbin Allow
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyGrantSource'
+        '200':
+          description: 相同来源已经有效，返回原记录
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyGrantSource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /proxy-grant-sources/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: 来源记录 ID。
+        schema:
+          type: string
+          maxLength: 64
+    delete:
+      tags: [Proxy grant sources]
+      operationId: revokeProxyGrantSource
+      summary: 撤销一个代理授权来源
+      description: |
+        重复撤销幂等。仍有其他有效来源时保留 Allow；最后来源撤销时仅删除来源服务拥有的 Allow。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RevokeRequest'
+      responses:
+        '200':
+          description: 已撤销或此前已经撤销
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyGrantSource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /proxy-grant-sources/check:
+    post:
+      tags: [Proxy grant sources]
+      operationId: checkProxyGrantSourceAuthority
+      summary: 预检 grantor 是否可以建立来源
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GrantRequest'
+      responses:
+        '200':
+          description: 预检完成；权限不足通过 allowed=false 表达
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /proxy-grant-sources/sync:
+    post:
+      tags: [Proxy grant sources]
+      operationId: syncProxyGrantSources
+      summary: 按最新发布模型全量同步来源
+      description: |
+        sources 是该 proxy 当前完整的 kn_proxy_binding 来源集合。服务先预检所有新增来源，
+        任一来源越权时整次同步拒绝且不改变来源或 Policy；删除项不影响人工或其他有效来源。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncRequest'
+      responses:
+        '200':
+          description: 同步完成
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+  /proxy-grant-sources/reconcile:
+    post:
+      tags: [Proxy grant sources]
+      operationId: reconcileProxyGrantSources
+      summary: 修复来源账本与 Casbin Allow 漂移
+      description: |
+        恢复有效来源缺失的 Allow，删除没有有效来源且仍由来源服务拥有的 Allow。
+        无物化标记的现有策略不会自动删除，而在 untracked_policies 中报告，避免误删历史人工授权。
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReconcileRequest'
+      responses:
+        '200':
+          description: 对账完成
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReconcileResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  responses:
+    BadRequest:
+      description: 请求缺少字段、字段超长、包含通配符或目标 operation 不在代理白名单/操作目录
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    Forbidden:
+      description: grantor 缺少目标 authorize 或准备授出的 operation，或来源不属于 proxy 对应知识网络
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    NotFound:
+      description: proxy account 或来源记录不存在
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    Conflict:
+      description: proxy account 已禁用或归档，不能新增授权来源
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    InternalError:
+      description: 数据库、Casbin 或审计写入失败；事务内失败会回滚，提交后缓存刷新失败可幂等重试
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+  schemas:
+    GrantRequest:
+      type: object
+      additionalProperties: false
+      required: [proxy_account_id, grantor_id, source]
+      properties:
+        proxy_account_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        grantor_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        source:
+          $ref: '#/components/schemas/SourceSpec'
+    RevokeRequest:
+      type: object
+      additionalProperties: false
+      required: [grantor_id]
+      properties:
+        grantor_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+    SyncRequest:
+      type: object
+      additionalProperties: false
+      required: [proxy_account_id, grantor_id, sources]
+      properties:
+        proxy_account_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        grantor_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceSpec'
+    ReconcileRequest:
+      type: object
+      additionalProperties: false
+      required: [requested_by]
+      properties:
+        proxy_account_id:
+          type: string
+          maxLength: 64
+          description: 省略时对账全部受管 proxy。
+        requested_by:
+          type: string
+          minLength: 1
+          maxLength: 64
+    SourceSpec:
+      type: object
+      additionalProperties: false
+      required:
+        - resource_type
+        - resource_id
+        - operation
+        - source_id
+        - kn_id
+        - binding_type
+        - binding_id
+      properties:
+        resource_type:
+          type: string
+          enum: [resource, tool_box, mcp]
+        resource_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        operation:
+          type: string
+          enum: [view_detail, query_data, execute]
+        source_type:
+          type: string
+          enum: [kn_proxy_binding, manual, admin]
+          default: kn_proxy_binding
+        source_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: 调用方生成的稳定来源键；同一绑定可为多个权限复用该值。
+        kn_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        binding_type:
+          type: string
+          minLength: 1
+          maxLength: 64
+        binding_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+    ProxyGrantSource:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - proxy_account_id
+        - resource_type
+        - resource_id
+        - operation
+        - source_type
+        - source_id
+        - kn_id
+        - binding_type
+        - binding_id
+        - granted_by
+        - lifecycle_status
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+        proxy_account_id:
+          type: string
+        resource_type:
+          type: string
+          enum: [resource, tool_box, mcp]
+        resource_id:
+          type: string
+        operation:
+          type: string
+          enum: [view_detail, query_data, execute]
+        source_type:
+          type: string
+          enum: [kn_proxy_binding, manual, admin]
+        source_id:
+          type: string
+        kn_id:
+          type: string
+        binding_type:
+          type: string
+        binding_id:
+          type: string
+        granted_by:
+          type: string
+        lifecycle_status:
+          type: string
+          enum: [active, revoked]
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        revoked_at:
+          type: string
+          format: date-time
+          nullable: true
+    CheckResult:
+      type: object
+      additionalProperties: false
+      required: [allowed]
+      properties:
+        allowed:
+          type: boolean
+        reason:
+          type: string
+          description: 仅 allowed=false 时返回，不包含目标连接信息。
+    SyncResult:
+      type: object
+      additionalProperties: false
+      required: [added, revoked, unchanged, sources]
+      properties:
+        added:
+          type: integer
+          minimum: 0
+        revoked:
+          type: integer
+          minimum: 0
+        unchanged:
+          type: integer
+          minimum: 0
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProxyGrantSource'
+    ReconcileResult:
+      type: object
+      additionalProperties: false
+      required:
+        - policies_restored
+        - policies_removed
+        - markers_created
+        - markers_removed
+        - untracked_policies
+      properties:
+        policies_restored:
+          type: integer
+          minimum: 0
+        policies_removed:
+          type: integer
+          minimum: 0
+        markers_created:
+          type: integer
+          minimum: 0
+        markers_removed:
+          type: integer
+          minimum: 0
+        untracked_policies:
+          type: integer
+          minimum: 0

--- a/docs/api/bkn-safe/proxy-grants.yaml
+++ b/docs/api/bkn-safe/proxy-grants.yaml
@@ -4,16 +4,18 @@
 
 openapi: 3.0.3
 info:
-  title: BKN Safe 代理授权来源 API
+  title: BKN Safe Proxy Grant Source API
   version: 0.1.5
   description: |
-    供受信任 BKN workload 维护受管代理账号的底层最小权限来源。本接口只存在于
-    ClusterIP 内部面，不经 Ingress 暴露。
+    Allows trusted BKN workloads to maintain least-privilege grant sources for managed proxy
+    accounts. This API is available only on the internal ClusterIP surface and is not exposed
+    through Ingress.
 
-    来源记录、物化标记、授权审计和 Casbin Allow 在同一个数据库事务内更新。同一
-    来源重复写入幂等；多个来源可共享一条 Allow；只有最后一个有效来源撤销且该 Allow
-    由来源服务创建时才删除。来源建立前已存在的人工或历史 Allow 会保留并在 reconcile
-    结果中报告为未追踪策略。
+    Source records, materialization markers, authorization audit entries, and Casbin Allow
+    policies are updated in one database transaction. Replaying the same source is idempotent;
+    multiple sources may share one Allow policy; the policy is removed only when its last active
+    source is revoked and the source service owns that policy. Manual or legacy Allow policies
+    that predate the source are preserved and reported as untracked during reconciliation.
 servers:
   - url: /api/safe/in/v1
 security: []
@@ -22,10 +24,11 @@ paths:
     post:
       tags: [Proxy grant sources]
       operationId: createProxyGrantSource
-      summary: 新增或恢复一个代理授权来源
+      summary: Create or reactivate a proxy grant source
       description: |
-        grantor 必须是 enabled 的非受管账号，并同时持有目标 authorize 和准备授出的
-        operation。首次创建返回 201；相同来源重放返回 200。
+        The grantor must be an enabled, non-managed account and must hold both `authorize` and
+        the operation being delegated on the target. The first creation returns 201; replaying
+        the same source returns 200.
       requestBody:
         required: true
         content:
@@ -34,13 +37,13 @@ paths:
               $ref: '#/components/schemas/GrantRequest'
       responses:
         '201':
-          description: 来源已创建，必要时同时创建 Casbin Allow
+          description: The source was created, together with a Casbin Allow policy when required
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProxyGrantSource'
         '200':
-          description: 相同来源已经有效，返回原记录
+          description: The same source is already active; the existing record is returned
           content:
             application/json:
               schema:
@@ -60,16 +63,17 @@ paths:
       - name: id
         in: path
         required: true
-        description: 来源记录 ID。
+        description: Source record ID.
         schema:
           type: string
           maxLength: 64
     delete:
       tags: [Proxy grant sources]
       operationId: revokeProxyGrantSource
-      summary: 撤销一个代理授权来源
+      summary: Revoke a proxy grant source
       description: |
-        重复撤销幂等。仍有其他有效来源时保留 Allow；最后来源撤销时仅删除来源服务拥有的 Allow。
+        Repeated revocation is idempotent. The Allow policy is preserved while another active
+        source remains; revoking the final source removes only policies owned by this service.
       requestBody:
         required: true
         content:
@@ -78,7 +82,7 @@ paths:
               $ref: '#/components/schemas/RevokeRequest'
       responses:
         '200':
-          description: 已撤销或此前已经撤销
+          description: The source was revoked or was already revoked
           content:
             application/json:
               schema:
@@ -95,7 +99,7 @@ paths:
     post:
       tags: [Proxy grant sources]
       operationId: checkProxyGrantSourceAuthority
-      summary: 预检 grantor 是否可以建立来源
+      summary: Check whether a grantor may establish a source
       requestBody:
         required: true
         content:
@@ -104,7 +108,7 @@ paths:
               $ref: '#/components/schemas/GrantRequest'
       responses:
         '200':
-          description: 预检完成；权限不足通过 allowed=false 表达
+          description: The check completed; insufficient authority is represented by `allowed=false`
           content:
             application/json:
               schema:
@@ -117,10 +121,12 @@ paths:
     post:
       tags: [Proxy grant sources]
       operationId: syncProxyGrantSources
-      summary: 按最新发布模型全量同步来源
+      summary: Synchronize the complete source set from the latest published model
       description: |
-        sources 是该 proxy 当前完整的 kn_proxy_binding 来源集合。服务先预检所有新增来源，
-        任一来源越权时整次同步拒绝且不改变来源或 Policy；删除项不影响人工或其他有效来源。
+        `sources` is the proxy account's complete current set of `kn_proxy_binding` sources.
+        Every new source is checked before any mutation. If one source is unauthorized, the
+        entire synchronization is rejected without changing sources or policies. Removed entries
+        do not affect manual sources or other active sources.
       requestBody:
         required: true
         content:
@@ -129,7 +135,7 @@ paths:
               $ref: '#/components/schemas/SyncRequest'
       responses:
         '200':
-          description: 同步完成
+          description: Synchronization completed
           content:
             application/json:
               schema:
@@ -148,10 +154,12 @@ paths:
     post:
       tags: [Proxy grant sources]
       operationId: reconcileProxyGrantSources
-      summary: 修复来源账本与 Casbin Allow 漂移
+      summary: Repair drift between the source ledger and Casbin Allow policies
       description: |
-        恢复有效来源缺失的 Allow，删除没有有效来源且仍由来源服务拥有的 Allow。
-        无物化标记的现有策略不会自动删除，而在 untracked_policies 中报告，避免误删历史人工授权。
+        Restores Allow policies missing for active sources and removes source-owned Allow policies
+        that have no active source. Existing policies without a materialization marker are reported
+        in `untracked_policies` instead of being deleted, avoiding accidental removal of historical
+        manual grants.
       requestBody:
         required: true
         content:
@@ -160,7 +168,7 @@ paths:
               $ref: '#/components/schemas/ReconcileRequest'
       responses:
         '200':
-          description: 对账完成
+          description: Reconciliation completed
           content:
             application/json:
               schema:
@@ -174,31 +182,31 @@ paths:
 components:
   responses:
     BadRequest:
-      description: 请求缺少字段、字段超长、包含通配符或目标 operation 不在代理白名单/操作目录
+      description: The request is missing fields, exceeds length limits, contains wildcards, or targets an operation outside the proxy allowlist or operation catalog
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     Forbidden:
-      description: grantor 缺少目标 authorize 或准备授出的 operation，或来源不属于 proxy 对应知识网络
+      description: The grantor lacks `authorize` or the delegated operation on the target, or the source belongs to a different knowledge network
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     NotFound:
-      description: proxy account 或来源记录不存在
+      description: The proxy account or source record does not exist
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     Conflict:
-      description: proxy account 已禁用或归档，不能新增授权来源
+      description: The proxy account is disabled or archived and cannot receive a new grant source
       content:
         application/json:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     InternalError:
-      description: 数据库、Casbin 或审计写入失败；事务内失败会回滚，提交后缓存刷新失败可幂等重试
+      description: A database, Casbin, or audit write failed; in-transaction failures are rolled back, while a post-commit cache reload failure may be retried idempotently
       content:
         application/json:
           schema:
@@ -253,7 +261,7 @@ components:
         proxy_account_id:
           type: string
           maxLength: 64
-          description: 省略时对账全部受管 proxy。
+          description: When omitted, all managed proxy accounts are reconciled.
         requested_by:
           type: string
           minLength: 1
@@ -288,7 +296,7 @@ components:
           type: string
           minLength: 1
           maxLength: 128
-          description: 调用方生成的稳定来源键；同一绑定可为多个权限复用该值。
+          description: Stable caller-generated source key; one binding may reuse it across multiple permissions.
         kn_id:
           type: string
           minLength: 1
@@ -367,7 +375,7 @@ components:
           type: boolean
         reason:
           type: string
-          description: 仅 allowed=false 时返回，不包含目标连接信息。
+          description: Returned only when `allowed=false`; it does not contain target connection details.
     SyncResult:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## What Changed

- [x] Added a durable proxy-grant source ledger, policy ownership markers, and decision audit records.
- [x] Added internal grant, revoke, authorization preflight, full synchronization, and reconciliation APIs.
- [x] Materialized source records and Casbin policies within one database transaction, with synchronized in-process policy access.
- [x] Protected managed proxy policies from generic resource cleanup while active sources remain.
- [x] Added focused service, HTTP, transaction, concurrency, rollback, idempotency, and drift-repair coverage.
- [x] Added OpenAPI documentation and deployment guidance; the Helm chart explicitly enforces one replica until cross-pod policy cache synchronization exists.

---

## Why

- Related Issue: Closes #1305
- Related Feature: Managed knowledge-network proxy authorization
- Background: Published-model bindings need traceable, least-privilege grants for managed KN proxy accounts. Direct Casbin writes alone cannot explain why a grant exists or safely decide when a shared grant may be removed.

---

## How

- Stores one immutable provenance row per proxy, permission tuple, source type, and source ID.
- Uses a policy marker to distinguish source-owned Casbin rows from pre-existing manual or legacy policies.
- Serializes local policy writes and performs relational writes, audit writes, and Casbin adapter mutations under the same transaction boundary.
- Validates that the grantor is enabled, is not a managed proxy, owns the target KN binding, and holds both `authorize` and the delegated operation.
- Preserves shared or untracked policies when revoking one source, and provides reconciliation for missing or stale owned policies.
- Breaking changes: Helm rendering now rejects `replicaCount` values other than `1` until a cross-pod Casbin watcher is implemented. No existing API is removed.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go build ./...`
- `go test ./... -count=1 -p=1`
- `go vet ./...`
- `go test -race ./internal/authz -run 'PolicyTransaction|RemoveResourcePolicies' -count=1`
- `go test -race ./internal/proxygrant -count=1`
- Redocly lint passed for `authorization.yaml` and `proxy-grants.yaml`.
- Helm render/lint was not run because Helm is not installed in the local environment.

---

## Risk & Rollback

- Potential risks: database AutoMigrate creates three additive tables; a post-commit Casbin reload failure can return an error after the durable mutation has committed, so clients must retry idempotently; deployments configured for multiple replicas will fail Helm rendering by design.
- Rollback plan: revoke or synchronize active proxy-grant sources first, then revert this commit and redeploy the previous bkn-safe image/chart. The additive tables may remain unused and can be removed later through the separately approved schema-cleanup process.

---

## Additional Notes

- This is a stacked PR based on `feat/1304-managed-proxy` / #1313. It should be rebased or retargeted to `main` after #1313 merges.
- The internal endpoints remain ClusterIP-only and must not be exposed through ingress.
