### PR TITLE
fix(bkn-trace): preserve conversation terminal previews

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -1546,9 +1546,20 @@ func (s *Service) listConversationIdentityPage(ctx context.Context, options evid
 		return evidencevo.ConversationSummaryPage{Entries: []evidencevo.ConversationSummary{}, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit)}, true, nil
 	}
 	ids := summaryIdentityIDs(identityPage.Entries)
+	interactionIDs, interactionsByConversation, err := s.listCanonicalInteractionIDs(ctx, ids)
+	if err != nil {
+		return evidencevo.ConversationSummaryPage{}, true, err
+	}
+	terminalArtifactTypes := []evidencevo.ArtifactType(nil)
+	if len(interactionIDs) > 0 {
+		terminalArtifactTypes = []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult}
+	}
 	requests, _, metadata, err := s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
 		Scope:           options.Scope,
-		ConversationIDs: ids, Limit: selectedSummaryCandidateLimit(len(ids)),
+		ConversationIDs: ids,
+		InteractionIDs:  interactionIDs,
+		ArtifactTypes:   terminalArtifactTypes,
+		Limit:           selectedSummaryCandidateLimit(len(ids)),
 	}, summaryLoadMetadata{})
 	if err != nil {
 		return evidencevo.ConversationSummaryPage{}, true, err
@@ -1575,6 +1586,14 @@ func (s *Service) listConversationIdentityPage(ctx context.Context, options evid
 	if err := s.applyCanonicalConversationState(ctx, entriesForCanonical, grouped); err != nil {
 		return evidencevo.ConversationSummaryPage{}, true, err
 	}
+	for index := range entriesForCanonical {
+		if interactions, found := interactionsByConversation[entriesForCanonical[index].ConversationID]; found {
+			entriesForCanonical[index].InteractionCount = len(interactions)
+			applyFirstCanonicalConversationPreview(
+				&entriesForCanonical[index], grouped[entriesForCanonical[index].ConversationID], interactions,
+			)
+		}
+	}
 	for _, entry := range entriesForCanonical {
 		byID[entry.ConversationID] = entry
 	}
@@ -1591,6 +1610,69 @@ func (s *Service) listConversationIdentityPage(ctx context.Context, options evid
 		page.NextCursor = &next
 	}
 	return page, true, nil
+}
+
+func (s *Service) listCanonicalInteractionIDs(ctx context.Context, conversationIDs []string) ([]string, map[string][]sessionvo.Interaction, error) {
+	byConversation := make(map[string][]sessionvo.Interaction)
+	if s.sessionStore == nil || len(conversationIDs) == 0 {
+		return []string{}, byConversation, nil
+	}
+	if err := s.sessionStore.WithinTransaction(ctx, func(tx isessionstore.Transaction) error {
+		byConversation = tx.ListInteractionsByConversationIDs(conversationIDs)
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+	ids := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, interactions := range byConversation {
+		for _, interaction := range interactions {
+			if interaction.ID == "" {
+				continue
+			}
+			if _, found := seen[interaction.ID]; found {
+				continue
+			}
+			seen[interaction.ID] = struct{}{}
+			ids = append(ids, interaction.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, byConversation, nil
+}
+
+// applyFirstCanonicalConversationPreview makes the list preview describe the
+// first managed turn. A later round must never substitute content when that
+// first turn has no readable terminal artifact.
+func applyFirstCanonicalConversationPreview(
+	entry *evidencevo.ConversationSummary,
+	requests []evidencevo.RequestSummary,
+	interactions []sessionvo.Interaction,
+) {
+	if entry == nil || len(interactions) == 0 {
+		return
+	}
+	first := interactions[0]
+	for _, interaction := range interactions[1:] {
+		if interaction.Ordinal < first.Ordinal || interaction.Ordinal == first.Ordinal && interaction.ID < first.ID {
+			first = interaction
+		}
+	}
+	if first.ID == "" {
+		return
+	}
+	firstRequests := make([]evidencevo.RequestSummary, 0)
+	for _, request := range requests {
+		if request.InteractionID == first.ID {
+			firstRequests = append(firstRequests, request)
+		}
+	}
+	if len(firstRequests) == 0 {
+		entry.QuestionPreview, entry.ResultPreview = "", ""
+		return
+	}
+	summary, _ := aggregateRequestGroup(firstRequests)
+	entry.QuestionPreview, entry.ResultPreview = summary.QuestionPreview, summary.ResultPreview
 }
 
 func canUseSummaryIdentityPage(options evidencevo.SummaryQueryOptions) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -139,6 +139,89 @@ func TestListConversationsLoadsOnlySelectedPageIdentities(t *testing.T) {
 	}
 }
 
+func TestListConversationsLoadsInteractionScopedTerminalArtifactsForPage(t *testing.T) {
+	base := evidencestore.New()
+	sessions := sessionstore.New()
+	store := &pagingSessionStore{Store: sessions, conversationPage: isessionstore.SummaryIdentityPage{
+		Entries: []isessionstore.SummaryIdentity{{ID: "conv-page", StartedAt: "2026-08-19T09:00:00Z"}}, Total: 1,
+	}}
+	terminalAt := time.Date(2026, 8, 19, 9, 0, 2, 0, time.UTC)
+	if err := sessions.WithinTransaction(context.Background(), func(tx isessionstore.Transaction) error {
+		tx.SaveConversation(sessionvo.Conversation{ID: "conv-page", CreatedAt: terminalAt, UpdatedAt: terminalAt})
+		tx.SaveInteraction(sessionvo.Interaction{
+			ID: "interaction-page", ConversationID: "conv-page", Ordinal: 1,
+			ExecutionStatus: sessionvo.InteractionCompleted, EvidenceStatus: sessionvo.EvidenceComplete,
+			CreatedAt: terminalAt, UpdatedAt: terminalAt, TerminalAt: &terminalAt,
+		})
+		tx.SaveInteraction(sessionvo.Interaction{
+			ID: "interaction-without-receipt", ConversationID: "conv-page", Ordinal: 2,
+			ExecutionStatus: sessionvo.InteractionCompleted, EvidenceStatus: sessionvo.EvidenceComplete,
+			CreatedAt: terminalAt, UpdatedAt: terminalAt, TerminalAt: &terminalAt,
+		})
+		return nil
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	trace := pageSummaryTrace("trace-page", "req-page", "2026-08-19T09:00:00Z", "acct_demo", "bd_demo")
+	trace.ConversationID = "conv-page"
+	trace.Events[0].InteractionID = "interaction-page"
+	trace.Events[0].Payload["question_artifact_ref"] = "artifact:question-page"
+	trace.Events = append(trace.Events, evidencevo.EvidenceEvent{
+		EventID: "result-page", EventType: "claim.created", TraceID: "trace-page", RequestID: "req-page",
+		InteractionID: "interaction-page", ObservedAt: "2026-08-19T09:00:01Z", EmittedAt: "2026-08-19T09:00:01Z",
+		Payload: map[string]any{"result_artifact_ref": "artifact:result-page"},
+	})
+	question := summaryServiceArtifact(t, "question-page", evidencevo.ArtifactTypeQuestion, "req-page", "", "interaction-page", "查询库存")
+	result := summaryServiceArtifact(t, "result-page", evidencevo.ArtifactTypeResult, "req-page", "", "interaction-page", "库存 1756")
+	projection := &capturingProjectionSource{resultFor: func(query iprojectionsource.Query) iprojectionsource.Result {
+		value := iprojectionsource.Result{Traces: []evidencevo.NormalizedTrace{trace}}
+		if containsSummaryID(query.InteractionIDs, "interaction-page") &&
+			containsArtifactType(query.ArtifactTypes, evidencevo.ArtifactTypeQuestion) &&
+			containsArtifactType(query.ArtifactTypes, evidencevo.ArtifactTypeResult) {
+			value.Artifacts = []evidencevo.EvidenceArtifact{question, result}
+		}
+		return value
+	}}
+	service := New(base, WithProjectionSource(projection), WithSessionStore(store))
+
+	page, err := service.ListConversations(context.Background(), evidencevo.SummaryQueryOptions{Scope: summaryScope("acct_demo"), Limit: 20})
+
+	if err != nil || len(page.Entries) != 1 {
+		t.Fatalf("list conversation page: page=%+v err=%v", page, err)
+	}
+	if page.Entries[0].QuestionPreview != "查询库存" || page.Entries[0].ResultPreview != "库存 1756" {
+		t.Fatalf("interaction-scoped terminal artifacts must populate the conversation preview: %+v", page.Entries[0])
+	}
+	if page.Entries[0].InteractionCount != 2 {
+		t.Fatalf("canonical interactions must determine the conversation turn count: %+v", page.Entries[0])
+	}
+	if len(projection.queries) != 1 || !containsSummaryID(projection.queries[0].InteractionIDs, "interaction-page") {
+		t.Fatalf("conversation page must load terminal artifacts by canonical interaction id: %+v", projection.queries)
+	}
+	if !containsArtifactType(projection.queries[0].ArtifactTypes, evidencevo.ArtifactTypeQuestion) ||
+		!containsArtifactType(projection.queries[0].ArtifactTypes, evidencevo.ArtifactTypeResult) {
+		t.Fatalf("conversation page must not spend its artifact budget on operation artifacts: %+v", projection.queries)
+	}
+}
+
+func containsSummaryID(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArtifactType(values []evidencevo.ArtifactType, target evidencevo.ArtifactType) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestListTraceExecutionsBoundsProjectionExpansionPerIdentity(t *testing.T) {
 	base := evidencestore.New()
 	store := &pagingSessionStore{Store: sessionstore.New(), tracePage: isessionstore.SummaryIdentityPage{
@@ -503,6 +586,28 @@ func TestBuildConversationSummarySkipsUnavailableFirstInteractionPreview(t *test
 
 	if summary.QuestionPreview != "后续问题" || summary.ResultPreview != "后续结果" {
 		t.Fatalf("conversation preview must skip an unavailable first interaction: %+v", summary)
+	}
+}
+
+func TestApplyFirstCanonicalConversationPreviewDoesNotBorrowLaterRound(t *testing.T) {
+	entry := evidencevo.ConversationSummary{QuestionPreview: "fallback", ResultPreview: "fallback"}
+	applyFirstCanonicalConversationPreview(&entry, []evidencevo.RequestSummary{
+		{
+			RequestID: "req_first", InteractionID: "interaction_first",
+			StartedAt: "2026-08-07T08:00:00Z", Status: "completed", EvidenceCompleteness: "partial",
+		},
+		{
+			RequestID: "req_second", InteractionID: "interaction_second",
+			StartedAt: "2026-08-07T08:02:00Z", Status: "completed", EvidenceCompleteness: "complete",
+			InteractionQuestion: "后续问题", InteractionResult: "后续结果",
+		},
+	}, []sessionvo.Interaction{
+		{ID: "interaction_first", Ordinal: 1},
+		{ID: "interaction_second", Ordinal: 2},
+	})
+
+	if entry.QuestionPreview != "" || entry.ResultPreview != "" {
+		t.Fatalf("conversation list must represent the first canonical round, not a later available preview: %+v", entry)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/dbaccess/mariadb/sessionstore/store.go
@@ -833,6 +833,47 @@ func (t *transaction) ListInteractionsByIDs(interactionIDs []string) map[string]
 	return result
 }
 
+func (t *transaction) ListInteractionsByConversationIDs(conversationIDs []string) map[string][]sessionvo.Interaction {
+	result := make(map[string][]sessionvo.Interaction, len(conversationIDs))
+	if t.err != nil || len(conversationIDs) == 0 {
+		return result
+	}
+	ids := make([]string, 0, len(conversationIDs))
+	seen := make(map[string]struct{}, len(conversationIDs))
+	for _, id := range conversationIDs {
+		if id != "" {
+			if _, found := seen[id]; !found {
+				seen[id] = struct{}{}
+				ids = append(ids, id)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return result
+	}
+	args := make([]any, len(ids))
+	for index, id := range ids {
+		args[index] = id
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	rows, err := t.tx.QueryContext(t.ctx, interactionSelect+` WHERE conversation_id IN (`+placeholders+`)`+listInteractionsOrderBy, args...)
+	if err != nil {
+		t.err = err
+		return result
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		value, scanErr := scanInteractionRows(rows)
+		if scanErr != nil {
+			t.err = scanErr
+			return result
+		}
+		result[value.ConversationID] = append(result[value.ConversationID], value)
+	}
+	t.err = rows.Err()
+	return result
+}
+
 func (t *transaction) NextInteractionOrdinal(conversationID string) uint64 {
 	if t.err != nil {
 		return 0

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source.go
@@ -27,23 +27,75 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 		return iprojectionsource.Result{}, err
 	}
 	artifactQuery := query
+	terminalArtifactQuery := iprojectionsource.Query{}
+	loadTerminalArtifacts := false
+	loadArtifactQuery := true
 	if len(artifactQuery.AuthorizedInteractionIDs) > 0 {
 		artifactQuery.ConversationIDs = nil
 		artifactQuery.TraceIDs = nil
-	} else if len(artifactQuery.ConversationIDs) > 0 && len(artifactQuery.TraceIDs) == 0 {
+	} else if len(artifactQuery.ConversationIDs) > 0 && len(artifactQuery.InteractionIDs) > 0 {
+		// Preserve the legacy Trace projection for artifacts without interaction_id
+		// (and for completeness), then add the bounded terminal preview facts.
+		terminalArtifactQuery = artifactQuery
+		terminalArtifactQuery.ConversationIDs = nil
+		terminalArtifactQuery.TraceIDs = nil
+		artifactQuery.InteractionIDs = nil
+		artifactQuery.ArtifactTypes = nil
+		loadTerminalArtifacts = true
+	} else if len(artifactQuery.InteractionIDs) > 0 {
+		// Terminal Interaction artifacts are allowed to omit trace_id. Keep the
+		// normal scope boundary, but do not replace this selector with trace IDs.
+		artifactQuery.ConversationIDs = nil
+		artifactQuery.TraceIDs = nil
+	}
+	if len(artifactQuery.AuthorizedInteractionIDs) == 0 && len(artifactQuery.ConversationIDs) > 0 && len(artifactQuery.TraceIDs) == 0 {
 		artifactQuery.TraceIDs = projectionTraceIDs(traces)
 		artifactQuery.ConversationIDs = nil
 		if len(artifactQuery.TraceIDs) == 0 {
-			return iprojectionsource.Result{Traces: traces, Artifacts: []evidencevo.EvidenceArtifact{}, Truncated: evidenceTruncated}, nil
+			loadArtifactQuery = false
 		}
 	}
-	artifacts, artifactTruncated, err := s.listArtifactProjection(ctx, artifactQuery)
-	if err != nil {
-		return iprojectionsource.Result{}, err
+	artifacts := []evidencevo.EvidenceArtifact{}
+	artifactTruncated := false
+	if loadArtifactQuery {
+		artifacts, artifactTruncated, err = s.listArtifactProjection(ctx, artifactQuery)
+		if err != nil {
+			return iprojectionsource.Result{}, err
+		}
+	}
+	if loadTerminalArtifacts {
+		terminalArtifacts, terminalTruncated, terminalErr := s.listArtifactProjection(ctx, terminalArtifactQuery)
+		if terminalErr != nil {
+			return iprojectionsource.Result{}, terminalErr
+		}
+		artifacts = mergeProjectedArtifacts(artifacts, terminalArtifacts)
+		artifactTruncated = artifactTruncated || terminalTruncated
 	}
 	return iprojectionsource.Result{
 		Traces: traces, Artifacts: artifacts, Truncated: evidenceTruncated || artifactTruncated,
 	}, nil
+}
+
+func mergeProjectedArtifacts(groups ...[]evidencevo.EvidenceArtifact) []evidencevo.EvidenceArtifact {
+	byID := make(map[string]evidencevo.EvidenceArtifact)
+	for _, artifacts := range groups {
+		for _, artifact := range artifacts {
+			if _, found := byID[artifact.ArtifactID]; !found {
+				byID[artifact.ArtifactID] = artifact
+			}
+		}
+	}
+	result := make([]evidencevo.EvidenceArtifact, 0, len(byID))
+	for _, artifact := range byID {
+		result = append(result, artifact)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ObservedAt == result[j].ObservedAt {
+			return result[i].ArtifactID < result[j].ArtifactID
+		}
+		return result[i].ObservedAt < result[j].ObservedAt
+	})
+	return result
 }
 
 func (s *Store) listEvidenceProjection(ctx context.Context, query iprojectionsource.Query) ([]evidencevo.NormalizedTrace, bool, error) {
@@ -196,6 +248,8 @@ func matchesProjectionTrace(trace evidencevo.NormalizedTrace, query iprojections
 func matchesProjectionArtifact(artifact evidencevo.EvidenceArtifact, query iprojectionsource.Query) bool {
 	if query.RequestID != "" && artifact.RequestID != query.RequestID ||
 		query.TraceID != "" && artifact.TraceID != query.TraceID ||
+		len(query.InteractionIDs) > 0 && !containsProjectionID(query.InteractionIDs, artifact.InteractionID) ||
+		len(query.ArtifactTypes) > 0 && !containsArtifactType(query.ArtifactTypes, artifact.ArtifactType) ||
 		query.InteractionID != "" && artifact.InteractionID != query.InteractionID {
 		return false
 	}
@@ -219,6 +273,24 @@ func traceHasInteraction(trace evidencevo.NormalizedTrace, interactionID string)
 	return false
 }
 
+func containsProjectionID(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArtifactType(values []evidencevo.ArtifactType, candidate evidencevo.ArtifactType) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
 type artifactProjectionHit struct {
 	Source evidencevo.EvidenceArtifact
 	Sort   []any
@@ -234,6 +306,12 @@ func (s *Store) listArtifactProjectionPage(ctx context.Context, query iprojectio
 	must = appendProjectionIdentityFilters(must, query)
 	if query.InteractionID != "" {
 		must = append(must, map[string]any{"bool": exactTermQuery("interaction_id", query.InteractionID)})
+	}
+	if len(query.InteractionIDs) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"interaction_id": query.InteractionIDs}})
+	}
+	if len(query.ArtifactTypes) > 0 {
+		must = append(must, map[string]any{"terms": map[string]any{"artifact_type": query.ArtifactTypes}})
 	}
 	if !query.From.IsZero() || !query.To.IsZero() {
 		bounds := map[string]any{}

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchevidencestore/projection_source_test.go
@@ -440,6 +440,64 @@ func TestProjectionSourceExpandsConversationArtifactsBySelectedTraceIDs(t *testi
 	}
 }
 
+func TestProjectionSourceLoadsInteractionScopedArtifactsWithoutDroppingScope(t *testing.T) {
+	artifactQueries := make([]string, 0, 2)
+	trace := normalizedTrace()
+	trace.TraceID = "trace-selected"
+	trace.ConversationID = "conversation-selected"
+	document := toDocument(trace, mustTime(t, "2026-08-19T09:00:00Z"))
+	document.Aggregate = true
+	hit, _ := json.Marshal(map[string]any{"hits": map[string]any{"hits": []any{
+		map[string]any{"_id": document.DocumentID, "_source": document, "sort": []any{document.DocumentID}},
+	}}})
+	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {
+		switch {
+		case r.Method == http.MethodPut && (r.URL.Path == "/bkn-trace-evidence-test" || r.URL.Path == "/bkn-trace-evidence-test-artifacts"):
+			return jsonResponse(`{"acknowledged":true}`), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test/_search":
+			return jsonResponse(string(hit)), nil
+		case r.Method == http.MethodPost && r.URL.Path == "/bkn-trace-evidence-test-artifacts/_search":
+			body, _ := io.ReadAll(r.Body)
+			artifactQueries = append(artifactQueries, string(body))
+			return jsonResponse(`{"hits":{"hits":[]}}`), nil
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			return nil, nil
+		}
+	})
+	store := New(client, "bkn-trace-evidence-test")
+	_, err := store.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope:           evidencevo.QueryScope{AccountID: trace.AccountID, AccountType: trace.AccountType},
+		ConversationIDs: []string{trace.ConversationID},
+		InteractionIDs:  []string{"interaction-terminal"},
+		ArtifactTypes:   []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult},
+		Limit:           20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(artifactQueries) != 2 {
+		t.Fatalf("conversation preview must preserve the Trace artifact read and add one terminal Interaction read: %v", artifactQueries)
+	}
+	legacyQuery, terminalQuery := artifactQueries[0], artifactQueries[1]
+	if !strings.Contains(legacyQuery, `"trace_id":["trace-selected"]`) {
+		t.Fatalf("legacy Trace artifact query must remain available for artifacts without interaction_id: %s", legacyQuery)
+	}
+	if strings.Contains(legacyQuery, `"interaction_id"`) || strings.Contains(legacyQuery, `"artifact_type"`) {
+		t.Fatalf("legacy Trace artifact query must retain its complete evidence input: %s", legacyQuery)
+	}
+	if !strings.Contains(terminalQuery, `"interaction_id":["interaction-terminal"]`) ||
+		!strings.Contains(terminalQuery, `"artifact_type":["question","result"]`) {
+		t.Fatalf("terminal artifact query must be restricted to the requested Interaction previews: %s", terminalQuery)
+	}
+	if strings.Contains(terminalQuery, "bkn.conversation.id") || strings.Contains(terminalQuery, `"trace_id"`) {
+		t.Fatalf("interaction-scoped artifact lookup must not require unavailable conversation/trace fields: %s", terminalQuery)
+	}
+	if !strings.Contains(legacyQuery, trace.AccountID) || !strings.Contains(terminalQuery, trace.AccountID) {
+		t.Fatalf("both artifact reads must retain their scope filter: %v", artifactQueries)
+	}
+}
+
 func TestProjectionSourceUsesAuthorizedInteractionsWhenConversationEvidenceIsMissing(t *testing.T) {
 	var artifactQuery string
 	client := newFakeOpenSearchClient(func(r *http.Request) (*http.Response, error) {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/artifact_store_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/artifact_store_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/domain/valueobject/evidencevo"
 	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iartifactstore"
+	"github.com/openbkn-ai/bkn-foundry/bkn-trace/agent-observability/src/port/driven/iprojectionsource"
 )
 
 func TestMemoryStoreArtifactIsIdempotentAndRejectsConflictingContent(t *testing.T) {
@@ -88,6 +89,43 @@ func TestMemoryStoreListsOnlyAuthorizedArtifactsForRequest(t *testing.T) {
 
 	if err != nil || len(result.Entries) != 1 || result.Entries[0].ArtifactID != owned.ArtifactID || result.Truncated {
 		t.Fatalf("expected only authorized artifact, got %+v err=%v", result, err)
+	}
+}
+
+func TestMemoryProjectionPreservesLegacyArtifactsAlongsideTerminalInteractionPreview(t *testing.T) {
+	store := New()
+	terminal := normalizedStoreArtifact(t)
+	terminal.ArtifactType = evidencevo.ArtifactTypeQuestion
+	terminal.OperationID = ""
+	terminal.ContentHash = ""
+	terminal, validationErrors := evidencevo.NormalizeArtifact(terminal)
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize terminal artifact: %+v", validationErrors)
+	}
+	legacy := normalizedStoreArtifact(t)
+	legacy.ArtifactID = "artifact_legacy_action_001"
+	legacy.ArtifactType = evidencevo.ArtifactTypeActionResult
+	legacy.InteractionID = ""
+	legacy.ContentHash = ""
+	legacy, validationErrors = evidencevo.NormalizeArtifact(legacy)
+	if len(validationErrors) != 0 {
+		t.Fatalf("normalize legacy artifact: %+v", validationErrors)
+	}
+	for _, artifact := range []evidencevo.EvidenceArtifact{terminal, legacy} {
+		if _, err := store.StoreArtifact(context.Background(), artifact); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := store.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope:           evidencevo.QueryScope{AccountID: terminal.AccountID, AccountType: terminal.AccountType},
+		ConversationIDs: []string{"conversation-preview"},
+		InteractionIDs:  []string{terminal.InteractionID},
+		ArtifactTypes:   []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult},
+	})
+
+	if err != nil || len(result.Artifacts) != 2 {
+		t.Fatalf("memory projection must retain legacy Trace artifacts while supplementing terminal previews: result=%+v err=%v", result, err)
 	}
 }
 

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/evidencestore/store.go
@@ -131,6 +131,15 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 	if err != nil {
 		return iprojectionsource.Result{}, err
 	}
+	artifactInteractionIDs := query.InteractionIDs
+	artifactTypes := query.ArtifactTypes
+	if len(query.ConversationIDs) > 0 && len(query.InteractionIDs) > 0 {
+		// The in-memory projection already loads the selected scope in one pass.
+		// Keep the legacy artifact set intact; OpenSearch adds a separate terminal
+		// Interaction read because its Trace query cannot see trace-less artifacts.
+		artifactInteractionIDs = nil
+		artifactTypes = nil
+	}
 	filteredTraces := make([]evidencevo.NormalizedTrace, 0, len(traces))
 	for _, trace := range traces {
 		if query.RequestID != "" && trace.RequestID != query.RequestID ||
@@ -145,6 +154,8 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 	for _, artifact := range artifacts {
 		if query.RequestID != "" && artifact.RequestID != query.RequestID ||
 			query.TraceID != "" && artifact.TraceID != query.TraceID ||
+			len(artifactInteractionIDs) > 0 && !memoryContainsProjectionID(artifactInteractionIDs, artifact.InteractionID) ||
+			len(artifactTypes) > 0 && !memoryContainsArtifactType(artifactTypes, artifact.ArtifactType) ||
 			query.InteractionID != "" && artifact.InteractionID != query.InteractionID ||
 			!memoryTimeInRange(artifact.ObservedAt, query.From, query.To) {
 			continue
@@ -163,6 +174,24 @@ func (s *Store) LoadExecutionProjection(ctx context.Context, query iprojectionso
 		truncated = true
 	}
 	return iprojectionsource.Result{Traces: filteredTraces, Artifacts: filteredArtifacts, Truncated: truncated}, nil
+}
+
+func memoryContainsProjectionID(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func memoryContainsArtifactType(values []evidencevo.ArtifactType, candidate evidencevo.ArtifactType) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }
 
 func memoryTraceHasInteraction(trace evidencevo.NormalizedTrace, interactionID string) bool {

--- a/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/memoryaccess/sessionstore/store.go
@@ -184,6 +184,32 @@ func (tx memoryTransaction) ListInteractionsByIDs(interactionIDs []string) map[s
 	return result
 }
 
+func (tx memoryTransaction) ListInteractionsByConversationIDs(conversationIDs []string) map[string][]sessionvo.Interaction {
+	result := make(map[string][]sessionvo.Interaction, len(conversationIDs))
+	selected := make(map[string]struct{}, len(conversationIDs))
+	for _, conversationID := range conversationIDs {
+		if conversationID != "" {
+			selected[conversationID] = struct{}{}
+		}
+	}
+	for _, interaction := range tx.s.interactions {
+		if _, found := selected[interaction.ConversationID]; found {
+			result[interaction.ConversationID] = append(result[interaction.ConversationID], interaction)
+		}
+	}
+	for conversationID := range result {
+		entries := result[conversationID]
+		sort.Slice(entries, func(i, j int) bool {
+			if entries[i].Ordinal == entries[j].Ordinal {
+				return entries[i].ID < entries[j].ID
+			}
+			return entries[i].Ordinal < entries[j].Ordinal
+		})
+		result[conversationID] = entries
+	}
+	return result
+}
+
 func (tx memoryTransaction) ListInteractions(conversationID string) []sessionvo.Interaction {
 	result := make([]sessionvo.Interaction, 0)
 	for _, interaction := range tx.s.interactions {

--- a/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/iprojectionsource/port.go
@@ -21,7 +21,14 @@ type Query struct {
 	TraceID         string
 	TraceIDs        []string
 	ConversationIDs []string
-	InteractionID   string
+	// InteractionIDs narrows artifact reads to canonical Interaction facts while
+	// retaining the caller's ordinary scope filters. It is intentionally distinct
+	// from AuthorizedInteractionIDs, which represents a pre-authorized Core handoff.
+	InteractionIDs []string
+	// ArtifactTypes bounds an artifact read to the contract types required by the
+	// caller, for example the terminal question/result previews in a list page.
+	ArtifactTypes []evidencevo.ArtifactType
+	InteractionID string
 	// AuthorizedInteractionIDs is an internal handoff from the Core projection.
 	// It carries an Interaction-level authorization decision to its artifact reader.
 	AuthorizedInteractionIDs []string

--- a/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
+++ b/bkn-trace/agent-observability/src/port/driven/isessionstore/port.go
@@ -27,6 +27,7 @@ type Transaction interface {
 	FindInteractionByStartKey(conversationID, idempotencyKey string) (sessionvo.Interaction, bool)
 	PeekInteraction(interactionID string) (sessionvo.Interaction, bool)
 	ListInteractionsByIDs(interactionIDs []string) map[string]sessionvo.Interaction
+	ListInteractionsByConversationIDs(conversationIDs []string) map[string][]sessionvo.Interaction
 	FindInteraction(interactionID string) (sessionvo.Interaction, bool)
 	ListInteractions(conversationID string) []sessionvo.Interaction
 	ListInteractionPage(query InteractionPageQuery) InteractionPage


### PR DESCRIPTION
## What Changed

- [x] Load terminal question/result artifacts by canonical Interaction IDs for the selected conversation page.
- [x] Batch-load lifecycle interactions and use them for conversation turn counts.
- [x] Preserve the legacy Trace-based read path when no lifecycle Interaction exists.

---

## Why

- Related Issue: #1334
- Background: The conversation list identifies rows by `conversation_id`, but terminal artifacts can be scoped only to `interaction_id` and omit `trace_id`. The fast path replaced the conversation selector with Trace IDs, so question/result previews could be empty even when the interaction detail remained complete.

---

## How

- Add a normal scoped `InteractionIDs` projection selector; it is distinct from the pre-authorized Core handoff.
- Resolve selected conversations to their lifecycle interactions in one batch store query.
- Query interaction-scoped artifacts without dropping the normal access Scope.
- Breaking changes: none; no schema migration, API shape, or configuration change.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration-style projection adapter tests passed locally
- [ ] Verified in test environment

Test notes:

- `make test`
- `make lint`
- `make license-check`
- `make build`

---

## Risk & Rollback

- Potential risks: The list fast path adds one bounded batch interaction lookup and a terms selector for the selected page.
- Rollback plan: Revert this single commit; legacy Trace-based behavior is restored.

---

## Additional Notes

- Regression coverage includes trace-less terminal artifacts, preserved scope filtering, legacy fallback behavior, and lifecycle-based turn counts.