### PR TITLE
feat(bkn): backfill capability metadata, mark dangling bindings, report box top-up

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -342,3 +342,54 @@ func (aoa *agentOperatorAccess) ListBoxTools(ctx context.Context, boxID string) 
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 	return tools, nil
 }
+
+// GetSkillNamesByIDs resolves skill names in bulk (POST .../skills/names).
+//
+// The endpoint's contract is that unknown IDs are skipped rather than returned empty, which is
+// what makes the difference between the request and the answer a usable dangling-reference set.
+func (aoa *agentOperatorAccess) GetSkillNamesByIDs(ctx context.Context, skillIDs []string) (map[string]string, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "GetSkillNamesByIDs")
+	defer span.End()
+
+	names := map[string]string{}
+	if len(skillIDs) == 0 {
+		return names, nil
+	}
+
+	url := fmt.Sprintf("%s/skills/names", aoa.agentOperatorURL)
+	oteltrace.AddAttrs4InternalHttp(span, oteltrace.TraceAttrs{
+		HttpUrl:         url,
+		HttpMethod:      http.MethodPost,
+		HttpContentType: rest.ContentTypeJson,
+	})
+
+	respCode, result, err := aoa.httpClient.PostNoUnmarshal(ctx, url, aoa.execFactoryHeaders(ctx),
+		map[string]any{"ids": skillIDs})
+	if err != nil {
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http post skill names failed")
+		common.LogSafeError(ctx, "Skill name lookup request failed", err)
+		return nil, fmt.Errorf("skill name lookup failed: %w", err)
+	}
+	if respCode != http.StatusOK {
+		common.LogSafeError(ctx, "Skill name lookup failed",
+			fmt.Errorf("skill name lookup returned HTTP %d", respCode))
+		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Post skill names failed")
+		return nil, fmt.Errorf("skill name lookup returned HTTP %d", respCode)
+	}
+
+	var payload struct {
+		Entries []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"entries"`
+	}
+	if err = json.Unmarshal(result, &payload); err != nil {
+		common.LogSafeError(ctx, "Unmarshal skill names failed", err)
+		return nil, fmt.Errorf("skill name lookup failed: %w", err)
+	}
+	for _, entry := range payload.Entries {
+		names[entry.ID] = entry.Name
+	}
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return names, nil
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
@@ -9,6 +9,7 @@ package driveradapters
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/audit"
@@ -196,6 +197,7 @@ func (r *restHandler) ListCapabilities(c *gin.Context, vis hydra.Visitor) {
 		Branch:         branch,
 		CapabilityType: c.Query("type"),
 		OwnerID:        c.Query("owner_id"),
+		WithDetail:     strings.EqualFold(strings.TrimSpace(c.Query("with_detail")), "true"),
 	})
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)

--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
@@ -196,8 +196,9 @@ func (r *restHandler) ListCapabilities(c *gin.Context, vis hydra.Visitor) {
 		KNID:           knID,
 		Branch:         branch,
 		CapabilityType: c.Query("type"),
-		OwnerID:        c.Query("owner_id"),
-		WithDetail:     strings.EqualFold(strings.TrimSpace(c.Query("with_detail")), "true"),
+		// Either spelling narrows by tool box; box_id is what every other surface calls it.
+		OwnerID:    firstNonEmpty(c.Query("owner_id"), c.Query("box_id")),
+		WithDetail: strings.EqualFold(strings.TrimSpace(c.Query("with_detail")), "true"),
 	})
 	if err != nil {
 		httpErr := err.(*rest.HTTPError)

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -17,7 +17,21 @@ const (
 	EXEC_BOX_STATUS_PUBLISHED = "published"
 	// EXEC_SKILL_STATUS_PUBLISHED is the skill lifecycle state that makes it loadable.
 	EXEC_SKILL_STATUS_PUBLISHED = "published"
+	// EXEC_SKILL_STATUS_EDITING is a skill that was published and has been edited since. Its
+	// published version stays in the retrieval index and stays loadable, so it is bindable too:
+	// editing a description must not make a skill unmountable.
+	EXEC_SKILL_STATUS_EDITING = "editing"
 )
+
+// SkillIsBindable reports whether a skill can be bound to a knowledge network.
+//
+// Both published and editing qualify. The execution factory flips published to editing on a
+// metadata edit while keeping the published version in the index, so treating editing as
+// unusable would tell the caller to publish a skill that is already published — and re-publishing
+// would be the only way out of an error the caller did not cause.
+func SkillIsBindable(status string) bool {
+	return status == EXEC_SKILL_STATUS_PUBLISHED || status == EXEC_SKILL_STATUS_EDITING
+}
 
 // SkillBrief is the part of a skill BKN needs to validate a capability binding: whether it
 // exists, and whether it is usable. Everything else stays in the execution factory.

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -17,21 +17,7 @@ const (
 	EXEC_BOX_STATUS_PUBLISHED = "published"
 	// EXEC_SKILL_STATUS_PUBLISHED is the skill lifecycle state that makes it loadable.
 	EXEC_SKILL_STATUS_PUBLISHED = "published"
-	// EXEC_SKILL_STATUS_EDITING is a skill that was published and has been edited since. Its
-	// published version stays in the retrieval index and stays loadable, so it is bindable too:
-	// editing a description must not make a skill unmountable.
-	EXEC_SKILL_STATUS_EDITING = "editing"
 )
-
-// SkillIsBindable reports whether a skill can be bound to a knowledge network.
-//
-// Both published and editing qualify. The execution factory flips published to editing on a
-// metadata edit while keeping the published version in the index, so treating editing as
-// unusable would tell the caller to publish a skill that is already published — and re-publishing
-// would be the only way out of an error the caller did not cause.
-func SkillIsBindable(status string) bool {
-	return status == EXEC_SKILL_STATUS_PUBLISHED || status == EXEC_SKILL_STATUS_EDITING
-}
 
 // SkillBrief is the part of a skill BKN needs to validate a capability binding: whether it
 // exists, and whether it is usable. Everything else stays in the execution factory.

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -65,6 +65,10 @@ type AgentOperatorAccess interface {
 	// skill does not exist, so the caller can tell "no such skill" from "exists but unpublished"
 	// — the market endpoint collapses both into 404, which is why it is not used here.
 	GetSkillByID(ctx context.Context, skillID string) (*SkillBrief, error)
+	// GetSkillNamesByIDs resolves several skills to their names in one call. Skills that do not
+	// exist are absent from the result rather than present with an empty name, so the difference
+	// between the request and the answer is exactly the set of dangling references.
+	GetSkillNamesByIDs(ctx context.Context, skillIDs []string) (map[string]string, error)
 	// ListBoxTools reads every tool of a tool box in one call, each with its status. It returns
 	// (nil, nil) when the box does not exist. The box endpoint inlines its tools, so validating
 	// and expanding a whole-box mount both cost one request per box rather than one per tool.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -74,12 +74,44 @@ type CapabilityBindingsQueryParams struct {
 	CapabilityType string
 	OwnerID        string
 	CapabilityIDs  []string
+	// WithDetail also fills description and status. Names alone cost one call per tool box and
+	// one for all skills; the detail of a skill has to be read one skill at a time, so it is
+	// asked for rather than always paid.
+	WithDetail bool
+}
+
+// CAPABILITY_STATUS_MISSING marks a binding whose target is gone from the execution factory.
+// Such a row is reported, never deleted: removing it silently would erase the only evidence that
+// the network once pointed at something, and retrieval already skips it without saying so.
+const CAPABILITY_STATUS_MISSING = "missing"
+
+// CapabilityBoxSummary reports how much of a tool box this branch has mounted. It exists because
+// a whole-box mount is expanded at write time and does not follow the box afterwards: without
+// this, a tool added to the box later is invisible to the person who mounted it.
+type CapabilityBoxSummary struct {
+	BoxID string `json:"box_id"`
+	// BoxName is empty when the execution factory could not be reached.
+	BoxName string `json:"box_name,omitempty"`
+	// BoxMissing marks a box that no longer exists; every binding under it is missing too.
+	BoxMissing bool `json:"box_missing,omitempty"`
+	// TotalTools counts the enabled tools currently in the box.
+	TotalTools int `json:"total_tools"`
+	// MountedTools counts those already bound to this branch.
+	MountedTools int `json:"mounted_tools"`
+	// UnmountedTools is what a one-click top-up would add.
+	UnmountedTools int `json:"unmounted_tools"`
 }
 
 // CapabilityBindingsList is the list response for GET .../capabilities.
 type CapabilityBindingsList struct {
 	Entries    []*CapabilityBinding `json:"entries"`
 	TotalCount int                  `json:"total_count"`
+	// Boxes summarises the tool boxes behind the whole-box mounts on this page.
+	Boxes []*CapabilityBoxSummary `json:"boxes,omitempty"`
+	// MetadataAvailable is false when the execution factory could not be reached. The bindings
+	// are still returned in full — the names are missing, not the memberships — and the flag
+	// says so explicitly so an empty name is not read as a deleted capability.
+	MetadataAvailable bool `json:"metadata_available"`
 }
 
 // AttachCapabilityEntry is one item of a mount request.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -29,16 +29,15 @@ type CapabilityBinding struct {
 	KNID           string `json:"kn_id" mapstructure:"kn_id"`
 	Branch         string `json:"branch" mapstructure:"branch"`
 	CapabilityType string `json:"capability_type" mapstructure:"capability_type"`
-	OwnerID        string `json:"owner_id,omitempty" mapstructure:"owner_id"`
-	CapabilityID   string `json:"capability_id" mapstructure:"capability_id"`
-	// BoundAsBox records how the row was created: by expanding a whole-box mount rather than by
-	// naming the tool. It is provenance, not current coverage — a tool bound individually and
-	// later included in a whole-box mount keeps the flag false, because that first gesture is
-	// still what created it.
-	//
-	// Anything asking "which tools of this box are bound" must therefore group by box, not
-	// filter on this flag. The row is an ordinary tool-level binding either way and can be
-	// released on its own.
+	// OwnerID is the container the capability belongs to: the tool box for a function, empty
+	// for a skill. The wire name is box_id, matching what the execution factory, Context Loader
+	// and Studio all call it; the field and its column stay type-neutral so a later capability
+	// type can bring a different kind of container without a migration.
+	OwnerID      string `json:"box_id,omitempty" mapstructure:"owner_id"`
+	CapabilityID string `json:"capability_id" mapstructure:"capability_id"`
+	// BoundAsBox marks a row produced by expanding a whole-box mount. It does not change the
+	// binding semantics — the row is still an ordinary tool-level binding and can be released
+	// on its own — it only lets the list view report how many tools of a box are not mounted.
 	BoundAsBox bool   `json:"bound_as_box" mapstructure:"bound_as_box"`
 	Comment    string `json:"comment,omitempty" mapstructure:"comment"`
 
@@ -117,9 +116,10 @@ type CapabilityBindingsList struct {
 // AttachCapabilityEntry is one item of a mount request.
 type AttachCapabilityEntry struct {
 	CapabilityType string `json:"capability_type"`
-	OwnerID        string `json:"owner_id"`
-	CapabilityID   string `json:"capability_id"`
-	Comment        string `json:"comment"`
+	// OwnerID names the tool box for a function binding and is ignored for a skill.
+	OwnerID      string `json:"box_id"`
+	CapabilityID string `json:"capability_id"`
+	Comment      string `json:"comment"`
 	// AllTools mounts every enabled tool of the box named by OwnerID. It is expanded at write
 	// time into one tool-level binding per tool, so the stored rows carry no box-level scope and
 	// the read path never expands anything. Tools added to the box later are not inherited: a

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
@@ -70,6 +70,21 @@ func (mr *MockAgentOperatorAccessMockRecorder) GetSkillByID(ctx, skillID any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillByID", reflect.TypeOf((*MockAgentOperatorAccess)(nil).GetSkillByID), ctx, skillID)
 }
 
+// GetSkillNamesByIDs mocks base method.
+func (m *MockAgentOperatorAccess) GetSkillNamesByIDs(ctx context.Context, skillIDs []string) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSkillNamesByIDs", ctx, skillIDs)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSkillNamesByIDs indicates an expected call of GetSkillNamesByIDs.
+func (mr *MockAgentOperatorAccessMockRecorder) GetSkillNamesByIDs(ctx, skillIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSkillNamesByIDs", reflect.TypeOf((*MockAgentOperatorAccess)(nil).GetSkillNamesByIDs), ctx, skillIDs)
+}
+
 // GetToolByID mocks base method.
 func (m *MockAgentOperatorAccess) GetToolByID(ctx context.Context, boxID, toolID string) error {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
@@ -1,0 +1,178 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
+
+	"bkn-backend/interfaces"
+)
+
+// backfillResult carries what a page of bindings needs beyond the stored rows.
+type backfillResult struct {
+	boxes []*interfaces.CapabilityBoxSummary
+	// available is false when any execution-factory call failed. The bindings are still returned;
+	// the flag stops an empty name from being read as a deleted capability.
+	available bool
+}
+
+// backfillMetadata fills name, description and status on a page of bindings, marks the ones whose
+// target is gone, and summarises the tool boxes behind whole-box mounts.
+//
+// Function metadata is read per box, not per tool: the box endpoint inlines its tools, so a page
+// of twenty function bindings spread over three boxes costs three calls rather than twenty. Skill
+// names are one call for the whole page. Only skill *detail* is per skill, which is why it is
+// behind with_detail rather than always paid.
+//
+// An execution factory that cannot be reached degrades to the stored rows. Listing memberships is
+// the point of the endpoint; the names are decoration, and failing the whole request over them
+// would take the mount UI down with the factory.
+func (cbs *capabilityBindingService) backfillMetadata(ctx context.Context,
+	bindings []*interfaces.CapabilityBinding, withDetail bool) backfillResult {
+	result := backfillResult{available: true}
+	if len(bindings) == 0 {
+		return result
+	}
+
+	boxBindings := map[string][]*interfaces.CapabilityBinding{}
+	skillBindings := map[string][]*interfaces.CapabilityBinding{}
+	for _, binding := range bindings {
+		switch binding.CapabilityType {
+		case interfaces.CAPABILITY_TYPE_FUNCTION:
+			boxBindings[binding.OwnerID] = append(boxBindings[binding.OwnerID], binding)
+		case interfaces.CAPABILITY_TYPE_SKILL:
+			skillBindings[binding.CapabilityID] = append(skillBindings[binding.CapabilityID], binding)
+		}
+	}
+
+	if len(boxBindings) > 0 {
+		summaries, ok := cbs.backfillFunctions(ctx, boxBindings, withDetail)
+		result.boxes = summaries
+		result.available = result.available && ok
+	}
+	if len(skillBindings) > 0 {
+		result.available = cbs.backfillSkills(ctx, skillBindings, withDetail) && result.available
+	}
+	return result
+}
+
+// backfillFunctions resolves one tool box per call and reports what is bound versus what the box
+// currently holds.
+func (cbs *capabilityBindingService) backfillFunctions(ctx context.Context,
+	boxBindings map[string][]*interfaces.CapabilityBinding, withDetail bool) ([]*interfaces.CapabilityBoxSummary, bool) {
+	available := true
+	summaries := make([]*interfaces.CapabilityBoxSummary, 0, len(boxBindings))
+
+	for boxID, bindings := range boxBindings {
+		tools, err := cbs.aoa.ListBoxTools(ctx, boxID)
+		if err != nil {
+			// Unreachable is not the same as absent: leaving the metadata empty and flagging the
+			// page keeps a transient outage from looking like a deleted tool box.
+			logger.Warnf("capability metadata backfill: tool box %s unreachable: %v", boxID, err)
+			available = false
+			continue
+		}
+
+		summary := &interfaces.CapabilityBoxSummary{BoxID: boxID}
+		if tools == nil {
+			// The box is gone, so every binding under it dangles.
+			summary.BoxMissing = true
+			for _, binding := range bindings {
+				binding.Status = interfaces.CAPABILITY_STATUS_MISSING
+			}
+			summaries = append(summaries, summary)
+			continue
+		}
+
+		byToolID := make(map[string]*interfaces.ToolBrief, len(tools))
+		for _, tool := range tools {
+			byToolID[tool.ToolID] = tool
+			if tool.Status == interfaces.EXEC_TOOL_STATUS_ENABLED {
+				summary.TotalTools++
+			}
+			summary.BoxName = tool.BoxName
+		}
+
+		mounted := map[string]struct{}{}
+		for _, binding := range bindings {
+			tool, ok := byToolID[binding.CapabilityID]
+			if !ok {
+				binding.Status = interfaces.CAPABILITY_STATUS_MISSING
+				continue
+			}
+			binding.Name = tool.Name
+			binding.OwnerName = tool.BoxName
+			if withDetail {
+				binding.Description = tool.Description
+			}
+			binding.Status = tool.Status
+			if tool.Status == interfaces.EXEC_TOOL_STATUS_ENABLED {
+				mounted[tool.ToolID] = struct{}{}
+			}
+		}
+		summary.MountedTools = len(mounted)
+		summary.UnmountedTools = summary.TotalTools - summary.MountedTools
+		if summary.UnmountedTools < 0 {
+			summary.UnmountedTools = 0
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, available
+}
+
+// backfillSkills resolves names for the whole page in one call. The IDs that come back missing are
+// exactly the dangling ones, because the endpoint skips unknown IDs instead of returning them
+// empty.
+func (cbs *capabilityBindingService) backfillSkills(ctx context.Context,
+	skillBindings map[string][]*interfaces.CapabilityBinding, withDetail bool) bool {
+	skillIDs := make([]string, 0, len(skillBindings))
+	for skillID := range skillBindings {
+		skillIDs = append(skillIDs, skillID)
+	}
+
+	names, err := cbs.aoa.GetSkillNamesByIDs(ctx, skillIDs)
+	if err != nil {
+		logger.Warnf("capability metadata backfill: skill names unreachable: %v", err)
+		return false
+	}
+
+	available := true
+	for skillID, bindings := range skillBindings {
+		name, found := names[skillID]
+		for _, binding := range bindings {
+			if !found {
+				binding.Status = interfaces.CAPABILITY_STATUS_MISSING
+				continue
+			}
+			binding.Name = name
+		}
+		if !found || !withDetail {
+			continue
+		}
+		// Description and status of a skill are only available one skill at a time, so this fan-out
+		// is bounded by the page size and is the reason detail is opt-in.
+		skill, detailErr := cbs.aoa.GetSkillByID(ctx, skillID)
+		if detailErr != nil {
+			logger.Warnf("capability metadata backfill: skill %s detail unreachable: %v", skillID, detailErr)
+			available = false
+			continue
+		}
+		if skill == nil {
+			for _, binding := range bindings {
+				binding.Status = interfaces.CAPABILITY_STATUS_MISSING
+			}
+			continue
+		}
+		for _, binding := range bindings {
+			binding.Description = skill.Description
+			binding.Status = skill.Status
+		}
+	}
+	return available
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
@@ -34,7 +34,8 @@ type backfillResult struct {
 // the point of the endpoint; the names are decoration, and failing the whole request over them
 // would take the mount UI down with the factory.
 func (cbs *capabilityBindingService) backfillMetadata(ctx context.Context,
-	bindings []*interfaces.CapabilityBinding, withDetail bool) backfillResult {
+	query interfaces.CapabilityBindingsQueryParams, bindings []*interfaces.CapabilityBinding,
+	withDetail bool) backfillResult {
 	result := backfillResult{available: true}
 	if len(bindings) == 0 {
 		return result
@@ -52,7 +53,7 @@ func (cbs *capabilityBindingService) backfillMetadata(ctx context.Context,
 	}
 
 	if len(boxBindings) > 0 {
-		summaries, ok := cbs.backfillFunctions(ctx, boxBindings, withDetail)
+		summaries, ok := cbs.backfillFunctions(ctx, query, boxBindings, withDetail)
 		result.boxes = summaries
 		result.available = result.available && ok
 	}
@@ -65,7 +66,8 @@ func (cbs *capabilityBindingService) backfillMetadata(ctx context.Context,
 // backfillFunctions resolves one tool box per call and reports what is bound versus what the box
 // currently holds.
 func (cbs *capabilityBindingService) backfillFunctions(ctx context.Context,
-	boxBindings map[string][]*interfaces.CapabilityBinding, withDetail bool) ([]*interfaces.CapabilityBoxSummary, bool) {
+	query interfaces.CapabilityBindingsQueryParams, boxBindings map[string][]*interfaces.CapabilityBinding,
+	withDetail bool) ([]*interfaces.CapabilityBoxSummary, bool) {
 	available := true
 	summaries := make([]*interfaces.CapabilityBoxSummary, 0, len(boxBindings))
 
@@ -99,7 +101,6 @@ func (cbs *capabilityBindingService) backfillFunctions(ctx context.Context,
 			summary.BoxName = tool.BoxName
 		}
 
-		mounted := map[string]struct{}{}
 		for _, binding := range bindings {
 			tool, ok := byToolID[binding.CapabilityID]
 			if !ok {
@@ -112,11 +113,21 @@ func (cbs *capabilityBindingService) backfillFunctions(ctx context.Context,
 				binding.Description = tool.Description
 			}
 			binding.Status = tool.Status
-			if tool.Status == interfaces.EXEC_TOOL_STATUS_ENABLED {
-				mounted[tool.ToolID] = struct{}{}
-			}
 		}
-		summary.MountedTools = len(mounted)
+
+		// The mounted count is over the whole branch, not over this page. Counting the page
+		// against a box-wide total mixes two scales: page one of a fully mounted 23-tool box
+		// would read "10 of 23 mounted, 13 to add", and the top-up it offers would do nothing
+		// because every tool is already bound.
+		mounted, err := cbs.countMountedTools(ctx, query, boxID, byToolID)
+		if err != nil {
+			// A wrong number is worse than no number: the summary is dropped rather than
+			// published with a count that would send the caller after tools already bound.
+			logger.Warnf("capability metadata backfill: mounted count for box %s failed: %v", boxID, err)
+			available = false
+			continue
+		}
+		summary.MountedTools = mounted
 		summary.UnmountedTools = summary.TotalTools - summary.MountedTools
 		if summary.UnmountedTools < 0 {
 			summary.UnmountedTools = 0
@@ -175,4 +186,34 @@ func (cbs *capabilityBindingService) backfillSkills(ctx context.Context,
 		}
 	}
 	return available
+}
+
+// countMountedTools counts the box's enabled tools bound anywhere on this branch.
+//
+// It reads the bindings of one box rather than reusing the page: the page is a slice of the whole
+// list, while the box total it is compared against is not, and subtracting one from the other
+// produces a number that is only right when the page happens to hold every binding of the box.
+func (cbs *capabilityBindingService) countMountedTools(ctx context.Context,
+	query interfaces.CapabilityBindingsQueryParams, boxID string,
+	tools map[string]*interfaces.ToolBrief) (int, error) {
+	rows, err := cbs.cba.ListBindings(ctx, interfaces.CapabilityBindingsQueryParams{
+		KNID:           query.KNID,
+		Branch:         query.Branch,
+		CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+		OwnerID:        boxID,
+	})
+	if err != nil {
+		return 0, err
+	}
+	mounted := map[string]struct{}{}
+	for _, row := range rows {
+		tool, ok := tools[row.CapabilityID]
+		if !ok || tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+			// A binding to a tool that is gone or disabled is not something a top-up would
+			// re-add, so it does not count as mounted either.
+			continue
+		}
+		mounted[row.CapabilityID] = struct{}{}
+	}
+	return len(mounted), nil
 }

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
@@ -186,3 +186,42 @@ func TestBackfillDegrades(t *testing.T) {
 		So(list.MetadataAvailable, ShouldBeFalse)
 	})
 }
+
+// TestWholeBoxTopUpIsAnotherMount pins the flow behind the list page's top-up button: re-issuing
+// the same whole-box mount adds only what is missing. Without this, "3 tools not mounted" would
+// need an endpoint of its own, and the frontend would have to diff the box against the bindings
+// itself.
+func TestWholeBoxTopUpIsAnotherMount(t *testing.T) {
+	Convey("重发整箱挂载即补挂,已绑定的不重复写入", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		existing := &interfaces.CapabilityBinding{
+			ID: "b1", KNID: "kn1", Branch: "main", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			OwnerID: "box-1", CapabilityID: "t1", BoundAsBox: true,
+		}
+		// The box now holds a tool that was added after the first mount.
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+			{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t2-new", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil)
+		cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
+			interfaces.CAPABILITY_TYPE_FUNCTION, "box-1", "t1").Return(existing, nil)
+		cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
+			interfaces.CAPABILITY_TYPE_FUNCTION, "box-1", "t2-new").Return(nil, nil)
+		// Only the new tool is written.
+		cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+		bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+			[]*interfaces.AttachCapabilityEntry{
+				{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", AllTools: true},
+			})
+
+		So(err, ShouldBeNil)
+		So(len(bindings), ShouldEqual, 2)
+		So(bindings[0].ID, ShouldEqual, "b1")
+		So(bindings[1].CapabilityID, ShouldEqual, "t2-new")
+		So(bindings[1].BoundAsBox, ShouldBeTrue)
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
@@ -40,7 +40,7 @@ func TestBackfillFanOut(t *testing.T) {
 			ID: "b-t9", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
 			OwnerID: "box-2", CapabilityID: "t9",
 		})
-		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(bindings, nil)
+		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(bindings, nil).AnyTimes()
 		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(4, nil)
 
 		// Four bindings, two boxes: exactly two calls.
@@ -74,7 +74,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "alive"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "deleted"},
-			}, nil)
+			}, nil).AnyTimes()
 			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
 			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
 				{BoxID: "box-1", ToolID: "alive", Name: "还在", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
@@ -94,7 +94,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t1"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t2"},
-			}, nil)
+			}, nil).AnyTimes()
 			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
 			aoa.EXPECT().ListBoxTools(gomock.Any(), "gone").Return(nil, nil)
 
@@ -112,7 +112,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "alive"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "deleted"},
-			}, nil)
+			}, nil).AnyTimes()
 			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
 			aoa.EXPECT().GetSkillNamesByIDs(gomock.Any(), gomock.Any()).
 				Return(map[string]string{"alive": "还在的技能"}, nil)
@@ -142,7 +142,7 @@ func TestBackfillBoxTopUp(t *testing.T) {
 		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1", BoundAsBox: true},
 			{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t2", BoundAsBox: true},
-		}, nil)
+		}, nil).AnyTimes()
 		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
 			{BoxID: "box-1", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
@@ -172,7 +172,7 @@ func TestBackfillDegrades(t *testing.T) {
 		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
 		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
-		}, nil)
+		}, nil).AnyTimes()
 		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return(nil, errors.New("connection refused"))
 
@@ -223,5 +223,54 @@ func TestWholeBoxTopUpIsAnotherMount(t *testing.T) {
 		So(bindings[0].ID, ShouldEqual, "b1")
 		So(bindings[1].CapabilityID, ShouldEqual, "t2-new")
 		So(bindings[1].BoundAsBox, ShouldBeTrue)
+	})
+}
+
+// TestBoxCountsAreBranchScoped pins the scale of the top-up counts. The page is a slice of the
+// list; the box total is not. Counting one against the other reads "10 of 23 mounted" for a box
+// that is fully mounted, and the top-up it offers does nothing because every tool is already
+// bound.
+func TestBoxCountsAreBranchScoped(t *testing.T) {
+	Convey("补挂计数按分支统计而不是按当前页", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+
+		page := []*interfaces.CapabilityBinding{
+			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
+			{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t2"},
+		}
+		everything := append(append([]*interfaces.CapabilityBinding{}, page...),
+			&interfaces.CapabilityBinding{ID: "b3", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+				OwnerID: "box-1", CapabilityID: "t3"})
+
+		// First call is the page (limit 2); the second is the box-scoped count with no limit.
+		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, q interfaces.CapabilityBindingsQueryParams) ([]*interfaces.CapabilityBinding, error) {
+				if q.Limit > 0 {
+					return page, nil
+				}
+				So(q.OwnerID, ShouldEqual, "box-1")
+				So(q.CapabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_FUNCTION)
+				return everything, nil
+			}).Times(2)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+			{BoxID: "box-1", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", ToolID: "t2", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", ToolID: "t3", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil)
+
+		query := listQuery()
+		query.Limit = 2
+		list, err := service.ListCapabilities(context.Background(), query)
+
+		So(err, ShouldBeNil)
+		So(len(list.Entries), ShouldEqual, 2)
+		// Three of three are mounted even though this page shows two.
+		So(list.Boxes[0].TotalTools, ShouldEqual, 3)
+		So(list.Boxes[0].MountedTools, ShouldEqual, 3)
+		So(list.Boxes[0].UnmountedTools, ShouldEqual, 0)
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
@@ -1,0 +1,188 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/interfaces"
+)
+
+func listQuery() interfaces.CapabilityBindingsQueryParams {
+	return interfaces.CapabilityBindingsQueryParams{KNID: "kn1", Branch: "main"}
+}
+
+// TestBackfillFanOut covers the cost rule of #1263: function metadata is read per tool box, not
+// per tool, so a page stays cheap as the number of bound tools grows.
+func TestBackfillFanOut(t *testing.T) {
+	Convey("function 回填按箱不按工具", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		bindings := []*interfaces.CapabilityBinding{}
+		for _, toolID := range []string{"t1", "t2", "t3"} {
+			bindings = append(bindings, &interfaces.CapabilityBinding{
+				ID: "b-" + toolID, CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+				OwnerID: "box-1", CapabilityID: toolID,
+			})
+		}
+		bindings = append(bindings, &interfaces.CapabilityBinding{
+			ID: "b-t9", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			OwnerID: "box-2", CapabilityID: "t9",
+		})
+		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(bindings, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(4, nil)
+
+		// Four bindings, two boxes: exactly two calls.
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+			{BoxID: "box-1", BoxName: "库存工具箱", ToolID: "t1", Name: "查库存", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", BoxName: "库存工具箱", ToolID: "t2", Name: "改库存", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", BoxName: "库存工具箱", ToolID: "t3", Name: "删库存", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil).Times(1)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-2").Return([]*interfaces.ToolBrief{
+			{BoxID: "box-2", BoxName: "另一个箱", ToolID: "t9", Name: "别的工具", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil).Times(1)
+
+		list, err := service.ListCapabilities(context.Background(), listQuery())
+
+		So(err, ShouldBeNil)
+		So(list.MetadataAvailable, ShouldBeTrue)
+		So(list.Entries[0].Name, ShouldEqual, "查库存")
+		So(list.Entries[0].OwnerName, ShouldEqual, "库存工具箱")
+	})
+}
+
+// TestBackfillMarksDangling covers the rule that a vanished target is reported, not deleted.
+// Retrieval already skips such a reference silently, so the list is the only place the gap shows.
+func TestBackfillMarksDangling(t *testing.T) {
+	Convey("悬空绑定被标记而不是被删除", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("工具在执行工厂侧被删除", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "alive"},
+				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "deleted"},
+			}, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+				{BoxID: "box-1", ToolID: "alive", Name: "还在", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			}, nil)
+			// No delete expectation: the controller fails the test if the row is removed.
+
+			list, err := service.ListCapabilities(context.Background(), listQuery())
+
+			So(err, ShouldBeNil)
+			So(len(list.Entries), ShouldEqual, 2)
+			So(list.Entries[0].Status, ShouldEqual, interfaces.EXEC_TOOL_STATUS_ENABLED)
+			So(list.Entries[1].Status, ShouldEqual, interfaces.CAPABILITY_STATUS_MISSING)
+		})
+
+		Convey("整个工具箱不存在时该箱下全部绑定判为悬空", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t1"},
+				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t2"},
+			}, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			aoa.EXPECT().ListBoxTools(gomock.Any(), "gone").Return(nil, nil)
+
+			list, err := service.ListCapabilities(context.Background(), listQuery())
+
+			So(err, ShouldBeNil)
+			for _, entry := range list.Entries {
+				So(entry.Status, ShouldEqual, interfaces.CAPABILITY_STATUS_MISSING)
+			}
+			So(list.Boxes[0].BoxMissing, ShouldBeTrue)
+		})
+
+		Convey("技能被删除:names 不返回该 id 即为悬空", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "alive"},
+				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "deleted"},
+			}, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			aoa.EXPECT().GetSkillNamesByIDs(gomock.Any(), gomock.Any()).
+				Return(map[string]string{"alive": "还在的技能"}, nil)
+
+			list, err := service.ListCapabilities(context.Background(), listQuery())
+
+			So(err, ShouldBeNil)
+			byID := map[string]*interfaces.CapabilityBinding{}
+			for _, entry := range list.Entries {
+				byID[entry.ID] = entry
+			}
+			So(byID["b1"].Name, ShouldEqual, "还在的技能")
+			So(byID["b2"].Status, ShouldEqual, interfaces.CAPABILITY_STATUS_MISSING)
+		})
+	})
+}
+
+// TestBackfillBoxTopUp covers the count the list page needs to offer a one-click top-up: a
+// whole-box mount is expanded at write time and does not follow the box, so a tool added later is
+// invisible without this.
+func TestBackfillBoxTopUp(t *testing.T) {
+	Convey("箱内新增工具后能给出未挂载数量", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1", BoundAsBox: true},
+			{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t2", BoundAsBox: true},
+		}, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
+			{BoxID: "box-1", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", ToolID: "t2", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			{BoxID: "box-1", ToolID: "t3-new", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+			// A disabled tool is not something a top-up would add, so it is not counted.
+			{BoxID: "box-1", ToolID: "t4-off", Status: "disabled"},
+		}, nil)
+
+		list, err := service.ListCapabilities(context.Background(), listQuery())
+
+		So(err, ShouldBeNil)
+		So(len(list.Boxes), ShouldEqual, 1)
+		So(list.Boxes[0].TotalTools, ShouldEqual, 3)
+		So(list.Boxes[0].MountedTools, ShouldEqual, 2)
+		So(list.Boxes[0].UnmountedTools, ShouldEqual, 1)
+	})
+}
+
+// TestBackfillDegrades covers the outage rule: listing memberships is the job, names are
+// decoration, and an unreachable factory must not take the mount UI down with it.
+func TestBackfillDegrades(t *testing.T) {
+	Convey("执行工厂不可达时仍返回绑定并标注元数据缺失", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
+		}, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return(nil, errors.New("connection refused"))
+
+		list, err := service.ListCapabilities(context.Background(), listQuery())
+
+		So(err, ShouldBeNil)
+		So(len(list.Entries), ShouldEqual, 1)
+		So(list.Entries[0].Name, ShouldBeEmpty)
+		// An outage must not read as a deleted capability.
+		So(list.Entries[0].Status, ShouldNotEqual, interfaces.CAPABILITY_STATUS_MISSING)
+		So(list.MetadataAvailable, ShouldBeFalse)
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -267,7 +267,7 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 			berrors.BknBackend_CapabilityBinding_InternalError_GetBindingsTotalFailed).WithErrorDetails(err.Error())
 	}
 
-	backfilled := cbs.backfillMetadata(ctx, entries, query.WithDetail)
+	backfilled := cbs.backfillMetadata(ctx, query, entries, query.WithDetail)
 
 	span.SetStatus(codes.Ok, "")
 	return &interfaces.CapabilityBindingsList{

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -267,8 +267,15 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 			berrors.BknBackend_CapabilityBinding_InternalError_GetBindingsTotalFailed).WithErrorDetails(err.Error())
 	}
 
+	backfilled := cbs.backfillMetadata(ctx, entries, query.WithDetail)
+
 	span.SetStatus(codes.Ok, "")
-	return &interfaces.CapabilityBindingsList{Entries: entries, TotalCount: total}, nil
+	return &interfaces.CapabilityBindingsList{
+		Entries:           entries,
+		TotalCount:        total,
+		Boxes:             backfilled.boxes,
+		MetadataAvailable: backfilled.available,
+	}, nil
 }
 
 func (cbs *capabilityBindingService) GetCapabilityTotalsByType(ctx context.Context, knID,

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
@@ -165,7 +165,7 @@ func (cbs *capabilityBindingService) validateSkill(ctx context.Context, skillID 
 			berrors.BknBackend_CapabilityBinding_TargetNotFound).
 			WithErrorDetails(fmt.Sprintf("skill not found: skill_id=%s", skillID))
 	}
-	if skill.Status != interfaces.EXEC_SKILL_STATUS_PUBLISHED {
+	if !interfaces.SkillIsBindable(skill.Status) {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest,
 			berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
 			WithErrorDetails(fmt.Sprintf("skill is not published: skill_id=%s status=%s", skillID, skill.Status))

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation.go
@@ -165,7 +165,7 @@ func (cbs *capabilityBindingService) validateSkill(ctx context.Context, skillID 
 			berrors.BknBackend_CapabilityBinding_TargetNotFound).
 			WithErrorDetails(fmt.Sprintf("skill not found: skill_id=%s", skillID))
 	}
-	if !interfaces.SkillIsBindable(skill.Status) {
+	if skill.Status != interfaces.EXEC_SKILL_STATUS_PUBLISHED {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest,
 			berrors.BknBackend_CapabilityBinding_TargetNotAvailable).
 			WithErrorDetails(fmt.Sprintf("skill is not published: skill_id=%s status=%s", skillID, skill.Status))

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
@@ -239,3 +239,48 @@ func TestBoxIDIsTheOnlySpelling(t *testing.T) {
 		})
 	})
 }
+
+// TestSkillEditingIsBindable covers the state a skill enters after its metadata is edited.
+//
+// The execution factory flips published to editing on a metadata edit and keeps the published
+// version in the retrieval index, so such a skill is still loadable. Refusing to bind it would
+// answer "publish it first" about a skill that is already published, and re-publishing would be
+// the only way out of an error the caller did not cause.
+func TestSkillEditingIsBindable(t *testing.T) {
+	Convey("已发布后又编辑过的技能仍可挂载", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("editing 可挂载", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
+				Return(&interfaces.SkillBrief{SkillID: "s1", Status: interfaces.EXEC_SKILL_STATUS_EDITING}, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
+				interfaces.CAPABILITY_TYPE_SKILL, "", "s1").Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+				[]*interfaces.AttachCapabilityEntry{
+					{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
+				})
+
+			So(err, ShouldBeNil)
+			So(len(bindings), ShouldEqual, 1)
+		})
+
+		Convey("从未发布与已下线仍被拒", func() {
+			for _, status := range []string{"unpublish", "offline"} {
+				service, _, aoa := newTestServiceWithFactory(t, ctrl)
+				aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
+					Return(&interfaces.SkillBrief{SkillID: "s1", Status: status}, nil)
+
+				_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
+					[]*interfaces.AttachCapabilityEntry{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
+					})
+
+				So(errorCodeOf(t, err), ShouldContainSubstring, "TargetNotAvailable")
+			}
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/validation_test.go
@@ -8,6 +8,7 @@ package capability_binding
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"testing"
@@ -202,47 +203,39 @@ func TestAttachExpandsWholeBox(t *testing.T) {
 	})
 }
 
-// TestSkillEditingIsBindable covers the state a skill enters after its metadata is edited.
-//
-// The execution factory flips published to editing on a metadata edit and keeps the published
-// version in the retrieval index, so such a skill is still loadable. Refusing to bind it would
-// answer "publish it first" about a skill that is already published, and re-publishing would be
-// the only way out of an error the caller did not cause.
-func TestSkillEditingIsBindable(t *testing.T) {
-	Convey("已发布后又编辑过的技能仍可挂载", t, func() {
+// TestBoxIDIsTheOnlySpelling pins the wire name. The stored column is type-neutral (a skill has
+// no container, and a later capability type may bring a different kind), but the payload uses the
+// name the execution factory, Context Loader and Studio already use for a tool box.
+func TestBoxIDIsTheOnlySpelling(t *testing.T) {
+	Convey("工具箱在报文里叫 box_id", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		Convey("editing 可挂载", func() {
-			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
-			aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
-				Return(&interfaces.SkillBrief{SkillID: "s1", Status: interfaces.EXEC_SKILL_STATUS_EDITING}, nil)
-			cba.EXPECT().GetBindingByCapability(gomock.Any(), "kn1", "main",
-				interfaces.CAPABILITY_TYPE_SKILL, "", "s1").Return(nil, nil)
-			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
-
-			bindings, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
-				[]*interfaces.AttachCapabilityEntry{
-					{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
-				})
-
-			So(err, ShouldBeNil)
-			So(len(bindings), ShouldEqual, 1)
+		Convey("请求体解析 box_id", func() {
+			entry := &interfaces.AttachCapabilityEntry{}
+			So(json.Unmarshal([]byte(`{"capability_type":"function","box_id":"box-1","capability_id":"t1"}`), entry), ShouldBeNil)
+			So(entry.OwnerID, ShouldEqual, "box-1")
 		})
 
-		Convey("从未发布与已下线仍被拒", func() {
-			for _, status := range []string{"unpublish", "offline"} {
-				service, _, aoa := newTestServiceWithFactory(t, ctrl)
-				aoa.EXPECT().GetSkillByID(gomock.Any(), "s1").
-					Return(&interfaces.SkillBrief{SkillID: "s1", Status: status}, nil)
+		Convey("旧的 owner_id 不再被识别", func() {
+			entry := &interfaces.AttachCapabilityEntry{}
+			So(json.Unmarshal([]byte(`{"capability_type":"function","owner_id":"box-1","capability_id":"t1"}`), entry), ShouldBeNil)
+			So(entry.OwnerID, ShouldBeEmpty)
+		})
 
-				_, err := service.AttachCapabilities(context.Background(), nil, "kn1", "main",
-					[]*interfaces.AttachCapabilityEntry{
-						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1"},
-					})
+		Convey("function 出参是 box_id,skill 不带该字段", func() {
+			fn, err := json.Marshal(&interfaces.CapabilityBinding{
+				CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1",
+			})
+			So(err, ShouldBeNil)
+			So(string(fn), ShouldContainSubstring, `"box_id":"box-1"`)
+			So(string(fn), ShouldNotContainSubstring, "owner_id")
 
-				So(errorCodeOf(t, err), ShouldContainSubstring, "TargetNotAvailable")
-			}
+			skill, err := json.Marshal(&interfaces.CapabilityBinding{
+				CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "s1",
+			})
+			So(err, ShouldBeNil)
+			So(string(skill), ShouldNotContainSubstring, "box_id")
 		})
 	})
 }

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -76,10 +76,45 @@ info:
     with no tool to mount is a 400, not a silent success — "I mounted the box" and "nothing
     happened" must not look alike.
 
-    ## Not covered here
+    ## Metadata is backfilled, not stored
 
-    Metadata backfill and dangling marking arrive with the rest of the capability binding work;
-    this file describes the CRUD surface only.
+    A binding stores only the reference. Names, descriptions and statuses are read from the
+    execution factory when the list is served, so they never go stale and the master data stays
+    in one place.
+
+    The reads are shaped around what costs what. Function metadata comes **per tool box**, not
+    per tool: the box endpoint inlines its tools, so a page of twenty function bindings across
+    three boxes costs three calls. Skill names are one call for the whole page. Only a skill's
+    description and status must be read one skill at a time, which is why they are behind
+    `with_detail=true` rather than always paid.
+
+    ## Dangling bindings are marked, never deleted
+
+    A binding whose target has been removed from the execution factory comes back with
+    `status: "missing"`. It is not deleted: removing it silently would erase the evidence that
+    the network once pointed at something, and it is the owner's decision whether to clean it up
+    or restore the capability. When a whole tool box is gone, every binding under it is marked
+    and the box appears in `boxes` with `box_missing: true`.
+
+    This matters because retrieval treats a dangling reference as simply absent — it matches
+    nothing and says nothing. Without the marker the only symptom is "the navigation says four
+    functions but only three ever come back".
+
+    ## Whole-box top-up
+
+    A whole-box mount is expanded at write time and does not follow the box afterwards, so tools
+    added later are not bound. `boxes` reports `total_tools`, `mounted_tools` and
+    `unmounted_tools` per box so the list can show "20 of 23 mounted" and offer to add the rest
+    deliberately. Disabled tools are excluded from the totals: they are not something a top-up
+    would add.
+
+    ## When the execution factory is down
+
+    Listing degrades rather than fails: the bindings come back in full with empty metadata and
+    `metadata_available: false`. Listing memberships is the point of the endpoint and the names
+    are decoration — failing the request would take the mount UI down with the factory. The flag
+    exists so an empty name is not read as a deleted capability; an outage and a deletion must
+    not look alike.
 
     **Prefix aliases**: every path below is also served under `/api/ontology-manager/v1`, and
     the internal face under `/api/bkn-backend/in/v1` and `/api/ontology-manager/in/v1`.
@@ -111,6 +146,14 @@ paths:
           description: Filter by owning tool box. Only meaningful for functions.
           schema:
             type: string
+          in: query
+        - name: with_detail
+          description: >-
+            Also fill description and status. A skill's detail is read one skill at a time, so
+            this is opt-in; function detail arrives with the box response either way.
+          schema:
+            type: boolean
+            default: false
           in: query
         - name: offset
           description: Offset. Defaults to 0.
@@ -299,7 +342,9 @@ components:
           description: Capability description, backfilled from the execution factory
           type: string
         status:
-          description: Capability status in the execution factory, backfilled
+          description: >-
+            Capability status in the execution factory, backfilled. The value `missing` means the
+            target no longer exists there; the binding is reported, not deleted.
           type: string
         owner_name:
           description: Tool box name, backfilled
@@ -316,12 +361,39 @@ components:
           description: Update time in milliseconds
           type: integer
           format: int64
+    CapabilityBoxSummary:
+      description: How much of a tool box this branch has mounted
+      type: object
+      required:
+        - box_id
+        - total_tools
+        - mounted_tools
+        - unmounted_tools
+      properties:
+        box_id:
+          type: string
+        box_name:
+          description: Empty when the execution factory could not be reached
+          type: string
+        box_missing:
+          description: The box no longer exists; every binding under it is missing too
+          type: boolean
+        total_tools:
+          description: Enabled tools currently in the box
+          type: integer
+        mounted_tools:
+          description: Of those, the ones bound to this branch
+          type: integer
+        unmounted_tools:
+          description: What a one-click top-up would add
+          type: integer
     CapabilityBindingList:
       description: Capability binding list
       type: object
       required:
         - entries
         - total_count
+        - metadata_available
       properties:
         entries:
           type: array
@@ -330,6 +402,16 @@ components:
         total_count:
           description: Total matching bindings, ignoring pagination
           type: integer
+        boxes:
+          description: The tool boxes behind the whole-box mounts on this page
+          type: array
+          items:
+            $ref: '#/components/schemas/CapabilityBoxSummary'
+        metadata_available:
+          description: >-
+            False when the execution factory could not be reached. The bindings are still
+            complete; only their names, descriptions and statuses are missing.
+          type: boolean
     AttachCapabilitiesRequest:
       description: Mount request
       type: object

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -13,15 +13,20 @@ info:
 
     A capability is identified by three parts:
 
-    | capability_type | owner_id | capability_id |
+    | capability_type | box_id | capability_id |
     |---|---|---|
     | `skill` | empty | `skill_id` |
     | `function` | `box_id` | `tool_id` |
 
-    `owner_id` is required for a function because a tool id is scoped to its box in the
-    execution factory. A skill has no owning container, so an `owner_id` sent with a skill is
-    dropped rather than stored — keeping it would create a second row for the same skill that
-    the unique key cannot collapse, and repeated mounts would stop being idempotent.
+    `box_id` is required for a function because a tool id is scoped to its box in the execution
+    factory, and it is the same name the execution factory, Context Loader and Studio already
+    use. A skill has no container and omits it.
+
+    The stored column behind it is type-neutral (`f_owner_id`) so a later capability type can
+    bring a different kind of container without a migration; that name does not appear on the
+    wire. A `box_id` sent with a skill is dropped rather than stored — keeping it would create a
+    second row for the same skill that the unique key cannot collapse, and repeated mounts would
+    stop being idempotent.
 
     ## What a binding answers
 
@@ -62,7 +67,7 @@ info:
 
     ## Whole-box mounting
 
-    `{"capability_type": "function", "owner_id": "box-x", "all_tools": true}` mounts every
+    `{"capability_type": "function", "box_id": "box-x", "all_tools": true}` mounts every
     enabled tool of that box. The expansion happens **at write time**: the stored rows are
     ordinary tool-level bindings carrying `bound_as_box: true`, so the read path never expands
     anything and any single row can be released on its own.
@@ -142,7 +147,7 @@ paths:
               - function
             type: string
           in: query
-        - name: owner_id
+        - name: box_id
           description: Filter by owning tool box. Only meaningful for functions.
           schema:
             type: string
@@ -230,7 +235,7 @@ paths:
         '400':
           description: >-
             Empty capability list, unsupported capability_type, missing capability_id, a
-            function without owner_id, or a value longer than its column: owner_id and
+            function without box_id, or a value longer than its column: box_id and
             capability_id are limited to 64 characters and comment to 255. Over-long values are
             rejected here rather than reaching the database, where they would surface as a 500
             under strict SQL mode or be silently truncated into a binding pointing at a
@@ -256,7 +261,7 @@ paths:
       description: |
         Releases by binding ID, comma separated for a batch. IDs that are already gone are not
         an error. Binding IDs are used rather than the capability identity because a
-        tool-level binding needs owner_id as well to be located, and identifiers containing
+        tool-level binding needs box_id as well to be located, and identifiers containing
         special characters would have to be escaped in the path.
       parameters:
         - name: kn_id
@@ -318,8 +323,8 @@ components:
             - skill
             - function
           type: string
-        owner_id:
-          description: Owning tool box ID. Present for functions, empty for skills.
+        box_id:
+          description: Owning tool box ID. Present for functions, absent for skills.
           type: string
         capability_id:
           description: Execution-factory identifier — skill_id for a skill, tool_id for a function
@@ -435,7 +440,7 @@ components:
             - skill
             - function
           type: string
-        owner_id:
+        box_id:
           description: Tool box ID. Required for a function, ignored for a skill.
           type: string
         capability_id:
@@ -444,7 +449,7 @@ components:
           type: string
         all_tools:
           description: >-
-            Mount every enabled tool of the box named by owner_id. Expanded at write time into
+            Mount every enabled tool of the box named by box_id. Expanded at write time into
             one tool-level binding per tool, each with bound_as_box true; tools added to the box
             later are not inherited.
           type: boolean

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -113,6 +113,12 @@ info:
     deliberately. Disabled tools are excluded from the totals: they are not something a top-up
     would add.
 
+    These counts are **per branch, not per page**. Pagination slices the entry list, not the box,
+    so counting a page against a box-wide total would read "10 of 23 mounted" for a box that is
+    fully mounted and offer a top-up that does nothing. When the count cannot be established the
+    box is omitted from `boxes` and `metadata_available` turns false, rather than published with
+    a number that would send the caller after tools that are already bound.
+
     ## When the execution factory is down
 
     Listing degrades rather than fails: the bindings come back in full with empty metadata and


### PR DESCRIPTION
Closes #1263. Part of Epic #1266. **Stacked on #1326** (`feat/1258-capability-write-validation`) because it uses the execution-factory client that PR adds; retarget to `main` once #1326 lands.

This is what the Studio list page needs: without it a bound capability is a bare UUID, a deleted one is indistinguishable from a live one, and a whole-box mount silently stops covering the box.

## Reads shaped by what they cost

| Metadata | Source | Fan-out |
|---|---|---|
| Function name / description / status | `GET /internal-v1/tool-box/{box_id}` — inlines its tools | number of **boxes** on the page |
| Skill name | `POST /internal-v1/skills/names` | one call for the page |
| Skill description / status | `GET /internal-v1/skills/{id}` | one per skill — hence `with_detail=true` |

Twenty function bindings across three boxes cost three calls, and stay flat as tools are added.

## Dangling is marked, never deleted

A binding whose target is gone comes back with `status: "missing"`. Deleting it would erase the evidence that the network once pointed at something, and cleaning up versus restoring is the owner's call. A vanished box marks every binding under it and reports `box_missing`.

This matters because retrieval treats a dangling reference as simply absent — it matches nothing and says nothing. Without the marker the only symptom is "the navigation says four functions but three come back".

## Whole-box top-up

A whole-box mount is expanded at write time and does not follow the box. Each box now reports `total_tools` / `mounted_tools` / `unmounted_tools`, which is what the page needs to show "20 of 23 mounted" and offer to add the rest deliberately. Disabled tools are excluded — a top-up would not add them.

## Outage ≠ deletion

An unreachable execution factory degrades: bindings come back in full, metadata empty, `metadata_available: false`. Listing memberships is the point of the endpoint; names are decoration. The flag exists so an empty name is not read as a deleted capability.

## Verified on the test server

Isolated deployment copies, binary md5 checked local → server → pod. The shared execution factory there predates #1290, so a copy built from current `main` was stood up and the verification backend pointed at it via its own ConfigMap.

| Check | Result |
|---|---|
| Names and box name backfilled | `PostmanEcho_GET … owner: 行动` |
| Box summary after a whole-box mount | `total 7 / mounted 7 / unmounted 0` |
| Binding to a deleted tool | `status: "missing"`, row still in the table |
| Releasing one row | summary moves to `7 / 6 / 1` |
| `with_detail=true` | 604-character description present |
| Without it | description empty |
| Box that no longer exists | both its bindings missing, `box_missing: true` |
| Factory scaled to zero | HTTP 200, 8 complete bindings, `metadata_available: false`, names empty, status *not* "missing" |

`go build ./...` passes; `go test ./...` is 0 FAIL. Test data and every temporary namespace object were removed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)