### PR TITLE
fix(trace): link Function BKN reads to their parent operation

### DIFF
--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_tools.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_tools.go
@@ -223,6 +223,11 @@ func (o *operatorIntegrationClient) ExecutePublishedTool(
 	// bkn-interaction-id) that the lifecycle guard put on the context, which is
 	// what lets the Function read BKN inside the same Interaction.
 	header := o.skillHeader(ctx, "operator.published_tool.execute")
+	// The transport operation is derived, but Function reads need the Guard's
+	// persisted operation as their parent. Keep those identities separate.
+	if traceContext, ok := common.GetTraceContextFromCtx(ctx); ok && traceContext.OperationID != "" {
+		header[common.HeaderBKNParentOperationID] = traceContext.OperationID
+	}
 	header["Authorization"] = "Bearer " + token
 
 	parameters := req.Parameters

--- a/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_tools_test.go
+++ b/adp/context-loader/agent-retrieval/server/drivenadapters/operator_integration_tools_test.go
@@ -81,6 +81,8 @@ func TestExecutePublishedToolCarriesCallerAndInteraction(t *testing.T) {
 		convey.So(gotHeader["Authorization"], convey.ShouldEqual, "Bearer caller-token")
 		convey.So(gotHeader["bkn-conversation-id"], convey.ShouldEqual, "conv_1")
 		convey.So(gotHeader["bkn-interaction-id"], convey.ShouldEqual, "int_1")
+		convey.So(gotHeader["bkn-parent-operation-id"], convey.ShouldEqual, "op_1")
+		convey.So(gotHeader["bkn-operation-id"], convey.ShouldNotEqual, "op_1")
 
 		// The Toolbox proxy expects HTTPRequestParams: business parameters go in
 		// its body field, or the proxied request arrives with an empty body.

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -953,3 +953,73 @@ func TestLifecycleToolRegistryDoesNotExposeCallerControlledFinalize(t *testing.T
 		t.Fatal("third-party callers must not be allowed to finalize platform execution receipts")
 	}
 }
+
+// Function reads remain independent operations while retaining their invoker.
+func TestFunctionReadsPreserveParentThroughLifecycle(t *testing.T) {
+	parents := []string{"op-function-a", "op-function-a", "op-function-b", ""}
+	var children []string
+	client := &http.Client{Transport: lifecycleAdapterRoundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/interactions/int-1"):
+			return lifecycleAdapterJSONResponse(http.StatusOK, bkntrace.Interaction{
+				InteractionID: "int-1", ConversationID: "conv-1",
+				ExecutionStatus: "active", LeaseToken: "lease-1", LeaseEpoch: 1,
+			}), nil
+		case strings.HasSuffix(r.URL.Path, "/operations:ensure"):
+			var body struct {
+				ParentOperationID string `json:"parent_operation_id"`
+				OperationKey      string `json:"operation_key"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.ParentOperationID != parents[len(children)] {
+				t.Fatalf("parent sent to Trace=%q want=%q", body.ParentOperationID, parents[len(children)])
+			}
+			child := "op-child-" + body.OperationKey
+			for _, previous := range children {
+				if previous == child {
+					t.Fatal("distinct reads reused an operation key")
+				}
+			}
+			children = append(children, child)
+			return lifecycleAdapterJSONResponse(http.StatusOK, bkntrace.OperationResult{
+				Created: true, Execute: true,
+				Operation: bkntrace.Operation{OperationID: child, ConversationID: "conv-1", InteractionID: "int-1", Attempt: 1, AttemptStatus: "pending"},
+				Receipt:   bkntrace.Receipt{ReceiptID: "receipt-" + child, ReceiptStatus: "pending"},
+			}), nil
+		case strings.HasSuffix(r.URL.Path, "/attempts/1:complete"):
+			child := children[len(children)-1]
+			return lifecycleAdapterJSONResponse(http.StatusOK, bkntrace.OperationResult{
+				Operation: bkntrace.Operation{OperationID: child, Attempt: 1, AttemptStatus: "completed"},
+				Receipt:   bkntrace.Receipt{ReceiptID: "receipt-" + child, ReceiptStatus: "completed"},
+			}), nil
+		default:
+			return lifecycleAdapterJSONResponse(http.StatusNotFound, map[string]any{}), nil
+		}
+	})}
+	handler := lifecycleToolMiddleware(bkntrace.NewLifecycleClient("http://trace.test", client))(
+		func(ctx context.Context, _ mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			traceContext, _ := common.GetTraceContextFromCtx(ctx)
+			if traceContext.OperationID != children[len(children)-1] {
+				t.Fatal("child execution did not receive its own operation ID")
+			}
+			return mcpsdk.NewToolResultStructured(map[string]any{"datas": []any{}}, `{"datas":[]}`), nil
+		},
+	)
+	ctx := trustedMCPIntegrationContext(context.Background(), 77)
+	for index, parent := range parents {
+		request := businessToolRequest("session-1", "conv-1", "int-1", "read-"+string(rune('a'+index)))
+		request.Params.Name = "query_object_instance"
+		args := request.Params.Arguments.(map[string]any)
+		args["kn_id"], args["ot_id"] = "kn-1", "inventory"
+		args["bkn_context"].(map[string]any)["parent_operation_id"] = parent
+		result, err := handler(ctx, request)
+		if err != nil || result == nil || result.IsError {
+			t.Fatalf("read %d failed: %#v %v", index, result, err)
+		}
+	}
+	if len(children) != len(parents) {
+		t.Fatalf("children=%v", children)
+	}
+}

--- a/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
+++ b/adp/context-loader/agent-retrieval/server/infra/common/context_manage.go
@@ -32,6 +32,7 @@ const (
 	HeaderBKNConversationID     = "bkn-conversation-id"
 	HeaderBKNInteractionID      = "bkn-interaction-id"
 	HeaderBKNOperationID        = "bkn-operation-id"
+	HeaderBKNParentOperationID  = "bkn-parent-operation-id"
 	HeaderBKNReceiptID          = "bkn-receipt-id"
 	HeaderBKNClientInvocationID = "X-OpenBKN-Client-Invocation-Id"
 	HeaderBKNCausationEventID   = "bkn-causation-event-id"
@@ -314,6 +315,7 @@ func StripBusinessTraceHeaders(header map[string]string) {
 			HeaderBKNConversationID,
 			HeaderBKNInteractionID,
 			HeaderBKNOperationID,
+			HeaderBKNParentOperationID,
 			HeaderBKNCausationEventID,
 			HeaderBKNClaimID,
 			HeaderBKNAttempt,

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy.go
@@ -121,7 +121,7 @@ func executionEnvKeys() []string {
 		// BKN identity and session context. Must be listed here: newExecutionEnv Rely on this list to put each key.
 		// Preset it as an empty string, so as to achieve "the complete set is delivered every time it is executed". Missing one, the previous caller in the pooled session.
 		// The token will be left for the next one - and what the token misses is not the mark, but the identity.
-		"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID",
+		"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID", "BKN_PARENT_OPERATION_ID",
 	}
 }
 
@@ -261,6 +261,7 @@ func fillManagedInteractionFromRequest(env map[string]any, c *gin.Context) map[s
 	env["BKN_TOKEN"] = token
 	env["BKN_CONVERSATION_ID"] = conversationID
 	env["BKN_INTERACTION_ID"] = interactionID
+	env["BKN_PARENT_OPERATION_ID"] = strings.TrimSpace(c.GetHeader(string(interfaces.HeaderBKNParentOperationID)))
 	return env
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/common/proxy_test.go
@@ -283,6 +283,7 @@ func TestBuildFunctionProxyExecutionEnvCarriesAManagedInteraction(t *testing.T) 
 	c := newRequestContext("tok-req", "acct-req")
 	c.Request.Header.Set("bkn-conversation-id", "conv_1")
 	c.Request.Header.Set("bkn-interaction-id", "int_1")
+	c.Request.Header.Set("bkn-parent-operation-id", "op_function")
 
 	env, err := buildFunctionProxyExecutionEnv(c, "11111111-1111-4111-8111-111111111111")
 	if err != nil {
@@ -290,9 +291,10 @@ func TestBuildFunctionProxyExecutionEnvCarriesAManagedInteraction(t *testing.T) 
 	}
 
 	for key, want := range map[string]string{
-		"BKN_TOKEN":           "tok-req",
-		"BKN_CONVERSATION_ID": "conv_1",
-		"BKN_INTERACTION_ID":  "int_1",
+		"BKN_TOKEN":               "tok-req",
+		"BKN_CONVERSATION_ID":     "conv_1",
+		"BKN_INTERACTION_ID":      "int_1",
+		"BKN_PARENT_OPERATION_ID": "op_function",
 	} {
 		if env[key] != want {
 			t.Fatalf("%s 未随受管调用下发，期望 %s，得到 %v", key, want, env[key])
@@ -344,6 +346,22 @@ func TestInferSchemaExecutionEnvCarriesNoCredential(t *testing.T) {
 	for _, key := range []string{"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID", "user_id"} {
 		if value, ok := env[key]; !ok || value != "" {
 			t.Fatalf("%s 不应带凭据: %v", key, env)
+		}
+	}
+}
+
+func TestFunctionExecutionParentIsClearedWithoutManagedInvocation(t *testing.T) {
+	c := newRequestContext("tok-req", "acct-req")
+	c.Request.Header.Set("bkn-parent-operation-id", "op_unrelated")
+	env, err := buildFunctionProxyExecutionEnv(c, "11111111-1111-4111-8111-111111111111")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, values := range map[string]map[string]any{
+		"proxy": env, "direct": buildFunctionExecutionEnv(c, nil), "schema": inferSchemaExecutionEnv(),
+	} {
+		if value, ok := values["BKN_PARENT_OPERATION_ID"]; !ok || value != "" {
+			t.Fatalf("%s must clear parent operation, got %v", name, values)
 		}
 	}
 }

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/function_parent_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/function_parent_test.go
@@ -1,0 +1,41 @@
+package toolbox
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+func TestExecuteToolCapturesFunctionParentFromRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	service := mocks.NewMockIToolService(ctrl)
+	service.EXPECT().ExecuteTool(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *interfaces.ExecuteToolReq) (*interfaces.HTTPResponse, error) {
+			if req.BKNParentOperationID != "op_function" {
+				t.Fatalf("parent=%q", req.BKNParentOperationID)
+			}
+			if req.BKNConversationID != "conv_1" || req.BKNInteractionID != "int_1" {
+				t.Fatal("lost interaction")
+			}
+			return &interfaces.HTTPResponse{StatusCode: http.StatusOK}, nil
+		},
+	)
+	handler := &toolBoxHandler{ToolService: service}
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"body":{},"BKNParentOperationID":"wrong-parent"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("user_id", "user_1")
+	c.Request.Header.Set("Authorization", "Bearer test-token")
+	c.Request.Header.Set("bkn-conversation-id", "conv_1")
+	c.Request.Header.Set("bkn-interaction-id", "int_1")
+	c.Request.Header.Set("bkn-parent-operation-id", "op_function")
+	c.Params = gin.Params{{Key: "box_id", Value: "box_1"}, {Key: "tool_id", Value: "tool_1"}}
+	handler.ExecuteTool(c)
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/toolbox/toolbox.go
@@ -632,6 +632,7 @@ func (h *toolBoxHandler) ExecuteTool(c *gin.Context) {
 	}
 	req.BKNConversationID = c.GetHeader(string(interfaces.HeaderBKNConversationID))
 	req.BKNInteractionID = c.GetHeader(string(interfaces.HeaderBKNInteractionID))
+	req.BKNParentOperationID = c.GetHeader(string(interfaces.HeaderBKNParentOperationID))
 	resp, err := h.ToolService.ExecuteTool(c.Request.Context(), req)
 	rest.ReplyWithExecutionMode(c, resp, err)
 }

--- a/adp/execution-factory/operator-integration/server/interfaces/infra.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/infra.go
@@ -52,6 +52,8 @@ const (
 	HeaderBKNConversationID HeaderKey = "bkn-conversation-id"
 	// HeaderBKNInteractionID managed Interaction the call belongs to.
 	HeaderBKNInteractionID HeaderKey = "bkn-interaction-id"
+	// HeaderBKNParentOperationID is the persisted operation invoking the Function.
+	HeaderBKNParentOperationID HeaderKey = "bkn-parent-operation-id"
 )
 
 const ()

--- a/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go
@@ -333,6 +333,7 @@ type ExecuteToolReq struct {
 	RequestAuthorization string `json:"-"`
 	BKNConversationID    string `json:"-"`
 	BKNInteractionID     string `json:"-"`
+	BKNParentOperationID string `json:"-"`
 	HTTPRequestParams    `json:",inline"`
 }
 

--- a/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_env_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/sandbox/session_pool_env_test.go
@@ -7,15 +7,16 @@ import "testing"
 // By leaving the credentials there, you're leaving a call's token in clear text for half a day - long after the execution that initiated it ended.
 func TestSessionScopedEnvVarsDropsCredentials(t *testing.T) {
 	scoped := sessionScopedEnvVars(map[string]any{
-		"source":              "function_debug",
-		"task_id":             "t1",
-		"user_id":             "u1",
-		"BKN_TOKEN":           "bak_secret",
-		"BKN_CONVERSATION_ID": "conv_1",
-		"BKN_INTERACTION_ID":  "int_1",
+		"source":                  "function_debug",
+		"task_id":                 "t1",
+		"user_id":                 "u1",
+		"BKN_TOKEN":               "bak_secret",
+		"BKN_CONVERSATION_ID":     "conv_1",
+		"BKN_INTERACTION_ID":      "int_1",
+		"BKN_PARENT_OPERATION_ID": "op_function",
 	})
 
-	for _, key := range []string{"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID"} {
+	for _, key := range []string{"BKN_TOKEN", "BKN_CONVERSATION_ID", "BKN_INTERACTION_ID", "BKN_PARENT_OPERATION_ID"} {
 		if _, leaked := scoped[key]; leaked {
 			t.Fatalf("%s 不该进入会话级 env: %v", key, scoped)
 		}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
@@ -446,13 +446,14 @@ func functionRuntimeHeaders(headers map[string]any, req *interfaces.ExecuteToolR
 		req.BKNConversationID == "" || req.BKNInteractionID == "" {
 		return headers
 	}
-	forwarded := make(map[string]any, len(headers)+3)
+	forwarded := make(map[string]any, len(headers)+4)
 	for key, value := range headers {
 		forwarded[key] = value
 	}
 	forwarded["Authorization"] = req.RequestAuthorization
 	forwarded[string(interfaces.HeaderBKNConversationID)] = req.BKNConversationID
 	forwarded[string(interfaces.HeaderBKNInteractionID)] = req.BKNInteractionID
+	forwarded[string(interfaces.HeaderBKNParentOperationID)] = req.BKNParentOperationID
 	return forwarded
 }
 

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/function_runtime_headers_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/function_runtime_headers_test.go
@@ -17,12 +17,14 @@ func TestFunctionRuntimeHeadersForwardsAManagedCall(t *testing.T) {
 				RequestAuthorization: "Bearer caller-token",
 				BKNConversationID:    "conv_1",
 				BKNInteractionID:     "int_1",
+				BKNParentOperationID: "op_function",
 			},
 		)
 
 		So(headers["Authorization"], ShouldEqual, "Bearer caller-token")
 		So(headers["bkn-conversation-id"], ShouldEqual, "conv_1")
 		So(headers["bkn-interaction-id"], ShouldEqual, "int_1")
+		So(headers["bkn-parent-operation-id"], ShouldEqual, "op_function")
 		So(headers["X-Api-Key"], ShouldEqual, "tool-own-key")
 	})
 }
@@ -62,12 +64,14 @@ func TestFunctionRuntimeHeadersOverridesBodySuppliedValues(t *testing.T) {
 				RequestAuthorization: "Bearer caller-token",
 				BKNConversationID:    "conv_1",
 				BKNInteractionID:     "int_1",
+				BKNParentOperationID: "op_function",
 			},
 		)
 
 		So(headers["Authorization"], ShouldEqual, "Bearer caller-token")
 		So(headers["bkn-conversation-id"], ShouldEqual, "conv_1")
 		So(headers["bkn-interaction-id"], ShouldEqual, "int_1")
+		So(headers["bkn-parent-operation-id"], ShouldEqual, "op_function")
 	})
 }
 
@@ -107,6 +111,7 @@ func TestFunctionRuntimeHeadersDoesNotMutateTheInput(t *testing.T) {
 			RequestAuthorization: "Bearer caller-token",
 			BKNConversationID:    "conv_1",
 			BKNInteractionID:     "int_1",
+			BKNParentOperationID: "op_function",
 		})
 
 		So(len(original), ShouldEqual, 1)

--- a/docs/plans/2026-09-05-1319-function-trace-parent.md
+++ b/docs/plans/2026-09-05-1319-function-trace-parent.md
@@ -1,0 +1,35 @@
+# Function Trace parent propagation (#1319)
+
+## Design
+
+Preserve the lifecycle Guard's persisted execute_tool operation as the parent of Function reads. Carry it separately from the derived downstream bkn-operation-id through an internal bkn-parent-operation-id header, then the per-execution BKN_PARENT_OPERATION_ID environment variable. Both sandbox_sdk.bkn and bkn_osdk must put it in bkn_context.parent_operation_id. Each child still obtains its own operation and receipt from the existing Guard. No new operation layer or storage schema is needed.
+
+A header containing a derived downstream ID is not a substitute for a persisted parent. Do not change business Function inputs, results, kn_id, names, or historical data. Clear the per-execution parent when absent. Direct execution continues to use its explicit envelope and does not infer parentage from arbitrary headers.
+
+## Implementation plan
+
+- [x] Reproduce missing parent in the published-tool client and both Python SDK paths with failing tests.
+- [x] Add parent header to the Context Loader published-tool adapter and capture/forward it in Execution Factory.
+- [x] Set/reset the parent environment variable in Function execution; cover managed and direct paths.
+- [x] Consume the variable in the legacy SDK and Python OSDK, verifying multiple calls, subsequent invocations, and root calls.
+- [x] Verify Trace Guard / Core already accept and persist the supplied parent; add topology coverage where missing.
+- [x] Run targeted and module tests, lint/build, and review the complete diff (baseline lint findings noted below).
+
+## Delivery
+
+Requires rebuilding Context Loader, Execution Factory and sandbox SDK images. The Python OSDK change is in the companion [bkn-sdk PR #96](https://github.com/openbkn-ai/bkn-sdk/pull/96); the sandbox image dependency is pinned to its published commit `3d99c6b3d8faec780e728d6c57be381200a1ae18`. Merge the companion SDK change before this PR. Do not claim a live fix until deployment integration is verified. No deployment has been performed.
+
+## Verification (2026-09-05)
+
+- Context Loader: `GOCACHE=/tmp/bkn-1319-go-cache make test` passed, 26 tested packages / 831 top-level tests. The subsequently added `TestFunctionReadsPreserveParentThroughLifecycle` passed separately.
+- Execution Factory: `GOCACHE=/tmp/bkn-1319-go-cache make test` passed, 34 tested packages / 242 top-level tests. The subsequently added `TestExecuteToolCapturesFunctionParentFromRequest` passed separately.
+- Both Go modules: `go build ./...` passed. Full golangci-lint reports existing main findings; `golangci-lint run --new-from-rev=HEAD` passes for both modules.
+- Executor: isolated environment `python -m pytest tests/unit/ -q`: 324 passed, including a red/green regression for explicit turn override.
+- Python OSDK: 412 passed, 32 live tests skipped; 43 traced-path tests rerun after formatting. Ruff and mypy passed (46 source files). Wheel/sdist built; wheel installed and parent-context behavior checked outside the source directory.
+- Independent review identified legacy environment-parent leakage across an explicit turn override; reproduced with a failing test and fixed by matching the environment conversation/interaction before inheriting the parent.
+
+## Remaining integration check
+
+- [x] Advance `infra/sandbox/images/templates/executor/bkn-requirements.txt` from `00e128e` to published SDK commit `3d99c6b3d8faec780e728d6c57be381200a1ae18`.
+- [ ] Merge the companion SDK PR and rebuild the images. If its final commit changes during review, update the pin before merging this PR.
+- [ ] Deploy reviewed artifacts and run two Functions with multiple internal reads plus a direct query; inspect operation and operation_call_fact rows for persisted parent links and distinct child IDs. No live deployment or database mutation was performed here.

--- a/infra/sandbox/images/templates/executor/bkn-requirements.txt
+++ b/infra/sandbox/images/templates/executor/bkn-requirements.txt
@@ -20,4 +20,4 @@
 # Note for mirror-only builds: this is a PEP 508 direct URL, so `USE_MIRROR`
 # does not redirect it -- the build host needs to reach github.com even when pip
 # itself is pointed at a mirror.
-bkn-osdk @ https://github.com/openbkn-ai/bkn-sdk/archive/00e128e.zip#subdirectory=python
+bkn-osdk @ https://github.com/openbkn-ai/bkn-sdk/archive/3d99c6b3d8faec780e728d6c57be381200a1ae18.zip#subdirectory=python

--- a/infra/sandbox/runtime/executor/tests/unit/sdk/test_bkn.py
+++ b/infra/sandbox/runtime/executor/tests/unit/sdk/test_bkn.py
@@ -208,3 +208,53 @@ def test_shipped_artifact_is_importable_and_versioned():
     for name in ("list_knowledge_networks", "query_object_instance",
                  "run_sql", "list_resources"):
         assert callable(getattr(_bkn_tools, name)), name
+
+
+def test_internal_queries_carry_parent_without_reusing_operation_id(monkeypatch):
+    from sandbox_sdk import _bkn_tools
+
+    monkeypatch.setenv("BKN_TOKEN", "test-token")
+    monkeypatch.setenv("BKN_SANDBOX_MCP_URL", "http://svc/mcp/")
+    monkeypatch.setenv("BKN_CONVERSATION_ID", "conv_test")
+    monkeypatch.setenv("BKN_INTERACTION_ID", "int_test")
+    monkeypatch.setattr(_bkn_tools, "_ensure_session", lambda: None)
+    # Avoid _configure's working-directory setup; keep the real call serializer.
+    def configure(event):
+        monkeypatch.setattr(_bkn_tools, "_CFG", dict(event))
+
+    monkeypatch.setattr(_bkn_tools, "_configure", configure)
+    calls = []
+
+    def rpc(method, params):
+        calls.append(params)
+        return {"result": {"content": [{"type": "text", "text": '{"datas": []}'}]}}
+
+    monkeypatch.setattr(_bkn_tools, "_rpc", rpc)
+    for parent in ("op_function_a", "op_function_b", ""):
+        monkeypatch.setenv("BKN_PARENT_OPERATION_ID", parent)
+        bkn.configure_runtime({})
+        for ot in ("bom", "inventory"):
+            bkn.query_object_instance(kn_id="kn_test", ot_id=ot)
+            ctx = calls[-1]["arguments"]["bkn_context"]
+            assert ctx.get("parent_operation_id", "") == parent
+            assert ctx["interaction_id"] == "int_test"
+            assert "operation_id" not in ctx
+            assert "operation_key" not in ctx
+
+
+def test_explicit_runtime_parent_wins(monkeypatch):
+    monkeypatch.setenv("BKN_PARENT_OPERATION_ID", "op_env")
+    bkn.configure_runtime({"bkn": {"parent_operation_id": "op_explicit"}})
+    assert bkn._business_context()["parent_operation_id"] == "op_explicit"
+
+
+def test_environment_parent_does_not_cross_explicit_turn(monkeypatch):
+    monkeypatch.setenv("BKN_CONVERSATION_ID", "conv_env")
+    monkeypatch.setenv("BKN_INTERACTION_ID", "int_env")
+    monkeypatch.setenv("BKN_PARENT_OPERATION_ID", "op_env")
+    bkn.configure_runtime({"bkn": {
+        "conversation_id": "conv_other", "interaction_id": "int_other",
+    }})
+    assert bkn._business_context() == {
+        "conversation_id": "conv_other", "interaction_id": "int_other",
+    }

--- a/infra/sandbox/runtime/sandbox_sdk/bkn.py
+++ b/infra/sandbox/runtime/sandbox_sdk/bkn.py
@@ -64,6 +64,7 @@ _MCP_URL_ENV = "BKN_SANDBOX_MCP_URL"
 _TOKEN_ENV = "BKN_TOKEN"
 _CONVERSATION_ENV = "BKN_CONVERSATION_ID"
 _INTERACTION_ENV = "BKN_INTERACTION_ID"
+_PARENT_OPERATION_ENV = "BKN_PARENT_OPERATION_ID"
 
 # 显式不走代理：MCP 端点是集群内地址，任何继承来的代理配置都只会让请求发不出去；
 # 且 urllib 一旦认定要走代理就改发 absolute-form 请求行（POST http://host/path），
@@ -126,6 +127,18 @@ def _business_context() -> dict:
             value = os.environ.get(env_name, "").strip()
             if value:
                 context[key] = value
+    # An environment parent belongs to this execution's turn. An explicit
+    # runtime context for another turn must not inherit that parent.
+    if (
+        not str(context.get("parent_operation_id") or "").strip()
+        and context.get("conversation_id")
+        and context.get("interaction_id")
+        and context.get("conversation_id") == os.environ.get(_CONVERSATION_ENV, "").strip()
+        and context.get("interaction_id") == os.environ.get(_INTERACTION_ENV, "").strip()
+    ):
+        parent = os.environ.get(_PARENT_OPERATION_ENV, "").strip()
+        if parent:
+            context["parent_operation_id"] = parent
     return context
 
 


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Propagate the persisted `execute_tool` operation through the Function proxy and per-execution sandbox environment as the parent of internal BKN reads.
- [x] Preserve separate child operations in the legacy sandbox SDK, including explicit turn overrides and subsequent invocations.
- [x] Pin the sandbox Python OSDK to the companion fix and document validation and rollout requirements.

---

## Why

- Closes #1319
- Related Feature: Function execution Trace ancestry.
- Background: Internal reads already belong to the same interaction, but the Function invocation context drops their parent operation. Trace therefore cannot reliably attribute those reads to the Function that caused them.

---

## How

- Carry the Guard's persisted operation in `bkn-parent-operation-id`, separately from the derived downstream transport operation ID.
- Capture and forward the parent through the Toolbox proxy, then set `BKN_PARENT_OPERATION_ID` for each sandbox execution. Clear it when absent.
- The legacy SDK includes the parent in `bkn_context` only for the matching host turn; explicit runtime parent values retain precedence. The existing Guard/Core creates independent children and validates/persists their parent links.
- Pin `bkn-osdk` to `3d99c6b3d8faec780e728d6c57be381200a1ae18`, from https://github.com/openbkn-ai/bkn-sdk/pull/96.
- Breaking changes: None. No business Function signatures/results or database schemas change. No historical backfill.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Context Loader full module tests: 26 tested packages / 831 top-level tests; added lifecycle protocol test passed separately.
- Execution Factory full module tests: 34 tested packages / 242 top-level tests; added Toolbox handler test passed separately.
- Executor full unit suite: 324 passed.
- Both Go modules build successfully. Full lint reports existing main findings; lint restricted to changes against the base passes in both modules.
- SDK companion: 412 passed / 32 live tests skipped; Ruff and mypy passed, package build/install verified.
- Regression tests were observed failing before the fixes. Coverage includes independent child IDs, multiple reads, successive Function calls, absent parent, and explicit turn override.
- Tests cover the individual transport and lifecycle boundaries; full deployed execution and inspection of persisted operation/fact parent links remain pending.

---

## Risk & Rollback

- Potential risks: Context Loader, Execution Factory and sandbox images must be rebuilt for the complete fix. Merge SDK PR #96 first; if its final commit changes during review, update this dependency pin before merge.
- Rollback plan: Revert this PR and restore the previous service/sandbox images and SDK pin. No data migration or repair job is required.

---

## Additional Notes

- Companion PR: https://github.com/openbkn-ai/bkn-sdk/pull/96
- Design and validation: `docs/plans/2026-09-05-1319-function-trace-parent.md`.
- Outbox payload size, finish retries, and business Function optimization are outside this fix.
- No deployment performed. After deployment, execute two Functions with multiple internal reads and one direct query, then verify the persisted topology.
