### PR TITLE
fix(trace): classify evidence ingest configuration failures

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -319,6 +319,58 @@ func TestStartInteractionCreatesCorrelationAndUsesCoreCreatedAtForQuestionEviden
 	}
 }
 
+func TestStartInteractionReportsIngestConfigurationFailureWithoutRetryGuidance(t *testing.T) {
+	startCalls := 0
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/agent-observability/v1/conversations/conv-1/interactions":
+			startCalls++
+			_ = json.NewEncoder(w).Encode(bkntrace.Interaction{
+				InteractionID: "int-1", ConversationID: "conv-1",
+				ExecutionStatus: "active", EvidenceStatus: "pending",
+				CreatedAt: time.Date(2026, 9, 5, 10, 0, 0, 0, time.UTC),
+			})
+		case "/api/agent-observability/v1/evidence/artifacts":
+			w.WriteHeader(http.StatusCreated)
+		case "/api/agent-observability/v1/evidence/events":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{
+				"code":    "INGEST_AUTH_NOT_CONFIGURED",
+				"message": "evidence ingest authentication is not configured",
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+	t.Setenv("BKN_TRACE_EVIDENCE_INGEST_URL", backend.URL+"/api/agent-observability/v1/evidence/events")
+	t.Setenv("BKN_TRACE_EVIDENCE_INGEST_TOKEN", "ingest-token")
+
+	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{RequestID: "req-ingest-config-1"})
+	ctx = common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{
+		AccountID: "user-1", AccountType: interfaces.AccessorTypeUser,
+		TokenInfo: &interfaces.TokenInfo{ClientID: "cursor-app"},
+	})
+	result, err := handleLifecycleTool(
+		bkntrace.NewLifecycleClient(backend.URL, backend.Client()),
+		"bkn_start_interaction",
+	)(ctx, mcpsdk.CallToolRequest{Params: mcpsdk.CallToolParams{Arguments: map[string]any{
+		"conversation_id": "conv-1", "conversation_mode": "continue", "question": "查询 BOM", "agent_name": "供应链分析助手",
+	}}})
+	if err != nil || !result.IsError {
+		t.Fatalf("start must stop after evidence configuration failure: result=%#v err=%v", result, err)
+	}
+	if startCalls != 1 {
+		t.Fatalf("start interaction calls = %d, want 1", startCalls)
+	}
+	errorValue := lifecycleErrorFromResult(t, result)
+	if errorValue["code"] != "evidence_capture_failed" ||
+		errorValue["required_action"] != "contact_platform_operator" ||
+		errorValue["retryable"] != false {
+		t.Fatalf("start returned retry guidance for a configuration defect: %#v", errorValue)
+	}
+}
+
 func TestFinishInteractionUsesCoreUpdatedAtForServerOwnedResultEvidence(t *testing.T) {
 	updatedAt := time.Date(2026, 8, 3, 6, 32, 0, 789000000, time.UTC)
 	var artifact map[string]any

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -280,6 +280,16 @@ func lifecycleAvailabilityError(err error) lifecycleError {
 		if message == "" {
 			message = "BKN Trace evidence could not be recorded"
 		}
+		// A missing ingest credential is a deployment defect, not a transient
+		// Core outage. Returning retry_later here made a caller start another
+		// interaction after Core had already accepted the first one, leaving
+		// empty active interactions behind until their leases expired.
+		if coreErr.Code == "INGEST_AUTH_NOT_CONFIGURED" {
+			return lifecycleError{
+				Code: "evidence_capture_failed", Message: message,
+				RequiredAction: "contact_platform_operator",
+			}
+		}
 		switch coreErr.StatusCode {
 		case http.StatusUnauthorized, http.StatusForbidden:
 			return lifecycleError{

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -219,6 +219,19 @@ func TestLifecycleAvailabilityErrorPreservesEvidenceAuthorizationFailure(t *test
 	}
 }
 
+func TestLifecycleAvailabilityErrorPreservesEvidenceIngestConfigurationFailure(t *testing.T) {
+	result := lifecycleAvailabilityError(&bkntrace.CoreHTTPError{
+		StatusCode: http.StatusServiceUnavailable,
+		Code:       "INGEST_AUTH_NOT_CONFIGURED",
+		Message:    "evidence ingest authentication is not configured",
+	})
+	if result.Code != "evidence_capture_failed" ||
+		result.Message != "evidence ingest authentication is not configured" ||
+		result.RequiredAction != "contact_platform_operator" || result.Retryable {
+		t.Fatalf("evidence ingest configuration failure was misclassified: %#v", result)
+	}
+}
+
 func trustedSessionGuardContext() context.Context {
 	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{})
 	return common.SetAccountAuthContextToCtx(ctx, &interfaces.AccountAuthContext{


### PR DESCRIPTION
## 问题

当 Trace Core 已成功创建 Interaction、但首个问题证据因 `INGEST_AUTH_NOT_CONFIGURED` 无法摄入时，MCP 将该确定性部署故障错误归类为 `trace_core_unavailable` / `retry_later`。调用方会据此尝试新的启动，留下空的 active Interaction。

## 修复

- 将该精确 Core 错误映射为既有的 `evidence_capture_failed`，并保留原始错误消息。
- 明确为不可重试，并引导 `contact_platform_operator`。
- 不增加 API、状态机、自动取消或空历史投影。

## 验证

- `go test ./server/driveradapters/mcp -count=1`
- `go test ./server/driveradapters/... -count=1`
- `go test ./server/infra/bkntrace -count=1`

包含单元分类回归和从启动到证据摄入失败的完整 MCP 回归。
