### PR TITLE
feat(execution-factory): enforce managed proxy execution authorization

### DIFF
--- a/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/authorization_safe.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
@@ -256,11 +257,14 @@ func (s *safeAuthorization) get(ctx context.Context, path string, query url.Valu
 		return err
 	}
 	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
+	for key, value := range common.BuildTraceHeaders(ctx) {
+		req.Header.Set(key, value)
+	}
 	resp, err := s.http.Do(req)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("bkn-safe GET %s: %d: %s", path, resp.StatusCode, data)
@@ -282,11 +286,14 @@ func (s *safeAuthorization) do(ctx context.Context, method, path string, body, o
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(sharedrest.AcceptLanguageHeader, sharedrest.GetLanguageByCtx(ctx))
+	for key, value := range common.BuildTraceHeaders(ctx) {
+		req.Header.Set(key, value)
+	}
 	resp, err := s.http.Do(req)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("bkn-safe %s %s: %d: %s", method, path, resp.StatusCode, data)

--- a/adp/execution-factory/operator-integration/server/drivenadapters/proxy_execution_authorization.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/proxy_execution_authorization.go
@@ -1,0 +1,85 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+const maximumManagedProxyResponse = 1 << 20
+
+type proxyExecutionAuthorizationAccess struct {
+	safe *safeAuthorization
+}
+
+// NewProxyExecutionAuthorizationAccess creates the bkn-safe access used by the
+// mandatory managed-proxy PEP. It intentionally does not depend on AUTH_ENABLED.
+func NewProxyExecutionAuthorizationAccess() interfaces.ProxyExecutionAuthorizationAccess {
+	baseURL := strings.TrimRight(strings.TrimSpace(os.Getenv("BKN_SAFE_URL")), "/")
+	return &proxyExecutionAuthorizationAccess{
+		safe: newSafeAuthorization(baseURL, config.NewConfigLoader().GetLogger()),
+	}
+}
+
+func (a *proxyExecutionAuthorizationAccess) GetManagedProxy(
+	ctx context.Context, proxyID string,
+) (*interfaces.ManagedProxyAccount, error) {
+	if a == nil || a.safe == nil || a.safe.baseURL == "" {
+		return nil, fmt.Errorf("BKN_SAFE_URL is not configured")
+	}
+
+	path := "/api/safe/in/v1/managed-proxy-accounts/" + url.PathEscape(strings.TrimSpace(proxyID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.safe.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	for key, value := range common.BuildTraceHeaders(ctx) {
+		req.Header.Set(key, value)
+	}
+	resp, err := a.safe.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("bkn-safe GET %s: status %d", path, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maximumManagedProxyResponse+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maximumManagedProxyResponse {
+		return nil, fmt.Errorf("bkn-safe managed proxy response is too large")
+	}
+	var account interfaces.ManagedProxyAccount
+	if err := json.Unmarshal(data, &account); err != nil {
+		return nil, err
+	}
+	return &account, nil
+}
+
+func (a *proxyExecutionAuthorizationAccess) CheckPermission(
+	ctx context.Context, proxyID, resourceType, resourceID, operation string,
+) (bool, error) {
+	if a == nil || a.safe == nil || a.safe.baseURL == "" {
+		return false, fmt.Errorf("BKN_SAFE_URL is not configured")
+	}
+	return a.safe.checkOne(ctx, proxyID, resourceType, resourceID, operation)
+}

--- a/adp/execution-factory/operator-integration/server/drivenadapters/proxy_execution_authorization_test.go
+++ b/adp/execution-factory/operator-integration/server/drivenadapters/proxy_execution_authorization_test.go
@@ -1,0 +1,107 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package drivenadapters
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+)
+
+func TestProxyExecutionAuthorizationAccessReadsStateAndExactGrant(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/safe/in/v1/managed-proxy-accounts/proxy-1", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get(common.HeaderBKNRequestID); got != "req_12345678" {
+			t.Errorf("request id = %q, want req_12345678", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"proxy_account_id":      "proxy-1",
+			"account_type":          "app",
+			"managed_by":            "bkn",
+			"managed_resource_type": "knowledge_network",
+			"managed_resource_id":   "kn-1",
+			"lifecycle_status":      "active",
+			"enabled":               true,
+			"version":               7,
+		})
+	})
+	mux.HandleFunc("/api/safe/v1/authz/check", func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			AccessorID string `json:"accessor_id"`
+			Resource   struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"resource"`
+			Operation string `json:"operation"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.AccessorID != "proxy-1" || request.Resource.Type != "tool_box" ||
+			request.Resource.ID != "box-1" || request.Operation != "execute" {
+			t.Errorf("authorization request = %+v", request)
+		}
+		if got := r.Header.Get(common.HeaderBKNRequestID); got != "req_12345678" {
+			t.Errorf("request id = %q, want req_12345678", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]bool{"allowed": true})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	access := &proxyExecutionAuthorizationAccess{
+		safe: newSafeAuthorization(server.URL, testLogger{}),
+	}
+	ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{RequestID: "req_12345678"})
+	account, err := access.GetManagedProxy(ctx, "proxy-1")
+	if err != nil {
+		t.Fatalf("GetManagedProxy() error = %v", err)
+	}
+	if account.ProxyAccountID != "proxy-1" || account.ManagedResourceID != "kn-1" || !account.Enabled {
+		t.Fatalf("account = %+v", account)
+	}
+	allowed, err := access.CheckPermission(ctx, "proxy-1", "tool_box", "box-1", "execute")
+	if err != nil || !allowed {
+		t.Fatalf("CheckPermission() = %v, %v", allowed, err)
+	}
+}
+
+func TestProxyExecutionAuthorizationAccessFailsClosed(t *testing.T) {
+	t.Run("missing configuration", func(t *testing.T) {
+		access := &proxyExecutionAuthorizationAccess{safe: newSafeAuthorization("", testLogger{})}
+		if _, err := access.GetManagedProxy(context.Background(), "proxy-1"); err == nil {
+			t.Fatal("GetManagedProxy() error = nil, want configuration error")
+		}
+		if _, err := access.CheckPermission(context.Background(), "proxy-1", "mcp", "mcp-1", "execute"); err == nil {
+			t.Fatal("CheckPermission() error = nil, want configuration error")
+		}
+	})
+
+	t.Run("missing account", func(t *testing.T) {
+		server := httptest.NewServer(http.NotFoundHandler())
+		defer server.Close()
+		access := &proxyExecutionAuthorizationAccess{safe: newSafeAuthorization(server.URL, testLogger{})}
+		account, err := access.GetManagedProxy(context.Background(), "missing")
+		if err != nil || account != nil {
+			t.Fatalf("GetManagedProxy() = %+v, %v; want nil, nil", account, err)
+		}
+	})
+
+	t.Run("oversized response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(strings.Repeat("x", maximumManagedProxyResponse+1)))
+		}))
+		defer server.Close()
+		access := &proxyExecutionAuthorizationAccess{safe: newSafeAuthorization(server.URL, testLogger{})}
+		if _, err := access.GetManagedProxy(context.Background(), "proxy-1"); err == nil {
+			t.Fatal("GetManagedProxy() error = nil, want response size error")
+		}
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/proxy_execution.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/proxy_execution.go
@@ -1,0 +1,141 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	stderrors "errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	oerrors "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/rest"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
+)
+
+var trustedProxyExecutionHeaders = []string{
+	interfaces.HTTPHeaderBKNCallerID,
+	interfaces.HTTPHeaderBKNCallerType,
+	interfaces.HTTPHeaderBKNKnowledgeID,
+	interfaces.HTTPHeaderBKNChildType,
+	interfaces.HTTPHeaderBKNChildID,
+	interfaces.HTTPHeaderBKNProxyVersion,
+	interfaces.HTTPHeaderBKNTargetType,
+	interfaces.HTTPHeaderBKNTargetID,
+	interfaces.HTTPHeaderBKNOperation,
+	interfaces.HTTPHeaderBKNExecutionID,
+}
+
+// stripProxyExecutionHeaders ensures the public Tool and MCP APIs always keep
+// their direct-caller behavior even when a client forges internal proxy headers.
+func stripProxyExecutionHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		for _, header := range trustedProxyExecutionHeaders {
+			c.Request.Header.Del(header)
+		}
+		c.Next()
+	}
+}
+
+// managedProxyExecutionBoundary recognizes only ontology-query's trusted
+// dual-principal context, rejects every non-execution internal route, and
+// passes validated context to the final PEP at the physical outbound boundary.
+func managedProxyExecutionBoundary(recorder interfaces.ProxyExecutionAuditRecorder) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !hasProxyExecutionContext(c) {
+			c.Next()
+			return
+		}
+
+		request, err := proxyExecutionContextFromHeaders(c)
+		if err != nil {
+			rejectProxyExecution(c, recorder, request, http.StatusForbidden, "invalid_trusted_context")
+			return
+		}
+		// The caller's platform credential is never a third-party Tool or MCP
+		// credential. Configured business headers in the execution body remain
+		// available and are sanitized by the existing outbound clients.
+		c.Request.Header.Del("Authorization")
+		c.Request.Header.Del("X-Authorization")
+		c.Request.Header.Del("X-Api-Key")
+		c.Request = c.Request.WithContext(interfaces.WithProxyExecutionContext(c.Request.Context(), request))
+		c.Next()
+	}
+}
+
+func hasProxyExecutionContext(c *gin.Context) bool {
+	for _, header := range trustedProxyExecutionHeaders {
+		if strings.TrimSpace(c.GetHeader(header)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func proxyExecutionContextFromHeaders(c *gin.Context) (interfaces.ProxyExecutionContext, error) {
+	request := interfaces.ProxyExecutionContext{
+		CallerID:    strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNCallerID)),
+		CallerType:  strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNCallerType)),
+		KnowledgeID: strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNKnowledgeID)),
+		ChildType:   strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNChildType)),
+		ChildID:     strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNChildID)),
+		ProxyID:     strings.TrimSpace(c.GetHeader(string(interfaces.HeaderXAccountID))),
+		ProxyType:   strings.TrimSpace(c.GetHeader(string(interfaces.HeaderXAccountType))),
+		TargetType:  strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNTargetType)),
+		TargetID:    strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNTargetID)),
+		Operation:   strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNOperation)),
+		ExecutionID: strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNExecutionID)),
+	}
+	version, err := strconv.ParseUint(strings.TrimSpace(c.GetHeader(interfaces.HTTPHeaderBKNProxyVersion)), 10, 64)
+	request.ProxyVersion = version
+	if err != nil || version == 0 {
+		return request, stderrors.New("proxy version must be a positive integer")
+	}
+	if request.CallerID == "" || request.CallerType == "" || request.KnowledgeID == "" ||
+		request.ChildType == "" || request.ChildID == "" || request.ProxyID == "" ||
+		request.ProxyType != interfaces.ProxyAccountTypeApp ||
+		request.Operation != interfaces.ProxyOperationExecute {
+		return request, stderrors.New("trusted proxy context is incomplete")
+	}
+	if request.ChildType == interfaces.ProxyChildTypeAction && request.ExecutionID == "" {
+		return request, stderrors.New("action proxy context requires an execution id")
+	}
+
+	switch {
+	case c.Request.Method == http.MethodPost &&
+		strings.HasSuffix(c.FullPath(), "/tool-box/:box_id/proxy/:tool_id"):
+		if request.TargetType != interfaces.ProxyTargetTypeToolBox ||
+			request.TargetID == "" || request.TargetID != strings.TrimSpace(c.Param("box_id")) ||
+			(request.ChildType != interfaces.ProxyChildTypeAction &&
+				request.ChildType != interfaces.ProxyChildTypeLogic) {
+			return request, stderrors.New("proxy target does not match the Tool execution route")
+		}
+	case c.Request.Method == http.MethodPost &&
+		strings.HasSuffix(c.FullPath(), "/mcp/proxy/:mcp_id/tool/call"):
+		if request.TargetType != interfaces.ProxyTargetTypeMCP ||
+			request.TargetID == "" || request.TargetID != strings.TrimSpace(c.Param("mcp_id")) ||
+			request.ChildType != interfaces.ProxyChildTypeAction {
+			return request, stderrors.New("proxy target does not match the MCP execution route")
+		}
+	default:
+		return request, stderrors.New("managed proxies may use only Tool or MCP execution routes")
+	}
+	return request, nil
+}
+
+func rejectProxyExecution(
+	c *gin.Context,
+	recorder interfaces.ProxyExecutionAuditRecorder,
+	request interfaces.ProxyExecutionContext,
+	status int,
+	reason string,
+) {
+	proxyexecution.RecordDecision(c.Request.Context(), recorder, request, "deny", reason)
+	c.Abort()
+	rest.ReplyError(c, oerrors.DefaultHTTPError(c.Request.Context(), status, reason))
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/proxy_execution_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/proxy_execution_test.go
@@ -1,0 +1,242 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type recordingProxyExecutionAudit struct {
+	events []interfaces.ProxyExecutionAuditEvent
+}
+
+func (r *recordingProxyExecutionAudit) RecordProxyExecution(
+	_ context.Context, event interfaces.ProxyExecutionAuditEvent,
+) {
+	r.events = append(r.events, event)
+}
+
+func addValidProxyExecutionHeaders(request *http.Request, targetType, targetID, childType string) {
+	request.Header.Set(string(interfaces.HeaderXAccountID), "proxy-1")
+	request.Header.Set(string(interfaces.HeaderXAccountType), interfaces.ProxyAccountTypeApp)
+	request.Header.Set(interfaces.HTTPHeaderBKNCallerID, "caller-1")
+	request.Header.Set(interfaces.HTTPHeaderBKNCallerType, "user")
+	request.Header.Set(interfaces.HTTPHeaderBKNKnowledgeID, "kn-1")
+	request.Header.Set(interfaces.HTTPHeaderBKNChildType, childType)
+	request.Header.Set(interfaces.HTTPHeaderBKNChildID, "action-1")
+	request.Header.Set(interfaces.HTTPHeaderBKNProxyVersion, "3")
+	request.Header.Set(interfaces.HTTPHeaderBKNTargetType, targetType)
+	request.Header.Set(interfaces.HTTPHeaderBKNTargetID, targetID)
+	request.Header.Set(interfaces.HTTPHeaderBKNOperation, interfaces.ProxyOperationExecute)
+	request.Header.Set(interfaces.HTTPHeaderBKNExecutionID, "execution-1")
+	request.Header.Set(common.HeaderBKNRequestID, "req_12345678")
+}
+
+func proxyExecutionTestEngine(
+	recorder interfaces.ProxyExecutionAuditRecorder,
+	handler gin.HandlerFunc,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(middlewareTraceContext, managedProxyExecutionBoundary(recorder))
+	engine.POST("/api/agent-operator-integration/internal-v1/tool-box/:box_id/proxy/:tool_id", handler)
+	engine.POST("/api/agent-operator-integration/internal-v1/mcp/proxy/:mcp_id/tool/call", handler)
+	engine.POST("/api/agent-operator-integration/internal-v1/tool-box/:box_id/tool/:tool_id/debug", handler)
+	return engine
+}
+
+func TestManagedProxyExecutionAllowsOnlyExactExecutionRoutes(t *testing.T) {
+	t.Run("Tool execution", func(t *testing.T) {
+		recorder := &recordingProxyExecutionAudit{}
+		handlerCalls := 0
+		engine := proxyExecutionTestEngine(recorder, func(c *gin.Context) {
+			handlerCalls++
+			if c.GetHeader("Authorization") != "" || c.GetHeader("X-Authorization") != "" ||
+				c.GetHeader("X-Api-Key") != "" {
+				t.Error("platform credentials reached the execution handler")
+			}
+			proxy, ok := interfaces.ProxyExecutionContextFromContext(c.Request.Context())
+			if !ok || proxy.ExecutionID != "execution-1" || proxy.TargetID != "box-1" {
+				t.Errorf("proxy context = %+v, %v", proxy, ok)
+			}
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/internal-v1/tool-box/box-1/proxy/tool-1", nil)
+		addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeAction)
+		request.Header.Set("Authorization", "Bearer caller-oauth")
+		request.Header.Set("X-Authorization", "caller-oauth")
+		request.Header.Set("X-Api-Key", "caller-app-key")
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK || handlerCalls != 1 {
+			t.Fatalf("status=%d handler=%d", response.Code, handlerCalls)
+		}
+		if len(recorder.events) != 0 {
+			t.Fatalf("route validation emitted final audit events: %+v", recorder.events)
+		}
+	})
+
+	t.Run("MCP execution", func(t *testing.T) {
+		handlerCalls := 0
+		engine := proxyExecutionTestEngine(nil, func(c *gin.Context) {
+			handlerCalls++
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/internal-v1/mcp/proxy/mcp-1/tool/call", nil)
+		addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeMCP, "mcp-1", interfaces.ProxyChildTypeAction)
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK || handlerCalls != 1 {
+			t.Fatalf("status=%d handler=%d", response.Code, handlerCalls)
+		}
+	})
+
+	t.Run("logical property Tool execution", func(t *testing.T) {
+		handlerCalls := 0
+		engine := proxyExecutionTestEngine(nil, func(c *gin.Context) {
+			handlerCalls++
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/internal-v1/tool-box/box-1/proxy/tool-1", nil)
+		addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeLogic)
+		request.Header.Del(interfaces.HTTPHeaderBKNExecutionID)
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK || handlerCalls != 1 {
+			t.Fatalf("status=%d handler=%d", response.Code, handlerCalls)
+		}
+	})
+}
+
+func TestManagedProxyExecutionRejectsInvalidContextBeforeHandler(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		configure func(*http.Request)
+	}{
+		{
+			name: "target tamper",
+			path: "/api/agent-operator-integration/internal-v1/tool-box/box-2/proxy/tool-1",
+			configure: func(request *http.Request) {
+				addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeAction)
+			},
+		},
+		{
+			name: "debug route",
+			path: "/api/agent-operator-integration/internal-v1/tool-box/box-1/tool/tool-1/debug",
+			configure: func(request *http.Request) {
+				addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeAction)
+			},
+		},
+		{
+			name: "missing execution id",
+			path: "/api/agent-operator-integration/internal-v1/tool-box/box-1/proxy/tool-1",
+			configure: func(request *http.Request) {
+				addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeAction)
+				request.Header.Del(interfaces.HTTPHeaderBKNExecutionID)
+			},
+		},
+		{
+			name: "invalid mapping version",
+			path: "/api/agent-operator-integration/internal-v1/mcp/proxy/mcp-1/tool/call",
+			configure: func(request *http.Request) {
+				addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeMCP, "mcp-1", interfaces.ProxyChildTypeAction)
+				request.Header.Set(interfaces.HTTPHeaderBKNProxyVersion, "0")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &recordingProxyExecutionAudit{}
+			handlerCalls := 0
+			engine := proxyExecutionTestEngine(recorder, func(c *gin.Context) {
+				handlerCalls++
+				c.Status(http.StatusOK)
+			})
+			request := httptest.NewRequest(http.MethodPost, test.path, nil)
+			test.configure(request)
+			response := httptest.NewRecorder()
+
+			engine.ServeHTTP(response, request)
+
+			if response.Code != http.StatusForbidden || handlerCalls != 0 {
+				t.Fatalf("status=%d handler=%d", response.Code, handlerCalls)
+			}
+			if len(recorder.events) != 1 || recorder.events[0].Decision != "deny" ||
+				recorder.events[0].Reason != "invalid_trusted_context" {
+				t.Fatalf("audit events = %+v", recorder.events)
+			}
+		})
+	}
+}
+
+func TestDirectExecutionAndPublicRoutesRemainUnchanged(t *testing.T) {
+	t.Run("internal direct execution without proxy context", func(t *testing.T) {
+		engine := proxyExecutionTestEngine(nil, func(c *gin.Context) {
+			if c.GetHeader("Authorization") != "Bearer direct-caller" {
+				t.Errorf("Authorization = %q", c.GetHeader("Authorization"))
+			}
+			if _, ok := interfaces.ProxyExecutionContextFromContext(c.Request.Context()); ok {
+				t.Error("direct call received a proxy execution context")
+			}
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/internal-v1/tool-box/box-1/proxy/tool-1", nil)
+		request.Header.Set("Authorization", "Bearer direct-caller")
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK {
+			t.Fatalf("status=%d", response.Code)
+		}
+	})
+
+	t.Run("public routes strip forged proxy context", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		engine := gin.New()
+		engine.Use(stripProxyExecutionHeaders())
+		engine.POST("/api/agent-operator-integration/v1/tool-box/:box_id/proxy/:tool_id", func(c *gin.Context) {
+			for _, header := range trustedProxyExecutionHeaders {
+				if c.GetHeader(header) != "" {
+					t.Errorf("forged header %s reached public handler", header)
+				}
+			}
+			if c.GetHeader("Authorization") != "Bearer direct-caller" {
+				t.Errorf("Authorization = %q", c.GetHeader("Authorization"))
+			}
+			c.Status(http.StatusOK)
+		})
+		request := httptest.NewRequest(http.MethodPost,
+			"/api/agent-operator-integration/v1/tool-box/box-1/proxy/tool-1", nil)
+		addValidProxyExecutionHeaders(request, interfaces.ProxyTargetTypeToolBox, "box-1", interfaces.ProxyChildTypeAction)
+		request.Header.Set("Authorization", "Bearer direct-caller")
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", response.Code)
+		}
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_private_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/driveradapters/common"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/config"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
 	sharedrest "github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 )
 
@@ -42,7 +43,15 @@ func NewRestPrivateHandler() interfaces.HTTPRouterInterface {
 // RegisterRouter internal interface register route.
 func (r *restPrivateHandler) RegisterRouter(engine *gin.RouterGroup) {
 	mws := []gin.HandlerFunc{}
-	mws = append(mws, middlewareRequestLog(r.Logger), middlewareTrace, middlewareTraceContext, sharedrest.LanguageMiddleware(), sharedrest.PrivateNoCacheMiddleware(), middlewareHeaderAuthContext(r.Hydra))
+	mws = append(mws,
+		middlewareRequestLog(r.Logger),
+		middlewareTrace,
+		middlewareTraceContext,
+		sharedrest.LanguageMiddleware(),
+		sharedrest.PrivateNoCacheMiddleware(),
+		managedProxyExecutionBoundary(proxyexecution.NewAuditLogger(r.Logger)),
+		middlewareHeaderAuthContext(r.Hydra),
+	)
 	engine.Use(mws...)
 	// Operator interface.
 	r.OperatorRestHandler.RegisterPrivate(engine)

--- a/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/rest_public_handler.go
@@ -65,6 +65,7 @@ func (r *restPublicHandler) RegisterRouter(engine *gin.RouterGroup) {
 		middlewareTraceContext,
 		sharedrest.LanguageMiddleware(),
 		sharedrest.PrivateNoCacheMiddleware(),
+		stripProxyExecutionHeaders(),
 		middlewareIntrospectVerify(r.Hydra, r.AppKeys),
 		OperationAudit(r.auditStore),
 	)

--- a/adp/execution-factory/operator-integration/server/interfaces/proxy_execution.go
+++ b/adp/execution-factory/operator-integration/server/interfaces/proxy_execution.go
@@ -1,0 +1,119 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	HTTPHeaderBKNCallerID     = "x-bkn-caller-id"
+	HTTPHeaderBKNCallerType   = "x-bkn-caller-type"
+	HTTPHeaderBKNKnowledgeID  = "x-bkn-kn-id"
+	HTTPHeaderBKNChildType    = "x-bkn-child-type"
+	HTTPHeaderBKNChildID      = "x-bkn-child-id"
+	HTTPHeaderBKNProxyVersion = "x-bkn-proxy-version"
+	HTTPHeaderBKNTargetType   = "x-bkn-target-type"
+	HTTPHeaderBKNTargetID     = "x-bkn-target-id"
+	HTTPHeaderBKNOperation    = "x-bkn-operation"
+	HTTPHeaderBKNExecutionID  = "x-bkn-execution-id"
+
+	ProxyAccountTypeApp        = "app"
+	ProxyManagerBKN            = "bkn"
+	ProxyManagedResourceTypeKN = "knowledge_network"
+	ProxyLifecycleActive       = "active"
+	ProxyTargetTypeToolBox     = "tool_box"
+	ProxyTargetTypeMCP         = "mcp"
+	ProxyChildTypeAction       = "action_type"
+	ProxyChildTypeLogic        = "logic_property"
+	ProxyOperationExecute      = "execute"
+)
+
+var (
+	ErrProxyExecutionDenied      = errors.New("proxy execution denied")
+	ErrProxyExecutionUnavailable = errors.New("proxy execution authorization unavailable")
+)
+
+// ProxyExecutionContext is the trusted dual-principal context produced from a
+// current published knowledge-network binding by ontology-query.
+type ProxyExecutionContext struct {
+	CallerID     string
+	CallerType   string
+	KnowledgeID  string
+	ChildType    string
+	ChildID      string
+	ProxyID      string
+	ProxyType    string
+	ProxyVersion uint64
+	TargetType   string
+	TargetID     string
+	Operation    string
+	ExecutionID  string
+}
+
+type proxyExecutionContextKey struct{}
+
+// WithProxyExecutionContext attaches a route-validated internal proxy context.
+func WithProxyExecutionContext(ctx context.Context, request ProxyExecutionContext) context.Context {
+	return context.WithValue(ctx, proxyExecutionContextKey{}, request)
+}
+
+// ProxyExecutionContextFromContext returns the route-validated proxy context.
+func ProxyExecutionContextFromContext(ctx context.Context) (ProxyExecutionContext, bool) {
+	if ctx == nil {
+		return ProxyExecutionContext{}, false
+	}
+	request, ok := ctx.Value(proxyExecutionContextKey{}).(ProxyExecutionContext)
+	return request, ok
+}
+
+// ManagedProxyAccount is the current managed proxy state returned by bkn-safe.
+type ManagedProxyAccount struct {
+	ProxyAccountID      string `json:"proxy_account_id"`
+	AccountType         string `json:"account_type"`
+	ManagedBy           string `json:"managed_by"`
+	ManagedResourceType string `json:"managed_resource_type"`
+	ManagedResourceID   string `json:"managed_resource_id"`
+	LifecycleStatus     string `json:"lifecycle_status"`
+	Enabled             bool   `json:"enabled"`
+	Version             uint64 `json:"version"`
+}
+
+// ProxyExecutionAuthorizationAccess reads managed proxy state and exact
+// resource authorization directly from bkn-safe.
+type ProxyExecutionAuthorizationAccess interface {
+	GetManagedProxy(ctx context.Context, proxyID string) (*ManagedProxyAccount, error)
+	CheckPermission(ctx context.Context, proxyID, resourceType, resourceID, operation string) (bool, error)
+}
+
+// ProxyExecutionAuthorizer is the final PEP immediately before Tool or MCP execution.
+type ProxyExecutionAuthorizer interface {
+	Authorize(ctx context.Context, request ProxyExecutionContext) error
+}
+
+// ProxyExecutionAuditEvent correlates both principals with the final outbound decision.
+type ProxyExecutionAuditEvent struct {
+	CallerID       string `json:"caller_id"`
+	CallerType     string `json:"caller_type"`
+	KnowledgeID    string `json:"kn_id"`
+	ChildType      string `json:"kn_child_type"`
+	ChildID        string `json:"kn_child_id"`
+	ProxyAccountID string `json:"proxy_account_id"`
+	ProxyVersion   uint64 `json:"proxy_version"`
+	TargetType     string `json:"target_resource_type"`
+	TargetID       string `json:"target_resource_id"`
+	Operation      string `json:"operation"`
+	ExecutionID    string `json:"execution_id,omitempty"`
+	RequestID      string `json:"request_id,omitempty"`
+	TraceID        string `json:"trace_id,omitempty"`
+	Decision       string `json:"decision"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+// ProxyExecutionAuditRecorder persists or logs final proxy execution decisions.
+type ProxyExecutionAuditRecorder interface {
+	RecordProxyExecution(context.Context, ProxyExecutionAuditEvent)
+}

--- a/adp/execution-factory/operator-integration/server/logics/mcp/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/execute.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/telemetry"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metric"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 )
@@ -179,6 +180,9 @@ func (s *mcpServiceImpl) CallMCPTool(ctx context.Context, req *interfaces.MCPPro
 }
 
 func (s *mcpServiceImpl) callTool(ctx context.Context, req *CallToolRequest) (*CallToolResponse, error) {
+	if err := proxyexecution.AuthorizeOutbound(ctx, s.ProxyAuthorizer, s.ProxyAudit); err != nil {
+		return nil, err
+	}
 	mcpClient, err := s.getMCPClient(ctx, req.ListToolsRequest)
 	if err != nil {
 		s.logger.WithContext(ctx).Errorf("get mcp client error: %v", err)

--- a/adp/execution-factory/operator-integration/server/logics/mcp/index.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/index.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/category"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/mcpinstance"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metric"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/toolbox"
 )
 
@@ -38,13 +39,16 @@ type mcpServiceImpl struct {
 	ToolService               interfaces.IToolService
 	AuditLog                  interfaces.LogModelOperator[*metric.AuditLogBuilderParams]
 	MCPInstanceService        interfaces.InstanceService
+	ProxyAuthorizer           interfaces.ProxyExecutionAuthorizer
+	ProxyAudit                interfaces.ProxyExecutionAuditRecorder
 }
 
 // NewMCPServiceImpl initializes the MCP service.
 func NewMCPServiceImpl() interfaces.IMCPService {
 	mOnce.Do(func() {
+		conf := config.NewConfigLoader()
 		s := &mcpServiceImpl{
-			logger:                    config.NewConfigLoader().GetLogger(),
+			logger:                    conf.GetLogger(),
 			DBTx:                      dbaccess.NewBaseTx(),
 			DBMCPServerConfig:         dbaccess.NewMCPServerConfigDBSingleton(),
 			DBMCPServerRelease:        dbaccess.NewMCPServerReleaseDBSingleton(),
@@ -56,6 +60,10 @@ func NewMCPServiceImpl() interfaces.IMCPService {
 			AuthService:               auth.NewAuthServiceImpl(),
 			ToolService:               toolbox.NewToolServiceImpl(),
 			AuditLog:                  metric.NewAuditLogBuilder(),
+			ProxyAuthorizer: proxyexecution.NewAuthorizer(
+				drivenadapters.NewProxyExecutionAuthorizationAccess(),
+			),
+			ProxyAudit: proxyexecution.NewAuditLogger(conf.GetLogger()),
 		}
 		s.MCPInstanceService = mcpinstance.NewMCPInstanceService(s)
 		mcpService = s

--- a/adp/execution-factory/operator-integration/server/logics/mcp/proxy_execution_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/mcp/proxy_execution_test.go
@@ -1,0 +1,75 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type denyingMCPProxyAuthorizer struct {
+	calls int
+	err   error
+}
+
+func (a *denyingMCPProxyAuthorizer) Authorize(context.Context, interfaces.ProxyExecutionContext) error {
+	a.calls++
+	return a.err
+}
+
+type mcpProxyExecutionAudit struct {
+	events []interfaces.ProxyExecutionAuditEvent
+}
+
+func (a *mcpProxyExecutionAudit) RecordProxyExecution(_ context.Context, event interfaces.ProxyExecutionAuditEvent) {
+	a.events = append(a.events, event)
+}
+
+func TestCallMCPToolRechecksManagedProxyBeforeCreatingOutboundClient(t *testing.T) {
+	tests := map[string]error{
+		"grant revoked":        interfaces.ErrProxyExecutionDenied,
+		"bkn-safe unavailable": errors.New("connection refused"),
+	}
+	for name, authorizationErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			authorizer := &denyingMCPProxyAuthorizer{err: authorizationErr}
+			audit := &mcpProxyExecutionAudit{}
+			service := &mcpServiceImpl{
+				ProxyAuthorizer: authorizer,
+				ProxyAudit:      audit,
+			}
+			ctx := interfaces.WithProxyExecutionContext(context.Background(), interfaces.ProxyExecutionContext{
+				CallerID:     "caller-1",
+				CallerType:   "user",
+				KnowledgeID:  "kn-1",
+				ChildType:    interfaces.ProxyChildTypeAction,
+				ChildID:      "action-1",
+				ProxyID:      "proxy-1",
+				ProxyType:    interfaces.ProxyAccountTypeApp,
+				ProxyVersion: 3,
+				TargetType:   interfaces.ProxyTargetTypeMCP,
+				TargetID:     "mcp-1",
+				Operation:    interfaces.ProxyOperationExecute,
+				ExecutionID:  "execution-1",
+			})
+
+			response, err := service.callTool(ctx, &CallToolRequest{})
+
+			if err == nil || response != nil {
+				t.Fatalf("callTool() = %+v, %v; want final authorization failure", response, err)
+			}
+			if authorizer.calls != 1 {
+				t.Fatalf("authorizer calls = %d, want 1", authorizer.calls)
+			}
+			if len(audit.events) != 1 || audit.events[0].Decision != "deny" ||
+				audit.events[0].ExecutionID != "execution-1" {
+				t.Fatalf("audit events = %+v", audit.events)
+			}
+		})
+	}
+}

--- a/adp/execution-factory/operator-integration/server/logics/proxy_execution/authorization.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy_execution/authorization.go
@@ -1,0 +1,158 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package proxy_execution implements the final authorization policy
+// enforcement point for knowledge-network managed proxy execution.
+package proxy_execution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/bytedance/sonic"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	oerrors "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type authorizer struct {
+	access interfaces.ProxyExecutionAuthorizationAccess
+}
+
+// NewAuthorizer creates a fail-closed proxy execution authorizer.
+func NewAuthorizer(access interfaces.ProxyExecutionAuthorizationAccess) interfaces.ProxyExecutionAuthorizer {
+	return &authorizer{access: access}
+}
+
+// Authorize rechecks proxy ownership, current state, and the exact execution
+// grant for every Tool or MCP call.
+func (a *authorizer) Authorize(ctx context.Context, request interfaces.ProxyExecutionContext) error {
+	if a.access == nil {
+		return fmt.Errorf("%w: bkn-safe access is not configured", interfaces.ErrProxyExecutionUnavailable)
+	}
+
+	account, err := a.access.GetManagedProxy(ctx, request.ProxyID)
+	if err != nil {
+		return fmt.Errorf("%w: load managed proxy: %v", interfaces.ErrProxyExecutionUnavailable, err)
+	}
+	if !matchesCurrentProxy(account, request) {
+		return interfaces.ErrProxyExecutionDenied
+	}
+
+	allowed, err := a.access.CheckPermission(
+		ctx, request.ProxyID, request.TargetType, request.TargetID, request.Operation,
+	)
+	if err != nil {
+		return fmt.Errorf("%w: check resource policy: %v", interfaces.ErrProxyExecutionUnavailable, err)
+	}
+	if !allowed {
+		return interfaces.ErrProxyExecutionDenied
+	}
+	return nil
+}
+
+func matchesCurrentProxy(account *interfaces.ManagedProxyAccount, request interfaces.ProxyExecutionContext) bool {
+	// ProxyVersion is the BKN mapping version. bkn-safe's Version is a separate
+	// account lifecycle counter, so the two values must not be compared. The
+	// mapping version is validated against the latest published model upstream
+	// and retained here for trusted-context validation and audit correlation.
+	return account != nil &&
+		account.ProxyAccountID == request.ProxyID &&
+		account.AccountType == interfaces.ProxyAccountTypeApp &&
+		account.ManagedBy == interfaces.ProxyManagerBKN &&
+		account.ManagedResourceType == interfaces.ProxyManagedResourceTypeKN &&
+		account.ManagedResourceID == request.KnowledgeID &&
+		account.LifecycleStatus == interfaces.ProxyLifecycleActive &&
+		account.Enabled
+}
+
+type auditLogger struct {
+	logger interfaces.Logger
+}
+
+// NewAuditLogger creates a structured audit recorder for proxy execution decisions.
+func NewAuditLogger(logger interfaces.Logger) interfaces.ProxyExecutionAuditRecorder {
+	return auditLogger{logger: logger}
+}
+
+func (a auditLogger) RecordProxyExecution(ctx context.Context, event interfaces.ProxyExecutionAuditEvent) {
+	if a.logger == nil {
+		return
+	}
+	encoded, err := sonic.MarshalString(event)
+	if err != nil {
+		a.logger.WithContext(ctx).Errorf("marshal proxy execution audit failed: %v", err)
+		return
+	}
+	a.logger.WithContext(ctx).Infof("proxy execution authorization audit: %s", encoded)
+}
+
+// AuthorizeOutbound runs the final PEP only when the request carries a
+// route-validated managed proxy context. Callers must invoke it immediately
+// before creating or using an outbound client.
+func AuthorizeOutbound(
+	ctx context.Context,
+	authorizer interfaces.ProxyExecutionAuthorizer,
+	recorder interfaces.ProxyExecutionAuditRecorder,
+) error {
+	request, ok := interfaces.ProxyExecutionContextFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if authorizer == nil {
+		RecordDecision(ctx, recorder, request, "deny", "authorization_unavailable")
+		return oerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable, "proxy execution authorization is unavailable")
+	}
+	err := authorizer.Authorize(ctx, request)
+	if err == nil {
+		RecordDecision(ctx, recorder, request, "allow", "")
+		return nil
+	}
+	if errors.Is(err, interfaces.ErrProxyExecutionDenied) {
+		RecordDecision(ctx, recorder, request, "deny", "proxy_or_policy_denied")
+		return oerrors.DefaultHTTPError(ctx, http.StatusForbidden, "proxy execution is forbidden")
+	}
+	RecordDecision(ctx, recorder, request, "deny", "authorization_unavailable")
+	return oerrors.DefaultHTTPError(ctx, http.StatusServiceUnavailable, "proxy execution authorization is unavailable")
+}
+
+// RecordDecision emits a correlated dual-principal authorization decision.
+func RecordDecision(
+	ctx context.Context,
+	recorder interfaces.ProxyExecutionAuditRecorder,
+	request interfaces.ProxyExecutionContext,
+	decision string,
+	reason string,
+) {
+	if recorder == nil {
+		return
+	}
+	traceContext, _ := common.GetTraceContextFromCtx(ctx)
+	spanContext := trace.SpanContextFromContext(ctx)
+	traceID := ""
+	if spanContext.IsValid() {
+		traceID = spanContext.TraceID().String()
+	}
+	recorder.RecordProxyExecution(ctx, interfaces.ProxyExecutionAuditEvent{
+		CallerID:       request.CallerID,
+		CallerType:     request.CallerType,
+		KnowledgeID:    request.KnowledgeID,
+		ChildType:      request.ChildType,
+		ChildID:        request.ChildID,
+		ProxyAccountID: request.ProxyID,
+		ProxyVersion:   request.ProxyVersion,
+		TargetType:     request.TargetType,
+		TargetID:       request.TargetID,
+		Operation:      request.Operation,
+		ExecutionID:    request.ExecutionID,
+		RequestID:      traceContext.RequestID,
+		TraceID:        traceID,
+		Decision:       decision,
+		Reason:         reason,
+	})
+}

--- a/adp/execution-factory/operator-integration/server/logics/proxy_execution/authorization_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/proxy_execution/authorization_test.go
@@ -1,0 +1,213 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package proxy_execution
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/common"
+	oerrors "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/infra/errors"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
+)
+
+type fakeAuthorizationAccess struct {
+	account         *interfaces.ManagedProxyAccount
+	accountErr      error
+	permission      bool
+	permissionErr   error
+	permissionCalls int
+}
+
+func (f *fakeAuthorizationAccess) GetManagedProxy(context.Context, string) (*interfaces.ManagedProxyAccount, error) {
+	return f.account, f.accountErr
+}
+
+func (f *fakeAuthorizationAccess) CheckPermission(context.Context, string, string, string, string) (bool, error) {
+	f.permissionCalls++
+	return f.permission, f.permissionErr
+}
+
+func validRequest() interfaces.ProxyExecutionContext {
+	return interfaces.ProxyExecutionContext{
+		CallerID:     "caller-1",
+		CallerType:   "user",
+		KnowledgeID:  "kn-1",
+		ChildType:    interfaces.ProxyChildTypeAction,
+		ChildID:      "action-1",
+		ProxyID:      "proxy-1",
+		ProxyType:    interfaces.ProxyAccountTypeApp,
+		ProxyVersion: 3,
+		TargetType:   interfaces.ProxyTargetTypeToolBox,
+		TargetID:     "box-1",
+		Operation:    interfaces.ProxyOperationExecute,
+		ExecutionID:  "execution-1",
+	}
+}
+
+func validManagedProxy() *interfaces.ManagedProxyAccount {
+	return &interfaces.ManagedProxyAccount{
+		ProxyAccountID:      "proxy-1",
+		AccountType:         interfaces.ProxyAccountTypeApp,
+		ManagedBy:           interfaces.ProxyManagerBKN,
+		ManagedResourceType: interfaces.ProxyManagedResourceTypeKN,
+		ManagedResourceID:   "kn-1",
+		LifecycleStatus:     interfaces.ProxyLifecycleActive,
+		Enabled:             true,
+		Version:             9,
+	}
+}
+
+func TestAuthorizerAllowsCurrentManagedProxyWithExactGrant(t *testing.T) {
+	access := &fakeAuthorizationAccess{account: validManagedProxy(), permission: true}
+	if err := NewAuthorizer(access).Authorize(context.Background(), validRequest()); err != nil {
+		t.Fatalf("Authorize() error = %v", err)
+	}
+	if access.permissionCalls != 1 {
+		t.Fatalf("permission calls = %d, want 1", access.permissionCalls)
+	}
+}
+
+func TestAuthorizerRejectsInvalidManagedProxyBeforePolicyCheck(t *testing.T) {
+	tests := map[string]func(*interfaces.ManagedProxyAccount){
+		"missing":           func(account *interfaces.ManagedProxyAccount) { *account = interfaces.ManagedProxyAccount{} },
+		"wrong id":          func(account *interfaces.ManagedProxyAccount) { account.ProxyAccountID = "proxy-2" },
+		"wrong type":        func(account *interfaces.ManagedProxyAccount) { account.AccountType = "user" },
+		"wrong manager":     func(account *interfaces.ManagedProxyAccount) { account.ManagedBy = "other" },
+		"wrong owner type":  func(account *interfaces.ManagedProxyAccount) { account.ManagedResourceType = "other" },
+		"wrong owner":       func(account *interfaces.ManagedProxyAccount) { account.ManagedResourceID = "kn-2" },
+		"revoked lifecycle": func(account *interfaces.ManagedProxyAccount) { account.LifecycleStatus = "archived" },
+		"disabled":          func(account *interfaces.ManagedProxyAccount) { account.Enabled = false },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			account := validManagedProxy()
+			mutate(account)
+			access := &fakeAuthorizationAccess{account: account, permission: true}
+			err := NewAuthorizer(access).Authorize(context.Background(), validRequest())
+			if !errors.Is(err, interfaces.ErrProxyExecutionDenied) {
+				t.Fatalf("Authorize() error = %v, want denied", err)
+			}
+			if access.permissionCalls != 0 {
+				t.Fatalf("permission calls = %d, want 0", access.permissionCalls)
+			}
+		})
+	}
+}
+
+func TestAuthorizerFailsClosedWhenStateOrPolicyIsUnavailable(t *testing.T) {
+	t.Run("state unavailable", func(t *testing.T) {
+		access := &fakeAuthorizationAccess{accountErr: errors.New("safe unavailable")}
+		err := NewAuthorizer(access).Authorize(context.Background(), validRequest())
+		if !errors.Is(err, interfaces.ErrProxyExecutionUnavailable) {
+			t.Fatalf("Authorize() error = %v, want unavailable", err)
+		}
+	})
+	t.Run("policy unavailable", func(t *testing.T) {
+		access := &fakeAuthorizationAccess{
+			account:       validManagedProxy(),
+			permissionErr: errors.New("safe unavailable"),
+		}
+		err := NewAuthorizer(access).Authorize(context.Background(), validRequest())
+		if !errors.Is(err, interfaces.ErrProxyExecutionUnavailable) {
+			t.Fatalf("Authorize() error = %v, want unavailable", err)
+		}
+	})
+	t.Run("policy denied", func(t *testing.T) {
+		access := &fakeAuthorizationAccess{account: validManagedProxy(), permission: false}
+		err := NewAuthorizer(access).Authorize(context.Background(), validRequest())
+		if !errors.Is(err, interfaces.ErrProxyExecutionDenied) {
+			t.Fatalf("Authorize() error = %v, want denied", err)
+		}
+	})
+	t.Run("access missing", func(t *testing.T) {
+		err := NewAuthorizer(nil).Authorize(context.Background(), validRequest())
+		if !errors.Is(err, interfaces.ErrProxyExecutionUnavailable) {
+			t.Fatalf("Authorize() error = %v, want unavailable", err)
+		}
+	})
+}
+
+type recordingAudit struct {
+	events []interfaces.ProxyExecutionAuditEvent
+}
+
+func (r *recordingAudit) RecordProxyExecution(_ context.Context, event interfaces.ProxyExecutionAuditEvent) {
+	r.events = append(r.events, event)
+}
+
+func TestAuthorizeOutboundRunsOnlyAtManagedProxyBoundary(t *testing.T) {
+	if err := AuthorizeOutbound(context.Background(), nil, nil); err != nil {
+		t.Fatalf("direct execution error = %v", err)
+	}
+
+	t.Run("allowed", func(t *testing.T) {
+		access := &fakeAuthorizationAccess{account: validManagedProxy(), permission: true}
+		recorder := &recordingAudit{}
+		ctx := common.SetTraceContextToCtx(context.Background(), common.TraceContext{RequestID: "req_12345678"})
+		ctx = interfaces.WithProxyExecutionContext(ctx, validRequest())
+
+		if err := AuthorizeOutbound(ctx, NewAuthorizer(access), recorder); err != nil {
+			t.Fatalf("AuthorizeOutbound() error = %v", err)
+		}
+		if len(recorder.events) != 1 || recorder.events[0].Decision != "allow" ||
+			recorder.events[0].ExecutionID != "execution-1" ||
+			recorder.events[0].RequestID != "req_12345678" {
+			t.Fatalf("audit events = %+v", recorder.events)
+		}
+	})
+
+	tests := []struct {
+		name       string
+		access     *fakeAuthorizationAccess
+		authorizer interfaces.ProxyExecutionAuthorizer
+		wantStatus int
+		wantReason string
+	}{
+		{
+			name: "revoked after submission",
+			access: &fakeAuthorizationAccess{
+				account: validManagedProxy(), permission: false,
+			},
+			wantStatus: http.StatusForbidden,
+			wantReason: "proxy_or_policy_denied",
+		},
+		{
+			name: "bkn-safe unavailable",
+			access: &fakeAuthorizationAccess{
+				accountErr: errors.New("connection refused"),
+			},
+			wantStatus: http.StatusServiceUnavailable,
+			wantReason: "authorization_unavailable",
+		},
+		{
+			name:       "authorizer missing",
+			authorizer: nil,
+			wantStatus: http.StatusServiceUnavailable,
+			wantReason: "authorization_unavailable",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &recordingAudit{}
+			ctx := interfaces.WithProxyExecutionContext(context.Background(), validRequest())
+			authorizer := test.authorizer
+			if test.access != nil {
+				authorizer = NewAuthorizer(test.access)
+			}
+			err := AuthorizeOutbound(ctx, authorizer, recorder)
+			var httpErr *oerrors.HTTPError
+			if !errors.As(err, &httpErr) || httpErr.HTTPCode != test.wantStatus {
+				t.Fatalf("AuthorizeOutbound() error = %v, want HTTP %d", err, test.wantStatus)
+			}
+			if len(recorder.events) != 1 || recorder.events[0].Decision != "deny" ||
+				recorder.events[0].Reason != test.wantReason {
+				t.Fatalf("audit events = %+v", recorder.events)
+			}
+		})
+	}
+}

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/interfaces/model"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metric"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
 )
@@ -364,6 +365,9 @@ func (s *ToolServiceImpl) executeTool(ctx context.Context, req *interfaces.Execu
 		} else {
 			s.logWithheldManagedContext(ctx, req, url)
 		}
+	}
+	if err = proxyexecution.AuthorizeOutbound(ctx, s.ProxyAuthorizer, s.ProxyAudit); err != nil {
+		return nil, err
 	}
 	resp, err = s.Proxy.HandlerRequest(ctx, proxyReq)
 	return

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/execute_params_test.go
@@ -3,6 +3,7 @@ package toolbox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -182,5 +183,71 @@ func TestDebugTool_StripsPlatformHeadersBeforeExternalCall(t *testing.T) {
 	got := (*fixture.captured).Headers
 	if len(got) != 1 || got["X-Api-Key"] != "business-secret" {
 		t.Fatalf("external headers = %#v", got)
+	}
+}
+
+type failingProxyExecutionAuthorizer struct {
+	calls int
+	err   error
+}
+
+func (a *failingProxyExecutionAuthorizer) Authorize(context.Context, interfaces.ProxyExecutionContext) error {
+	a.calls++
+	return a.err
+}
+
+type toolProxyExecutionAudit struct {
+	events []interfaces.ProxyExecutionAuditEvent
+}
+
+func (a *toolProxyExecutionAudit) RecordProxyExecution(_ context.Context, event interfaces.ProxyExecutionAuditEvent) {
+	a.events = append(a.events, event)
+}
+
+func TestExecuteToolRechecksManagedProxyImmediatelyBeforeOutbound(t *testing.T) {
+	tests := map[string]error{
+		"grant revoked":        interfaces.ErrProxyExecutionDenied,
+		"bkn-safe unavailable": errors.New("connection refused"),
+	}
+	for name, authorizationErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := newDebugToolFixture(t, string(interfaces.ToolStatusTypeEnabled))
+			authorizer := &failingProxyExecutionAuthorizer{err: authorizationErr}
+			audit := &toolProxyExecutionAudit{}
+			fixture.service.ProxyAuthorizer = authorizer
+			fixture.service.ProxyAudit = audit
+			ctx := interfaces.WithProxyExecutionContext(context.Background(), interfaces.ProxyExecutionContext{
+				CallerID:     "caller-1",
+				CallerType:   "user",
+				KnowledgeID:  "kn-1",
+				ChildType:    interfaces.ProxyChildTypeAction,
+				ChildID:      "action-1",
+				ProxyID:      "proxy-1",
+				ProxyType:    interfaces.ProxyAccountTypeApp,
+				ProxyVersion: 3,
+				TargetType:   interfaces.ProxyTargetTypeToolBox,
+				TargetID:     "b1",
+				Operation:    interfaces.ProxyOperationExecute,
+				ExecutionID:  "execution-1",
+			})
+
+			response, err := fixture.service.ExecuteTool(ctx, &interfaces.ExecuteToolReq{
+				UserID: "u1", BoxID: "b1", ToolID: "t1",
+			})
+
+			if err == nil || response != nil {
+				t.Fatalf("ExecuteTool() = %+v, %v; want final authorization failure", response, err)
+			}
+			if authorizer.calls != 1 {
+				t.Fatalf("authorizer calls = %d, want 1", authorizer.calls)
+			}
+			if *fixture.captured != nil {
+				t.Fatalf("outbound request = %+v, want none", *fixture.captured)
+			}
+			if len(audit.events) != 1 || audit.events[0].Decision != "deny" ||
+				audit.events[0].ExecutionID != "execution-1" {
+				t.Fatalf("audit events = %+v", audit.events)
+			}
+		})
 	}
 }

--- a/adp/execution-factory/operator-integration/server/logics/toolbox/index.go
+++ b/adp/execution-factory/operator-integration/server/logics/toolbox/index.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/metric"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/operator"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy"
+	proxyexecution "github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/logics/proxy_execution"
 )
 
 var (
@@ -49,6 +50,8 @@ type ToolServiceImpl struct {
 	MetadataService  interfaces.IMetadataService
 	ActionEvidence   bkntrace.Emitter
 	ActionExecutions bkntrace.ExecutionGate
+	ProxyAuthorizer  interfaces.ProxyExecutionAuthorizer
+	ProxyAudit       interfaces.ProxyExecutionAuditRecorder
 }
 
 // NewToolServiceImpl creates a toolbox service.
@@ -72,6 +75,10 @@ func NewToolServiceImpl() interfaces.IToolService {
 			MetadataService:  metadata.NewMetadataService(),
 			ActionEvidence:   bkntrace.NewHTTPEmitter(),
 			ActionExecutions: bkntrace.NewRedisExecutionGate(redisClient),
+			ProxyAuthorizer: proxyexecution.NewAuthorizer(
+				drivenadapters.NewProxyExecutionAuthorizationAccess(),
+			),
+			ProxyAudit: proxyexecution.NewAuditLogger(conf.GetLogger()),
 		}
 	})
 	return toolService

--- a/adp/execution-factory/operator-integration/server/utils/external_headers_test.go
+++ b/adp/execution-factory/operator-integration/server/utils/external_headers_test.go
@@ -8,19 +8,21 @@ import "testing"
 
 func TestSanitizeThirdPartyHeaders(t *testing.T) {
 	input := map[string]string{
-		"Authorization":  "Bearer third-party-credential",
-		"X-Api-Key":      "business-key",
-		"x-account-id":   "internal-user",
-		"X-Account-Type": "user",
-		"user_id":        "internal-user",
-		"BKN-Request-ID": "request-1",
-		"traceparent":    "trace",
+		"Authorization":      "Bearer third-party-credential",
+		"X-Api-Key":          "business-key",
+		"x-account-id":       "internal-user",
+		"X-Account-Type":     "user",
+		"user_id":            "internal-user",
+		"BKN-Request-ID":     "request-1",
+		"x-bkn-caller-id":    "caller-1",
+		"X-BKN-Execution-ID": "execution-1",
+		"traceparent":        "trace",
 	}
 	got := SanitizeThirdPartyHeaders(input)
 	if len(got) != 2 || got["Authorization"] != input["Authorization"] || got["X-Api-Key"] != input["X-Api-Key"] {
 		t.Fatalf("sanitized headers = %#v", got)
 	}
-	if len(input) != 7 {
+	if len(input) != 9 {
 		t.Fatalf("input map was mutated: %#v", input)
 	}
 }

--- a/docs/api/bkn-safe/proxy-execution-pep.yaml
+++ b/docs/api/bkn-safe/proxy-execution-pep.yaml
@@ -1,0 +1,217 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+x-internal: true
+info:
+  title: Knowledge Network Managed Proxy Execution API
+  version: 0.1.0
+  description: |
+    Cluster-internal Tool and MCP execution contract used by ontology-query
+    after it resolves a current published ActionSource.
+
+    The caller remains the business principal that submitted an Action or
+    Schedule. X-Account-ID is the knowledge network's managed proxy account
+    and is used only as the effective principal for the bound target.
+
+    Execution Factory validates the complete trusted context and exact route,
+    then rechecks the managed proxy lifecycle and its exact execute grant in
+    bkn-safe immediately before creating or using the outbound client. Missing
+    context, revoked state, denied grants, and authorization dependency errors
+    all fail closed before a third-party request is sent.
+
+    This tokenless surface must remain behind the cluster network boundary.
+    The complete header set is trusted only when supplied by ontology-query; no
+    individual header is a standalone credential.
+servers:
+  - url: /api/agent-operator-integration/internal-v1
+security: []
+paths:
+  /tool-box/{box_id}/proxy/{tool_id}:
+    post:
+      operationId: executeToolAsKnowledgeNetworkProxy
+      summary: Execute a Tool through a managed knowledge-network proxy
+      description: |
+        Only an action_type or logic_property binding may use this route.
+        An action_type call must include its persisted execution ID.
+      parameters:
+        - $ref: '#/components/parameters/BoxID'
+        - $ref: '#/components/parameters/ToolID'
+        - $ref: '#/components/parameters/ProxyAccountID'
+        - $ref: '#/components/parameters/ProxyAccountType'
+        - $ref: '#/components/parameters/CallerID'
+        - $ref: '#/components/parameters/CallerType'
+        - $ref: '#/components/parameters/KnowledgeNetworkID'
+        - $ref: '#/components/parameters/ChildType'
+        - $ref: '#/components/parameters/ChildID'
+        - $ref: '#/components/parameters/ProxyVersion'
+        - $ref: '#/components/parameters/ToolBoxTargetType'
+        - $ref: '#/components/parameters/TargetID'
+        - $ref: '#/components/parameters/ExecuteOperation'
+        - $ref: '#/components/parameters/OptionalExecutionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolExecutionRequest'
+      responses:
+        '200':
+          description: Tool execution result.
+        '400':
+          description: The execution request or target configuration is invalid.
+        '403':
+          description: The trusted context is invalid, the proxy is inactive, or the exact grant is denied.
+        '503':
+          description: The final authorization check is unavailable.
+  /mcp/proxy/{mcp_id}/tool/call:
+    post:
+      operationId: callMCPToolAsKnowledgeNetworkProxy
+      summary: Call an MCP tool through a managed knowledge-network proxy
+      description: Only an action_type binding with a persisted execution ID may use this route.
+      parameters:
+        - $ref: '#/components/parameters/MCPID'
+        - $ref: '#/components/parameters/ProxyAccountID'
+        - $ref: '#/components/parameters/ProxyAccountType'
+        - $ref: '#/components/parameters/CallerID'
+        - $ref: '#/components/parameters/CallerType'
+        - $ref: '#/components/parameters/KnowledgeNetworkID'
+        - $ref: '#/components/parameters/ActionChildType'
+        - $ref: '#/components/parameters/ChildID'
+        - $ref: '#/components/parameters/ProxyVersion'
+        - $ref: '#/components/parameters/MCPTargetType'
+        - $ref: '#/components/parameters/TargetID'
+        - $ref: '#/components/parameters/ExecuteOperation'
+        - $ref: '#/components/parameters/ExecutionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MCPToolCallRequest'
+      responses:
+        '200':
+          description: MCP tool call result.
+        '400':
+          description: The call request or target configuration is invalid.
+        '403':
+          description: The trusted context is invalid, the proxy is inactive, or the exact grant is denied.
+        '503':
+          description: The final authorization check is unavailable.
+components:
+  parameters:
+    BoxID:
+      name: box_id
+      in: path
+      required: true
+      schema: { type: string }
+    ToolID:
+      name: tool_id
+      in: path
+      required: true
+      schema: { type: string }
+    MCPID:
+      name: mcp_id
+      in: path
+      required: true
+      schema: { type: string }
+    ProxyAccountID:
+      name: X-Account-ID
+      in: header
+      required: true
+      description: Effective managed proxy account ID.
+      schema: { type: string }
+    ProxyAccountType:
+      name: X-Account-Type
+      in: header
+      required: true
+      schema: { type: string, enum: [app] }
+    CallerID:
+      name: X-BKN-Caller-ID
+      in: header
+      required: true
+      description: Original business caller ID.
+      schema: { type: string }
+    CallerType:
+      name: X-BKN-Caller-Type
+      in: header
+      required: true
+      description: Original business caller type.
+      schema: { type: string }
+    KnowledgeNetworkID:
+      name: X-BKN-KN-ID
+      in: header
+      required: true
+      schema: { type: string }
+    ChildType:
+      name: X-BKN-Child-Type
+      in: header
+      required: true
+      schema: { type: string, enum: [action_type, logic_property] }
+    ActionChildType:
+      name: X-BKN-Child-Type
+      in: header
+      required: true
+      schema: { type: string, enum: [action_type] }
+    ChildID:
+      name: X-BKN-Child-ID
+      in: header
+      required: true
+      description: Published knowledge-network child ID.
+      schema: { type: string }
+    ProxyVersion:
+      name: X-BKN-Proxy-Version
+      in: header
+      required: true
+      description: Positive version of the BKN knowledge-network-to-proxy mapping.
+      schema: { type: integer, format: int64, minimum: 1 }
+    ToolBoxTargetType:
+      name: X-BKN-Target-Type
+      in: header
+      required: true
+      schema: { type: string, enum: [tool_box] }
+    MCPTargetType:
+      name: X-BKN-Target-Type
+      in: header
+      required: true
+      schema: { type: string, enum: [mcp] }
+    TargetID:
+      name: X-BKN-Target-ID
+      in: header
+      required: true
+      description: Must equal the target ID in the route.
+      schema: { type: string }
+    ExecuteOperation:
+      name: X-BKN-Operation
+      in: header
+      required: true
+      schema: { type: string, enum: [execute] }
+    ExecutionID:
+      name: X-BKN-Execution-ID
+      in: header
+      required: true
+      description: Persisted Action or Schedule-trigger execution ID.
+      schema: { type: string }
+    OptionalExecutionID:
+      name: X-BKN-Execution-ID
+      in: header
+      required: false
+      description: Required for action_type; omitted for logic_property.
+      schema: { type: string }
+  schemas:
+    ToolExecutionRequest:
+      type: object
+      additionalProperties: true
+      description: |
+        Existing Tool execution envelope. Business headers configured for the
+        third-party API are allowed; platform identity, trace, and internal BKN
+        headers are removed before the outbound request.
+    MCPToolCallRequest:
+      type: object
+      required: [tool_name]
+      properties:
+        tool_name: { type: string }
+        parameters:
+          type: object
+          additionalProperties: true

--- a/docs/api/execution-factory/README.md
+++ b/docs/api/execution-factory/README.md
@@ -19,6 +19,12 @@
 
 **All 89 public operations are documented.**
 
+The separate
+[managed-proxy contract](../bkn-safe/proxy-execution-pep.yaml)
+documents the cluster-internal, fail-closed Action and Schedule Tool/MCP
+execution boundary. It is linted but unpublished and is not part of the
+89-operation public API count.
+
 ## Run a function end to end
 
 **1. Read the template.** The entry function must be named `handler`.


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add a trusted managed-proxy execution boundary for Tool Box and MCP calls.
- [x] Enforce a fail-closed final authorization check immediately before outbound execution.
- [x] Add regression coverage and an unpublished English OpenAPI contract for the internal proxy routes.

---

## Why

- Related Issue: [Issue #1309](https://github.com/openbkn-ai/bkn-foundry/issues/1309)
- Related Feature: Action and Schedule managed proxy execution
- Background: Action and Schedule bindings must execute through a KN-managed proxy identity while preserving the original caller for audit, preventing target tampering and platform credential leakage, and rechecking the current proxy lifecycle and exact target grant at the final outbound boundary.

Closes #1309

---

## How

- Key implementation points:
  - Validate the trusted proxy context only on the internal Tool Box and MCP execution routes.
  - Strip proxy headers from public requests so existing direct calls retain their current behavior.
  - Clear inbound platform credentials before dispatching managed proxy requests.
  - Load the current managed proxy account from bkn-safe and validate its lifecycle, KN ownership, and exact execute grant.
  - Deny inactive, revoked, mismatched, malformed, or unauthorized requests before creating an MCP client or sending a Tool Box request.
  - Emit correlated structured audit events for allowed, denied, and unavailable authorization decisions.
- Breaking changes (API, config, database, etc.): No public API, database, or schema breaking changes. Managed proxy execution requires BKN_SAFE_URL; when that dependency is unavailable, the internal proxy path fails closed with HTTP 503.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — Not applicable yet because the upstream Action/Schedule proxy dispatch changes in #1307 and #1308 are not merged.
- [ ] Verified in test environment — Not run; no test-environment deployment was performed.

Test notes:

- go test ./server/logics/toolbox ./server/logics/mcp ./server/logics/proxy_execution ./server/driveradapters ./server/drivenadapters ./server/utils
- ./project.sh -t
- golangci-lint run --timeout=10m --new ./... (0 issues)
- redocly lint --config .redocly.yaml docs/api/bkn-safe/proxy-execution-pep.yaml
- git diff --check
- The repository project.sh -l wrapper uses the removed --exclude-dirs option with the locally installed golangci-lint v2.12.2. A direct full lint reports 41 pre-existing repository findings outside this change; new-diff lint passes.

---

## Risk & Rollback

- Potential risks: Incorrect proxy metadata or an unavailable bkn-safe service blocks managed proxy execution by design. End-to-end Action/Schedule integration remains dependent on #1307 and #1308.
- Rollback plan: Revert commit 0afb2f1e2; public direct Tool Box and MCP execution paths are otherwise unchanged.

---

## Additional Notes

- The internal request-header and route contract matches the currently submitted implementation in #1307.
- The managed-proxy OpenAPI contract is intentionally unpublished and is not included in the public execution-factory API operation count.
