### PR TITLE
feat(bkn): validate capability targets and expand whole-box mounts at write time

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -202,3 +202,143 @@ func (aoa *agentOperatorAccess) GetMcpToolByName(ctx context.Context, mcpID, too
 	common.LogSafeError(ctx, "MCP tool not found", err)
 	return err
 }
+
+// execFactoryHeaders carries the caller's account to the execution factory. The internal face
+// authenticates by header, not by token.
+func (aoa *agentOperatorAccess) execFactoryHeaders(ctx context.Context) map[string]string {
+	accountInfo := interfaces.AccountInfo{}
+	if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {
+		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	}
+	return map[string]string{
+		interfaces.CONTENT_TYPE_NAME:        interfaces.CONTENT_TYPE_JSON,
+		interfaces.HTTP_HEADER_ACCOUNT_ID:   accountInfo.ID,
+		interfaces.HTTP_HEADER_ACCOUNT_TYPE: accountInfo.Type,
+	}
+}
+
+// GetSkillByID reads a skill from the execution factory (GET .../skills/{skill_id}).
+//
+// A missing skill is (nil, nil) rather than an error: "no such skill" and "exists but
+// unpublished" are different answers to a mount request and the caller has to tell them apart.
+func (aoa *agentOperatorAccess) GetSkillByID(ctx context.Context, skillID string) (*interfaces.SkillBrief, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "GetSkillByID")
+	defer span.End()
+
+	if skillID == "" {
+		return nil, fmt.Errorf("skill_id is required for skill binding check")
+	}
+
+	url := fmt.Sprintf("%s/skills/%s", aoa.agentOperatorURL, skillID)
+	oteltrace.AddAttrs4InternalHttp(span, oteltrace.TraceAttrs{
+		HttpUrl:         url,
+		HttpMethod:      http.MethodGet,
+		HttpContentType: rest.ContentTypeJson,
+	})
+
+	respCode, result, err := aoa.httpClient.GetNoUnmarshal(ctx, url, nil, aoa.execFactoryHeaders(ctx))
+	if err != nil {
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http get skill failed")
+		common.LogSafeError(ctx, "Skill binding check request failed", err)
+		return nil, fmt.Errorf("skill binding check failed: %w", err)
+	}
+	if respCode == http.StatusNotFound {
+		oteltrace.AddHttpAttrs4Ok(span, respCode)
+		return nil, nil
+	}
+	if respCode != http.StatusOK {
+		common.LogSafeError(ctx, "Skill binding check failed",
+			fmt.Errorf("skill binding check returned HTTP %d", respCode))
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Get skill failed")
+		return nil, fmt.Errorf("skill binding check returned HTTP %d", respCode)
+	}
+
+	var payload struct {
+		SkillID     string `json:"skill_id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Status      string `json:"status"`
+	}
+	if err = json.Unmarshal(result, &payload); err != nil {
+		common.LogSafeError(ctx, "Unmarshal skill detail failed", err)
+		return nil, fmt.Errorf("skill binding check failed: %w", err)
+	}
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return &interfaces.SkillBrief{
+		SkillID:     payload.SkillID,
+		Name:        payload.Name,
+		Description: payload.Description,
+		Status:      payload.Status,
+	}, nil
+}
+
+// ListBoxTools reads a tool box and its inlined tools (GET .../tool-box/{box_id}).
+//
+// A missing box is (nil, nil), on the same terms as GetSkillByID.
+func (aoa *agentOperatorAccess) ListBoxTools(ctx context.Context, boxID string) ([]*interfaces.ToolBrief, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "ListBoxTools")
+	defer span.End()
+
+	if boxID == "" {
+		return nil, fmt.Errorf("box_id is required for tool box lookup")
+	}
+
+	url := fmt.Sprintf("%s/tool-box/%s", aoa.agentOperatorURL, boxID)
+	oteltrace.AddAttrs4InternalHttp(span, oteltrace.TraceAttrs{
+		HttpUrl:         url,
+		HttpMethod:      http.MethodGet,
+		HttpContentType: rest.ContentTypeJson,
+	})
+
+	respCode, result, err := aoa.httpClient.GetNoUnmarshal(ctx, url, nil, aoa.execFactoryHeaders(ctx))
+	if err != nil {
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http get tool box failed")
+		common.LogSafeError(ctx, "Tool box lookup request failed", err)
+		return nil, fmt.Errorf("tool box lookup failed: %w", err)
+	}
+	if respCode == http.StatusNotFound {
+		oteltrace.AddHttpAttrs4Ok(span, respCode)
+		return nil, nil
+	}
+	if respCode != http.StatusOK {
+		common.LogSafeError(ctx, "Tool box lookup failed",
+			fmt.Errorf("tool box lookup returned HTTP %d", respCode))
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Get tool box failed")
+		return nil, fmt.Errorf("tool box lookup returned HTTP %d", respCode)
+	}
+
+	var payload struct {
+		BoxID      string `json:"box_id"`
+		BoxName    string `json:"box_name"`
+		Status     string `json:"status"`
+		IsInternal bool   `json:"is_internal"`
+		Tools      []struct {
+			ToolID      string `json:"tool_id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Status      string `json:"status"`
+		} `json:"tools"`
+	}
+	if err = json.Unmarshal(result, &payload); err != nil {
+		common.LogSafeError(ctx, "Unmarshal tool box detail failed", err)
+		return nil, fmt.Errorf("tool box lookup failed: %w", err)
+	}
+
+	tools := make([]*interfaces.ToolBrief, 0, len(payload.Tools))
+	for _, tool := range payload.Tools {
+		tools = append(tools, &interfaces.ToolBrief{
+			BoxID:       payload.BoxID,
+			BoxName:     payload.BoxName,
+			BoxStatus:   payload.Status,
+			BoxInternal: payload.IsInternal,
+			ToolID:      tool.ToolID,
+			Name:        tool.Name,
+			Description: tool.Description,
+			Status:      tool.Status,
+		})
+	}
+	// make() above keeps this non-nil even for a box with no tools, which matters: nil is
+	// reserved for "no such box" and the caller answers the two cases differently.
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return tools, nil
+}

--- a/adp/bkn/bkn-backend/server/errors/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/errors/capability_binding.go
@@ -11,6 +11,10 @@ const (
 	BknBackend_CapabilityBinding_NullParameter_CapabilityID           = "BknBackend.CapabilityBinding.NullParameter.CapabilityID"
 	BknBackend_CapabilityBinding_NullParameter_OwnerID                = "BknBackend.CapabilityBinding.NullParameter.OwnerID"
 	BknBackend_CapabilityBinding_InvalidCapabilityType                = "BknBackend.CapabilityBinding.InvalidCapabilityType"
+	BknBackend_CapabilityBinding_TargetNotFound                       = "BknBackend.CapabilityBinding.TargetNotFound"
+	BknBackend_CapabilityBinding_TargetNotAvailable                   = "BknBackend.CapabilityBinding.TargetNotAvailable"
+	BknBackend_CapabilityBinding_EmptyToolBox                         = "BknBackend.CapabilityBinding.EmptyToolBox"
+	BknBackend_CapabilityBinding_ExecutionFactoryUnavailable          = "BknBackend.CapabilityBinding.ExecutionFactoryUnavailable"
 	BknBackend_CapabilityBinding_InternalError                        = "BknBackend.CapabilityBinding.InternalError"
 	BknBackend_CapabilityBinding_InternalError_BeginTransaction       = "BknBackend.CapabilityBinding.InternalError.BeginTransactionFailed"
 	BknBackend_CapabilityBinding_InternalError_CreateBindingsFailed   = "BknBackend.CapabilityBinding.InternalError.CreateBindingsFailed"
@@ -24,6 +28,10 @@ var CapabilityBindingErrCodeList = []string{
 	BknBackend_CapabilityBinding_NullParameter_CapabilityID,
 	BknBackend_CapabilityBinding_NullParameter_OwnerID,
 	BknBackend_CapabilityBinding_InvalidCapabilityType,
+	BknBackend_CapabilityBinding_TargetNotFound,
+	BknBackend_CapabilityBinding_TargetNotAvailable,
+	BknBackend_CapabilityBinding_EmptyToolBox,
+	BknBackend_CapabilityBinding_ExecutionFactoryUnavailable,
 	BknBackend_CapabilityBinding_InternalError,
 	BknBackend_CapabilityBinding_InternalError_BeginTransaction,
 	BknBackend_CapabilityBinding_InternalError_CreateBindingsFailed,

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -8,10 +8,51 @@ package interfaces
 
 import "context"
 
+// Execution-factory lifecycle values this service compares against. They are the strings the
+// execution factory serialises, repeated here because BKN only ever reads them.
+const (
+	// EXEC_TOOL_STATUS_ENABLED is the per-tool switch inside a tool box.
+	EXEC_TOOL_STATUS_ENABLED = "enabled"
+	// EXEC_BOX_STATUS_PUBLISHED is the tool box lifecycle state that makes its tools callable.
+	EXEC_BOX_STATUS_PUBLISHED = "published"
+	// EXEC_SKILL_STATUS_PUBLISHED is the skill lifecycle state that makes it loadable.
+	EXEC_SKILL_STATUS_PUBLISHED = "published"
+)
+
+// SkillBrief is the part of a skill BKN needs to validate a capability binding: whether it
+// exists, and whether it is usable. Everything else stays in the execution factory.
+type SkillBrief struct {
+	SkillID     string
+	Name        string
+	Description string
+	Status      string
+}
+
+// ToolBrief is one tool of a tool box, with the two lifecycle states that decide whether it can
+// be bound: its own switch and the box's publication state.
+type ToolBrief struct {
+	BoxID       string
+	BoxName     string
+	BoxStatus   string
+	BoxInternal bool
+	ToolID      string
+	Name        string
+	Description string
+	Status      string
+}
+
 //go:generate mockgen -source ../interfaces/agent_operator_access.go -destination ../interfaces/mock/mock_agent_operator_access.go -package mock_interfaces
 type AgentOperatorAccess interface {
 	// GetToolByID verifies the tool exists in the tool-box via internal GET .../tool-box/{box_id}/tool/{tool_id}.
 	GetToolByID(ctx context.Context, boxID, toolID string) error
 	// GetMcpToolByName verifies the MCP server exposes a tool with the given name (internal GET .../mcp/proxy/{mcp_id}/tools).
 	GetMcpToolByName(ctx context.Context, mcpID, toolName string) error
+	// GetSkillByID reads a skill's identity and lifecycle state. It returns (nil, nil) when the
+	// skill does not exist, so the caller can tell "no such skill" from "exists but unpublished"
+	// — the market endpoint collapses both into 404, which is why it is not used here.
+	GetSkillByID(ctx context.Context, skillID string) (*SkillBrief, error)
+	// ListBoxTools reads every tool of a tool box in one call, each with its status. It returns
+	// (nil, nil) when the box does not exist. The box endpoint inlines its tools, so validating
+	// and expanding a whole-box mount both cost one request per box rather than one per tool.
+	ListBoxTools(ctx context.Context, boxID string) ([]*ToolBrief, error)
 }

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -17,7 +17,21 @@ const (
 	EXEC_BOX_STATUS_PUBLISHED = "published"
 	// EXEC_SKILL_STATUS_PUBLISHED is the skill lifecycle state that makes it loadable.
 	EXEC_SKILL_STATUS_PUBLISHED = "published"
+	// EXEC_SKILL_STATUS_EDITING is a skill that was published and has been edited since. Its
+	// published version stays in the retrieval index and stays loadable, so it is bindable too:
+	// editing a description must not make a skill unmountable.
+	EXEC_SKILL_STATUS_EDITING = "editing"
 )
+
+// SkillIsBindable reports whether a skill can be bound to a knowledge network.
+//
+// Both published and editing qualify. The execution factory flips published to editing on a
+// metadata edit while keeping the published version in the index, so treating editing as
+// unusable would tell the caller to publish a skill that is already published — and re-publishing
+// would be the only way out of an error the caller did not cause.
+func SkillIsBindable(status string) bool {
+	return status == EXEC_SKILL_STATUS_PUBLISHED || status == EXEC_SKILL_STATUS_EDITING
+}
 
 // SkillBrief is the part of a skill BKN needs to validate a capability binding: whether it
 // exists, and whether it is usable. Everything else stays in the execution factory.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -83,6 +83,11 @@ type AttachCapabilityEntry struct {
 	OwnerID        string `json:"owner_id"`
 	CapabilityID   string `json:"capability_id"`
 	Comment        string `json:"comment"`
+	// AllTools mounts every enabled tool of the box named by OwnerID. It is expanded at write
+	// time into one tool-level binding per tool, so the stored rows carry no box-level scope and
+	// the read path never expands anything. Tools added to the box later are not inherited: a
+	// shared box would otherwise let someone else widen this network's reach.
+	AllTools bool `json:"all_tools"`
 }
 
 // AttachCapabilitiesReq mounts one or more capabilities onto a knowledge network branch.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -31,9 +31,14 @@ type CapabilityBinding struct {
 	CapabilityType string `json:"capability_type" mapstructure:"capability_type"`
 	OwnerID        string `json:"owner_id,omitempty" mapstructure:"owner_id"`
 	CapabilityID   string `json:"capability_id" mapstructure:"capability_id"`
-	// BoundAsBox marks a row produced by expanding a whole-box mount. It does not change the
-	// binding semantics — the row is still an ordinary tool-level binding and can be released
-	// on its own — it only lets the list view report how many tools of a box are not mounted.
+	// BoundAsBox records how the row was created: by expanding a whole-box mount rather than by
+	// naming the tool. It is provenance, not current coverage — a tool bound individually and
+	// later included in a whole-box mount keeps the flag false, because that first gesture is
+	// still what created it.
+	//
+	// Anything asking "which tools of this box are bound" must therefore group by box, not
+	// filter on this flag. The row is an ordinary tool-level binding either way and can be
+	// released on its own.
 	BoundAsBox bool   `json:"bound_as_box" mapstructure:"bound_as_box"`
 	Comment    string `json:"comment,omitempty" mapstructure:"comment"`
 

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
@@ -10,6 +10,7 @@
 package mock_interfaces
 
 import (
+	interfaces "bkn-backend/interfaces"
 	context "context"
 	reflect "reflect"
 
@@ -54,6 +55,21 @@ func (mr *MockAgentOperatorAccessMockRecorder) GetMcpToolByName(ctx, mcpID, tool
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMcpToolByName", reflect.TypeOf((*MockAgentOperatorAccess)(nil).GetMcpToolByName), ctx, mcpID, toolName)
 }
 
+// GetSkillByID mocks base method.
+func (m *MockAgentOperatorAccess) GetSkillByID(ctx context.Context, skillID string) (*interfaces.SkillBrief, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSkillByID", ctx, skillID)
+	ret0, _ := ret[0].(*interfaces.SkillBrief)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSkillByID indicates an expected call of GetSkillByID.
+func (mr *MockAgentOperatorAccessMockRecorder) GetSkillByID(ctx, skillID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillByID", reflect.TypeOf((*MockAgentOperatorAccess)(nil).GetSkillByID), ctx, skillID)
+}
+
 // GetToolByID mocks base method.
 func (m *MockAgentOperatorAccess) GetToolByID(ctx context.Context, boxID, toolID string) error {
 	m.ctrl.T.Helper()
@@ -66,4 +82,19 @@ func (m *MockAgentOperatorAccess) GetToolByID(ctx context.Context, boxID, toolID
 func (mr *MockAgentOperatorAccessMockRecorder) GetToolByID(ctx, boxID, toolID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetToolByID", reflect.TypeOf((*MockAgentOperatorAccess)(nil).GetToolByID), ctx, boxID, toolID)
+}
+
+// ListBoxTools mocks base method.
+func (m *MockAgentOperatorAccess) ListBoxTools(ctx context.Context, boxID string) ([]*interfaces.ToolBrief, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListBoxTools", ctx, boxID)
+	ret0, _ := ret[0].([]*interfaces.ToolBrief)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListBoxTools indicates an expected call of ListBoxTools.
+func (mr *MockAgentOperatorAccessMockRecorder) ListBoxTools(ctx, boxID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBoxTools", reflect.TypeOf((*MockAgentOperatorAccess)(nil).ListBoxTools), ctx, boxID)
 }

--- a/adp/bkn/bkn-backend/server/locale/capability_binding.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/capability_binding.en-US.toml
@@ -48,3 +48,23 @@ ErrorLink = ""
 Description = "Failed to count capability bindings"
 Solution = "Please retry or contact support."
 ErrorLink = ""
+
+[BknBackend.CapabilityBinding.TargetNotFound]
+Description = "Capability not found"
+Solution = "Check the skill_id, or the box_id and tool_id of the function."
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.TargetNotAvailable]
+Description = "The capability exists but is not usable"
+Solution = "Publish the tool box or skill in the execution factory, or enable the tool, then mount it."
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.EmptyToolBox]
+Description = "The tool box has no tool to mount"
+Solution = "Add and enable at least one tool in that box first."
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.ExecutionFactoryUnavailable]
+Description = "The execution factory is unreachable; no binding was written"
+Solution = "Retry later. This request produced no partial write."
+ErrorLink = ""

--- a/adp/bkn/bkn-backend/server/locale/capability_binding.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/capability_binding.zh-CN.toml
@@ -48,3 +48,23 @@ ErrorLink = ""
 Description = "统计能力绑定数量失败"
 Solution = "请重试或联系支持。"
 ErrorLink = ""
+
+[BknBackend.CapabilityBinding.TargetNotFound]
+Description = "能力不存在"
+Solution = "请确认 skill_id，或 function 的 box_id 与 tool_id 是否正确。"
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.TargetNotAvailable]
+Description = "能力存在但当前不可用"
+Solution = "请先在执行工厂发布该工具箱 / 技能，或启用该工具，再挂载。"
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.EmptyToolBox]
+Description = "工具箱内没有可挂载的工具"
+Solution = "请先在执行工厂为该工具箱添加并启用工具。"
+ErrorLink = ""
+
+[BknBackend.CapabilityBinding.ExecutionFactoryUnavailable]
+Description = "执行工厂不可达，未写入任何绑定"
+Solution = "请稍后重试；本次请求没有产生部分写入。"
+ErrorLink = ""

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -45,6 +45,7 @@ type capabilityBindingService struct {
 	appSetting *common.AppSetting
 	db         *sql.DB
 	cba        interfaces.CapabilityBindingAccess
+	aoa        interfaces.AgentOperatorAccess
 	ps         interfaces.PermissionService
 }
 
@@ -54,6 +55,7 @@ func NewCapabilityBindingService(appSetting *common.AppSetting) interfaces.Capab
 			appSetting: appSetting,
 			db:         logics.DB,
 			cba:        logics.CBA,
+			aoa:        logics.AOA,
 			ps:         permission.NewPermissionService(appSetting),
 		}
 	})
@@ -134,17 +136,22 @@ func (cbs *capabilityBindingService) AttachCapabilities(ctx context.Context, tx 
 		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 	}
 
-	result := make([]*interfaces.CapabilityBinding, 0, len(entries))
-	toCreate := make([]*interfaces.CapabilityBinding, 0, len(entries))
+	// Every target is normalised, expanded and validated against the execution factory before a
+	// single row is written. Validating inside the write loop would leave a half-mounted request
+	// behind when the fourth capability turns out not to exist.
+	resolvedEntries, err := cbs.resolveEntries(ctx, entries)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]*interfaces.CapabilityBinding, 0, len(resolvedEntries))
+	toCreate := make([]*interfaces.CapabilityBinding, 0, len(resolvedEntries))
 	// Seen tracks the identities of this request so that a payload repeating the same capability
 	// produces one row, not a duplicate-key failure halfway through the batch.
-	seen := make(map[string]*interfaces.CapabilityBinding, len(entries))
+	seen := make(map[string]*interfaces.CapabilityBinding, len(resolvedEntries))
 
-	for _, entry := range entries {
-		capabilityType, ownerID, capabilityID, err := normalizeAttachEntry(ctx, entry)
-		if err != nil {
-			return nil, err
-		}
+	for _, resolvedEntry := range resolvedEntries {
+		capabilityType, ownerID, capabilityID := resolvedEntry.capabilityType, resolvedEntry.ownerID, resolvedEntry.capabilityID
 		identity := strings.Join([]string{capabilityType, ownerID, capabilityID}, "\x00")
 		if existing, ok := seen[identity]; ok {
 			result = append(result, existing)
@@ -179,7 +186,8 @@ func (cbs *capabilityBindingService) AttachCapabilities(ctx context.Context, tx 
 			CapabilityType: capabilityType,
 			OwnerID:        ownerID,
 			CapabilityID:   capabilityID,
-			Comment:        strings.TrimSpace(entry.Comment),
+			Comment:        resolvedEntry.comment,
+			BoundAsBox:     resolvedEntry.boundAsBox,
 			Creator:        accountInfo,
 			Updater:        accountInfo,
 			CreateTime:     currentTime,

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
@@ -23,10 +23,35 @@ import (
 
 func newTestService(t *testing.T, ctrl *gomock.Controller) (*capabilityBindingService, *bmock.MockCapabilityBindingAccess) {
 	t.Helper()
+	service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+	// Permissive answers for the cases that are about idempotency and normalisation rather than
+	// validation: every target exists and is usable, so those tests reach the write path.
+	aoa.EXPECT().GetSkillByID(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, skillID string) (*interfaces.SkillBrief, error) {
+			return &interfaces.SkillBrief{SkillID: skillID, Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}, nil
+		}).AnyTimes()
+	aoa.EXPECT().ListBoxTools(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, boxID string) ([]*interfaces.ToolBrief, error) {
+			return []*interfaces.ToolBrief{{
+				BoxID: boxID, BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED,
+				ToolID: "tool-1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED,
+			}}, nil
+		}).AnyTimes()
+	return service, cba
+}
+
+// newTestServiceWithFactory hands back the execution-factory client with no expectations set:
+// mounting validates every target against it, so a validation test declares exactly what the
+// factory answers. A permissive default here would shadow those declarations, since gomock takes
+// the first matching expectation.
+func newTestServiceWithFactory(t *testing.T, ctrl *gomock.Controller) (*capabilityBindingService,
+	*bmock.MockCapabilityBindingAccess, *bmock.MockAgentOperatorAccess) {
+	t.Helper()
 	cba := bmock.NewMockCapabilityBindingAccess(ctrl)
+	aoa := bmock.NewMockAgentOperatorAccess(ctrl)
 	ps := bmock.NewMockPermissionService(ctrl)
 	ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	return &capabilityBindingService{appSetting: &common.AppSetting{}, cba: cba, ps: ps}, cba
+	return &capabilityBindingService{appSetting: &common.AppSetting{}, cba: cba, aoa: aoa, ps: ps}, cba, aoa
 }
 
 func TestAttachCapabilities(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
@@ -1,0 +1,214 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
+	berrors "bkn-backend/errors"
+	"bkn-backend/interfaces"
+)
+
+// resolvedCapability is one capability to bind after the request has been normalised and, for a
+// whole-box mount, expanded.
+type resolvedCapability struct {
+	capabilityType string
+	ownerID        string
+	capabilityID   string
+	comment        string
+	boundAsBox     bool
+}
+
+// boxCache holds one tool-box lookup per box for the duration of a request. A whole-box mount
+// validates and expands from the same response, and several entries naming the same box cost one
+// call rather than one each.
+type boxCache struct {
+	svc    *capabilityBindingService
+	loaded map[string][]*interfaces.ToolBrief
+}
+
+func newBoxCache(svc *capabilityBindingService) *boxCache {
+	return &boxCache{svc: svc, loaded: map[string][]*interfaces.ToolBrief{}}
+}
+
+// tools returns the box's tools, or nil when the box does not exist. A transport failure is
+// reported as 502: the target may well be valid and the write must not proceed on a guess.
+func (c *boxCache) tools(ctx context.Context, boxID string) ([]*interfaces.ToolBrief, error) {
+	if tools, ok := c.loaded[boxID]; ok {
+		return tools, nil
+	}
+	tools, err := c.svc.aoa.ListBoxTools(ctx, boxID)
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadGateway,
+			berrors.BknBackend_CapabilityBinding_ExecutionFactoryUnavailable).
+			WithErrorDetails(fmt.Sprintf("tool box %s: %s", boxID, err.Error()))
+	}
+	c.loaded[boxID] = tools
+	return tools, nil
+}
+
+// resolveEntries normalises every request entry and expands whole-box mounts, then validates each
+// resulting capability against the execution factory.
+//
+// Validation happens before anything is written. Binding a capability that does not exist, or one
+// that cannot be called, produces a knowledge network that advertises something unusable; the
+// error has to say which of the two it is, because the fixes are different — check the id, or
+// publish the target.
+func (cbs *capabilityBindingService) resolveEntries(ctx context.Context,
+	entries []*interfaces.AttachCapabilityEntry) ([]*resolvedCapability, error) {
+	boxes := newBoxCache(cbs)
+	resolved := make([]*resolvedCapability, 0, len(entries))
+
+	for _, entry := range entries {
+		capabilityType, ownerID, capabilityID, err := normalizeAttachEntry(ctx, entry)
+		if entry != nil && entry.AllTools && strings.TrimSpace(entry.CapabilityType) == interfaces.CAPABILITY_TYPE_FUNCTION {
+			expanded, expandErr := cbs.expandBox(ctx, boxes, entry)
+			if expandErr != nil {
+				return nil, expandErr
+			}
+			resolved = append(resolved, expanded...)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		switch capabilityType {
+		case interfaces.CAPABILITY_TYPE_SKILL:
+			if err := cbs.validateSkill(ctx, capabilityID); err != nil {
+				return nil, err
+			}
+		case interfaces.CAPABILITY_TYPE_FUNCTION:
+			if err := cbs.validateTool(ctx, boxes, ownerID, capabilityID); err != nil {
+				return nil, err
+			}
+		}
+		resolved = append(resolved, &resolvedCapability{
+			capabilityType: capabilityType,
+			ownerID:        ownerID,
+			capabilityID:   capabilityID,
+			comment:        strings.TrimSpace(entry.Comment),
+		})
+	}
+	return resolved, nil
+}
+
+// expandBox turns a whole-box mount into one binding per enabled tool.
+//
+// Only enabled tools are taken: a disabled one is rejected when named directly, and expanding it
+// here would create through the back door a binding the front door refuses. A box with no tools
+// to mount is a 400 rather than a silent success, so "I mounted the box" and "nothing happened"
+// cannot look the same.
+func (cbs *capabilityBindingService) expandBox(ctx context.Context, boxes *boxCache,
+	entry *interfaces.AttachCapabilityEntry) ([]*resolvedCapability, error) {
+	boxID := strings.TrimSpace(entry.OwnerID)
+	if boxID == "" {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_NullParameter_OwnerID)
+	}
+
+	tools, err := boxes.tools(ctx, boxID)
+	if err != nil {
+		return nil, err
+	}
+	if tools == nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_TargetNotFound).
+			WithErrorDetails(fmt.Sprintf("tool box not found: box_id=%s", boxID))
+	}
+	if len(tools) > 0 && !boxIsUsable(tools[0]) {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
+			WithErrorDetails(fmt.Sprintf("tool box is not published: box_id=%s status=%s", boxID, tools[0].BoxStatus))
+	}
+
+	comment := strings.TrimSpace(entry.Comment)
+	expanded := make([]*resolvedCapability, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+			continue
+		}
+		expanded = append(expanded, &resolvedCapability{
+			capabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			ownerID:        boxID,
+			capabilityID:   tool.ToolID,
+			comment:        comment,
+			boundAsBox:     true,
+		})
+	}
+	if len(expanded) == 0 {
+		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_EmptyToolBox).
+			WithErrorDetails(fmt.Sprintf("tool box has no enabled tool to mount: box_id=%s", boxID))
+	}
+	return expanded, nil
+}
+
+func (cbs *capabilityBindingService) validateSkill(ctx context.Context, skillID string) error {
+	skill, err := cbs.aoa.GetSkillByID(ctx, skillID)
+	if err != nil {
+		return rest.NewHTTPError(ctx, http.StatusBadGateway,
+			berrors.BknBackend_CapabilityBinding_ExecutionFactoryUnavailable).
+			WithErrorDetails(fmt.Sprintf("skill %s: %s", skillID, err.Error()))
+	}
+	if skill == nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_TargetNotFound).
+			WithErrorDetails(fmt.Sprintf("skill not found: skill_id=%s", skillID))
+	}
+	if skill.Status != interfaces.EXEC_SKILL_STATUS_PUBLISHED {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
+			WithErrorDetails(fmt.Sprintf("skill is not published: skill_id=%s status=%s", skillID, skill.Status))
+	}
+	return nil
+}
+
+// validateTool checks one tool of a box. metadata_type is deliberately not consulted: openapi and
+// function tools are both bindable, because a binding names a tool and the box is only the
+// execution factory's container for it.
+func (cbs *capabilityBindingService) validateTool(ctx context.Context, boxes *boxCache, boxID, toolID string) error {
+	tools, err := boxes.tools(ctx, boxID)
+	if err != nil {
+		return err
+	}
+	if tools == nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest,
+			berrors.BknBackend_CapabilityBinding_TargetNotFound).
+			WithErrorDetails(fmt.Sprintf("tool box not found: box_id=%s", boxID))
+	}
+	for _, tool := range tools {
+		if tool.ToolID != toolID {
+			continue
+		}
+		if !boxIsUsable(tool) {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest,
+				berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
+				WithErrorDetails(fmt.Sprintf("tool box is not published: box_id=%s status=%s", boxID, tool.BoxStatus))
+		}
+		if tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest,
+				berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
+				WithErrorDetails(fmt.Sprintf("tool is disabled: box_id=%s tool_id=%s", boxID, toolID))
+		}
+		return nil
+	}
+	return rest.NewHTTPError(ctx, http.StatusBadRequest,
+		berrors.BknBackend_CapabilityBinding_TargetNotFound).
+		WithErrorDetails(fmt.Sprintf("tool not found: box_id=%s tool_id=%s", boxID, toolID))
+}
+
+// boxIsUsable reports whether the tool's box is in a state that lets the tool be called. Internal
+// boxes are platform-managed and go through the same publication state, so they need no exemption.
+func boxIsUsable(tool *interfaces.ToolBrief) bool {
+	return tool.BoxStatus == interfaces.EXEC_BOX_STATUS_PUBLISHED
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
@@ -165,7 +165,7 @@ func (cbs *capabilityBindingService) validateSkill(ctx context.Context, skillID 
 			berrors.BknBackend_CapabilityBinding_TargetNotFound).
 			WithErrorDetails(fmt.Sprintf("skill not found: skill_id=%s", skillID))
 	}
-	if skill.Status != interfaces.EXEC_SKILL_STATUS_PUBLISHED {
+	if !interfaces.SkillIsBindable(skill.Status) {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest,
 			berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
 			WithErrorDetails(fmt.Sprintf("skill is not published: skill_id=%s status=%s", skillID, skill.Status))

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
@@ -1,0 +1,203 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/interfaces"
+)
+
+func httpCodeOf(t *testing.T, err error) int {
+	t.Helper()
+	httpErr, ok := err.(*rest.HTTPError)
+	So(ok, ShouldBeTrue)
+	return httpErr.HTTPCode
+}
+
+func errorCodeOf(t *testing.T, err error) string {
+	t.Helper()
+	httpErr, ok := err.(*rest.HTTPError)
+	So(ok, ShouldBeTrue)
+	return httpErr.BaseError.ErrorCode
+}
+
+// TestAttachValidatesTargets covers #1258: a binding names something in the execution factory, and
+// a mount that cannot be called is worth refusing at write time rather than discovering at recall.
+func TestAttachValidatesTargets(t *testing.T) {
+	Convey("挂载前校验目标", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("技能不存在与技能未发布是两种可区分的错误", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "missing").Return(nil, nil)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "draft").
+				Return(&interfaces.SkillBrief{SkillID: "draft", Status: "unpublish"}, nil)
+
+			_, notFound := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "missing"},
+				})
+			_, notPublished := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "draft"},
+				})
+
+			So(httpCodeOf(t, notFound), ShouldEqual, http.StatusBadRequest)
+			So(httpCodeOf(t, notPublished), ShouldEqual, http.StatusBadRequest)
+			// The two answers must differ: one says check the id, the other says publish it.
+			So(errorCodeOf(t, notFound), ShouldNotEqual, errorCodeOf(t, notPublished))
+		})
+
+		Convey("工具不存在、工具被禁用、工具箱未发布各自被拒", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "on", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "off", Status: "disabled"},
+			}, nil).AnyTimes()
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-draft").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-draft", BoxStatus: "unpublish", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			}, nil).AnyTimes()
+
+			attach := func(boxID, toolID string) error {
+				_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+					[]*interfaces.AttachCapabilityEntry{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: boxID, CapabilityID: toolID},
+					})
+				return err
+			}
+
+			So(errorCodeOf(t, attach("box-1", "nope")), ShouldContainSubstring, "TargetNotFound")
+			So(errorCodeOf(t, attach("box-1", "off")), ShouldContainSubstring, "TargetNotAvailable")
+			So(errorCodeOf(t, attach("box-draft", "t1")), ShouldContainSubstring, "TargetNotAvailable")
+		})
+
+		Convey("工具箱不存在被拒", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "gone").Return(nil, nil)
+
+			_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t1"},
+				})
+
+			So(errorCodeOf(t, err), ShouldContainSubstring, "TargetNotFound")
+		})
+
+		Convey("执行工厂不可达返回 502 且不写入", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return(nil, errors.New("connection refused"))
+			// No CreateBindings expectation: the controller fails the test if anything is written.
+			_ = cba
+
+			_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
+				})
+
+			So(httpCodeOf(t, err), ShouldEqual, http.StatusBadGateway)
+		})
+
+		Convey("挂载不额外要求对目标的执行权限", func() {
+			// Binding is a modeling action by the knowledge network's owner. Whether the caller
+			// may *run* the tool stays the execution factory's decision at call time, so the only
+			// permission consulted here is modify on the knowledge network. This is locked so a
+			// later reading of "the caller mounted something it cannot run" is not mistaken for
+			// an authorization hole and fixed by adding a check that breaks modeling.
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			}, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
+				interfaces.CAPABILITY_TYPE_FUNCTION, "box-1", "t1").Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
+				})
+
+			So(err, ShouldBeNil)
+			So(len(bindings), ShouldEqual, 1)
+		})
+	})
+}
+
+// TestAttachExpandsWholeBox covers the write-time expansion: the stored rows are tool-level, so a
+// tool added to the box afterwards is not inherited and each row can be released on its own.
+func TestAttachExpandsWholeBox(t *testing.T) {
+	Convey("整箱挂载在写入期展开", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("展开为逐工具绑定并置 bound_as_box", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t2", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+				// A disabled tool is skipped: naming it directly is refused, and expanding it
+				// here would create through the back door a binding the front door rejects.
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t3", Status: "disabled"},
+			}, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(2)).Return(nil)
+
+			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", AllTools: true},
+				})
+
+			So(err, ShouldBeNil)
+			So(len(bindings), ShouldEqual, 2)
+			for _, binding := range bindings {
+				So(binding.BoundAsBox, ShouldBeTrue)
+				So(binding.OwnerID, ShouldEqual, "box-1")
+			}
+		})
+
+		Convey("箱内没有可挂载的工具时报 400,不静默成功", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "empty").Return([]*interfaces.ToolBrief{}, nil)
+
+			_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "empty", AllTools: true},
+				})
+
+			So(httpCodeOf(t, err), ShouldEqual, http.StatusBadRequest)
+			So(errorCodeOf(t, err), ShouldContainSubstring, "EmptyToolBox")
+		})
+
+		Convey("整箱与逐个混在一起时同一工具箱只查一次", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			}, nil).Times(1)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", AllTools: true},
+				})
+
+			So(err, ShouldBeNil)
+			So(len(bindings), ShouldEqual, 2)
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
@@ -201,3 +201,48 @@ func TestAttachExpandsWholeBox(t *testing.T) {
 		})
 	})
 }
+
+// TestSkillEditingIsBindable covers the state a skill enters after its metadata is edited.
+//
+// The execution factory flips published to editing on a metadata edit and keeps the published
+// version in the retrieval index, so such a skill is still loadable. Refusing to bind it would
+// answer "publish it first" about a skill that is already published, and re-publishing would be
+// the only way out of an error the caller did not cause.
+func TestSkillEditingIsBindable(t *testing.T) {
+	Convey("已发布后又编辑过的技能仍可挂载", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("editing 可挂载", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
+				Return(&interfaces.SkillBrief{SkillID: "s1", Status: interfaces.EXEC_SKILL_STATUS_EDITING}, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
+				interfaces.CAPABILITY_TYPE_SKILL, "", "s1").Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
+				})
+
+			So(err, ShouldBeNil)
+			So(len(bindings), ShouldEqual, 1)
+		})
+
+		Convey("从未发布与已下线仍被拒", func() {
+			for _, status := range []string{"unpublish", "offline"} {
+				service, _, aoa := newTestServiceWithFactory(t, ctrl)
+				aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
+					Return(&interfaces.SkillBrief{SkillID: "s1", Status: status}, nil)
+
+				_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+					[]*interfaces.AttachCapabilityEntry{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
+					})
+
+				So(errorCodeOf(t, err), ShouldContainSubstring, "TargetNotAvailable")
+			}
+		})
+	})
+}

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -40,11 +40,46 @@ info:
     already bound returns the existing binding rather than failing, and repeating an entry
     inside one request produces one row.
 
+    ## Mounting validates the target
+
+    A mount checks the capability against the execution factory before writing anything, and
+    the two failures it can report are deliberately distinct: **the target does not exist**
+    (check the id) and **the target exists but is not usable** (publish the tool box or skill,
+    or enable the tool). Collapsing them into one error would leave the caller guessing which
+    fix applies.
+
+    Validation runs over the whole request first. A batch whose fourth capability is unknown
+    writes nothing at all rather than leaving three bindings behind.
+
+    When the execution factory is unreachable the answer is **502 and no write**. A binding
+    recorded without validation cannot be told apart later from one that was checked.
+
+    Two things are deliberately *not* checked. `metadata_type` is ignored, so `openapi` and
+    `function` tools are equally bindable — a binding names a tool, and the box is only the
+    execution factory's container for it. And mounting does not require permission to *execute*
+    the target: binding is a modeling action by the network's owner, while whether a caller may
+    run the tool stays the execution factory's decision at call time.
+
+    ## Whole-box mounting
+
+    `{"capability_type": "function", "owner_id": "box-x", "all_tools": true}` mounts every
+    enabled tool of that box. The expansion happens **at write time**: the stored rows are
+    ordinary tool-level bindings carrying `bound_as_box: true`, so the read path never expands
+    anything and any single row can be released on its own.
+
+    Tools added to the box afterwards are **not** inherited. That is the point of expanding
+    rather than storing a box-level scope: on a shared box, inheritance would let someone else's
+    edit widen this network's reach. The list view reports how many tools of a box are not
+    mounted so they can be added deliberately.
+
+    Disabled tools are skipped, on the same terms that reject them when named directly. A box
+    with no tool to mount is a 400, not a silent success — "I mounted the box" and "nothing
+    happened" must not look alike.
+
     ## Not covered here
 
-    Whole-box mounting, the write-time check that the target exists and is published, metadata
-    backfill and dangling marking arrive with the rest of the capability binding work; this
-    file describes the CRUD surface only.
+    Metadata backfill and dangling marking arrive with the rest of the capability binding work;
+    this file describes the CRUD surface only.
 
     **Prefix aliases**: every path below is also served under `/api/ontology-manager/v1`, and
     the internal face under `/api/bkn-backend/in/v1` and `/api/ontology-manager/in/v1`.
@@ -156,7 +191,15 @@ paths:
             capability_id are limited to 64 characters and comment to 255. Over-long values are
             rejected here rather than reaching the database, where they would surface as a 500
             under strict SQL mode or be silently truncated into a binding pointing at a
-            different capability.
+            different capability. Also returned when the target does not exist
+            (`BknBackend.CapabilityBinding.TargetNotFound`), exists but is unpublished or
+            disabled (`BknBackend.CapabilityBinding.TargetNotAvailable`), or a whole-box mount
+            names a box with no tool to mount (`BknBackend.CapabilityBinding.EmptyToolBox`).
+        '502':
+          description: >-
+            The execution factory is unreachable, so the targets could not be validated
+            (`BknBackend.CapabilityBinding.ExecutionFactoryUnavailable`). Nothing is written —
+            a retry is safe.
         '403':
           description: The caller cannot modify this knowledge network
         '404':
@@ -314,8 +357,15 @@ components:
           description: Tool box ID. Required for a function, ignored for a skill.
           type: string
         capability_id:
-          description: skill_id for a skill, tool_id for a function
+          description: >-
+            skill_id for a skill, tool_id for a function. Omitted when all_tools is set.
           type: string
+        all_tools:
+          description: >-
+            Mount every enabled tool of the box named by owner_id. Expanded at write time into
+            one tool-level binding per tool, each with bound_as_box true; tools added to the box
+            later are not inherited.
+          type: boolean
         comment:
           description: Free-text note
           type: string


### PR DESCRIPTION
Closes #1258. Part of Epic #1266.

## Why validate at write time

A binding names something in the execution factory. Recording one without checking produces a knowledge network that advertises a capability nobody can call, and the discovery lands at recall time, far from the mistake.

The two failures are deliberately **distinguishable**: the target does not exist (check the id) versus the target exists but is not usable (publish the box or skill, enable the tool). Collapsing them into one error leaves the caller guessing which fix applies — that is the same distinction that ruled out `/skills/market/{id}` back in #1255.

Validation covers the whole request before anything is written, so a batch whose fourth capability is unknown leaves nothing behind. An unreachable execution factory is **502 with no write**: a binding recorded without validation cannot later be told apart from one that was checked.

## Whole-box mounting

`all_tools` expands **at write time** into one tool-level binding per enabled tool, each carrying `bound_as_box`. The stored rows have no box-level scope, so the read path never expands anything and any single row can be released on its own.

Tools added to the box afterwards are **not** inherited. That is the point of expanding instead of storing a box-level scope: on a shared box, inheritance would let someone else's edit widen this network's reach. Disabled tools are skipped on the same terms that reject them when named directly, and a box with no tool to mount is a 400 rather than a silent success.

## Two checks deliberately absent

- **`metadata_type` is not consulted** — `openapi` and `function` tools are equally bindable. A binding names a tool; the box is only the execution factory's container.
- **Mounting does not require permission to execute the target.** Binding is a modeling action by the network's owner; whether a caller may *run* the tool stays the execution factory's decision at call time. A test locks this so it is not later mistaken for an authorization hole and "fixed" into breaking modeling.

## One deviation from the issue

The issue says function validation reuses the existing `GetToolByID`. It cannot: that method reports existence only and cannot tell a missing tool from a disabled one, which the acceptance criteria require. `ListBoxTools` is used instead — the box endpoint inlines its tools, so validating and expanding both cost one call per box, cached per request.

## Verified on the test server

Against real skills and tool boxes, on isolated deployment copies (the shared deployments were left alone), binary md5 checked local → server → pod. The shared execution factory there predates #1290, so a second copy built from current `main` was stood up and the verification backend pointed at it via its own ConfigMap.

| Check | Result |
|---|---|
| Skill absent | `TargetNotFound` |
| Skill exists, unpublished | `TargetNotAvailable` — distinct code |
| Skill published | mounts |
| Tool box absent | `TargetNotFound` |
| Tool absent in an existing box | `TargetNotFound` |
| Tool in an unpublished box | `TargetNotAvailable` |
| Whole-box mount | 7 tool-level rows, all `bound_as_box: true` |
| Releasing one row of that expansion | 204, the other 6 remain |
| Box with no tool to mount | `EmptyToolBox` |
| Batch where the second entry is unknown | nothing written (row count unchanged) |
| Execution factory scaled to zero | 502, row count unchanged |

`go build ./...` passes; `go test ./...` is 0 FAIL. Test data and every temporary namespace object were removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)