### PR TITLE
fix(bkn): support proxy-aware knowledge network imports

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client.go
@@ -59,6 +59,10 @@ func (c *safeClient) Disable(ctx context.Context, proxyAccountID string) (*inter
 	return c.changeLifecycle(ctx, proxyAccountID, "disable")
 }
 
+func (c *safeClient) Restore(ctx context.Context, proxyAccountID string) (*interfaces.ManagedProxyAccount, error) {
+	return c.changeLifecycle(ctx, proxyAccountID, "restore")
+}
+
 func (c *safeClient) Archive(ctx context.Context, proxyAccountID string) (*interfaces.ManagedProxyAccount, error) {
 	return c.changeLifecycle(ctx, proxyAccountID, "archive")
 }
@@ -80,7 +84,10 @@ func (c *safeClient) changeLifecycle(ctx context.Context, proxyAccountID, action
 	if action == "archive" && account.LifecycleStatus != interfaces.KNProxyLifecycleArchived {
 		return nil, fmt.Errorf("invalid managed proxy archive state")
 	}
-	if account.Enabled || account.LoginEnabled || account.CredentialIssuanceEnabled {
+	if action == "restore" && (account.LifecycleStatus != interfaces.KNProxyLifecycleActive || !account.Enabled) {
+		return nil, fmt.Errorf("invalid managed proxy restore state")
+	}
+	if (action != "restore" && account.Enabled) || account.LoginEnabled || account.CredentialIssuanceEnabled {
 		return nil, fmt.Errorf("managed proxy lifecycle response is not fail-closed")
 	}
 	return &account, nil

--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
@@ -44,6 +44,11 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantCheckResult{Allowed: true})
 	})
+	mux.HandleFunc("/api/safe/in/v1/managed-proxy-accounts/proxy-1/restore", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(interfaces.ManagedProxyAccount{
+			ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive, Enabled: true,
+		})
+	})
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
@@ -51,6 +56,10 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 	account, created, err := client.Create(t.Context(), "kn-1", "network proxy")
 	if err != nil || !created || account.ProxyAccountID != "proxy-1" {
 		t.Fatalf("Create() = account %#v, created %v, err %v", account, created, err)
+	}
+	account, err = client.Restore(t.Context(), "proxy-1")
+	if err != nil || !account.Enabled || account.LifecycleStatus != interfaces.KNProxyLifecycleActive {
+		t.Fatalf("Restore() = account %#v, err %v", account, err)
 	}
 	result, err := client.CheckGrant(t.Context(), "proxy-1", "grantor-1", interfaces.ProxyGrantSourceSpec{
 		ResourceType: "resource", ResourceID: "resource-1", Operation: "query_data",

--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
@@ -184,7 +184,7 @@ func (r *restHandler) CreateActionTypes(c *gin.Context, visitor hydra.Visitor) {
 	}
 
 	// Create the resources.
-	atIDs, err := r.ats.CreateActionTypes(ctx, nil, actionTypes, mode, strictMode)
+	atIDs, err := r.createActionTypes(ctx, knID, branch, actionTypes, mode, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		// Set trace attributes for the error.
@@ -469,7 +469,7 @@ func (r *restHandler) UpdateActionType(c *gin.Context, visitor hydra.Visitor) {
 	actionType.IfNameModify = ifNameModify
 
 	// Update the resource by ID.
-	err = r.ats.UpdateActionType(ctx, nil, &actionType, strictMode)
+	err = r.updateActionType(ctx, &actionType, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -569,7 +569,7 @@ func (r *restHandler) DeleteActionTypes(c *gin.Context) {
 	}
 
 	// Delete action types in batch.
-	err = r.ats.DeleteActionTypesByIDs(ctx, nil, knID, branch, atIDs)
+	err = r.deleteActionTypes(ctx, knID, branch, atIDs)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		// Set trace attributes for the error.

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -265,13 +265,35 @@ func detachBKNExternalBindings(kn *interfaces.KN) {
 			}
 		}
 	}
+	detachRelationTypes := func(relationTypes []*interfaces.RelationType) {
+		for _, relationType := range relationTypes {
+			if relationType == nil {
+				continue
+			}
+			switch mapping := relationType.MappingRules.(type) {
+			case *interfaces.InDirectMapping:
+				if mapping != nil {
+					mapping.BackingDataSource = nil
+				}
+			case interfaces.InDirectMapping:
+				mapping.BackingDataSource = nil
+				relationType.MappingRules = mapping
+			case map[string]any:
+				if _, exists := mapping["backing_data_source"]; exists {
+					mapping["backing_data_source"] = nil
+				}
+			}
+		}
+	}
 	detachObjectTypes(kn.ObjectTypes)
+	detachRelationTypes(kn.RelationTypes)
 	detachActionTypes(kn.ActionTypes)
 	for _, conceptGroup := range kn.ConceptGroups {
 		if conceptGroup == nil {
 			continue
 		}
 		detachObjectTypes(conceptGroup.ObjectTypes)
+		detachRelationTypes(conceptGroup.RelationTypes)
 		detachActionTypes(conceptGroup.ActionTypes)
 	}
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/audit"
@@ -24,6 +25,11 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	"bkn-backend/logics"
+)
+
+const (
+	bknBindingPolicyPreserve = "preserve"
+	bknBindingPolicyDetach   = "detach"
 )
 
 // UploadBKN imports an uploaded BKN tar archive (external endpoint).
@@ -74,9 +80,17 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 
 	// Read form parameters.
 	branch := c.DefaultQuery("branch", interfaces.MAIN_BRANCH)
+	bindingPolicy := strings.TrimSpace(c.DefaultQuery("binding_policy", bknBindingPolicyPreserve))
+	if bindingPolicy != bknBindingPolicyPreserve && bindingPolicy != bknBindingPolicyDetach {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_KnowledgeNetwork_InvalidParameter).
+			WithErrorDetails(commonValidationDetail(ctx, "BindingPolicyInvalid", map[string]any{"value": bindingPolicy}))
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
 
-	logger.Debugf("Upload BKN: branch=%s, filename=%s, size=%d",
-		branch, header.Filename, header.Size)
+	logger.Debugf("Upload BKN: branch=%s, binding_policy=%s, filename=%s, size=%d",
+		branch, bindingPolicy, header.Filename, header.Size)
 
 	// Load the network directly from the tar archive in memory.
 	bknNetwork, err := bknsdk.LoadNetworkFromTar(file)
@@ -125,6 +139,9 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 			continue
 		}
 		kn.Metrics = append(kn.Metrics, logics.ToADPMetricDefinition(kn.KNID, branch, bknM))
+	}
+	if bindingPolicy == bknBindingPolicyDetach {
+		detachBKNExternalBindings(kn)
 	}
 
 	// Validate required knowledge network creation fields, lengths, and enum values.
@@ -219,6 +236,44 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 	logger.Debugf("Upload BKN completed: kn_id=%s", knID)
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 	rest.ReplyOK(c, http.StatusOK, map[string]string{"kn_id": knID})
+}
+
+// detachBKNExternalBindings keeps the portable model topology while removing
+// environment-local resource, toolbox, and MCP identifiers. The existing
+// incremental APIs can bind targets later and publish proxy grants atomically.
+func detachBKNExternalBindings(kn *interfaces.KN) {
+	if kn == nil {
+		return
+	}
+	detachObjectTypes := func(objectTypes []*interfaces.ObjectType) {
+		for _, objectType := range objectTypes {
+			if objectType == nil {
+				continue
+			}
+			objectType.DataSource = nil
+			for _, property := range objectType.LogicProperties {
+				if property != nil {
+					property.DataSource = nil
+				}
+			}
+		}
+	}
+	detachActionTypes := func(actionTypes []*interfaces.ActionType) {
+		for _, actionType := range actionTypes {
+			if actionType != nil {
+				actionType.ActionSource = interfaces.ActionSource{}
+			}
+		}
+	}
+	detachObjectTypes(kn.ObjectTypes)
+	detachActionTypes(kn.ActionTypes)
+	for _, conceptGroup := range kn.ConceptGroups {
+		if conceptGroup == nil {
+			continue
+		}
+		detachObjectTypes(conceptGroup.ObjectTypes)
+		detachActionTypes(conceptGroup.ActionTypes)
+	}
 }
 
 // DownloadBKN exports a BKN tar archive (external endpoint).

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
@@ -170,6 +170,14 @@ func Test_BKNRestHandler_UploadBKN(t *testing.T) {
 			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
+		Convey("Failed when binding_policy is invalid\n", func() {
+			req := newMultipartRequest(t, url+"?binding_policy=copy", "test.tar", newValidBKNTar(t))
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
 		Convey("Failed when CreateKN returns error\n", func() {
 			err := &rest.HTTPError{
 				HTTPCode: http.StatusInternalServerError,
@@ -187,6 +195,46 @@ func Test_BKNRestHandler_UploadBKN(t *testing.T) {
 			So(w.Result().StatusCode, ShouldEqual, http.StatusInternalServerError)
 		})
 	})
+}
+
+func TestDetachBKNExternalBindingsPreservesTopology(t *testing.T) {
+	relation := &interfaces.RelationType{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+		RTID: "rt-1", SourceObjectTypeID: "ot-1", TargetObjectTypeID: "ot-2",
+	}}
+	metric := &interfaces.MetricDefinition{ID: "metric-1", ScopeType: interfaces.ScopeTypeObjectType, ScopeRef: "ot-1"}
+	kn := &interfaces.KN{
+		ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+			OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			LogicProperties: []*interfaces.LogicProperty{{
+				Name: "forecast", Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL,
+				DataSource: &interfaces.ResourceInfo{Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL, BoxID: "box-1", ToolID: "tool-1"},
+			}},
+		}}},
+		RelationTypes: []*interfaces.RelationType{relation},
+		Metrics:       []*interfaces.MetricDefinition{metric},
+		ActionTypes: []*interfaces.ActionType{{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+			ATID: "at-1", ObjectTypeID: "ot-1",
+			ActionSource: interfaces.ActionSource{Type: interfaces.ACTION_SOURCE_TYPE_MCP, McpID: "mcp-1", ToolName: "run"},
+		}}},
+	}
+
+	detachBKNExternalBindings(kn)
+
+	if kn.ObjectTypes[0].DataSource != nil || kn.ObjectTypes[0].LogicProperties[0].DataSource != nil {
+		t.Fatalf("object bindings were not detached: %#v", kn.ObjectTypes[0])
+	}
+	if kn.ActionTypes[0].ActionSource != (interfaces.ActionSource{}) {
+		t.Fatalf("action source was not detached: %#v", kn.ActionTypes[0].ActionSource)
+	}
+	if kn.RelationTypes[0] != relation || relation.SourceObjectTypeID != "ot-1" || relation.TargetObjectTypeID != "ot-2" {
+		t.Fatalf("relation topology changed: %#v", kn.RelationTypes)
+	}
+	if kn.Metrics[0] != metric || metric.ScopeRef != "ot-1" {
+		t.Fatalf("metric topology changed: %#v", kn.Metrics)
+	}
+	if kn.ActionTypes[0].ObjectTypeID != "ot-1" {
+		t.Fatalf("action object binding changed: %#v", kn.ActionTypes[0])
+	}
 }
 
 func Test_BKNRestHandler_DownloadBKN(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
@@ -200,6 +200,13 @@ func Test_BKNRestHandler_UploadBKN(t *testing.T) {
 func TestDetachBKNExternalBindingsPreservesTopology(t *testing.T) {
 	relation := &interfaces.RelationType{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
 		RTID: "rt-1", SourceObjectTypeID: "ot-1", TargetObjectTypeID: "ot-2",
+		MappingRules: &interfaces.InDirectMapping{
+			BackingDataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "relation-resource-1"},
+			SourceMappingRules: []interfaces.Mapping{{
+				SourceProp: interfaces.SimpleProperty{Name: "source-id"},
+				TargetProp: interfaces.SimpleProperty{Name: "bridge-source-id"},
+			}},
+		},
 	}}
 	metric := &interfaces.MetricDefinition{ID: "metric-1", ScopeType: interfaces.ScopeTypeObjectType, ScopeRef: "ot-1"}
 	kn := &interfaces.KN{
@@ -228,6 +235,10 @@ func TestDetachBKNExternalBindingsPreservesTopology(t *testing.T) {
 	}
 	if kn.RelationTypes[0] != relation || relation.SourceObjectTypeID != "ot-1" || relation.TargetObjectTypeID != "ot-2" {
 		t.Fatalf("relation topology changed: %#v", kn.RelationTypes)
+	}
+	indirect, ok := relation.MappingRules.(*interfaces.InDirectMapping)
+	if !ok || indirect.BackingDataSource != nil || len(indirect.SourceMappingRules) != 1 {
+		t.Fatalf("relation binding was not detached or mapping topology changed: %#v", relation.MappingRules)
 	}
 	if kn.Metrics[0] != metric || metric.ScopeRef != "ot-1" {
 		t.Fatalf("metric topology changed: %#v", kn.Metrics)

--- a/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
@@ -190,7 +190,7 @@ func (r *restHandler) CreateConceptGroup(c *gin.Context, visitor hydra.Visitor) 
 	}
 
 	// Create the concept group.
-	cgID, err := r.cgs.CreateConceptGroup(ctx, nil, &cg, mode, strictMode)
+	cgID, err := r.createConceptGroup(ctx, &cg, mode, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
@@ -19,6 +19,22 @@ func (r *restHandler) publishKNChildMutation(ctx context.Context, changes *inter
 	return r.knProxyPublisher.PublishKNChildMutation(ctx, changes, mergeMode, mutate)
 }
 
+func (r *restHandler) createConceptGroup(ctx context.Context, conceptGroup *interfaces.ConceptGroup,
+	mode string, strictMode bool) (id string, err error) {
+	if len(conceptGroup.ObjectTypes) == 0 && len(conceptGroup.RelationTypes) == 0 && len(conceptGroup.ActionTypes) == 0 {
+		return r.cgs.CreateConceptGroup(ctx, nil, conceptGroup, mode, strictMode)
+	}
+	changes := &interfaces.KN{
+		KNID: conceptGroup.KNID, Branch: conceptGroup.Branch,
+		ObjectTypes: conceptGroup.ObjectTypes, RelationTypes: conceptGroup.RelationTypes, ActionTypes: conceptGroup.ActionTypes,
+	}
+	err = r.publishKNChildMutation(ctx, changes, mode, func(mutationCtx context.Context, tx *sql.Tx) error {
+		id, err = r.cgs.CreateConceptGroup(mutationCtx, tx, conceptGroup, mode, strictMode)
+		return err
+	})
+	return id, err
+}
+
 func (r *restHandler) createObjectTypes(ctx context.Context, knID, branch string,
 	entries []*interfaces.ObjectType, mode string, strictMode bool) (ids []string, err error) {
 	changes := &interfaces.KN{KNID: knID, Branch: branch, ObjectTypes: entries}

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
@@ -1,0 +1,128 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"context"
+	"database/sql"
+
+	"bkn-backend/interfaces"
+)
+
+func (r *restHandler) publishKNChildMutation(ctx context.Context, changes *interfaces.KN,
+	mutate func(context.Context, *sql.Tx) error) error {
+	if r.knProxyPublisher == nil {
+		return mutate(ctx, nil)
+	}
+	return r.knProxyPublisher.PublishKNChildMutation(ctx, changes, mutate)
+}
+
+func (r *restHandler) createObjectTypes(ctx context.Context, knID, branch string,
+	entries []*interfaces.ObjectType, mode string, strictMode bool) (ids []string, err error) {
+	changes := &interfaces.KN{KNID: knID, Branch: branch, ObjectTypes: entries}
+	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		ids, err = r.ots.CreateObjectTypes(mutationCtx, tx, entries, mode, true, strictMode)
+		return err
+	})
+	return ids, err
+}
+
+func (r *restHandler) updateObjectType(ctx context.Context, objectType *interfaces.ObjectType,
+	strictMode bool) error {
+	changes := &interfaces.KN{
+		KNID: objectType.KNID, Branch: objectType.Branch, ObjectTypes: []*interfaces.ObjectType{objectType},
+	}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ots.UpdateObjectType(mutationCtx, tx, objectType, strictMode)
+	})
+}
+
+func (r *restHandler) deleteObjectTypes(ctx context.Context, knID, branch string, ids []string) error {
+	changes := &interfaces.KN{KNID: knID, Branch: branch}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ots.DeleteObjectTypesByIDs(mutationCtx, tx, knID, branch, ids)
+	})
+}
+
+func (r *restHandler) createRelationTypes(ctx context.Context, knID, branch string,
+	entries []*interfaces.RelationType, mode string, strictMode bool) (ids []string, err error) {
+	changes := &interfaces.KN{KNID: knID, Branch: branch, RelationTypes: entries}
+	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		ids, err = r.rts.CreateRelationTypes(mutationCtx, tx, entries, mode, strictMode)
+		return err
+	})
+	return ids, err
+}
+
+func (r *restHandler) updateRelationType(ctx context.Context, relationType *interfaces.RelationType,
+	strictMode bool) error {
+	changes := &interfaces.KN{
+		KNID: relationType.KNID, Branch: relationType.Branch, RelationTypes: []*interfaces.RelationType{relationType},
+	}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.rts.UpdateRelationType(mutationCtx, tx, relationType, strictMode)
+	})
+}
+
+func (r *restHandler) deleteRelationTypes(ctx context.Context, knID, branch string, ids []string) error {
+	changes := &interfaces.KN{KNID: knID, Branch: branch}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.rts.DeleteRelationTypesByIDs(mutationCtx, tx, knID, branch, ids)
+	})
+}
+
+func (r *restHandler) createActionTypes(ctx context.Context, knID, branch string,
+	entries []*interfaces.ActionType, mode string, strictMode bool) (ids []string, err error) {
+	changes := &interfaces.KN{KNID: knID, Branch: branch, ActionTypes: entries}
+	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		ids, err = r.ats.CreateActionTypes(mutationCtx, tx, entries, mode, strictMode)
+		return err
+	})
+	return ids, err
+}
+
+func (r *restHandler) updateActionType(ctx context.Context, actionType *interfaces.ActionType,
+	strictMode bool) error {
+	changes := &interfaces.KN{
+		KNID: actionType.KNID, Branch: actionType.Branch, ActionTypes: []*interfaces.ActionType{actionType},
+	}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ats.UpdateActionType(mutationCtx, tx, actionType, strictMode)
+	})
+}
+
+func (r *restHandler) deleteActionTypes(ctx context.Context, knID, branch string, ids []string) error {
+	changes := &interfaces.KN{KNID: knID, Branch: branch}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ats.DeleteActionTypesByIDs(mutationCtx, tx, knID, branch, ids)
+	})
+}
+
+func (r *restHandler) createMetrics(ctx context.Context, knID, branch string,
+	entries []*interfaces.MetricDefinition, strictMode bool, mode string) (ids []string, err error) {
+	changes := &interfaces.KN{KNID: knID, Branch: branch, Metrics: entries}
+	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		ids, err = r.ms.CreateMetrics(mutationCtx, tx, entries, strictMode, mode)
+		return err
+	})
+	return ids, err
+}
+
+func (r *restHandler) updateMetric(ctx context.Context, metric *interfaces.MetricDefinition,
+	strictMode bool) error {
+	changes := &interfaces.KN{
+		KNID: metric.KnID, Branch: metric.Branch, Metrics: []*interfaces.MetricDefinition{metric},
+	}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ms.UpdateMetric(mutationCtx, tx, metric, strictMode)
+	})
+}
+
+func (r *restHandler) deleteMetrics(ctx context.Context, knID, branch string, ids []string) error {
+	changes := &interfaces.KN{KNID: knID, Branch: branch}
+	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+		return r.ms.DeleteMetricsByIDs(mutationCtx, tx, knID, branch, ids)
+	})
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
@@ -11,18 +11,18 @@ import (
 	"bkn-backend/interfaces"
 )
 
-func (r *restHandler) publishKNChildMutation(ctx context.Context, changes *interfaces.KN,
+func (r *restHandler) publishKNChildMutation(ctx context.Context, changes *interfaces.KN, mergeMode string,
 	mutate func(context.Context, *sql.Tx) error) error {
 	if r.knProxyPublisher == nil {
 		return mutate(ctx, nil)
 	}
-	return r.knProxyPublisher.PublishKNChildMutation(ctx, changes, mutate)
+	return r.knProxyPublisher.PublishKNChildMutation(ctx, changes, mergeMode, mutate)
 }
 
 func (r *restHandler) createObjectTypes(ctx context.Context, knID, branch string,
 	entries []*interfaces.ObjectType, mode string, strictMode bool) (ids []string, err error) {
 	changes := &interfaces.KN{KNID: knID, Branch: branch, ObjectTypes: entries}
-	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	err = r.publishKNChildMutation(ctx, changes, mode, func(mutationCtx context.Context, tx *sql.Tx) error {
 		ids, err = r.ots.CreateObjectTypes(mutationCtx, tx, entries, mode, true, strictMode)
 		return err
 	})
@@ -34,14 +34,14 @@ func (r *restHandler) updateObjectType(ctx context.Context, objectType *interfac
 	changes := &interfaces.KN{
 		KNID: objectType.KNID, Branch: objectType.Branch, ObjectTypes: []*interfaces.ObjectType{objectType},
 	}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ots.UpdateObjectType(mutationCtx, tx, objectType, strictMode)
 	})
 }
 
 func (r *restHandler) deleteObjectTypes(ctx context.Context, knID, branch string, ids []string) error {
 	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ots.DeleteObjectTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -49,7 +49,7 @@ func (r *restHandler) deleteObjectTypes(ctx context.Context, knID, branch string
 func (r *restHandler) createRelationTypes(ctx context.Context, knID, branch string,
 	entries []*interfaces.RelationType, mode string, strictMode bool) (ids []string, err error) {
 	changes := &interfaces.KN{KNID: knID, Branch: branch, RelationTypes: entries}
-	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	err = r.publishKNChildMutation(ctx, changes, mode, func(mutationCtx context.Context, tx *sql.Tx) error {
 		ids, err = r.rts.CreateRelationTypes(mutationCtx, tx, entries, mode, strictMode)
 		return err
 	})
@@ -61,14 +61,14 @@ func (r *restHandler) updateRelationType(ctx context.Context, relationType *inte
 	changes := &interfaces.KN{
 		KNID: relationType.KNID, Branch: relationType.Branch, RelationTypes: []*interfaces.RelationType{relationType},
 	}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.rts.UpdateRelationType(mutationCtx, tx, relationType, strictMode)
 	})
 }
 
 func (r *restHandler) deleteRelationTypes(ctx context.Context, knID, branch string, ids []string) error {
 	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.rts.DeleteRelationTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -76,7 +76,7 @@ func (r *restHandler) deleteRelationTypes(ctx context.Context, knID, branch stri
 func (r *restHandler) createActionTypes(ctx context.Context, knID, branch string,
 	entries []*interfaces.ActionType, mode string, strictMode bool) (ids []string, err error) {
 	changes := &interfaces.KN{KNID: knID, Branch: branch, ActionTypes: entries}
-	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	err = r.publishKNChildMutation(ctx, changes, mode, func(mutationCtx context.Context, tx *sql.Tx) error {
 		ids, err = r.ats.CreateActionTypes(mutationCtx, tx, entries, mode, strictMode)
 		return err
 	})
@@ -88,14 +88,14 @@ func (r *restHandler) updateActionType(ctx context.Context, actionType *interfac
 	changes := &interfaces.KN{
 		KNID: actionType.KNID, Branch: actionType.Branch, ActionTypes: []*interfaces.ActionType{actionType},
 	}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ats.UpdateActionType(mutationCtx, tx, actionType, strictMode)
 	})
 }
 
 func (r *restHandler) deleteActionTypes(ctx context.Context, knID, branch string, ids []string) error {
 	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ats.DeleteActionTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -103,7 +103,7 @@ func (r *restHandler) deleteActionTypes(ctx context.Context, knID, branch string
 func (r *restHandler) createMetrics(ctx context.Context, knID, branch string,
 	entries []*interfaces.MetricDefinition, strictMode bool, mode string) (ids []string, err error) {
 	changes := &interfaces.KN{KNID: knID, Branch: branch, Metrics: entries}
-	err = r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	err = r.publishKNChildMutation(ctx, changes, mode, func(mutationCtx context.Context, tx *sql.Tx) error {
 		ids, err = r.ms.CreateMetrics(mutationCtx, tx, entries, strictMode, mode)
 		return err
 	})
@@ -115,14 +115,14 @@ func (r *restHandler) updateMetric(ctx context.Context, metric *interfaces.Metri
 	changes := &interfaces.KN{
 		KNID: metric.KnID, Branch: metric.Branch, Metrics: []*interfaces.MetricDefinition{metric},
 	}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ms.UpdateMetric(mutationCtx, tx, metric, strictMode)
 	})
 }
 
 func (r *restHandler) deleteMetrics(ctx context.Context, knID, branch string, ids []string) error {
 	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, func(mutationCtx context.Context, tx *sql.Tx) error {
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ms.DeleteMetricsByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
@@ -47,6 +47,53 @@ func assertProxyMutation(t *testing.T, publisher *knProxyMutationPublisherStub, 
 	assertChanges(publisher.changes)
 }
 
+func TestConceptGroupImportWithBindingsUsesKNProxyPublisher(t *testing.T) {
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-1"}}
+	relationType := &interfaces.RelationType{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{RTID: "rt-1"}}
+	actionType := &interfaces.ActionType{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at-1"}}
+	conceptGroup := &interfaces.ConceptGroup{
+		CGID: "cg-1", KNID: "kn-1", Branch: interfaces.MAIN_BRANCH,
+		ObjectTypes: []*interfaces.ObjectType{objectType}, RelationTypes: []*interfaces.RelationType{relationType},
+		ActionTypes: []*interfaces.ActionType{actionType},
+	}
+	ctrl := gomock.NewController(t)
+	service := bmock.NewMockConceptGroupService(ctrl)
+	publisher := &knProxyMutationPublisherStub{}
+	service.EXPECT().CreateConceptGroup(gomock.Any(), nil, conceptGroup,
+		interfaces.ImportMode_Overwrite, true).Return("cg-1", nil)
+	handler := &restHandler{cgs: service, knProxyPublisher: publisher}
+
+	id, err := handler.createConceptGroup(t.Context(), conceptGroup, interfaces.ImportMode_Overwrite, true)
+	if err != nil || id != "cg-1" {
+		t.Fatalf("createConceptGroup() = %q, %v", id, err)
+	}
+	assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+		if len(changes.ObjectTypes) != 1 || changes.ObjectTypes[0] != objectType ||
+			len(changes.RelationTypes) != 1 || changes.RelationTypes[0] != relationType ||
+			len(changes.ActionTypes) != 1 || changes.ActionTypes[0] != actionType {
+			t.Fatalf("concept group proxy changes = %#v", changes)
+		}
+	})
+}
+
+func TestEmptyConceptGroupImportSkipsKNProxyPublisher(t *testing.T) {
+	conceptGroup := &interfaces.ConceptGroup{CGID: "cg-1", KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}
+	ctrl := gomock.NewController(t)
+	service := bmock.NewMockConceptGroupService(ctrl)
+	publisher := &knProxyMutationPublisherStub{}
+	service.EXPECT().CreateConceptGroup(gomock.Any(), nil, conceptGroup,
+		interfaces.ImportMode_Normal, true).Return("cg-1", nil)
+	handler := &restHandler{cgs: service, knProxyPublisher: publisher}
+
+	id, err := handler.createConceptGroup(t.Context(), conceptGroup, interfaces.ImportMode_Normal, true)
+	if err != nil || id != "cg-1" {
+		t.Fatalf("createConceptGroup() = %q, %v", id, err)
+	}
+	if publisher.calls != 0 {
+		t.Fatalf("proxy publisher calls = %d, want 0", publisher.calls)
+	}
+}
+
 func TestObjectTypeWritesUseKNProxyPublisher(t *testing.T) {
 	objectType := &interfaces.ObjectType{
 		ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-1"},

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
@@ -1,0 +1,293 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/interfaces"
+	bmock "bkn-backend/interfaces/mock"
+)
+
+type knProxyMutationPublisherStub struct {
+	calls     int
+	changes   *interfaces.KN
+	mergeMode string
+}
+
+func (s *knProxyMutationPublisherStub) PublishKNChildMutation(ctx context.Context, changes *interfaces.KN,
+	mergeMode string, mutate func(context.Context, *sql.Tx) error) error {
+	s.calls++
+	s.changes = changes
+	s.mergeMode = mergeMode
+	return mutate(ctx, nil)
+}
+
+func assertProxyMutation(t *testing.T, publisher *knProxyMutationPublisherStub, mergeMode string,
+	assertChanges func(*interfaces.KN)) {
+	t.Helper()
+	if publisher.calls != 1 {
+		t.Fatalf("proxy publisher calls = %d, want 1", publisher.calls)
+	}
+	if publisher.mergeMode != mergeMode {
+		t.Fatalf("proxy merge mode = %q, want %q", publisher.mergeMode, mergeMode)
+	}
+	if publisher.changes == nil {
+		t.Fatal("proxy mutation changes are nil")
+	}
+	if publisher.changes.KNID != "kn-1" || publisher.changes.Branch != interfaces.MAIN_BRANCH {
+		t.Fatalf("proxy mutation identity = %q/%q", publisher.changes.KNID, publisher.changes.Branch)
+	}
+	assertChanges(publisher.changes)
+}
+
+func TestObjectTypeWritesUseKNProxyPublisher(t *testing.T) {
+	objectType := &interfaces.ObjectType{
+		ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-1"},
+		KNID:                   "kn-1", Branch: interfaces.MAIN_BRANCH,
+	}
+
+	t.Run("create", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockObjectTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().CreateObjectTypes(gomock.Any(), nil, []*interfaces.ObjectType{objectType},
+			interfaces.ImportMode_Ignore, true, true).Return([]string{"ot-1"}, nil)
+		handler := &restHandler{ots: service, knProxyPublisher: publisher}
+
+		ids, err := handler.createObjectTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH,
+			[]*interfaces.ObjectType{objectType}, interfaces.ImportMode_Ignore, true)
+		if err != nil || len(ids) != 1 || ids[0] != "ot-1" {
+			t.Fatalf("createObjectTypes() = %#v, %v", ids, err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Ignore, func(changes *interfaces.KN) {
+			if len(changes.ObjectTypes) != 1 || changes.ObjectTypes[0] != objectType {
+				t.Fatalf("object type changes = %#v", changes.ObjectTypes)
+			}
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockObjectTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().UpdateObjectType(gomock.Any(), nil, objectType, true).Return(nil)
+		handler := &restHandler{ots: service, knProxyPublisher: publisher}
+
+		if err := handler.updateObjectType(t.Context(), objectType, true); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.ObjectTypes) != 1 || changes.ObjectTypes[0] != objectType {
+				t.Fatalf("object type changes = %#v", changes.ObjectTypes)
+			}
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockObjectTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().DeleteObjectTypesByIDs(gomock.Any(), nil, "kn-1", interfaces.MAIN_BRANCH,
+			[]string{"ot-1"}).Return(nil)
+		handler := &restHandler{ots: service, knProxyPublisher: publisher}
+
+		if err := handler.deleteObjectTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"ot-1"}); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
+			if len(changes.ObjectTypes) != 0 {
+				t.Fatalf("delete object type changes = %#v", changes.ObjectTypes)
+			}
+		})
+	})
+}
+
+func TestRelationTypeWritesUseKNProxyPublisher(t *testing.T) {
+	relationType := &interfaces.RelationType{
+		RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{RTID: "rt-1"},
+		KNID:                     "kn-1", Branch: interfaces.MAIN_BRANCH,
+	}
+
+	t.Run("create", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockRelationTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().CreateRelationTypes(gomock.Any(), nil, []*interfaces.RelationType{relationType},
+			interfaces.ImportMode_Ignore, true).Return([]string{"rt-1"}, nil)
+		handler := &restHandler{rts: service, knProxyPublisher: publisher}
+
+		ids, err := handler.createRelationTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH,
+			[]*interfaces.RelationType{relationType}, interfaces.ImportMode_Ignore, true)
+		if err != nil || len(ids) != 1 || ids[0] != "rt-1" {
+			t.Fatalf("createRelationTypes() = %#v, %v", ids, err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Ignore, func(changes *interfaces.KN) {
+			if len(changes.RelationTypes) != 1 || changes.RelationTypes[0] != relationType {
+				t.Fatalf("relation type changes = %#v", changes.RelationTypes)
+			}
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockRelationTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().UpdateRelationType(gomock.Any(), nil, relationType, true).Return(nil)
+		handler := &restHandler{rts: service, knProxyPublisher: publisher}
+
+		if err := handler.updateRelationType(t.Context(), relationType, true); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.RelationTypes) != 1 || changes.RelationTypes[0] != relationType {
+				t.Fatalf("relation type changes = %#v", changes.RelationTypes)
+			}
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockRelationTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().DeleteRelationTypesByIDs(gomock.Any(), nil, "kn-1", interfaces.MAIN_BRANCH,
+			[]string{"rt-1"}).Return(nil)
+		handler := &restHandler{rts: service, knProxyPublisher: publisher}
+
+		if err := handler.deleteRelationTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"rt-1"}); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
+			if len(changes.RelationTypes) != 0 {
+				t.Fatalf("delete relation type changes = %#v", changes.RelationTypes)
+			}
+		})
+	})
+}
+
+func TestActionTypeWritesUseKNProxyPublisher(t *testing.T) {
+	actionType := &interfaces.ActionType{
+		ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: "at-1"},
+		KNID:                   "kn-1", Branch: interfaces.MAIN_BRANCH,
+	}
+
+	t.Run("create", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockActionTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().CreateActionTypes(gomock.Any(), nil, []*interfaces.ActionType{actionType},
+			interfaces.ImportMode_Ignore, true).Return([]string{"at-1"}, nil)
+		handler := &restHandler{ats: service, knProxyPublisher: publisher}
+
+		ids, err := handler.createActionTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH,
+			[]*interfaces.ActionType{actionType}, interfaces.ImportMode_Ignore, true)
+		if err != nil || len(ids) != 1 || ids[0] != "at-1" {
+			t.Fatalf("createActionTypes() = %#v, %v", ids, err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Ignore, func(changes *interfaces.KN) {
+			if len(changes.ActionTypes) != 1 || changes.ActionTypes[0] != actionType {
+				t.Fatalf("action type changes = %#v", changes.ActionTypes)
+			}
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockActionTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().UpdateActionType(gomock.Any(), nil, actionType, true).Return(nil)
+		handler := &restHandler{ats: service, knProxyPublisher: publisher}
+
+		if err := handler.updateActionType(t.Context(), actionType, true); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.ActionTypes) != 1 || changes.ActionTypes[0] != actionType {
+				t.Fatalf("action type changes = %#v", changes.ActionTypes)
+			}
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockActionTypeService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().DeleteActionTypesByIDs(gomock.Any(), nil, "kn-1", interfaces.MAIN_BRANCH,
+			[]string{"at-1"}).Return(nil)
+		handler := &restHandler{ats: service, knProxyPublisher: publisher}
+
+		if err := handler.deleteActionTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"at-1"}); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
+			if len(changes.ActionTypes) != 0 {
+				t.Fatalf("delete action type changes = %#v", changes.ActionTypes)
+			}
+		})
+	})
+}
+
+func TestMetricWritesUseKNProxyPublisher(t *testing.T) {
+	metric := &interfaces.MetricDefinition{ID: "metric-1", KnID: "kn-1", Branch: interfaces.MAIN_BRANCH}
+
+	t.Run("create", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockMetricService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().CreateMetrics(gomock.Any(), nil, []*interfaces.MetricDefinition{metric}, true,
+			interfaces.ImportMode_Ignore).Return([]string{"metric-1"}, nil)
+		handler := &restHandler{ms: service, knProxyPublisher: publisher}
+
+		ids, err := handler.createMetrics(t.Context(), "kn-1", interfaces.MAIN_BRANCH,
+			[]*interfaces.MetricDefinition{metric}, true, interfaces.ImportMode_Ignore)
+		if err != nil || len(ids) != 1 || ids[0] != "metric-1" {
+			t.Fatalf("createMetrics() = %#v, %v", ids, err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Ignore, func(changes *interfaces.KN) {
+			if len(changes.Metrics) != 1 || changes.Metrics[0] != metric {
+				t.Fatalf("metric changes = %#v", changes.Metrics)
+			}
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockMetricService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().UpdateMetric(gomock.Any(), nil, metric, true).Return(nil)
+		handler := &restHandler{ms: service, knProxyPublisher: publisher}
+
+		if err := handler.updateMetric(t.Context(), metric, true); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.Metrics) != 1 || changes.Metrics[0] != metric {
+				t.Fatalf("metric changes = %#v", changes.Metrics)
+			}
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		service := bmock.NewMockMetricService(ctrl)
+		publisher := &knProxyMutationPublisherStub{}
+		service.EXPECT().DeleteMetricsByIDs(gomock.Any(), nil, "kn-1", interfaces.MAIN_BRANCH,
+			[]string{"metric-1"}).Return(nil)
+		handler := &restHandler{ms: service, knProxyPublisher: publisher}
+
+		if err := handler.deleteMetrics(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"metric-1"}); err != nil {
+			t.Fatal(err)
+		}
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
+			if len(changes.Metrics) != 0 {
+				t.Fatalf("delete metric changes = %#v", changes.Metrics)
+			}
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -92,6 +92,14 @@ func (r *restHandler) CreateKN(c *gin.Context, visitor hydra.Visitor) {
 		rest.ReplyError(c, httpErr)
 		return
 	}
+	bindingPolicy := strings.TrimSpace(c.DefaultQuery("binding_policy", bknBindingPolicyPreserve))
+	if bindingPolicy != bknBindingPolicyPreserve && bindingPolicy != bknBindingPolicyDetach {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_KnowledgeNetwork_InvalidParameter).
+			WithErrorDetails(commonValidationDetail(ctx, "BindingPolicyInvalid", map[string]any{"value": bindingPolicy}))
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
 
 	// Whether to validate dependencies, default true. Parse priority: strict_mode > validate_dependency (legacy) > true
 	strictModeStr := c.Query(interfaces.QueryParam_StrictMode)
@@ -193,6 +201,9 @@ func (r *restHandler) CreateKN(c *gin.Context, visitor hydra.Visitor) {
 				return
 			}
 		}
+	}
+	if bindingPolicy == bknBindingPolicyDetach {
+		detachBKNExternalBindings(&kn)
 	}
 
 	// Create the knowledge network.

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -206,8 +206,12 @@ func (r *restHandler) CreateKN(c *gin.Context, visitor hydra.Visitor) {
 		detachBKNExternalBindings(&kn)
 	}
 
+	// Detached imports have already been structurally validated above. Persist
+	// them without resolving the environment-local dependencies just removed.
+	persistenceStrictMode := strictMode && bindingPolicy != bknBindingPolicyDetach
+
 	// Create the knowledge network.
-	knID, err := r.kns.CreateKN(ctx, &kn, mode, strictMode)
+	knID, err := r.kns.CreateKN(ctx, &kn, mode, persistenceStrictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -205,6 +205,16 @@ func Test_KnowledgeNetworkRestHandler_CreateKN(t *testing.T) {
 			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
 		})
 
+		Convey("Invalid binding policy\n", func() {
+			reqParamByte, _ := sonic.Marshal(kn)
+			req := httptest.NewRequest(http.MethodPost, url+"?binding_policy=copy", bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
 		Convey("KN name is null\n", func() {
 			reqParamByte, _ := sonic.Marshal(interfaces.KN{})
 			req := httptest.NewRequest(http.MethodPost, url, bytes.NewReader(reqParamByte))

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler_test.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
@@ -213,6 +214,40 @@ func Test_KnowledgeNetworkRestHandler_CreateKN(t *testing.T) {
 			engine.ServeHTTP(w, req)
 
 			So(w.Result().StatusCode, ShouldEqual, http.StatusBadRequest)
+		})
+
+		Convey("Detach policy persists a structurally valid tool property without dependency lookups\n", func() {
+			portableKN := kn
+			portableKN.ObjectTypes = []*interfaces.ObjectType{{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID:   "ot1",
+					OTName: "object1",
+					DataProperties: []*interfaces.DataProperty{{
+						Name: "prop1", Type: "string", DisplayName: "prop1",
+					}},
+					PrimaryKeys: []string{"prop1"},
+					DisplayKey:  "prop1",
+					LogicProperties: []*interfaces.LogicProperty{{
+						Name: "forecast", Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL, DisplayName: "forecast",
+						DataSource: &interfaces.ResourceInfo{
+							Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL, BoxID: "box1", ToolID: "tool1",
+						},
+					}},
+				},
+			}}
+			kns.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any(), false).
+				DoAndReturn(func(_ context.Context, imported *interfaces.KN, _ string, _ bool) (string, error) {
+					So(imported.ObjectTypes[0].LogicProperties[0].DataSource, ShouldBeNil)
+					return "kn1", nil
+				})
+
+			reqParamByte, _ := sonic.Marshal(portableKN)
+			req := httptest.NewRequest(http.MethodPost, url+"?binding_policy=detach", bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusCreated)
 		})
 
 		Convey("KN name is null\n", func() {

--- a/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/metric_handler.go
@@ -145,7 +145,7 @@ func (r *restHandler) CreateMetrics(c *gin.Context, vis hydra.Visitor) {
 		metrics[i].Branch = branch
 	}
 
-	ids, err := r.ms.CreateMetrics(ctx, nil, metrics, strictMode, mode)
+	ids, err := r.createMetrics(ctx, knID, branch, metrics, strictMode, mode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
@@ -563,7 +563,7 @@ func (r *restHandler) UpdateMetric(c *gin.Context, vis hydra.Visitor) {
 		}
 	}
 
-	if err = r.ms.UpdateMetric(ctx, nil, &req, strictMode); err != nil {
+	if err = r.updateMetric(ctx, &req, strictMode); err != nil {
 		rest.ReplyError(c, err.(*rest.HTTPError))
 		return
 	}
@@ -612,7 +612,7 @@ func (r *restHandler) DeleteMetricsByIDs(c *gin.Context, vis hydra.Visitor) {
 	}
 
 	ids := common.StringToStringSlice(metricIDsStr)
-	if err = r.ms.DeleteMetricsByIDs(ctx, nil, knID, branch, ids); err != nil {
+	if err = r.deleteMetrics(ctx, knID, branch, ids); err != nil {
 		httpErr := err.(*rest.HTTPError)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -185,7 +185,7 @@ func (r *restHandler) CreateObjectTypes(c *gin.Context, visitor hydra.Visitor) {
 	}
 
 	// Create the resources.
-	otIDs, err := r.ots.CreateObjectTypes(ctx, nil, objectTypes, mode, true, strictMode)
+	otIDs, err := r.createObjectTypes(ctx, knID, branch, objectTypes, mode, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -472,7 +472,7 @@ func (r *restHandler) UpdateObjectType(c *gin.Context, visitor hydra.Visitor) {
 	objectType.IfNameModify = ifNameModify
 
 	// Update the resource by ID.
-	err = r.ots.UpdateObjectType(ctx, nil, &objectType, strictMode)
+	err = r.updateObjectType(ctx, &objectType, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -785,7 +785,7 @@ func (r *restHandler) DeleteObjectTypes(c *gin.Context) {
 	}
 
 	// Delete object types in batch.
-	err = r.ots.DeleteObjectTypesByIDs(ctx, nil, knID, branch, otIDs)
+	err = r.deleteObjectTypes(ctx, knID, branch, otIDs)
 	if err != nil {
 		// Guard against a plain downstream error: normalize it to 500 instead of panicking into a 502.
 		httpErr, ok := err.(*rest.HTTPError)

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -185,7 +185,7 @@ func (r *restHandler) CreateRelationTypes(c *gin.Context, visitor hydra.Visitor)
 
 	// Create the resources.
 	// Direct relation type creation validates dependencies by default.
-	rtIDs, err := r.rts.CreateRelationTypes(ctx, nil, relationTypes, mode, strictMode)
+	rtIDs, err := r.createRelationTypes(ctx, knID, branch, relationTypes, mode, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -447,7 +447,7 @@ func (r *restHandler) UpdateRelationType(c *gin.Context, visitor hydra.Visitor) 
 	}
 
 	// Update the resource by ID.
-	err = r.rts.UpdateRelationType(ctx, nil, &relationType, strictMode)
+	err = r.updateRelationType(ctx, &relationType, strictMode)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 
@@ -547,7 +547,7 @@ func (r *restHandler) DeleteRelationTypes(c *gin.Context) {
 	}
 
 	// Delete relation types in batch.
-	err = r.rts.DeleteRelationTypesByIDs(ctx, nil, knID, branch, rtIDs)
+	err = r.deleteRelationTypes(ctx, knID, branch, rtIDs)
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)
 		// Set trace attributes for the error.

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -54,6 +54,7 @@ type restHandler struct {
 	ats                     interfaces.ActionTypeService
 	cgs                     interfaces.ConceptGroupService
 	kns                     interfaces.KNService
+	knProxyPublisher        interfaces.KNProxyMutationPublisher
 	ots                     interfaces.ObjectTypeService
 	rts                     interfaces.RelationTypeService
 	rtsRisk                 interfaces.RiskTypeService
@@ -71,6 +72,7 @@ func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.St
 		}
 		projectionVerifier = &verifier
 	}
+	knService := knowledge_network.NewKNService(appSetting)
 	r := &restHandler{
 		appSetting:          appSetting,
 		auditRecorder:       auditStore,
@@ -88,7 +90,8 @@ func NewRestHandler(appSetting *common.AppSetting, auditStore *operationaudit.St
 		ass:                     action_schedule.NewActionScheduleService(appSetting),
 		ats:                     action_type.NewActionTypeService(appSetting),
 		cgs:                     concept_group.NewConceptGroupService(appSetting),
-		kns:                     knowledge_network.NewKNService(appSetting),
+		kns:                     knService,
+		knProxyPublisher:        knService,
 		ots:                     object_type.NewObjectTypeService(appSetting),
 		rts:                     relation_type.NewRelationTypeService(appSetting),
 		rtsRisk:                 risk_type.NewRiskTypeService(appSetting),

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -121,6 +121,7 @@ type KNProxyAccess interface {
 
 type ManagedProxyAccess interface {
 	Create(ctx context.Context, knID, name string) (*ManagedProxyAccount, bool, error)
+	Restore(ctx context.Context, proxyAccountID string) (*ManagedProxyAccount, error)
 	Disable(ctx context.Context, proxyAccountID string) (*ManagedProxyAccount, error)
 	Archive(ctx context.Context, proxyAccountID string) (*ManagedProxyAccount, error)
 	CheckGrant(ctx context.Context, proxyAccountID, grantorID string, source ProxyGrantSourceSpec) (ProxyGrantCheckResult, error)

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy_mutation.go
@@ -13,7 +13,7 @@ import (
 // with the knowledge-network proxy publication lifecycle. The callback receives
 // the transaction and context that own authorization compensation tracking.
 type KNProxyMutationPublisher interface {
-	PublishKNChildMutation(ctx context.Context, changes *KN,
+	PublishKNChildMutation(ctx context.Context, changes *KN, mergeMode string,
 		mutate func(context.Context, *sql.Tx) error) error
 }
 

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy_mutation.go
@@ -1,0 +1,23 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import (
+	"context"
+	"database/sql"
+)
+
+// KNProxyMutationPublisher serializes a main-branch child-resource mutation
+// with the knowledge-network proxy publication lifecycle. The callback receives
+// the transaction and context that own authorization compensation tracking.
+type KNProxyMutationPublisher interface {
+	PublishKNChildMutation(ctx context.Context, changes *KN,
+		mutate func(context.Context, *sql.Tx) error) error
+}
+
+type KNServiceWithProxyMutation interface {
+	KNService
+	KNProxyMutationPublisher
+}

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_kn_proxy.go
@@ -275,6 +275,21 @@ func (mr *MockManagedProxyAccessMockRecorder) ReconcileGrants(ctx, proxyAccountI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileGrants", reflect.TypeOf((*MockManagedProxyAccess)(nil).ReconcileGrants), ctx, proxyAccountID, requestedBy)
 }
 
+// Restore mocks base method.
+func (m *MockManagedProxyAccess) Restore(ctx context.Context, proxyAccountID string) (*interfaces.ManagedProxyAccount, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Restore", ctx, proxyAccountID)
+	ret0, _ := ret[0].(*interfaces.ManagedProxyAccount)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Restore indicates an expected call of Restore.
+func (mr *MockManagedProxyAccessMockRecorder) Restore(ctx, proxyAccountID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restore", reflect.TypeOf((*MockManagedProxyAccess)(nil).Restore), ctx, proxyAccountID)
+}
+
 // SyncGrants mocks base method.
 func (m *MockManagedProxyAccess) SyncGrants(ctx context.Context, proxyAccountID, grantorID string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/locale/errorcode.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/errorcode.en-US.toml
@@ -209,6 +209,7 @@ ConceptGroupModuleTypeInvalid = "The module type must be concept_group."
 KnowledgeNetworkNotFound = "Business knowledge network {{.knowledgeNetworkID}} was not found."
 UploadedFileReadFailed = "Failed to read the uploaded file."
 ArchiveFileTypeInvalid = "The uploaded file must be a tar archive."
+BindingPolicyInvalid = "binding_policy must be preserve or detach; got {{.value}}."
 ArchiveLoadFailed = "Failed to load the knowledge network from the archive."
 KnowledgeNetworkIDRequired = "kn_id is required."
 

--- a/adp/bkn/bkn-backend/server/locale/errorcode.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/errorcode.zh-CN.toml
@@ -209,6 +209,7 @@ ConceptGroupModuleTypeInvalid = "模块类型必须为 concept_group。"
 KnowledgeNetworkNotFound = "业务知识网络 {{.knowledgeNetworkID}} 不存在。"
 UploadedFileReadFailed = "读取上传文件失败。"
 ArchiveFileTypeInvalid = "上传文件必须为 tar 归档文件。"
+BindingPolicyInvalid = "binding_policy 必须是 preserve 或 detach，当前值为 {{.value}}。"
 ArchiveLoadFailed = "从归档文件加载业务知识网络失败。"
 KnowledgeNetworkIDRequired = "必须提供 kn_id。"
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -244,7 +244,7 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 
 	var proxyPlan *proxyPublishPlan
 	if isCreate || isUpdate {
-		proxyPlan, err = kns.prepareProxyPublish(ctx, kn)
+		proxyPlan, err = kns.prepareProxyImport(ctx, kn, isUpdate, mode)
 		if err != nil {
 			return "", err
 		}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -43,7 +43,7 @@ import (
 
 var (
 	knServiceOnce sync.Once
-	knService     interfaces.KNService
+	knService     interfaces.KNServiceWithProxyMutation
 )
 
 type knowledgeNetworkService struct {
@@ -70,7 +70,7 @@ type knowledgeNetworkService struct {
 	vbs        interfaces.VegaBackendService
 }
 
-func NewKNService(appSetting *common.AppSetting) interfaces.KNService {
+func NewKNService(appSetting *common.AppSetting) interfaces.KNServiceWithProxyMutation {
 	knServiceOnce.Do(func() {
 		knService = &knowledgeNetworkService{
 			appSetting: appSetting,

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -40,10 +40,20 @@ func (kns *knowledgeNetworkService) proxyOrchestrationEnabled(branch string) boo
 }
 
 func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn *interfaces.KN) (*proxyPublishPlan, error) {
+	return kns.prepareProxyPublishWithBaseline(ctx, kn, false, "")
+}
+
+func (kns *knowledgeNetworkService) prepareProxyImport(ctx context.Context, kn *interfaces.KN,
+	mergeCurrent bool, mergeMode string) (*proxyPublishPlan, error) {
+	return kns.prepareProxyPublishWithBaseline(ctx, kn, mergeCurrent, mergeMode)
+}
+
+func (kns *knowledgeNetworkService) prepareProxyPublishWithBaseline(ctx context.Context, kn *interfaces.KN,
+	mergeCurrent bool, mergeMode string) (*proxyPublishPlan, error) {
 	if !kns.proxyOrchestrationEnabled(kn.Branch) {
 		return nil, nil
 	}
-	plan, err := kns.beginProxyPublish(ctx, kn, true, false)
+	plan, err := kns.beginProxyPublish(ctx, kn, true, mergeCurrent)
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +65,28 @@ func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn 
 		}
 	}()
 
-	sources, version, err := buildProxyGrantSources(kn)
-	if err != nil {
-		return nil, proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
+	candidate := kn
+	var currentSources []interfaces.ProxyGrantSourceSpec
+	if mergeCurrent {
+		current, loadErr := kns.ExportKNForProjection(ctx, kn.KNID)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		currentSources, _, err = buildProxyGrantSources(current)
+		if err != nil {
+			return nil, invalidProxyTargetError(ctx, err)
+		}
+		candidate = mergeProxyMutationChanges(current, kn, mergeMode)
 	}
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, sources); err != nil {
+	sources, version, err := buildProxyGrantSources(candidate)
+	if err != nil {
+		return nil, invalidProxyTargetError(ctx, err)
+	}
+	preflightSources := sources
+	if mergeCurrent && !plan.createdMapping {
+		preflightSources = addedProxyGrantSources(currentSources, sources)
+	}
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, preflightSources); err != nil {
 		return nil, err
 	}
 	plan.modelVersion = version
@@ -105,6 +132,26 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 		if err != nil {
 			return nil, err
 		}
+	}
+	if mapping.LifecycleStatus == interfaces.KNProxyLifecycleArchived && createIfMissing {
+		if authorizeMissing {
+			if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   kn.KNID,
+			}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+				return nil, err
+			}
+		}
+		if _, err := kns.mpa.Restore(ctx, mapping.ProxyAccountID); err != nil {
+			return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "restore knowledge network proxy")
+		}
+		if err := kns.kpa.SetLifecycle(ctx, mapping.KNID, interfaces.KNProxyLifecycleActive,
+			time.Now().UnixMilli()); err != nil {
+			cleanupManagedProxy(context.WithoutCancel(ctx), kns.mpa, mapping.ProxyAccountID)
+			return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "record restored knowledge network proxy")
+		}
+		mapping.LifecycleStatus = interfaces.KNProxyLifecycleActive
+		createdMapping = true
 	}
 	if mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive {
 		return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy is not active")
@@ -189,7 +236,9 @@ func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, p
 			return proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
 		}
 		if !result.Allowed {
-			return proxyHTTPError(ctx, http.StatusForbidden, "proxy permission preflight denied")
+			return proxyHTTPError(ctx, http.StatusForbidden, fmt.Sprintf(
+				"proxy permission preflight denied for %s %s on %s %s with operation %s",
+				source.BindingType, source.BindingID, source.ResourceType, source.ResourceID, source.Operation))
 		}
 	}
 	return nil
@@ -226,11 +275,11 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	if err != nil {
 		return err
 	}
+	currentSources, currentVersion, buildErr := buildProxyGrantSources(current)
+	if buildErr != nil {
+		return invalidProxyTargetError(ctx, buildErr)
+	}
 	if plan.createdMapping {
-		currentSources, currentVersion, buildErr := buildProxyGrantSources(current)
-		if buildErr != nil {
-			return proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
-		}
 		if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, currentSources); err != nil {
 			return err
 		}
@@ -246,9 +295,15 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	candidate := mergeProxyMutationChanges(current, changes, mergeMode)
 	sources, version, err := buildProxyGrantSources(candidate)
 	if err != nil {
-		return proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
+		return invalidProxyTargetError(ctx, err)
 	}
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, sources); err != nil {
+	// Existing grants were already authorized when they were installed. Only
+	// additions and binding replacements require the current editor to hold
+	// AUTHORIZE plus the requested downstream operation. Removals are applied
+	// by the post-commit full sync and must remain usable as a repair path even
+	// when the old target no longer exists or is no longer delegable.
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID,
+		addedProxyGrantSources(currentSources, sources)); err != nil {
 		return err
 	}
 	plan.modelVersion = version
@@ -663,7 +718,7 @@ func (kns *knowledgeNetworkService) PlanKNProxySync(ctx context.Context, knID st
 	}
 	sources, version, err := buildProxyGrantSources(latest)
 	if err != nil {
-		return nil, proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
+		return nil, invalidProxyTargetError(ctx, err)
 	}
 	plan := &interfaces.KNProxySyncPlan{KNID: knID, ModelVersion: version, Sources: sources}
 	if mapping, getErr := kns.kpa.Get(ctx, knID); getErr != nil {
@@ -753,4 +808,12 @@ func accountIDFromContext(ctx context.Context) string {
 
 func proxyHTTPError(ctx context.Context, status int, detail string) *rest.HTTPError {
 	return rest.NewHTTPError(ctx, status, berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(detail)
+}
+
+func invalidProxyTargetError(ctx context.Context, cause error) *rest.HTTPError {
+	detail := "published model contains an invalid proxy target"
+	if cause != nil {
+		detail += ": " + cause.Error()
+	}
+	return proxyHTTPError(ctx, http.StatusBadRequest, detail)
 }

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,6 +19,7 @@ import (
 
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
+	"bkn-backend/logics/permission"
 )
 
 const (
@@ -41,31 +43,10 @@ func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn 
 	if !kns.proxyOrchestrationEnabled(kn.Branch) {
 		return nil, nil
 	}
-	grantorID := accountIDFromContext(ctx)
-	if grantorID == "" {
-		return nil, proxyHTTPError(ctx, http.StatusForbidden, "proxy grantor identity is unavailable")
-	}
-
-	mapping, err := kns.kpa.Get(ctx, kn.KNID)
+	plan, err := kns.beginProxyPublish(ctx, kn, true)
 	if err != nil {
-		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "load knowledge network proxy mapping")
-	}
-	createdMapping := false
-	if mapping == nil {
-		mapping, createdMapping, err = kns.createProxyMapping(ctx, kn)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive {
-		return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy is not active")
-	}
-
-	lockOwner := uuid.NewString()
-	if err := kns.acquireProxyLock(ctx, kn.KNID, lockOwner); err != nil {
 		return nil, err
 	}
-	plan := &proxyPublishPlan{mapping: mapping, grantorID: grantorID, lockOwner: lockOwner, createdMapping: createdMapping}
 	releaseOnError := true
 	defer func() {
 		if releaseOnError {
@@ -78,12 +59,50 @@ func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn 
 	if err != nil {
 		return nil, proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
 	}
-	if err := kns.preflightProxySources(ctx, mapping.ProxyAccountID, grantorID, sources); err != nil {
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, sources); err != nil {
 		return nil, err
 	}
 	plan.modelVersion = version
 	releaseOnError = false
 	return plan, nil
+}
+
+func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *interfaces.KN, createIfMissing bool) (*proxyPublishPlan, error) {
+	grantorID := accountIDFromContext(ctx)
+	if grantorID == "" {
+		return nil, proxyHTTPError(ctx, http.StatusForbidden, "proxy grantor identity is unavailable")
+	}
+
+	mapping, err := kns.kpa.Get(ctx, kn.KNID)
+	if err != nil {
+		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "load knowledge network proxy mapping")
+	}
+	createdMapping := false
+	if mapping == nil {
+		if !createIfMissing {
+			return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy mapping is unavailable; reconcile before publishing")
+		}
+		mapping, createdMapping, err = kns.createProxyMapping(ctx, kn)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive {
+		return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy is not active")
+	}
+
+	lockOwner := uuid.NewString()
+	if err := kns.acquireProxyLock(ctx, kn.KNID, lockOwner); err != nil {
+		if createdMapping {
+			kns.abortCreatedProxy(context.WithoutCancel(ctx), &proxyPublishPlan{
+				mapping: mapping, createdMapping: true,
+			})
+		}
+		return nil, err
+	}
+	return &proxyPublishPlan{
+		mapping: mapping, grantorID: grantorID, lockOwner: lockOwner, createdMapping: createdMapping,
+	}, nil
 }
 
 func (kns *knowledgeNetworkService) createProxyMapping(ctx context.Context, kn *interfaces.KN) (*interfaces.KNProxyAccount, bool, error) {
@@ -155,6 +174,141 @@ func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, p
 		}
 	}
 	return nil
+}
+
+// PublishKNChildMutation applies one standalone child-resource write through
+// the same serialized, fail-closed proxy publication lifecycle as whole-network
+// publication. The pending state and business rows commit atomically.
+func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, changes *interfaces.KN,
+	mutate func(context.Context, *sql.Tx) error) error {
+	if mutate == nil {
+		return proxyHTTPError(ctx, http.StatusInternalServerError, "child resource mutation callback is unavailable")
+	}
+	if changes == nil || changes.KNID == "" || changes.Branch == "" {
+		return proxyHTTPError(ctx, http.StatusBadRequest, "child resource mutation identity is invalid")
+	}
+	if !kns.proxyOrchestrationEnabled(changes.Branch) {
+		return mutate(ctx, nil)
+	}
+	if err := prepareProxyMutationIDs(ctx, changes); err != nil {
+		return err
+	}
+
+	plan, err := kns.beginProxyPublish(ctx, changes, false)
+	if err != nil {
+		return err
+	}
+	defer kns.releaseProxyLock(context.WithoutCancel(ctx), plan)
+
+	// Reload after acquiring the publication lock. This prevents a candidate
+	// assembled from a stale model from omitting targets published by a writer
+	// that held the lock immediately before this request.
+	current, err := kns.ExportKNForProjection(ctx, changes.KNID)
+	if err != nil {
+		return err
+	}
+	candidate := mergeProxyMutationChanges(current, changes)
+	sources, version, err := buildProxyGrantSources(candidate)
+	if err != nil {
+		return proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
+	}
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, sources); err != nil {
+		return err
+	}
+	plan.modelVersion = version
+
+	mutationCtx, parentTracker, parentTrackerOwner := permission.WithResourceParentTracker(ctx)
+	mutationCtx, policyTracker, policyTrackerOwner := permission.WithCreatedPolicyTracker(mutationCtx)
+	mutationCtx, cleanupTracker, cleanupTrackerOwner := permission.WithAuthorizationCleanupTracker(mutationCtx)
+	tx, err := kns.db.BeginTx(mutationCtx, nil)
+	if err != nil {
+		return proxyHTTPError(ctx, http.StatusInternalServerError, "begin child resource publication")
+	}
+	rollback := func() {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && rollbackErr != sql.ErrTxDone {
+			otellog.LogError(ctx, "Rollback child resource publication failed", rollbackErr)
+		}
+	}
+	cleanupCreatedAuthorization := func() {
+		if parentTrackerOwner {
+			_ = parentTracker.Cleanup(mutationCtx, kns.ps)
+		}
+		if policyTrackerOwner {
+			_ = policyTracker.Cleanup(mutationCtx, kns.ps)
+		}
+	}
+
+	if err := kns.markProxyPending(mutationCtx, tx, plan); err != nil {
+		rollback()
+		return err
+	}
+	if err := mutate(mutationCtx, tx); err != nil {
+		rollback()
+		cleanupCreatedAuthorization()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		rollback()
+		cleanupCreatedAuthorization()
+		return proxyHTTPError(ctx, http.StatusInternalServerError, "commit child resource publication")
+	}
+	if cleanupTrackerOwner {
+		_ = cleanupTracker.Cleanup(mutationCtx, kns.ps)
+	}
+	return kns.finishProxyPublish(ctx, plan)
+}
+
+func prepareProxyMutationIDs(ctx context.Context, changes *interfaces.KN) error {
+	for _, objectType := range changes.ObjectTypes {
+		if objectType == nil {
+			continue
+		}
+		id, err := permission.PrepareKNChildResourceID(ctx, objectType.OTID)
+		if err != nil {
+			return err
+		}
+		objectType.OTID = id
+	}
+	for _, relationType := range changes.RelationTypes {
+		if relationType == nil {
+			continue
+		}
+		id, err := permission.PrepareKNChildResourceID(ctx, relationType.RTID)
+		if err != nil {
+			return err
+		}
+		relationType.RTID = id
+	}
+	for _, actionType := range changes.ActionTypes {
+		if actionType == nil {
+			continue
+		}
+		id, err := permission.PrepareKNChildResourceID(ctx, actionType.ATID)
+		if err != nil {
+			return err
+		}
+		actionType.ATID = id
+	}
+	for _, metric := range changes.Metrics {
+		if metric == nil {
+			continue
+		}
+		id, err := permission.PrepareKNChildResourceID(ctx, strings.TrimSpace(metric.ID))
+		if err != nil {
+			return err
+		}
+		metric.ID = id
+	}
+	return nil
+}
+
+func mergeProxyMutationChanges(current, changes *interfaces.KN) *interfaces.KN {
+	candidate := *current
+	candidate.ObjectTypes = append(append([]*interfaces.ObjectType(nil), current.ObjectTypes...), changes.ObjectTypes...)
+	candidate.RelationTypes = append(append([]*interfaces.RelationType(nil), current.RelationTypes...), changes.RelationTypes...)
+	candidate.ActionTypes = append(append([]*interfaces.ActionType(nil), current.ActionTypes...), changes.ActionTypes...)
+	candidate.Metrics = append(append([]*interfaces.MetricDefinition(nil), current.Metrics...), changes.Metrics...)
+	return &candidate
 }
 
 func (kns *knowledgeNetworkService) markProxyPending(ctx context.Context, tx *sql.Tx, plan *proxyPublishPlan) error {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -43,7 +43,7 @@ func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn 
 	if !kns.proxyOrchestrationEnabled(kn.Branch) {
 		return nil, nil
 	}
-	plan, err := kns.beginProxyPublish(ctx, kn, true)
+	plan, err := kns.beginProxyPublish(ctx, kn, true, false)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,8 @@ func (kns *knowledgeNetworkService) prepareProxyPublish(ctx context.Context, kn 
 	return plan, nil
 }
 
-func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *interfaces.KN, createIfMissing bool) (*proxyPublishPlan, error) {
+func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *interfaces.KN,
+	createIfMissing, authorizeMissing bool) (*proxyPublishPlan, error) {
 	grantorID := accountIDFromContext(ctx)
 	if grantorID == "" {
 		return nil, proxyHTTPError(ctx, http.StatusForbidden, "proxy grantor identity is unavailable")
@@ -80,9 +81,27 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 	createdMapping := false
 	if mapping == nil {
 		if !createIfMissing {
-			return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy mapping is unavailable; reconcile before publishing")
+			return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy mapping is unavailable")
 		}
-		mapping, createdMapping, err = kns.createProxyMapping(ctx, kn)
+		if authorizeMissing {
+			if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   kn.KNID,
+			}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+				return nil, err
+			}
+		}
+		mappingKN := kn
+		if authorizeMissing && strings.TrimSpace(kn.KNName) == "" {
+			existingKN, loadErr := kns.kna.GetKNByID(ctx, kn.KNID, interfaces.MAIN_BRANCH)
+			if loadErr != nil || existingKN == nil {
+				return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "load knowledge network for proxy mapping")
+			}
+			mappingCopy := *kn
+			mappingCopy.KNName = existingKN.KNName
+			mappingKN = &mappingCopy
+		}
+		mapping, createdMapping, err = kns.createProxyMapping(ctx, mappingKN)
 		if err != nil {
 			return nil, err
 		}
@@ -93,7 +112,7 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 
 	lockOwner := uuid.NewString()
 	if err := kns.acquireProxyLock(ctx, kn.KNID, lockOwner); err != nil {
-		if createdMapping {
+		if createdMapping && !authorizeMissing {
 			kns.abortCreatedProxy(context.WithoutCancel(ctx), &proxyPublishPlan{
 				mapping: mapping, createdMapping: true,
 			})
@@ -179,7 +198,7 @@ func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, p
 // PublishKNChildMutation applies one standalone child-resource write through
 // the same serialized, fail-closed proxy publication lifecycle as whole-network
 // publication. The pending state and business rows commit atomically.
-func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, changes *interfaces.KN,
+func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, changes *interfaces.KN, mergeMode string,
 	mutate func(context.Context, *sql.Tx) error) error {
 	if mutate == nil {
 		return proxyHTTPError(ctx, http.StatusInternalServerError, "child resource mutation callback is unavailable")
@@ -194,7 +213,7 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 		return err
 	}
 
-	plan, err := kns.beginProxyPublish(ctx, changes, false)
+	plan, err := kns.beginProxyPublish(ctx, changes, true, true)
 	if err != nil {
 		return err
 	}
@@ -207,7 +226,24 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	candidate := mergeProxyMutationChanges(current, changes)
+	if plan.createdMapping {
+		currentSources, currentVersion, buildErr := buildProxyGrantSources(current)
+		if buildErr != nil {
+			return proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
+		}
+		if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, currentSources); err != nil {
+			return err
+		}
+		plan.modelVersion = currentVersion
+		if err := kns.markProxyPendingInNewTransaction(ctx, plan, currentVersion); err != nil {
+			return err
+		}
+		if err := kns.finishProxyPublish(ctx, plan); err != nil {
+			return err
+		}
+	}
+
+	candidate := mergeProxyMutationChanges(current, changes, mergeMode)
 	sources, version, err := buildProxyGrantSources(candidate)
 	if err != nil {
 		return proxyHTTPError(ctx, http.StatusBadRequest, "published model contains an invalid proxy target")
@@ -302,13 +338,68 @@ func prepareProxyMutationIDs(ctx context.Context, changes *interfaces.KN) error 
 	return nil
 }
 
-func mergeProxyMutationChanges(current, changes *interfaces.KN) *interfaces.KN {
+func mergeProxyMutationChanges(current, changes *interfaces.KN, mergeMode string) *interfaces.KN {
 	candidate := *current
-	candidate.ObjectTypes = append(append([]*interfaces.ObjectType(nil), current.ObjectTypes...), changes.ObjectTypes...)
-	candidate.RelationTypes = append(append([]*interfaces.RelationType(nil), current.RelationTypes...), changes.RelationTypes...)
-	candidate.ActionTypes = append(append([]*interfaces.ActionType(nil), current.ActionTypes...), changes.ActionTypes...)
-	candidate.Metrics = append(append([]*interfaces.MetricDefinition(nil), current.Metrics...), changes.Metrics...)
+	keepExisting := mergeMode != interfaces.ImportMode_Overwrite
+	candidate.ObjectTypes = mergeProxyItems(current.ObjectTypes, changes.ObjectTypes, keepExisting,
+		func(item *interfaces.ObjectType) (string, bool) {
+			if item == nil {
+				return "", false
+			}
+			return item.OTID, true
+		})
+	candidate.RelationTypes = mergeProxyItems(current.RelationTypes, changes.RelationTypes, keepExisting,
+		func(item *interfaces.RelationType) (string, bool) {
+			if item == nil {
+				return "", false
+			}
+			return item.RTID, true
+		})
+	candidate.ActionTypes = mergeProxyItems(current.ActionTypes, changes.ActionTypes, keepExisting,
+		func(item *interfaces.ActionType) (string, bool) {
+			if item == nil {
+				return "", false
+			}
+			return item.ATID, true
+		})
+	candidate.Metrics = mergeProxyItems(current.Metrics, changes.Metrics, keepExisting,
+		func(item *interfaces.MetricDefinition) (string, bool) {
+			if item == nil {
+				return "", false
+			}
+			return item.ID, true
+		})
 	return &candidate
+}
+
+func mergeProxyItems[T any](current, changes []T, keepExisting bool,
+	itemID func(T) (string, bool)) []T {
+	byID := make(map[string]T, len(current)+len(changes))
+	for _, item := range current {
+		if id, ok := itemID(item); ok {
+			byID[id] = item
+		}
+	}
+	for _, item := range changes {
+		id, ok := itemID(item)
+		if !ok {
+			continue
+		}
+		if _, exists := byID[id]; keepExisting && exists {
+			continue
+		}
+		byID[id] = item
+	}
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	merged := make([]T, 0, len(ids))
+	for _, id := range ids {
+		merged = append(merged, byID[id])
+	}
+	return merged
 }
 
 func (kns *knowledgeNetworkService) markProxyPending(ctx context.Context, tx *sql.Tx, plan *proxyPublishPlan) error {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -153,6 +153,9 @@ func TestMergeProxyMutationChangesReplacesBindingsByID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(sources) != 2 {
+		t.Fatalf("ignore sources = %#v, want exactly one resource binding", sources)
+	}
 	for _, source := range sources {
 		if source.ResourceID != "resource-old" {
 			t.Fatalf("ignore preflight replaced existing target with %q", source.ResourceID)
@@ -164,10 +167,126 @@ func TestMergeProxyMutationChangesReplacesBindingsByID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(sources) != 2 {
+		t.Fatalf("normal sources = %#v, want exactly one resource binding", sources)
+	}
 	for _, source := range sources {
 		if source.ResourceID != "resource-old" {
 			t.Fatalf("normal preflight replaced colliding target with %q", source.ResourceID)
 		}
+	}
+}
+
+func TestMergeProxyMutationChangesAppliesModeForEveryChildResource(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		current *interfaces.KN
+		changes *interfaces.KN
+		target  func(*interfaces.KN) string
+	}{
+		{
+			name: "object type",
+			current: &interfaces.KN{ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				OTID: "ot-1", DataSource: &interfaces.ResourceInfo{ID: "old"},
+			}}}},
+			changes: &interfaces.KN{ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				OTID: "ot-1", DataSource: &interfaces.ResourceInfo{ID: "new"},
+			}}}},
+			target: func(kn *interfaces.KN) string { return kn.ObjectTypes[0].DataSource.ID },
+		},
+		{
+			name: "relation type",
+			current: &interfaces.KN{RelationTypes: []*interfaces.RelationType{{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+				RTID: "rt-1", SourceObjectTypeID: "old",
+			}}}},
+			changes: &interfaces.KN{RelationTypes: []*interfaces.RelationType{{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+				RTID: "rt-1", SourceObjectTypeID: "new",
+			}}}},
+			target: func(kn *interfaces.KN) string { return kn.RelationTypes[0].SourceObjectTypeID },
+		},
+		{
+			name: "action type",
+			current: &interfaces.KN{ActionTypes: []*interfaces.ActionType{{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+				ATID: "at-1", ActionSource: interfaces.ActionSource{BoxID: "old"},
+			}}}},
+			changes: &interfaces.KN{ActionTypes: []*interfaces.ActionType{{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+				ATID: "at-1", ActionSource: interfaces.ActionSource{BoxID: "new"},
+			}}}},
+			target: func(kn *interfaces.KN) string { return kn.ActionTypes[0].ActionSource.BoxID },
+		},
+		{
+			name:    "metric",
+			current: &interfaces.KN{Metrics: []*interfaces.MetricDefinition{{ID: "metric-1", ScopeRef: "old"}}},
+			changes: &interfaces.KN{Metrics: []*interfaces.MetricDefinition{{ID: "metric-1", ScopeRef: "new"}}},
+			target:  func(kn *interfaces.KN) string { return kn.Metrics[0].ScopeRef },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			for _, mode := range []struct {
+				name string
+				mode string
+				want string
+			}{
+				{name: "overwrite", mode: interfaces.ImportMode_Overwrite, want: "new"},
+				{name: "normal", mode: interfaces.ImportMode_Normal, want: "old"},
+				{name: "ignore", mode: interfaces.ImportMode_Ignore, want: "old"},
+			} {
+				t.Run(mode.name, func(t *testing.T) {
+					got := test.target(mergeProxyMutationChanges(test.current, test.changes, mode.mode))
+					if got != mode.want {
+						t.Fatalf("merged target = %q, want %q", got, mode.want)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestPrepareProxyMutationIDsAssignsEveryChildResourceType(t *testing.T) {
+	changes := &interfaces.KN{
+		ObjectTypes:   []*interfaces.ObjectType{{}},
+		RelationTypes: []*interfaces.RelationType{{}},
+		ActionTypes:   []*interfaces.ActionType{{}},
+		Metrics:       []*interfaces.MetricDefinition{{ID: "  "}},
+	}
+	if err := prepareProxyMutationIDs(t.Context(), changes); err != nil {
+		t.Fatal(err)
+	}
+	ids := []string{
+		changes.ObjectTypes[0].OTID,
+		changes.RelationTypes[0].RTID,
+		changes.ActionTypes[0].ATID,
+		changes.Metrics[0].ID,
+	}
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			t.Fatalf("prepared IDs = %#v, want non-empty IDs", ids)
+		}
+		if _, exists := seen[id]; exists {
+			t.Fatalf("prepared IDs = %#v, want unique IDs", ids)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+func TestPublishKNChildMutationBypassesProxyOutsideMainBranch(t *testing.T) {
+	service := &knowledgeNetworkService{}
+	mutationCalled := false
+	err := service.PublishKNChildMutation(t.Context(),
+		&interfaces.KN{KNID: "kn-1", Branch: "draft"}, interfaces.ImportMode_Normal,
+		func(_ context.Context, tx *sql.Tx) error {
+			mutationCalled = true
+			if tx != nil {
+				t.Fatal("non-main mutation received a proxy transaction")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutationCalled {
+		t.Fatal("non-main mutation was not called")
 	}
 }
 
@@ -337,6 +456,191 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	}
 	if kpa.syncStatus != interfaces.KNProxySyncReady || kpa.syncedVersion != kpa.pendingVersion {
 		t.Fatalf("sync state = %q %q, pending version %q", kpa.syncStatus, kpa.syncedVersion, kpa.pendingVersion)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishKNChildMutationDeniedTargetDoesNotMutate(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+
+	oldObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-old"},
+	}}
+	newObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).
+		Return(&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}, nil)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return([]*interfaces.ObjectType{oldObjectType}, nil)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: false}
+	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	mutationCalled := false
+	err := service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{newObjectType}},
+		interfaces.ImportMode_Overwrite,
+		func(context.Context, *sql.Tx) error {
+			mutationCalled = true
+			return nil
+		})
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok || httpErr.HTTPCode != http.StatusForbidden {
+		t.Fatalf("PublishKNChildMutation() error = %#v, want HTTP 403", err)
+	}
+	if mutationCalled || kpa.pendingCount != 0 || !kpa.lockReleased {
+		t.Fatalf("denied mutation state: called=%t pending=%d lock_released=%t",
+			mutationCalled, kpa.pendingCount, kpa.lockReleased)
+	}
+	if len(mpa.checked) != 1 || mpa.checked[0].ResourceID != "resource-new" {
+		t.Fatalf("denied preflight sources = %#v, want replacement target only", mpa.checked)
+	}
+}
+
+func TestPublishKNChildMutationDeleteRevokesRemovedGrantsWithLegacyUnscopedMetric(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-old"},
+	}}
+	legacyMetric := &interfaces.MetricDefinition{ID: "metric-unscoped"}
+	base := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	loadCount := 0
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
+		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
+			loadCount++
+			if loadCount == 1 {
+				return []*interfaces.ObjectType{objectType}, nil
+			}
+			return nil, nil
+		}).Times(2)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).
+		Return([]*interfaces.MetricDefinition{legacyMetric}, nil).Times(2)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	mutationCalled := false
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}, interfaces.ImportMode_Normal,
+		func(_ context.Context, tx *sql.Tx) error {
+			mutationCalled = true
+			if tx == nil {
+				t.Fatal("mutation transaction is nil")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutationCalled || mpa.syncCalls != 1 || len(mpa.synced) != 0 {
+		t.Fatalf("delete synchronization: mutation=%t calls=%d grants=%#v", mutationCalled, mpa.syncCalls, mpa.synced)
+	}
+	if kpa.pendingCount != 2 || kpa.syncStatus != interfaces.KNProxySyncReady || !kpa.lockReleased {
+		t.Fatalf("delete proxy state: pending=%d sync=%q lock_released=%t",
+			kpa.pendingCount, kpa.syncStatus, kpa.lockReleased)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishKNChildMutationSyncFailureIsRecordedAfterCommit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	base := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	loadCount := 0
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
+		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
+			loadCount++
+			if loadCount == 2 {
+				return []*interfaces.ObjectType{objectType}, nil
+			}
+			return nil, nil
+		}).Times(2)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true, syncErr: errors.New("sync unavailable")}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	mutationCalled := false
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}},
+		interfaces.ImportMode_Normal,
+		func(context.Context, *sql.Tx) error {
+			mutationCalled = true
+			return nil
+		})
+	if err == nil {
+		t.Fatal("PublishKNChildMutation() error = nil, want synchronization failure")
+	}
+	if !mutationCalled || kpa.syncStatus != interfaces.KNProxySyncFailed || kpa.syncedVersion != "" {
+		t.Fatalf("failed synchronization state: mutation=%t status=%q version=%q",
+			mutationCalled, kpa.syncStatus, kpa.syncedVersion)
 	}
 	if err := databaseMock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -77,16 +77,20 @@ func (s *proxyAccessStub) ListProxyConflicts(context.Context) (map[string][]stri
 
 type managedProxyAccessStub struct {
 	allowed          bool
+	createCount      int
 	disabled         bool
 	disableLifecycle string
 	archived         bool
+	checked          []interfaces.ProxyGrantSourceSpec
 	synced           []interfaces.ProxyGrantSourceSpec
+	syncCalls        int
 	reconciled       []string
 	syncErr          error
 	events           *[]string
 }
 
 func (s *managedProxyAccessStub) Create(_ context.Context, knID, _ string) (*interfaces.ManagedProxyAccount, bool, error) {
+	s.createCount++
 	return &interfaces.ManagedProxyAccount{ProxyAccountID: "proxy-1", AccountType: interfaces.KNProxyAccountTypeApp, ManagedResourceID: knID}, true, nil
 }
 func (s *managedProxyAccessStub) Disable(context.Context, string) (*interfaces.ManagedProxyAccount, error) {
@@ -107,15 +111,156 @@ func (s *managedProxyAccessStub) Archive(context.Context, string) (*interfaces.M
 	}
 	return &interfaces.ManagedProxyAccount{ProxyAccountID: "proxy-1"}, nil
 }
-func (s *managedProxyAccessStub) CheckGrant(context.Context, string, string, interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantCheckResult, error) {
+func (s *managedProxyAccessStub) CheckGrant(_ context.Context, _, _ string, source interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantCheckResult, error) {
+	s.checked = append(s.checked, source)
 	return interfaces.ProxyGrantCheckResult{Allowed: s.allowed}, nil
 }
 func (s *managedProxyAccessStub) SyncGrants(_ context.Context, _, _ string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
+	s.syncCalls++
 	s.synced = append([]interfaces.ProxyGrantSourceSpec(nil), sources...)
 	if s.events != nil {
 		*s.events = append(*s.events, "grants:sync")
 	}
 	return interfaces.ProxyGrantSyncResult{}, s.syncErr
+}
+
+func TestMergeProxyMutationChangesReplacesBindingsByID(t *testing.T) {
+	currentObject := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-old"},
+	}}
+	changedObject := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	current := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{currentObject}}
+	changes := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{changedObject}}
+
+	overwrite := mergeProxyMutationChanges(current, changes, interfaces.ImportMode_Overwrite)
+	sources, _, err := buildProxyGrantSources(overwrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 2 {
+		t.Fatalf("overwrite sources = %#v, want exactly one resource binding", sources)
+	}
+	for _, source := range sources {
+		if source.ResourceID != "resource-new" {
+			t.Fatalf("overwrite preflight retained replaced target %q", source.ResourceID)
+		}
+	}
+
+	ignored := mergeProxyMutationChanges(current, changes, interfaces.ImportMode_Ignore)
+	sources, _, err = buildProxyGrantSources(ignored)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range sources {
+		if source.ResourceID != "resource-old" {
+			t.Fatalf("ignore preflight replaced existing target with %q", source.ResourceID)
+		}
+	}
+
+	normal := mergeProxyMutationChanges(current, changes, interfaces.ImportMode_Normal)
+	sources, _, err = buildProxyGrantSources(normal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, source := range sources {
+		if source.ResourceID != "resource-old" {
+			t.Fatalf("normal preflight replaced colliding target with %q", source.ResourceID)
+		}
+	}
+}
+
+func TestPublishKNChildMutationRejectsMissingProxyWithoutAuthorize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := bmock.NewMockPermissionService(ctrl)
+	wantErr := errors.New("authorize denied")
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(wantErr)
+
+	mpa := &managedProxyAccessStub{}
+	service := &knowledgeNetworkService{ps: ps, kpa: &proxyAccessStub{}, mpa: mpa}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	err := service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH},
+		interfaces.ImportMode_Normal,
+		func(context.Context, *sql.Tx) error { return nil })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PublishKNChildMutation() error = %v, want %v", err, wantErr)
+	}
+	if mpa.createCount != 0 {
+		t.Fatalf("managed proxy create count = %d, want 0", mpa.createCount)
+	}
+}
+
+func TestPublishKNChildMutationBackfillsMissingProxyBeforeMutation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(4)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+	loadCount := 0
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
+		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
+			loadCount++
+			if loadCount == 3 {
+				return []*interfaces.ObjectType{objectType}, nil
+			}
+			return nil, nil
+		}).Times(3)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+
+	kpa := &proxyAccessStub{}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, ps: ps, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	mutationCalled := false
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}},
+		interfaces.ImportMode_Normal,
+		func(context.Context, *sql.Tx) error {
+			mutationCalled = true
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutationCalled || mpa.createCount != 1 || mpa.syncCalls != 2 {
+		t.Fatalf("backfill state: mutation=%t creates=%d syncs=%d", mutationCalled, mpa.createCount, mpa.syncCalls)
+	}
+	if kpa.mapping == nil || kpa.mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive || !kpa.lockReleased {
+		t.Fatalf("mapping state = %#v, lock released = %t", kpa.mapping, kpa.lockReleased)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
@@ -134,7 +279,10 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	t.Cleanup(func() { _ = db.Close() })
 
 	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
-		DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	oldObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-old"},
 	}}
 	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
 	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
@@ -143,10 +291,10 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
 		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
 			loadCount++
-			if loadCount == 2 {
-				return []*interfaces.ObjectType{objectType}, nil
+			if loadCount == 1 {
+				return []*interfaces.ObjectType{oldObjectType}, nil
 			}
-			return nil, nil
+			return []*interfaces.ObjectType{objectType}, nil
 		}).Times(2)
 	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
@@ -164,7 +312,7 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
 	changes := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}}
 	mutationCalled := false
-	err = service.PublishKNChildMutation(ctx, changes, func(_ context.Context, tx *sql.Tx) error {
+	err = service.PublishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(_ context.Context, tx *sql.Tx) error {
 		mutationCalled = true
 		if tx == nil {
 			t.Fatal("mutation transaction is nil")
@@ -183,6 +331,9 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	}
 	if len(mpa.synced) != 2 || mpa.synced[0].ResourceID != "resource-new" || mpa.synced[1].ResourceID != "resource-new" {
 		t.Fatalf("synchronized sources = %#v, want new resource view and query grants", mpa.synced)
+	}
+	if len(mpa.checked) != 2 || mpa.checked[0].ResourceID != "resource-new" || mpa.checked[1].ResourceID != "resource-new" {
+		t.Fatalf("preflight sources = %#v, want only replacement resource grants", mpa.checked)
 	}
 	if kpa.syncStatus != interfaces.KNProxySyncReady || kpa.syncedVersion != kpa.pendingVersion {
 		t.Fatalf("sync state = %q %q, pending version %q", kpa.syncStatus, kpa.syncedVersion, kpa.pendingVersion)
@@ -228,6 +379,7 @@ func TestPublishKNChildMutationRollsBackPendingWithBusinessFailure(t *testing.T)
 	wantErr := errors.New("business mutation failed")
 	err = service.PublishKNChildMutation(ctx,
 		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH},
+		interfaces.ImportMode_Normal,
 		func(context.Context, *sql.Tx) error { return wantErr })
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("PublishKNChildMutation() error = %v, want %v", err, wantErr)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -21,15 +21,17 @@ import (
 )
 
 type proxyAccessStub struct {
-	mapping       *interfaces.KNProxyAccount
-	mappings      []*interfaces.KNProxyAccount
-	conflicts     map[string][]string
-	lifecycle     string
-	lockAcquired  bool
-	lockReleased  bool
-	syncStatus    string
-	syncedVersion string
-	events        *[]string
+	mapping        *interfaces.KNProxyAccount
+	mappings       []*interfaces.KNProxyAccount
+	conflicts      map[string][]string
+	lifecycle      string
+	lockAcquired   bool
+	lockReleased   bool
+	syncStatus     string
+	syncedVersion  string
+	pendingCount   int
+	pendingVersion string
+	events         *[]string
 }
 
 func (s *proxyAccessStub) Get(context.Context, string) (*interfaces.KNProxyAccount, error) {
@@ -42,7 +44,10 @@ func (s *proxyAccessStub) Ensure(_ context.Context, mapping *interfaces.KNProxyA
 	s.mapping = mapping
 	return mapping, true, nil
 }
-func (s *proxyAccessStub) SetPending(context.Context, *sql.Tx, string, string, string, int64) error {
+
+func (s *proxyAccessStub) SetPending(_ context.Context, _ *sql.Tx, _, version, _ string, _ int64) error {
+	s.pendingCount++
+	s.pendingVersion = version
 	return nil
 }
 
@@ -111,6 +116,128 @@ func (s *managedProxyAccessStub) SyncGrants(_ context.Context, _, _ string, sour
 		*s.events = append(*s.events, "grants:sync")
 	}
 	return interfaces.ProxyGrantSyncResult{}, s.syncErr
+}
+
+func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
+	}}
+	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	loadCount := 0
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
+		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
+			loadCount++
+			if loadCount == 2 {
+				return []*interfaces.ObjectType{objectType}, nil
+			}
+			return nil, nil
+		}).Times(2)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, ps: ps, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	changes := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}}
+	mutationCalled := false
+	err = service.PublishKNChildMutation(ctx, changes, func(_ context.Context, tx *sql.Tx) error {
+		mutationCalled = true
+		if tx == nil {
+			t.Fatal("mutation transaction is nil")
+		}
+		if objectType.OTID == "" {
+			t.Fatal("object type ID was not prepared before the mutation")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutationCalled || kpa.pendingCount != 1 || !kpa.lockReleased {
+		t.Fatalf("publication state: mutation=%t pending=%d lock_released=%t",
+			mutationCalled, kpa.pendingCount, kpa.lockReleased)
+	}
+	if len(mpa.synced) != 2 || mpa.synced[0].ResourceID != "resource-new" || mpa.synced[1].ResourceID != "resource-new" {
+		t.Fatalf("synchronized sources = %#v, want new resource view and query grants", mpa.synced)
+	}
+	if kpa.syncStatus != interfaces.KNProxySyncReady || kpa.syncedVersion != kpa.pendingVersion {
+		t.Fatalf("sync state = %q %q, pending version %q", kpa.syncStatus, kpa.syncedVersion, kpa.pendingVersion)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishKNChildMutationRollsBackPendingWithBusinessFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return(nil, nil)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectRollback()
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, ps: ps, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	wantErr := errors.New("business mutation failed")
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH},
+		func(context.Context, *sql.Tx) error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PublishKNChildMutation() error = %v, want %v", err, wantErr)
+	}
+	if len(mpa.synced) != 0 || !kpa.lockReleased {
+		t.Fatalf("rollback state: synced=%d lock_released=%t", len(mpa.synced), kpa.lockReleased)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestFinishProxyPublishReloadsLatestMainModel(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -81,6 +81,7 @@ type managedProxyAccessStub struct {
 	disabled         bool
 	disableLifecycle string
 	archived         bool
+	restored         bool
 	checked          []interfaces.ProxyGrantSourceSpec
 	synced           []interfaces.ProxyGrantSourceSpec
 	syncCalls        int
@@ -93,6 +94,10 @@ func (s *managedProxyAccessStub) Create(_ context.Context, knID, _ string) (*int
 	s.createCount++
 	return &interfaces.ManagedProxyAccount{ProxyAccountID: "proxy-1", AccountType: interfaces.KNProxyAccountTypeApp, ManagedResourceID: knID}, true, nil
 }
+func (s *managedProxyAccessStub) Restore(context.Context, string) (*interfaces.ManagedProxyAccount, error) {
+	s.restored = true
+	return &interfaces.ManagedProxyAccount{ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive, Enabled: true}, nil
+}
 func (s *managedProxyAccessStub) Disable(context.Context, string) (*interfaces.ManagedProxyAccount, error) {
 	s.disabled = true
 	if s.events != nil {
@@ -103,6 +108,27 @@ func (s *managedProxyAccessStub) Disable(context.Context, string) (*interfaces.M
 		lifecycle = interfaces.KNProxyLifecycleDisabling
 	}
 	return &interfaces.ManagedProxyAccount{ProxyAccountID: "proxy-1", LifecycleStatus: lifecycle}, nil
+}
+
+func TestPrepareProxyPublishRestoresCompensatedProxyForRetry(t *testing.T) {
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleArchived,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{kpa: kpa, mpa: mpa}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+
+	plan, err := service.prepareProxyPublish(ctx, &interfaces.KN{
+		KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer service.releaseProxyLock(t.Context(), plan)
+	if !mpa.restored || kpa.lifecycle != interfaces.KNProxyLifecycleActive || !plan.createdMapping {
+		t.Fatalf("restored proxy state: restored=%t lifecycle=%q compensated=%t",
+			mpa.restored, kpa.lifecycle, plan.createdMapping)
+	}
 }
 func (s *managedProxyAccessStub) Archive(context.Context, string) (*interfaces.ManagedProxyAccount, error) {
 	s.archived = true
@@ -239,6 +265,49 @@ func TestMergeProxyMutationChangesAppliesModeForEveryChildResource(t *testing.T)
 				})
 			}
 		})
+	}
+}
+
+func TestPrepareProxyImportPreflightsRelationAgainstExistingBoundObject(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	boundObject := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1"},
+	}}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).
+		Return(&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}, nil)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return([]*interfaces.ObjectType{boundObject}, nil)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	changes := &interfaces.KN{
+		KNID: "kn-1", Branch: interfaces.MAIN_BRANCH,
+		RelationTypes: []*interfaces.RelationType{{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+			RTID: "rt-1", SourceObjectTypeID: "ot-1", TargetObjectTypeID: "ot-1",
+		}}},
+	}
+
+	plan, err := service.prepareProxyImport(ctx, changes, true, interfaces.ImportMode_Overwrite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer service.releaseProxyLock(t.Context(), plan)
+	if len(mpa.checked) != 1 || mpa.checked[0].BindingType != interfaces.MODULE_TYPE_RELATION_TYPE ||
+		mpa.checked[0].ResourceID != "resource-1" {
+		t.Fatalf("import preflight sources = %#v, want new relation grant on existing object resource", mpa.checked)
 	}
 }
 
@@ -382,6 +451,85 @@ func TestPublishKNChildMutationBackfillsMissingProxyBeforeMutation(t *testing.T)
 	}
 }
 
+func TestPublishKNChildMutationAddsFirstBindingToEmptyNetwork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-first"},
+	}}
+	base := &interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	loadCount := 0
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
+		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
+			loadCount++
+			if loadCount == 2 {
+				return []*interfaces.ObjectType{objectType}, nil
+			}
+			return nil, nil
+		}).Times(2)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectCommit()
+
+	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
+		SyncStatus: interfaces.KNProxySyncReady,
+	}}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	mutationCalled := false
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}},
+		interfaces.ImportMode_Normal,
+		func(_ context.Context, tx *sql.Tx) error {
+			mutationCalled = true
+			if tx == nil {
+				t.Fatal("mutation transaction is nil")
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !mutationCalled || kpa.pendingCount != 1 || mpa.syncCalls != 1 || !kpa.lockReleased {
+		t.Fatalf("first binding state: mutation=%t pending=%d syncs=%d lock_released=%t",
+			mutationCalled, kpa.pendingCount, mpa.syncCalls, kpa.lockReleased)
+	}
+	if len(mpa.checked) != 2 || len(mpa.synced) != 2 {
+		t.Fatalf("first binding grants: checked=%#v synced=%#v", mpa.checked, mpa.synced)
+	}
+	for _, source := range append(append([]interfaces.ProxyGrantSourceSpec(nil), mpa.checked...), mpa.synced...) {
+		if source.ResourceID != "resource-first" {
+			t.Fatalf("first binding grant target = %q", source.ResourceID)
+		}
+	}
+	if kpa.syncStatus != interfaces.KNProxySyncReady || kpa.syncedVersion != kpa.pendingVersion {
+		t.Fatalf("first binding sync state = %q %q, pending version %q",
+			kpa.syncStatus, kpa.syncedVersion, kpa.pendingVersion)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	kna := bmock.NewMockKNAccess(ctrl)
@@ -403,6 +551,9 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	oldObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
 		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-old"},
 	}}
+	stableObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-stable", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-stable"},
+	}}
 	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
 	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(2)
 	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
@@ -411,9 +562,9 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
 			loadCount++
 			if loadCount == 1 {
-				return []*interfaces.ObjectType{oldObjectType}, nil
+				return []*interfaces.ObjectType{oldObjectType, stableObjectType}, nil
 			}
-			return []*interfaces.ObjectType{objectType}, nil
+			return []*interfaces.ObjectType{objectType, stableObjectType}, nil
 		}).Times(2)
 	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
@@ -448,8 +599,8 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 		t.Fatalf("publication state: mutation=%t pending=%d lock_released=%t",
 			mutationCalled, kpa.pendingCount, kpa.lockReleased)
 	}
-	if len(mpa.synced) != 2 || mpa.synced[0].ResourceID != "resource-new" || mpa.synced[1].ResourceID != "resource-new" {
-		t.Fatalf("synchronized sources = %#v, want new resource view and query grants", mpa.synced)
+	if len(mpa.synced) != 4 {
+		t.Fatalf("synchronized sources = %#v, want replacement and unchanged resource grants", mpa.synced)
 	}
 	if len(mpa.checked) != 2 || mpa.checked[0].ResourceID != "resource-new" || mpa.checked[1].ResourceID != "resource-new" {
 		t.Fatalf("preflight sources = %#v, want only replacement resource grants", mpa.checked)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
@@ -104,12 +104,19 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		if metric == nil {
 			continue
 		}
-		resourceID := objectResources[strings.TrimSpace(metric.ScopeRef)]
+		scopeType := strings.TrimSpace(metric.ScopeType)
+		scopeRef := strings.TrimSpace(metric.ScopeRef)
+		// Non-strict imports may persist metrics without a scope. Such metrics
+		// have no backing resource and therefore contribute no proxy grant.
+		if scopeType == "" && scopeRef == "" {
+			continue
+		}
+		resourceID := objectResources[scopeRef]
 		if resourceID == "" {
 			return nil, "", fmt.Errorf("metric %s references scope %s without a resource binding", metric.ID, metric.ScopeRef)
 		}
 		if err := add(interfaces.MODULE_TYPE_METRIC, metric.ID, "resource", resourceID,
-			interfaces.OPERATION_TYPE_QUERY_DATA, metric.ScopeType+":"+metric.ScopeRef); err != nil {
+			interfaces.OPERATION_TYPE_QUERY_DATA, scopeType+":"+scopeRef); err != nil {
 			return nil, "", err
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
@@ -32,6 +32,7 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 	}
 
 	objectResources := make(map[string]string, len(kn.ObjectTypes))
+	objectTypes := make(map[string]struct{}, len(kn.ObjectTypes))
 	sources := make([]interfaces.ProxyGrantSourceSpec, 0)
 	bindings := make([]proxyModelBinding, 0)
 	seen := make(map[string]struct{})
@@ -65,21 +66,48 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 	}
 
 	for _, objectType := range kn.ObjectTypes {
-		if objectType == nil || objectType.DataSource == nil || strings.TrimSpace(objectType.DataSource.ID) == "" {
+		if objectType == nil {
 			continue
 		}
-		if strings.TrimSpace(objectType.DataSource.Type) != interfaces.DATA_SOURCE_TYPE_RESOURCE {
-			return nil, "", fmt.Errorf("object type %s has unsupported data source type", objectType.OTID)
+		objectTypeID := strings.TrimSpace(objectType.OTID)
+		if objectTypeID != "" {
+			objectTypes[objectTypeID] = struct{}{}
 		}
-		resourceID := strings.TrimSpace(objectType.DataSource.ID)
-		objectResources[objectType.OTID] = resourceID
-		if err := add(interfaces.MODULE_TYPE_OBJECT_TYPE, objectType.OTID, "resource", resourceID,
-			interfaces.OPERATION_TYPE_VIEW_DETAIL, "schema"); err != nil {
-			return nil, "", err
+		if objectType.DataSource != nil && strings.TrimSpace(objectType.DataSource.ID) != "" {
+			if strings.TrimSpace(objectType.DataSource.Type) != interfaces.DATA_SOURCE_TYPE_RESOURCE {
+				return nil, "", fmt.Errorf("object type %s has unsupported data source type", objectType.OTID)
+			}
+			resourceID := strings.TrimSpace(objectType.DataSource.ID)
+			objectResources[objectTypeID] = resourceID
+			if err := add(interfaces.MODULE_TYPE_OBJECT_TYPE, objectType.OTID, "resource", resourceID,
+				interfaces.OPERATION_TYPE_VIEW_DETAIL, "schema"); err != nil {
+				return nil, "", err
+			}
+			if err := add(interfaces.MODULE_TYPE_OBJECT_TYPE, objectType.OTID, "resource", resourceID,
+				interfaces.OPERATION_TYPE_QUERY_DATA, "data"); err != nil {
+				return nil, "", err
+			}
 		}
-		if err := add(interfaces.MODULE_TYPE_OBJECT_TYPE, objectType.OTID, "resource", resourceID,
-			interfaces.OPERATION_TYPE_QUERY_DATA, "data"); err != nil {
-			return nil, "", err
+
+		for _, property := range objectType.LogicProperties {
+			if property == nil || property.DataSource == nil ||
+				strings.TrimSpace(property.DataSource.Type) != interfaces.LOGIC_PROPERTY_TYPE_TOOL {
+				continue
+			}
+			boxID := strings.TrimSpace(property.DataSource.BoxID)
+			toolID := strings.TrimSpace(property.DataSource.ToolID)
+			// Non-strict imports may keep an unbound logic property as a draft.
+			// Grant the toolbox only after the concrete tool binding is complete.
+			if boxID == "" || toolID == "" {
+				continue
+			}
+			propertyBindingID := stableProxySourceID(kn.KNID, "logic_property",
+				strings.Join([]string{objectTypeID, property.Name}, "\x00"))
+			if err := add("logic_property", propertyBindingID, "tool_box", boxID,
+				interfaces.OPERATION_TYPE_EXECUTE,
+				strings.Join([]string{objectTypeID, property.Name, toolID}, ":")); err != nil {
+				return nil, "", err
+			}
 		}
 	}
 
@@ -88,10 +116,21 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 			continue
 		}
 		for _, objectTypeID := range []string{relationType.SourceObjectTypeID, relationType.TargetObjectTypeID} {
+			objectTypeID = strings.TrimSpace(objectTypeID)
+			// A non-strict import may keep a relation endpoint empty while the
+			// model is still being assembled. It has no permission target yet.
+			if objectTypeID == "" {
+				continue
+			}
+			if _, exists := objectTypes[objectTypeID]; !exists {
+				// Dependency validation belongs to the model layer. Permission
+				// projection stays tolerant of draft or legacy references so a
+				// caller can repair or remove them through the same publish path.
+				continue
+			}
 			resourceID := objectResources[objectTypeID]
 			if resourceID == "" {
-				return nil, "", fmt.Errorf("relation type %s references object type %s without a resource binding",
-					relationType.RTID, objectTypeID)
+				continue
 			}
 			if err := add(interfaces.MODULE_TYPE_RELATION_TYPE, relationType.RTID, "resource", resourceID,
 				interfaces.OPERATION_TYPE_QUERY_DATA, objectTypeID); err != nil {
@@ -111,9 +150,12 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		if scopeType == "" && scopeRef == "" {
 			continue
 		}
+		if _, exists := objectTypes[scopeRef]; !exists {
+			continue
+		}
 		resourceID := objectResources[scopeRef]
 		if resourceID == "" {
-			return nil, "", fmt.Errorf("metric %s references scope %s without a resource binding", metric.ID, metric.ScopeRef)
+			continue
 		}
 		if err := add(interfaces.MODULE_TYPE_METRIC, metric.ID, "resource", resourceID,
 			interfaces.OPERATION_TYPE_QUERY_DATA, scopeType+":"+scopeRef); err != nil {
@@ -127,12 +169,20 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		}
 		switch strings.TrimSpace(actionType.ActionSource.Type) {
 		case interfaces.ACTION_SOURCE_TYPE_TOOL:
+			if strings.TrimSpace(actionType.ActionSource.BoxID) == "" ||
+				strings.TrimSpace(actionType.ActionSource.ToolID) == "" {
+				continue
+			}
 			if err := add(interfaces.MODULE_TYPE_ACTION_TYPE, actionType.ATID, "tool_box",
 				actionType.ActionSource.BoxID, interfaces.OPERATION_TYPE_EXECUTE,
 				"tool:"+actionType.ActionSource.ToolID); err != nil {
 				return nil, "", err
 			}
 		case interfaces.ACTION_SOURCE_TYPE_MCP:
+			if strings.TrimSpace(actionType.ActionSource.McpID) == "" ||
+				strings.TrimSpace(actionType.ActionSource.ToolName) == "" {
+				continue
+			}
 			if err := add(interfaces.MODULE_TYPE_ACTION_TYPE, actionType.ATID, "mcp",
 				actionType.ActionSource.McpID, interfaces.OPERATION_TYPE_EXECUTE,
 				"tool:"+actionType.ActionSource.ToolName); err != nil {
@@ -164,4 +214,26 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 func stableProxySourceID(knID, bindingType, bindingID string) string {
 	digest := sha256.Sum256([]byte(strings.Join([]string{knID, bindingType, bindingID}, "\x00")))
 	return hex.EncodeToString(digest[:])
+}
+
+func addedProxyGrantSources(current, candidate []interfaces.ProxyGrantSourceSpec) []interfaces.ProxyGrantSourceSpec {
+	currentKeys := make(map[string]struct{}, len(current))
+	for _, source := range current {
+		currentKeys[proxyGrantSourceKey(source)] = struct{}{}
+	}
+	added := make([]interfaces.ProxyGrantSourceSpec, 0, len(candidate))
+	for _, source := range candidate {
+		if _, exists := currentKeys[proxyGrantSourceKey(source)]; !exists {
+			added = append(added, source)
+		}
+	}
+	return added
+}
+
+func proxyGrantSourceKey(source interfaces.ProxyGrantSourceSpec) string {
+	return strings.Join([]string{
+		source.ResourceType, source.ResourceID, source.Operation,
+		source.SourceType, source.SourceID, source.KNID,
+		source.BindingType, source.BindingID,
+	}, "\x00")
 }

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
@@ -81,3 +81,32 @@ func TestBuildProxyGrantSourcesRejectsUnboundRelationEndpoint(t *testing.T) {
 		t.Fatal("buildProxyGrantSources() error = nil, want invalid binding error")
 	}
 }
+
+func TestBuildProxyGrantSourcesSkipsUnscopedMetric(t *testing.T) {
+	kn := &interfaces.KN{
+		KNID:    "kn-1",
+		Metrics: []*interfaces.MetricDefinition{{ID: "metric-unscoped"}},
+	}
+	sources, version, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("unscoped metric sources = %#v, want none", sources)
+	}
+	if version == "" {
+		t.Fatal("unscoped metric model version is empty")
+	}
+}
+
+func TestBuildProxyGrantSourcesRejectsUnboundMetricScope(t *testing.T) {
+	kn := &interfaces.KN{
+		KNID: "kn-1",
+		Metrics: []*interfaces.MetricDefinition{{
+			ID: "metric-invalid", ScopeType: interfaces.ScopeTypeObjectType, ScopeRef: "missing-ot",
+		}},
+	}
+	if _, _, err := buildProxyGrantSources(kn); err == nil {
+		t.Fatal("buildProxyGrantSources() error = nil, want invalid metric scope error")
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
@@ -70,15 +70,30 @@ func TestBuildProxyGrantSourcesVersionIncludesConcreteActionTool(t *testing.T) {
 	}
 }
 
-func TestBuildProxyGrantSourcesRejectsUnboundRelationEndpoint(t *testing.T) {
+func TestBuildProxyGrantSourcesSkipsUnboundRelationEndpoint(t *testing.T) {
 	kn := &interfaces.KN{
 		KNID: "kn-1",
+		ObjectTypes: []*interfaces.ObjectType{
+			{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-unbound"}},
+			{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-bound", DataSource: &interfaces.ResourceInfo{
+				Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-bound",
+			}}},
+		},
 		RelationTypes: []*interfaces.RelationType{{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
-			RTID: "rt-1", SourceObjectTypeID: "missing", TargetObjectTypeID: "missing",
+			RTID: "rt-1", SourceObjectTypeID: "ot-unbound", TargetObjectTypeID: "ot-bound",
 		}}},
 	}
-	if _, _, err := buildProxyGrantSources(kn); err == nil {
-		t.Fatal("buildProxyGrantSources() error = nil, want invalid binding error")
+	sources, _, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 3 {
+		t.Fatalf("unbound relation sources = %#v, want two object grants and one bound endpoint grant", sources)
+	}
+	for _, source := range sources {
+		if source.ResourceID != "resource-bound" {
+			t.Fatalf("unbound relation target = %q, want resource-bound", source.ResourceID)
+		}
 	}
 }
 
@@ -99,14 +114,72 @@ func TestBuildProxyGrantSourcesSkipsUnscopedMetric(t *testing.T) {
 	}
 }
 
-func TestBuildProxyGrantSourcesRejectsUnboundMetricScope(t *testing.T) {
+func TestBuildProxyGrantSourcesSkipsUnboundMetricScope(t *testing.T) {
 	kn := &interfaces.KN{
-		KNID: "kn-1",
+		KNID:        "kn-1",
+		ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-unbound"}}},
 		Metrics: []*interfaces.MetricDefinition{{
-			ID: "metric-invalid", ScopeType: interfaces.ScopeTypeObjectType, ScopeRef: "missing-ot",
+			ID: "metric-draft", ScopeType: interfaces.ScopeTypeObjectType, ScopeRef: "ot-unbound",
 		}},
 	}
-	if _, _, err := buildProxyGrantSources(kn); err == nil {
-		t.Fatal("buildProxyGrantSources() error = nil, want invalid metric scope error")
+	sources, _, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("unbound metric sources = %#v, want none", sources)
+	}
+}
+
+func TestBuildProxyGrantSourcesSkipsIncompleteActionBinding(t *testing.T) {
+	kn := &interfaces.KN{KNID: "kn-1", ActionTypes: []*interfaces.ActionType{
+		{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+			ATID: "tool-draft", ActionSource: interfaces.ActionSource{Type: interfaces.ACTION_SOURCE_TYPE_TOOL, BoxID: "box-1"},
+		}},
+		{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+			ATID: "mcp-draft", ActionSource: interfaces.ActionSource{Type: interfaces.ACTION_SOURCE_TYPE_MCP, McpID: "mcp-1"},
+		}},
+	}}
+	sources, _, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 0 {
+		t.Fatalf("incomplete action sources = %#v, want none", sources)
+	}
+}
+
+func TestBuildProxyGrantSourcesIncludesBoundLogicPropertyTool(t *testing.T) {
+	kn := &interfaces.KN{KNID: "kn-1", ObjectTypes: []*interfaces.ObjectType{{
+		ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+			OTID: "ot-1",
+			LogicProperties: []*interfaces.LogicProperty{{
+				Name: "forecast", Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL,
+				DataSource: &interfaces.ResourceInfo{Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL, BoxID: "box-1", ToolID: "tool-1"},
+			}},
+		},
+	}}}
+	sources, _, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sources) != 1 || sources[0].ResourceType != "tool_box" ||
+		sources[0].ResourceID != "box-1" || sources[0].Operation != interfaces.OPERATION_TYPE_EXECUTE {
+		t.Fatalf("logic property sources = %#v", sources)
+	}
+}
+
+func TestAddedProxyGrantSourcesReturnsOnlyNewTargets(t *testing.T) {
+	current := []interfaces.ProxyGrantSourceSpec{
+		{ResourceType: "resource", ResourceID: "resource-stable", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "stable"},
+		{ResourceType: "resource", ResourceID: "resource-old", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "changed"},
+	}
+	candidate := []interfaces.ProxyGrantSourceSpec{
+		{ResourceType: "resource", ResourceID: "resource-stable", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "stable"},
+		{ResourceType: "resource", ResourceID: "resource-new", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "changed"},
+	}
+	added := addedProxyGrantSources(current, candidate)
+	if len(added) != 1 || added[0].ResourceID != "resource-new" {
+		t.Fatalf("added sources = %#v, want replacement target only", added)
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -107,6 +107,10 @@ func (ots *objectTypeService) validateObjectTypeStrictExternalDeps(ctx context.C
 				return err
 			}
 		case interfaces.LOGIC_PROPERTY_TYPE_TOOL:
+			if lp.DataSource == nil {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
+					WithErrorDetails(invalidParameterDetail(ctx, "LogicPropertyDataSourceRequired", map[string]any{"objectType": objectType.OTName, "property": lp.Name}))
+			}
 			if err := ots.aoa.GetToolByID(ctx, lp.DataSource.BoxID, lp.DataSource.ToolID); err != nil {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
 					WithErrorDetails(invalidParameterDetail(ctx, "ToolLookupFailed", map[string]any{"objectType": objectType.OTName, "property": lp.Name, "box": lp.DataSource.BoxID, "tool": lp.DataSource.ToolID}))

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1063,6 +1063,27 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
+		Convey("Fails strict mode without panicking when a tool binding is absent\n", func() {
+			objectTypes := []*interfaces.ObjectType{
+				{
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+						OTName: "ot1",
+						LogicProperties: []*interfaces.LogicProperty{
+							{Name: "lp1", Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL},
+						},
+					},
+					KNID: "kn1",
+				},
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			expectImportModeOK()
+			err := service.ValidateObjectTypes(ctx, "kn1", interfaces.MAIN_BRANCH, objectTypes, true, nil, interfaces.ImportMode_Normal)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.BaseError.ErrorCode, ShouldEqual, berrors.BknBackend_ObjectType_InvalidParameter)
+		})
+
 		Convey("Success strict mode when tool binding resolves\n", func() {
 			objectTypes := []*interfaces.ObjectType{
 				{

--- a/bkn-safe/server/internal/httpapi/managedproxy.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy.go
@@ -46,6 +46,15 @@ func registerManagedProxyAccounts(r *gin.Engine, service *managedproxy.Service) 
 		writeManagedProxyResult(c, account, err)
 	})
 
+	group.POST("/:id/restore", func(c *gin.Context) {
+		account, err := service.Restore(c.Request.Context(), c.Param("id"))
+		if errors.Is(err, managedproxy.ErrInvalidLifecycle) {
+			replyPublicError(c, http.StatusConflict)
+			return
+		}
+		writeManagedProxyResult(c, account, err)
+	})
+
 	group.POST("/:id/disable", func(c *gin.Context) {
 		account, err := service.Disable(c.Request.Context(), c.Param("id"))
 		writeManagedProxyResult(c, account, err)

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -62,6 +62,15 @@ func TestManagedProxyAccountLifecycleAPI(t *testing.T) {
 	if account.Enabled || account.LifecycleStatus != managedproxy.StatusArchived {
 		t.Fatalf("archived response = %+v", account)
 	}
+
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts/"+account.ProxyAccountID+"/restore", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("restore = %d body=%s", w.Code, w.Body.String())
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &account)
+	if !account.Enabled || account.LifecycleStatus != managedproxy.StatusActive {
+		t.Fatalf("restored response = %+v", account)
+	}
 }
 
 func TestManagedProxyStatusControlsAuthorizationDecisions(t *testing.T) {

--- a/bkn-safe/server/internal/managedproxy/service.go
+++ b/bkn-safe/server/internal/managedproxy/service.go
@@ -31,6 +31,7 @@ const (
 
 var (
 	ErrInvalidManagedResource = errors.New("invalid managed resource")
+	ErrInvalidLifecycle       = errors.New("invalid managed proxy lifecycle transition")
 	ErrManagedAccount         = errors.New("managed proxy account is protected")
 	ErrInconsistentAccount    = errors.New("managed proxy account is inconsistent")
 )
@@ -131,6 +132,60 @@ func (s *Service) Get(ctx context.Context, proxyAccountID string) (*Account, err
 	return s.get(ctx, "proxy_account_id = ?", strings.TrimSpace(proxyAccountID))
 }
 
+// Restore reactivates an archived identity for an idempotent retry of the same
+// managed resource. A disabling proxy belongs to an in-progress delete and
+// cannot be restored until that lifecycle reaches archived.
+func (s *Service) Restore(ctx context.Context, proxyAccountID string) (*Account, error) {
+	proxyAccountID = strings.TrimSpace(proxyAccountID)
+	if proxyAccountID == "" {
+		return nil, gorm.ErrRecordNotFound
+	}
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var mapping model.ManagedProxyAccount
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&mapping,
+			"proxy_account_id = ?", proxyAccountID).Error; err != nil {
+			return err
+		}
+		var user model.User
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&user,
+			"id = ?", proxyAccountID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrInconsistentAccount
+			}
+			return err
+		}
+		if user.AccountType != model.AccountTypeApp || user.PasswordHash != "" {
+			return ErrInconsistentAccount
+		}
+		switch mapping.LifecycleStatus {
+		case StatusActive:
+			if !user.Enabled {
+				return ErrInconsistentAccount
+			}
+			return nil
+		case StatusArchived:
+			if user.Enabled {
+				return ErrInconsistentAccount
+			}
+		case StatusDisabling:
+			return ErrInvalidLifecycle
+		default:
+			return ErrInconsistentAccount
+		}
+		if err := tx.Model(&user).Update("enabled", true).Error; err != nil {
+			return err
+		}
+		return tx.Model(&mapping).Updates(map[string]any{
+			"lifecycle_status": StatusActive,
+			"version":          gorm.Expr("version + ?", 1),
+		}).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+	return s.Get(ctx, proxyAccountID)
+}
+
 func (s *Service) getByManagedResource(ctx context.Context, resourceType, resourceID string) (*Account, error) {
 	return s.get(ctx, "managed_by = ? AND managed_resource_type = ? AND managed_resource_id = ?",
 		ManagerBKN, resourceType, resourceID)
@@ -166,8 +221,9 @@ func (s *Service) Disable(ctx context.Context, proxyAccountID string) (*Account,
 	return s.transition(ctx, proxyAccountID, StatusDisabling)
 }
 
-// Archive permanently keeps the identity disabled while preserving the row for
-// historical audit joins.
+// Archive keeps the identity disabled while preserving the row for historical
+// audit joins. Only the dedicated restore transition can reactivate it for an
+// idempotent retry of the same managed resource.
 func (s *Service) Archive(ctx context.Context, proxyAccountID string) (*Account, error) {
 	return s.transition(ctx, proxyAccountID, StatusArchived)
 }

--- a/bkn-safe/server/internal/managedproxy/service_test.go
+++ b/bkn-safe/server/internal/managedproxy/service_test.go
@@ -193,6 +193,50 @@ func TestDisableAndArchiveAreIdempotent(t *testing.T) {
 	}
 }
 
+func TestRestoreArchivedProxyForCreationRetry(t *testing.T) {
+	service := managedproxy.New(managedProxyTestDB(t))
+	created, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-retry",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Archive(t.Context(), created.ProxyAccountID); err != nil {
+		t.Fatal(err)
+	}
+
+	restored, err := service.Restore(t.Context(), created.ProxyAccountID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.ProxyAccountID != created.ProxyAccountID || !restored.Enabled ||
+		restored.LifecycleStatus != managedproxy.StatusActive || restored.Version != 3 {
+		t.Fatalf("restored proxy = %+v", restored)
+	}
+	replayed, err := service.Restore(t.Context(), created.ProxyAccountID)
+	if err != nil || replayed.Version != restored.Version {
+		t.Fatalf("replayed Restore() = (%+v, %v)", replayed, err)
+	}
+}
+
+func TestRestoreRejectsDisablingProxy(t *testing.T) {
+	service := managedproxy.New(managedProxyTestDB(t))
+	created, _, err := service.Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-deleting",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Disable(t.Context(), created.ProxyAccountID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Restore(t.Context(), created.ProxyAccountID); !errors.Is(err, managedproxy.ErrInvalidLifecycle) {
+		t.Fatalf("Restore() error = %v, want ErrInvalidLifecycle", err)
+	}
+}
+
 func TestGetFailsClosedForCredentialedManagedIdentity(t *testing.T) {
 	db := managedProxyTestDB(t)
 	service := managedproxy.New(db)

--- a/docs/api/bkn-safe/managed-proxy.yaml
+++ b/docs/api/bkn-safe/managed-proxy.yaml
@@ -87,6 +87,34 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalError'
+  /managed-proxy-accounts/{id}/restore:
+    parameters:
+      - $ref: '#/components/parameters/ProxyAccountID'
+    post:
+      tags: [Managed proxy accounts]
+      operationId: restoreManagedProxyAccount
+      summary: Restore an archived managed proxy account
+      description: |
+        Reactivates the same environment-local identity after a compensated knowledge-network
+        creation failed, allowing the original import to be retried without creating another app.
+        Active accounts are returned unchanged. Accounts in disabling state return 409.
+      responses:
+        '200':
+          description: The account is active
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManagedProxyAccount'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: The account is currently disabling and cannot be restored
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /managed-proxy-accounts/{id}/archive:
     parameters:
       - $ref: '#/components/parameters/ProxyAccountID'
@@ -96,7 +124,7 @@ paths:
       summary: Archive a managed proxy account
       description: |
         Preserves the identity record for historical audit correlation and keeps the account
-        disabled. Repeated calls do not increment the version.
+        disabled until the dedicated restore transition is used. Repeated calls do not increment the version.
       responses:
         '200':
           description: The account was archived

--- a/docs/api/bkn/bkn.yaml
+++ b/docs/api/bkn/bkn.yaml
@@ -76,6 +76,16 @@ paths:
           schema:
             type: string
             default: main
+        - name: binding_policy
+          in: query
+          description: |
+            Controls how environment-local bindings in the archive are imported.
+            preserve keeps resource, Tool Box, and MCP identifiers and subjects them to proxy permission checks.
+            detach removes those identifiers while preserving the knowledge model topology so targets can be bound later through incremental APIs.
+          schema:
+            type: string
+            enum: [preserve, detach]
+            default: preserve
         - name: import_mode
           description: |
             Import mode. normal reports an error for duplicate concept names; overwrite replaces them;

--- a/docs/api/bkn/bkn.yaml
+++ b/docs/api/bkn/bkn.yaml
@@ -81,7 +81,7 @@ paths:
           description: |
             Controls how environment-local bindings in the archive are imported.
             preserve keeps resource, Tool Box, and MCP identifiers and subjects them to proxy permission checks.
-            detach removes those identifiers while preserving the knowledge model topology so targets can be bound later through incremental APIs.
+            detach removes those identifiers, including indirect-relation backing resources, while preserving the knowledge model topology so targets can be bound later through incremental APIs.
           schema:
             type: string
             enum: [preserve, detach]

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -85,8 +85,10 @@ paths:
         - name: binding_policy
           description: |
             Controls environment-local bindings in the imported model. preserve keeps resource,
-            Tool Box, and MCP identifiers and applies proxy permission checks. detach removes
-            those identifiers while preserving model topology for later incremental binding.
+            Tool Box, MCP, and indirect-relation backing resource identifiers and applies proxy
+            permission checks. detach removes those identifiers while preserving model topology
+            for later incremental binding. The request is structurally validated before detachment;
+            persistence then skips dependency lookups for the removed environment-local bindings.
           schema:
             type: string
             enum:

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -82,6 +82,18 @@ paths:
             type: boolean
             default: true
           in: query
+        - name: binding_policy
+          description: |
+            Controls environment-local bindings in the imported model. preserve keeps resource,
+            Tool Box, and MCP identifiers and applies proxy permission checks. detach removes
+            those identifiers while preserving model topology for later incremental binding.
+          schema:
+            type: string
+            enum:
+              - preserve
+              - detach
+            default: preserve
+          in: query
         - name: validate_dependency
           deprecated: true
           description: "Deprecated. Use strict_mode instead. This parameter is retained for compatibility and is read when strict_mode is empty."


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Route standalone child-resource and concept-group nested imports through the managed proxy publication lifecycle.
- [x] Support draft and unbound knowledge-network models and preflight only newly added or replaced downstream grants.
- [x] Add portable JSON and `.bkn` imports with `binding_policy=detach`, including dependency-safe persistence and indirect-relation binding removal.
- [x] Add archived-proxy restoration for safe retries and update BKN and bkn-safe OpenAPI contracts.

---

## Why

- Related Issue: Closes #1306
- Related Feature: [Knowledge-network proxy authorization design](https://github.com/openbkn-ai/bkn-foundry/issues/805)
- Background: Main-branch imports and standalone child mutations could either leave proxy grants stale or reject valid draft or cross-environment models whose real resources were not yet bound. Failed proxy compensation could also prevent retrying the same knowledge-network ID.

---

## How

- Key implementation points:
  - Derive grants only from complete real-resource, Tool Box, MCP, and logic-property tool bindings while tolerating unbound draft topology.
  - Build effective overwrite candidates under the per-network publication lock and compare current and candidate grant sources so only additions or replacements are preflighted.
  - Keep post-commit synchronization as a full desired-state sync, allowing deletions and binding removals to revoke obsolete grants without re-authorizing old targets.
  - Route concept-group imports containing nested object, relation, or action types through the same pending and business transaction plus proxy synchronization lifecycle.
  - Add optional `binding_policy=preserve|detach` to JSON and `.bkn` import endpoints. `detach` removes object, logic-property, action, and indirect-relation backing resource identifiers while preserving topology.
  - Structurally validate JSON imports before detachment, then persist detached models without resolving the environment-local dependencies that were removed. Strict service validation also returns a parameter error instead of panicking if a tool binding is absent.
  - Add an internal bkn-safe restore transition for compensated archived proxies and reactivate the BKN mapping before a retry.
- Breaking changes (API, config, database, etc.): None. `binding_policy` is optional and defaults to `preserve`; the restore endpoint is cluster-internal. No schema or configuration changes are introduced.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; no local end-to-end bkn-safe environment was available.
- [ ] Verified in test environment — not performed in this change.

Test notes:

- `I18N_MODE_UT=true go test ./logics/knowledge_network -count=1`
- `I18N_MODE_UT=true go test ./driveradapters -count=1`
- `I18N_MODE_UT=true go test ./logics/object_type -count=1`
- `I18N_MODE_UT=true go test ./drivenadapters/kn_proxy -count=1`
- `go vet ./logics/knowledge_network ./driveradapters ./logics/object_type ./drivenadapters/kn_proxy`
- `go test ./internal/managedproxy ./internal/httpapi -count=1`
- `go vet ./internal/managedproxy ./internal/httpapi`
- `npx @redocly/cli lint --config .redocly.yaml docs/api/bkn/bkn.yaml`
- `npx @redocly/cli lint --config .redocly.yaml docs/api/bkn/business-knowledge-network.yaml`
- `npx @redocly/cli lint --config .redocly.yaml docs/api/bkn-safe/managed-proxy.yaml`
- `git diff --check`

---

## Risk & Rollback

- Potential risks: Main-branch imports now depend on the proxy preflight and bkn-safe lifecycle endpoints. `binding_policy=detach` intentionally removes environment-local bindings, so callers must bind local targets later before data query or action execution. Post-commit synchronization remains fail-closed and can return an error after model persistence.
- Rollback plan: Revert the commits introduced by this PR. Existing imports continue to use the backward-compatible default `binding_policy=preserve`. If a post-commit synchronization fails, use the existing proxy retry operation to rebuild grants from the latest main model.

---

## Additional Notes

- The full repository test suite was not run; focused affected-package tests and OpenAPI validation passed.
- `binding_policy=map` is not included. `detach` provides the structure-first cross-environment import path, while explicit old-to-new resource mapping can be designed separately.
- Redocly reported only pre-existing warnings in the BKN specifications; all three changed OpenAPI documents are valid.
