### PR TITLE
feat(bkn): expose managed proxy governance APIs

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_handler.go
@@ -22,6 +22,15 @@ func proxyRequestContext(c *gin.Context) (context.Context, string) {
 	return context.WithValue(c.Request.Context(), interfaces.ACCOUNT_INFO_KEY, account), actor.ID
 }
 
+func (r *restHandler) proxyOAuthRequestContext(c *gin.Context) (context.Context, string, bool) {
+	actor, err := r.verifyOAuth(rest.GetLanguageCtx(c), c)
+	if err != nil {
+		return nil, "", false
+	}
+	account := interfaces.AccountInfo{ID: actor.ID, Type: string(actor.Type)}
+	return context.WithValue(rest.GetLanguageCtx(c), interfaces.ACCOUNT_INFO_KEY, account), actor.ID, true
+}
+
 func (r *restHandler) GetKNProxy(c *gin.Context) {
 	ctx, _ := proxyRequestContext(c)
 	mapping, err := r.kns.GetKNProxy(ctx, c.Param("kn_id"))
@@ -30,6 +39,32 @@ func (r *restHandler) GetKNProxy(c *gin.Context) {
 		return
 	}
 	rest.ReplyOK(c, http.StatusOK, mapping)
+}
+
+func (r *restHandler) GetKNProxyByEx(c *gin.Context) {
+	ctx, _, ok := r.proxyOAuthRequestContext(c)
+	if !ok {
+		return
+	}
+	mapping, err := r.kns.GetGovernedKNProxy(ctx, c.Param("kn_id"))
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, mapping)
+}
+
+func (r *restHandler) ListKNProxiesByEx(c *gin.Context) {
+	ctx, _, ok := r.proxyOAuthRequestContext(c)
+	if !ok {
+		return
+	}
+	mappings, err := r.kns.ListGovernedKNProxies(ctx)
+	if err != nil {
+		rest.ReplyError(c, err)
+		return
+	}
+	rest.ReplyOK(c, http.StatusOK, mappings)
 }
 
 func (r *restHandler) ResolveKNProxyBinding(c *gin.Context) {
@@ -50,9 +85,25 @@ func (r *restHandler) ResolveKNProxyBinding(c *gin.Context) {
 
 func (r *restHandler) RetryKNProxySync(c *gin.Context) {
 	ctx, _ := proxyRequestContext(c)
+	r.retryKNProxySync(c, ctx, false)
+}
+
+func (r *restHandler) RetryKNProxySyncByEx(c *gin.Context) {
+	ctx, _, ok := r.proxyOAuthRequestContext(c)
+	if !ok {
+		return
+	}
+	r.retryKNProxySync(c, ctx, true)
+}
+
+func (r *restHandler) retryKNProxySync(c *gin.Context, ctx context.Context, sanitize bool) {
 	mapping, err := r.kns.RetryKNProxySync(ctx, c.Param("kn_id"))
 	if err != nil {
-		rest.ReplyError(c, err.(*rest.HTTPError))
+		rest.ReplyError(c, err)
+		return
+	}
+	if sanitize {
+		rest.ReplyOK(c, http.StatusOK, interfaces.NewKNProxyGovernanceView(mapping))
 		return
 	}
 	rest.ReplyOK(c, http.StatusOK, mapping)
@@ -60,9 +111,21 @@ func (r *restHandler) RetryKNProxySync(c *gin.Context) {
 
 func (r *restHandler) PlanKNProxySync(c *gin.Context) {
 	ctx, _ := proxyRequestContext(c)
+	r.planKNProxySync(c, ctx)
+}
+
+func (r *restHandler) PlanKNProxySyncByEx(c *gin.Context) {
+	ctx, _, ok := r.proxyOAuthRequestContext(c)
+	if !ok {
+		return
+	}
+	r.planKNProxySync(c, ctx)
+}
+
+func (r *restHandler) planKNProxySync(c *gin.Context, ctx context.Context) {
 	plan, err := r.kns.PlanKNProxySync(ctx, c.Param("kn_id"))
 	if err != nil {
-		rest.ReplyError(c, err.(*rest.HTTPError))
+		rest.ReplyError(c, err)
 		return
 	}
 	rest.ReplyOK(c, http.StatusOK, plan)
@@ -79,9 +142,25 @@ func (r *restHandler) FinalizeKNProxyDeletion(c *gin.Context) {
 
 func (r *restHandler) ReconcileKNProxies(c *gin.Context) {
 	ctx, requestedBy := proxyRequestContext(c)
+	r.reconcileKNProxies(c, ctx, requestedBy, false)
+}
+
+func (r *restHandler) ReconcileKNProxiesByEx(c *gin.Context) {
+	ctx, requestedBy, ok := r.proxyOAuthRequestContext(c)
+	if !ok {
+		return
+	}
+	r.reconcileKNProxies(c, ctx, requestedBy, true)
+}
+
+func (r *restHandler) reconcileKNProxies(c *gin.Context, ctx context.Context, requestedBy string, sanitize bool) {
 	report, err := r.kns.ReconcileKNProxies(ctx, requestedBy)
 	if err != nil {
-		rest.ReplyError(c, err.(*rest.HTTPError))
+		rest.ReplyError(c, err)
+		return
+	}
+	if sanitize {
+		rest.ReplyOK(c, http.StatusOK, interfaces.NewKNProxyGovernanceReconcileReport(report))
 		return
 	}
 	rest.ReplyOK(c, http.StatusOK, report)

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/interfaces"
@@ -48,6 +49,37 @@ func TestResolveKNProxyBindingEndpointUsesServerMapping(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	engine.ServeHTTP(recorder, req)
 	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestListKNProxiesPublicEndpointUsesOAuthIdentity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := gomock.NewController(t)
+	authService := bmock.NewMockAuthService(ctrl)
+	service := bmock.NewMockKNService(ctrl)
+	handler := &restHandler{as: authService, kns: service}
+	engine := gin.New()
+	engine.GET("/api/bkn-backend/v1/proxy-accounts", handler.ListKNProxiesByEx)
+
+	authService.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).Return(hydra.Visitor{
+		ID: "operator-1", Type: hydra.VisitorType("user"),
+	}, nil)
+	service.EXPECT().ListGovernedKNProxies(gomock.Any()).DoAndReturn(
+		func(ctx context.Context) (*interfaces.KNProxyAccountList, error) {
+			account, _ := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+			if account.ID != "operator-1" || account.Type != "user" {
+				t.Fatalf("unexpected OAuth caller context: %#v", account)
+			}
+			return &interfaces.KNProxyAccountList{Entries: []*interfaces.KNProxyGovernanceView{{
+				KNID: "kn-1", ProxyAccountID: "proxy-1",
+			}}, Total: 1}, nil
+		})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/bkn-backend/v1/proxy-accounts", nil)
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK || !strings.Contains(recorder.Body.String(), `"proxy_account_id":"proxy-1"`) {
 		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/routers.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers.go
@@ -127,6 +127,11 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 	bknApiV1.POST("/trace/outbox/:outbox_id/abandon", r.verifyJsonContentType(), r.AbandonTraceOutbox)
 	bknApiV1.GET("/operation-audits", r.ListOperationAudits)
 	bknApiV1.GET("/operation-audits/:event_id", r.GetOperationAudit)
+	bknApiV1.GET("/proxy-accounts", r.ListKNProxiesByEx)
+	bknApiV1.GET("/knowledge-networks/:kn_id/proxy-account", r.GetKNProxyByEx)
+	bknApiV1.GET("/knowledge-networks/:kn_id/proxy-account/plan", r.PlanKNProxySyncByEx)
+	bknApiV1.POST("/knowledge-networks/:kn_id/proxy-account/sync", r.RetryKNProxySyncByEx)
+	bknApiV1.POST("/proxy-accounts/reconcile", r.ReconcileKNProxiesByEx)
 
 	for _, apiV1 := range []*gin.RouterGroup{bknApiV1, otlApiV1} {
 		// Knowledge networks.

--- a/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/routers_test.go
@@ -86,3 +86,27 @@ func Test_RestHandler_VerifyOAuth_Failure(t *testing.T) {
 		So(w.Result().StatusCode, ShouldEqual, http.StatusUnauthorized)
 	})
 }
+
+func TestRegisterPublicIncludesOAuthProxyGovernanceRoutes(t *testing.T) {
+	restoreGin := setGinMode()
+	defer restoreGin()
+	engine := gin.New()
+	handler := &restHandler{appSetting: &common.AppSetting{}}
+	handler.RegisterPublic(engine)
+
+	routes := map[string]bool{}
+	for _, route := range engine.Routes() {
+		routes[route.Method+" "+route.Path] = true
+	}
+	for _, want := range []string{
+		"GET /api/bkn-backend/v1/proxy-accounts",
+		"GET /api/bkn-backend/v1/knowledge-networks/:kn_id/proxy-account",
+		"GET /api/bkn-backend/v1/knowledge-networks/:kn_id/proxy-account/plan",
+		"POST /api/bkn-backend/v1/knowledge-networks/:kn_id/proxy-account/sync",
+		"POST /api/bkn-backend/v1/proxy-accounts/reconcile",
+	} {
+		if !routes[want] {
+			t.Fatalf("public proxy governance route %q is not registered", want)
+		}
+	}
+}

--- a/adp/bkn/bkn-backend/server/errors/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/errors/knowledge_network.go
@@ -25,7 +25,15 @@ const (
 	BknBackend_KnowledgeNetwork_NullParameter_SourceObjectTypeId   = "BknBackend.KnowledgeNetwork.NullParameter.SourceObjectTypeId"
 
 	// 404
-	BknBackend_KnowledgeNetwork_NotFound = "BknBackend.KnowledgeNetwork.NotFound"
+	BknBackend_KnowledgeNetwork_NotFound             = "BknBackend.KnowledgeNetwork.NotFound"
+	BknBackend_KnowledgeNetwork_ProxyMappingNotFound = "BknBackend.KnowledgeNetwork.Proxy.MappingNotFound"
+
+	// Proxy runtime state
+	BknBackend_KnowledgeNetwork_ProxyBindingInvalid = "BknBackend.KnowledgeNetwork.Proxy.BindingInvalid"
+	BknBackend_KnowledgeNetwork_ProxyDisabled       = "BknBackend.KnowledgeNetwork.Proxy.Disabled"
+	BknBackend_KnowledgeNetwork_ProxySyncFailed     = "BknBackend.KnowledgeNetwork.Proxy.SyncFailed"
+	BknBackend_KnowledgeNetwork_ProxySyncPending    = "BknBackend.KnowledgeNetwork.Proxy.SyncPending"
+	BknBackend_KnowledgeNetwork_ProxyUnavailable    = "BknBackend.KnowledgeNetwork.Proxy.Unavailable"
 
 	// 500
 	BknBackend_KnowledgeNetwork_InternalError                             = "BknBackend.KnowledgeNetwork.InternalError"
@@ -70,6 +78,14 @@ var (
 
 		// 404
 		BknBackend_KnowledgeNetwork_NotFound,
+		BknBackend_KnowledgeNetwork_ProxyMappingNotFound,
+
+		// Proxy runtime state
+		BknBackend_KnowledgeNetwork_ProxyBindingInvalid,
+		BknBackend_KnowledgeNetwork_ProxyDisabled,
+		BknBackend_KnowledgeNetwork_ProxySyncFailed,
+		BknBackend_KnowledgeNetwork_ProxySyncPending,
+		BknBackend_KnowledgeNetwork_ProxyUnavailable,
 
 		// 500
 		BknBackend_KnowledgeNetwork_InternalError,

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -161,13 +161,26 @@ func NewKNProxyGovernanceReconcileReport(report *KNProxyReconcileReport) *KNProx
 		failedKNIDs = append(failedKNIDs, knID)
 	}
 	sort.Strings(failedKNIDs)
-	return &KNProxyGovernanceReconcileReport{
+	view := &KNProxyGovernanceReconcileReport{
 		MissingMappings:    report.MissingMappings,
 		OrphanMappings:     report.OrphanMappings,
 		ConflictingProxy:   report.ConflictingProxy,
 		AuthorizationDrift: report.AuthorizationDrift,
 		FailedKNIDs:        failedKNIDs,
 	}
+	if view.MissingMappings == nil {
+		view.MissingMappings = []string{}
+	}
+	if view.OrphanMappings == nil {
+		view.OrphanMappings = []string{}
+	}
+	if view.ConflictingProxy == nil {
+		view.ConflictingProxy = map[string][]string{}
+	}
+	if view.AuthorizationDrift == nil {
+		view.AuthorizationDrift = map[string]ProxyGrantReconcileResult{}
+	}
+	return view
 }
 
 type KNProxySyncPlan struct {

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -7,6 +7,7 @@ package interfaces
 import (
 	"context"
 	"database/sql"
+	"sort"
 )
 
 const (
@@ -40,6 +41,50 @@ type KNProxyAccount struct {
 	LockUntil             int64  `json:"-"`
 	CreatedAt             int64  `json:"created_at"`
 	UpdatedAt             int64  `json:"updated_at"`
+}
+
+// KNProxyGovernanceView is the public, sanitized projection of a proxy
+// mapping. Internal synchronization details such as last_error and grantor or
+// lock identities are never returned by OAuth governance APIs.
+type KNProxyGovernanceView struct {
+	KNID                  string `json:"kn_id"`
+	ProxyAccountID        string `json:"proxy_account_id"`
+	ProxyAccountType      string `json:"proxy_account_type"`
+	LifecycleStatus       string `json:"lifecycle_status"`
+	LastErrorCode         string `json:"last_error_code,omitempty"`
+	Version               int64  `json:"version"`
+	SyncStatus            string `json:"sync_status"`
+	PublishedModelVersion string `json:"published_model_version"`
+	SyncedModelVersion    string `json:"synced_model_version"`
+	CreatedAt             int64  `json:"created_at"`
+	UpdatedAt             int64  `json:"updated_at"`
+}
+
+type KNProxyAccountList struct {
+	Entries []*KNProxyGovernanceView `json:"entries"`
+	Total   int                      `json:"total"`
+}
+
+func NewKNProxyGovernanceView(mapping *KNProxyAccount) *KNProxyGovernanceView {
+	if mapping == nil {
+		return nil
+	}
+	view := &KNProxyGovernanceView{
+		KNID:                  mapping.KNID,
+		ProxyAccountID:        mapping.ProxyAccountID,
+		ProxyAccountType:      mapping.ProxyAccountType,
+		LifecycleStatus:       mapping.LifecycleStatus,
+		Version:               mapping.Version,
+		SyncStatus:            mapping.SyncStatus,
+		PublishedModelVersion: mapping.PublishedModelVersion,
+		SyncedModelVersion:    mapping.SyncedModelVersion,
+		CreatedAt:             mapping.CreatedAt,
+		UpdatedAt:             mapping.UpdatedAt,
+	}
+	if mapping.LastSyncError != "" {
+		view.LastErrorCode = "PROXY_SYNC_FAILED"
+	}
+	return view
 }
 
 // ManagedProxyAccount is the lifecycle representation returned by bkn-safe.
@@ -97,6 +142,32 @@ type KNProxyReconcileReport struct {
 	ConflictingProxy   map[string][]string                  `json:"conflicting_proxy_accounts"`
 	AuthorizationDrift map[string]ProxyGrantReconcileResult `json:"authorization_drift"`
 	Errors             map[string]string                    `json:"errors,omitempty"`
+}
+
+type KNProxyGovernanceReconcileReport struct {
+	MissingMappings    []string                             `json:"missing_mappings"`
+	OrphanMappings     []string                             `json:"orphan_mappings"`
+	ConflictingProxy   map[string][]string                  `json:"conflicting_proxy_accounts"`
+	AuthorizationDrift map[string]ProxyGrantReconcileResult `json:"authorization_drift"`
+	FailedKNIDs        []string                             `json:"failed_kn_ids,omitempty"`
+}
+
+func NewKNProxyGovernanceReconcileReport(report *KNProxyReconcileReport) *KNProxyGovernanceReconcileReport {
+	if report == nil {
+		return nil
+	}
+	failedKNIDs := make([]string, 0, len(report.Errors))
+	for knID := range report.Errors {
+		failedKNIDs = append(failedKNIDs, knID)
+	}
+	sort.Strings(failedKNIDs)
+	return &KNProxyGovernanceReconcileReport{
+		MissingMappings:    report.MissingMappings,
+		OrphanMappings:     report.OrphanMappings,
+		ConflictingProxy:   report.ConflictingProxy,
+		AuthorizationDrift: report.AuthorizationDrift,
+		FailedKNIDs:        failedKNIDs,
+	}
 }
 
 type KNProxySyncPlan struct {

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
@@ -26,6 +26,8 @@ type KNService interface {
 	DeleteKN(ctx context.Context, kn *KN) error
 	FinalizeKNProxyDeletion(ctx context.Context, knID string) error
 	GetKNProxy(ctx context.Context, knID string) (*KNProxyAccount, error)
+	GetGovernedKNProxy(ctx context.Context, knID string) (*KNProxyGovernanceView, error)
+	ListGovernedKNProxies(ctx context.Context) (*KNProxyAccountList, error)
 	ResolveKNProxyBinding(ctx context.Context, knID string, binding KNProxyBinding) (*KNProxyAccount, error)
 	PlanKNProxySync(ctx context.Context, knID string) (*KNProxySyncPlan, error)
 	RetryKNProxySync(ctx context.Context, knID string) (*KNProxyAccount, error)

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
@@ -177,6 +177,21 @@ func (mr *MockKNServiceMockRecorder) GetKNProxy(ctx, knID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKNProxy", reflect.TypeOf((*MockKNService)(nil).GetKNProxy), ctx, knID)
 }
 
+// GetGovernedKNProxy mocks base method.
+func (m *MockKNService) GetGovernedKNProxy(ctx context.Context, knID string) (*interfaces.KNProxyGovernanceView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGovernedKNProxy", ctx, knID)
+	ret0, _ := ret[0].(*interfaces.KNProxyGovernanceView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGovernedKNProxy indicates an expected call of GetGovernedKNProxy.
+func (mr *MockKNServiceMockRecorder) GetGovernedKNProxy(ctx, knID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGovernedKNProxy", reflect.TypeOf((*MockKNService)(nil).GetGovernedKNProxy), ctx, knID)
+}
+
 // GetRelationTypePaths mocks base method.
 func (m *MockKNService) GetRelationTypePaths(ctx context.Context, query interfaces.RelationTypePathsBaseOnSource) ([]interfaces.RelationTypePath, error) {
 	m.ctrl.T.Helper()
@@ -221,6 +236,21 @@ func (m *MockKNService) ListKNs(ctx context.Context, query interfaces.KNsQueryPa
 func (mr *MockKNServiceMockRecorder) ListKNs(ctx, query any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKNs", reflect.TypeOf((*MockKNService)(nil).ListKNs), ctx, query)
+}
+
+// ListGovernedKNProxies mocks base method.
+func (m *MockKNService) ListGovernedKNProxies(ctx context.Context) (*interfaces.KNProxyAccountList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGovernedKNProxies", ctx)
+	ret0, _ := ret[0].(*interfaces.KNProxyAccountList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGovernedKNProxies indicates an expected call of ListGovernedKNProxies.
+func (mr *MockKNServiceMockRecorder) ListGovernedKNProxies(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGovernedKNProxies", reflect.TypeOf((*MockKNService)(nil).ListGovernedKNProxies), ctx)
 }
 
 // ListKnSrcs mocks base method.

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
@@ -89,6 +89,36 @@ Description = "The Knowledge Network Does Not Exist"
 Solution = "Please try again. If the error occurs again, please submit the work order or contact technical support."
 ErrorLink = ""
 
+[BknBackend.KnowledgeNetwork.Proxy.MappingNotFound]
+Description = "The knowledge-network proxy mapping does not exist"
+Solution = "Synchronize the proxy account for this knowledge network."
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.BindingInvalid]
+Description = "The requested target is not a current published binding"
+Solution = "Publish the binding and synchronize the proxy permissions before retrying."
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.Disabled]
+Description = "The knowledge-network proxy account is not active"
+Solution = "Restore the proxy account or complete the knowledge-network lifecycle operation."
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.SyncFailed]
+Description = "The knowledge-network proxy permission synchronization failed"
+Solution = "Inspect the synchronization error and retry the proxy synchronization."
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.SyncPending]
+Description = "The knowledge-network proxy permissions are not synchronized with the published model"
+Solution = "Wait for synchronization to finish or retry the proxy synchronization."
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.Unavailable]
+Description = "The knowledge-network proxy service is unavailable"
+Solution = "Try again later; contact an administrator if the problem persists."
+ErrorLink = ""
+
 [BknBackend.KnowledgeNetwork.InternalError]
 Description = "Internal Error"
 Solution = "Please try again. If the error occurs again, please submit the work order or contact technical support."

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
@@ -89,6 +89,36 @@ Description = "业务知识网络不存在"
 Solution = "请检查参数是否正确。"
 ErrorLink = ""
 
+[BknBackend.KnowledgeNetwork.Proxy.MappingNotFound]
+Description = "知识网络代理映射不存在"
+Solution = "请为该知识网络同步代理账号。"
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.BindingInvalid]
+Description = "请求的目标不是当前已发布绑定"
+Solution = "请先发布绑定并同步代理权限，然后重试。"
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.Disabled]
+Description = "知识网络代理账号未处于启用状态"
+Solution = "请恢复代理账号，或完成当前知识网络生命周期操作。"
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.SyncFailed]
+Description = "知识网络代理权限同步失败"
+Solution = "请检查同步错误并重试代理权限同步。"
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.SyncPending]
+Description = "知识网络代理权限尚未与已发布模型同步"
+Solution = "请等待同步完成，或重试代理权限同步。"
+ErrorLink = ""
+
+[BknBackend.KnowledgeNetwork.Proxy.Unavailable]
+Description = "知识网络代理服务不可用"
+Solution = "请稍后重试；若问题持续，请联系管理员。"
+ErrorLink = ""
+
 [BknBackend.KnowledgeNetwork.InternalError]
 Description = "内部错误"
 Solution = "请重试该操作，若再次出现该错误请提交工单或联系技术支持工程师。"

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -706,35 +706,106 @@ func (kns *knowledgeNetworkService) GetKNProxy(ctx context.Context, knID string)
 	return mapping, nil
 }
 
+// GetGovernedKNProxy exposes proxy state only after checking the caller's
+// authorize operation on the exact knowledge network. Runtime services must
+// continue to use GetKNProxy after separately authorizing the business call.
+func (kns *knowledgeNetworkService) GetGovernedKNProxy(ctx context.Context, knID string) (*interfaces.KNProxyGovernanceView, error) {
+	if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   knID,
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+		return nil, err
+	}
+	mapping, err := kns.GetKNProxy(ctx, knID)
+	if err != nil {
+		return nil, err
+	}
+	return interfaces.NewKNProxyGovernanceView(mapping), nil
+}
+
+// ListGovernedKNProxies returns only mappings in the caller's authorize scope,
+// so mapping existence and proxy identifiers are not disclosed across tenants.
+func (kns *knowledgeNetworkService) ListGovernedKNProxies(ctx context.Context) (*interfaces.KNProxyAccountList, error) {
+	if kns.kpa == nil {
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxyUnavailable, "proxy orchestration is disabled")
+	}
+	mappings, err := kns.kpa.List(ctx)
+	if err != nil {
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxyUnavailable, "list knowledge network proxy mappings")
+	}
+	ids := make([]string, 0, len(mappings))
+	for _, mapping := range mappings {
+		if mapping != nil && strings.TrimSpace(mapping.KNID) != "" {
+			ids = append(ids, mapping.KNID)
+		}
+	}
+	if len(ids) == 0 {
+		return &interfaces.KNProxyAccountList{Entries: []*interfaces.KNProxyGovernanceView{}}, nil
+	}
+	allowed, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, ids,
+		[]string{interfaces.OPERATION_TYPE_AUTHORIZE}, true, interfaces.COMMON_OPERATIONS)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]*interfaces.KNProxyGovernanceView, 0, len(allowed))
+	for _, mapping := range mappings {
+		if mapping == nil {
+			continue
+		}
+		if _, ok := allowed[mapping.KNID]; ok {
+			entries = append(entries, interfaces.NewKNProxyGovernanceView(mapping))
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].KNID < entries[j].KNID })
+	return &interfaces.KNProxyAccountList{Entries: entries, Total: len(entries)}, nil
+}
+
 // ResolveKNProxyBinding validates a server-derived runtime target against the
 // latest published main model and returns the proxy mapping only when that
 // exact model version has finished permission synchronization.
 func (kns *knowledgeNetworkService) ResolveKNProxyBinding(ctx context.Context, knID string,
 	binding interfaces.KNProxyBinding) (*interfaces.KNProxyAccount, error) {
 	if kns.kpa == nil {
-		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy orchestration is disabled")
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxyUnavailable, "proxy orchestration is disabled")
 	}
 	mapping, err := kns.kpa.Get(ctx, knID)
 	if err != nil {
-		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "load knowledge network proxy mapping")
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxyUnavailable, "load knowledge network proxy mapping")
 	}
 	if mapping == nil {
-		return nil, proxyHTTPError(ctx, http.StatusNotFound, "knowledge network proxy mapping not found")
+		return nil, proxyStateHTTPError(ctx, http.StatusNotFound,
+			berrors.BknBackend_KnowledgeNetwork_ProxyMappingNotFound, "knowledge network proxy mapping not found")
 	}
-	if mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive ||
-		mapping.SyncStatus != interfaces.KNProxySyncReady ||
+	if mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive {
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxyDisabled, "knowledge network proxy is not active")
+	}
+	if mapping.SyncStatus == interfaces.KNProxySyncFailed {
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxySyncFailed, "knowledge network proxy synchronization failed")
+	}
+	if mapping.SyncStatus != interfaces.KNProxySyncReady ||
 		mapping.PublishedModelVersion == "" || mapping.SyncedModelVersion != mapping.PublishedModelVersion {
-		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "knowledge network proxy is not synchronized with the current published model")
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxySyncPending,
+			"knowledge network proxy is not synchronized with the current published model")
 	}
 	sources, modelVersion, err := kns.loadPublishedProxyBindings(ctx, knID, mapping.PublishedModelVersion)
 	if err != nil {
 		return nil, err
 	}
 	if !containsProxyBinding(sources, knID, binding) {
-		return nil, proxyHTTPError(ctx, http.StatusForbidden, "target is not a current published binding")
+		return nil, proxyStateHTTPError(ctx, http.StatusForbidden,
+			berrors.BknBackend_KnowledgeNetwork_ProxyBindingInvalid, "target is not a current published binding")
 	}
 	if mapping.PublishedModelVersion != modelVersion || mapping.SyncedModelVersion != modelVersion {
-		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "knowledge network proxy is not synchronized with the current published model")
+		return nil, proxyStateHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_KnowledgeNetwork_ProxySyncPending,
+			"knowledge network proxy is not synchronized with the current published model")
 	}
 	return mapping, nil
 }
@@ -889,6 +960,10 @@ func accountIDFromContext(ctx context.Context) string {
 
 func proxyHTTPError(ctx context.Context, status int, detail string) *rest.HTTPError {
 	return rest.NewHTTPError(ctx, status, berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(detail)
+}
+
+func proxyStateHTTPError(ctx context.Context, status int, code, detail string) *rest.HTTPError {
+	return rest.NewHTTPError(ctx, status, code).WithErrorDetails(detail)
 }
 
 func invalidProxyTargetError(ctx context.Context, cause error) *rest.HTTPError {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -898,16 +898,23 @@ func (kns *knowledgeNetworkService) ReconcileKNProxies(ctx context.Context, requ
 	if err != nil {
 		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "list proxy mappings for reconciliation")
 	}
-	// Reconciliation mutates bkn-safe policy materialization. Authorize every
-	// live knowledge network before applying any mutation so the operation is
-	// all-or-nothing with respect to the caller's governance scope.
-	for _, mapping := range mappings {
-		if _, exists := knsByID[mapping.KNID]; !exists {
+	// Reconciliation reports missing mappings from the complete set of live
+	// knowledge networks and mutates bkn-safe policy materialization. Authorize
+	// every live knowledge network, including those without a mapping, before
+	// computing the report or applying any mutation. Otherwise an empty or
+	// incomplete mapping table could bypass authorization and disclose KN IDs.
+	liveKNIDs := make([]string, 0, len(knsByID))
+	for knID, kn := range knsByID {
+		if kn == nil || kn.Branch != interfaces.MAIN_BRANCH {
 			continue
 		}
+		liveKNIDs = append(liveKNIDs, knID)
+	}
+	sort.Strings(liveKNIDs)
+	for _, knID := range liveKNIDs {
 		if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
 			Type: interfaces.RESOURCE_TYPE_KN,
-			ID:   mapping.KNID,
+			ID:   knID,
 		}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
 			return nil, err
 		}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -1023,7 +1023,7 @@ func TestGovernedKNProxyViewOmitsInternalFailureDetails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(encoded), "secret") || string(encoded) != `{"missing_mappings":null,"orphan_mappings":null,"conflicting_proxy_accounts":null,"authorization_drift":null,"failed_kn_ids":["kn-1","kn-2"]}` {
+	if strings.Contains(string(encoded), "secret") || string(encoded) != `{"missing_mappings":[],"orphan_mappings":[],"conflicting_proxy_accounts":{},"authorization_drift":{},"failed_kn_ids":["kn-1","kn-2"]}` {
 		t.Fatalf("public reconcile view leaked internal details: %s", encoded)
 	}
 }
@@ -1147,6 +1147,10 @@ func TestReconcileKNProxiesReportsMissingOrphanAndConflict(t *testing.T) {
 	permissionService := bmock.NewMockPermissionService(ctrl)
 	permissionService.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
 		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   "kn-live",
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
+	permissionService.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
 		ID:   "kn-mapped",
 	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
 	mpa := &managedProxyAccessStub{}
@@ -1167,6 +1171,30 @@ func TestReconcileKNProxiesReportsMissingOrphanAndConflict(t *testing.T) {
 	}
 	if !reflect.DeepEqual(mpa.reconciled, []string{"proxy-mapped"}) {
 		t.Fatalf("reconciled proxies = %#v, want live authorized mapping only", mpa.reconciled)
+	}
+}
+
+func TestReconcileKNProxiesAuthorizesNetworksWithoutMappings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	kna.EXPECT().GetAllMainBranchKNs(gomock.Any()).Return(map[string]*interfaces.KN{
+		"kn-unmapped": {KNID: "kn-unmapped", Branch: interfaces.MAIN_BRANCH},
+	}, nil)
+	kpa := &proxyAccessStub{}
+	permissionService := bmock.NewMockPermissionService(ctrl)
+	permissionService.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   "kn-unmapped",
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(
+		rest.NewHTTPError(t.Context(), http.StatusForbidden, rest.PublicError_Forbidden))
+	mpa := &managedProxyAccessStub{}
+	service := &knowledgeNetworkService{kna: kna, kpa: kpa, mpa: mpa, ps: permissionService}
+
+	if _, err := service.ReconcileKNProxies(t.Context(), "operator-1"); err == nil {
+		t.Fatal("ReconcileKNProxies() error = nil, want authorization failure for unmapped knowledge network")
+	}
+	if len(mpa.reconciled) != 0 {
+		t.Fatalf("reconciliation mutated proxies before authorization completed: %#v", mpa.reconciled)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -7,15 +7,18 @@ package knowledge_network
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"go.uber.org/mock/gomock"
 
+	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
 )
@@ -950,6 +953,116 @@ func TestGetKNProxyResolvesMappingWithoutBusinessAuthorize(t *testing.T) {
 	}
 	if got != mapping {
 		t.Fatalf("GetKNProxy() = %#v, want %#v", got, mapping)
+	}
+}
+
+func TestGetGovernedKNProxyRequiresAuthorizePermission(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	permissionService := bmock.NewMockPermissionService(ctrl)
+	mapping := &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1"}
+	permissionService.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
+	service := &knowledgeNetworkService{kpa: &proxyAccessStub{mapping: mapping}, ps: permissionService}
+
+	got, err := service.GetGovernedKNProxy(t.Context(), "kn-1")
+	if err != nil || got.KNID != mapping.KNID || got.ProxyAccountID != mapping.ProxyAccountID {
+		t.Fatalf("GetGovernedKNProxy() = %#v, %v", got, err)
+	}
+}
+
+func TestListGovernedKNProxiesFiltersUnauthorizedMappings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	permissionService := bmock.NewMockPermissionService(ctrl)
+	mappings := []*interfaces.KNProxyAccount{
+		{KNID: "kn-hidden", ProxyAccountID: "proxy-hidden"},
+		{KNID: "kn-b", ProxyAccountID: "proxy-b"},
+		{KNID: "kn-a", ProxyAccountID: "proxy-a"},
+	}
+	permissionService.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN,
+		[]string{"kn-hidden", "kn-b", "kn-a"}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}, true,
+		interfaces.COMMON_OPERATIONS).Return(map[string]interfaces.PermissionResourceOps{
+		"kn-a": {},
+		"kn-b": {},
+	}, nil)
+	service := &knowledgeNetworkService{kpa: &proxyAccessStub{mappings: mappings}, ps: permissionService}
+
+	got, err := service.ListGovernedKNProxies(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Total != 2 || len(got.Entries) != 2 || got.Entries[0].KNID != "kn-a" || got.Entries[1].KNID != "kn-b" {
+		t.Fatalf("ListGovernedKNProxies() = %#v", got)
+	}
+	for _, entry := range got.Entries {
+		if entry.ProxyAccountID == "proxy-hidden" {
+			t.Fatal("unauthorized proxy mapping leaked")
+		}
+	}
+}
+
+func TestGovernedKNProxyViewOmitsInternalFailureDetails(t *testing.T) {
+	mapping := &interfaces.KNProxyAccount{
+		KNID: "kn-1", ProxyAccountID: "proxy-1", LastSyncError: "credential secret",
+		LastGrantorID: "grantor-secret", LockOwner: "lock-owner-secret",
+	}
+	view := interfaces.NewKNProxyGovernanceView(mapping)
+	encoded, err := json.Marshal(view)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "secret") || strings.Contains(string(encoded), `"last_error":`) ||
+		!strings.Contains(string(encoded), `"last_error_code":"PROXY_SYNC_FAILED"`) {
+		t.Fatalf("public proxy view leaked internal details: %s", encoded)
+	}
+	reconcileView := interfaces.NewKNProxyGovernanceReconcileReport(&interfaces.KNProxyReconcileReport{
+		Errors: map[string]string{"kn-2": "credential secret", "kn-1": "downstream secret"},
+	})
+	encoded, err = json.Marshal(reconcileView)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "secret") || string(encoded) != `{"missing_mappings":null,"orphan_mappings":null,"conflicting_proxy_accounts":null,"authorization_drift":null,"failed_kn_ids":["kn-1","kn-2"]}` {
+		t.Fatalf("public reconcile view leaked internal details: %s", encoded)
+	}
+}
+
+func TestResolveKNProxyBindingReturnsStableStateErrors(t *testing.T) {
+	tests := map[string]struct {
+		mapping *interfaces.KNProxyAccount
+		status  int
+		code    string
+	}{
+		"mapping missing": {
+			status: http.StatusNotFound,
+			code:   berrors.BknBackend_KnowledgeNetwork_ProxyMappingNotFound,
+		},
+		"proxy disabled": {
+			mapping: &interfaces.KNProxyAccount{LifecycleStatus: interfaces.KNProxyLifecycleArchived},
+			status:  http.StatusServiceUnavailable,
+			code:    berrors.BknBackend_KnowledgeNetwork_ProxyDisabled,
+		},
+		"sync failed": {
+			mapping: &interfaces.KNProxyAccount{LifecycleStatus: interfaces.KNProxyLifecycleActive, SyncStatus: interfaces.KNProxySyncFailed},
+			status:  http.StatusServiceUnavailable,
+			code:    berrors.BknBackend_KnowledgeNetwork_ProxySyncFailed,
+		},
+		"sync pending": {
+			mapping: &interfaces.KNProxyAccount{LifecycleStatus: interfaces.KNProxyLifecycleActive, SyncStatus: interfaces.KNProxySyncPending},
+			status:  http.StatusServiceUnavailable,
+			code:    berrors.BknBackend_KnowledgeNetwork_ProxySyncPending,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			service := &knowledgeNetworkService{kpa: &proxyAccessStub{mapping: test.mapping}}
+			_, err := service.ResolveKNProxyBinding(t.Context(), "kn-1", interfaces.KNProxyBinding{})
+			httpErr, ok := err.(*rest.HTTPError)
+			if !ok || httpErr.HTTPCode != test.status || httpErr.BaseError.ErrorCode != test.code {
+				t.Fatalf("ResolveKNProxyBinding() error = %#v, want status %d code %q", err, test.status, test.code)
+			}
+		})
 	}
 }
 

--- a/adp/bkn/ontology-query/server/drivenadapters/kn_proxy/kn_proxy_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/kn_proxy/kn_proxy_access.go
@@ -34,6 +34,10 @@ type resolveProxyBindingRequest struct {
 	Operation  string `json:"operation"`
 }
 
+type proxyErrorResponse struct {
+	ErrorCode string `json:"error_code"`
+}
+
 func NewKnowledgeNetworkProxyAccess(appSetting *common.AppSetting) interfaces.KnowledgeNetworkProxyAccess {
 	baseURL := ""
 	if appSetting != nil {
@@ -72,7 +76,12 @@ func (a *knowledgeNetworkProxyAccess) ResolveKnowledgeNetworkProxy(
 		return nil, fmt.Errorf("call BKN proxy lookup: %w", err)
 	}
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("BKN proxy lookup returned status %d", status)
+		response := proxyErrorResponse{}
+		_ = sonic.Unmarshal(body, &response)
+		return nil, &interfaces.KnowledgeNetworkProxyResolveError{
+			StatusCode: status,
+			Code:       strings.TrimSpace(response.ErrorCode),
+		}
 	}
 	if len(body) == 0 {
 		return nil, fmt.Errorf("BKN proxy lookup returned an empty response")

--- a/adp/bkn/ontology-query/server/drivenadapters/kn_proxy/kn_proxy_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/kn_proxy/kn_proxy_access_test.go
@@ -76,3 +76,25 @@ func TestResolveKnowledgeNetworkProxyRejectsIncompleteResponses(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveKnowledgeNetworkProxyPreservesOnlyStableDownstreamErrorContract(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	httpClient := rmock.NewMockHTTPClient(ctrl)
+	httpClient.EXPECT().PostNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(http.StatusServiceUnavailable, []byte(`{
+			"error_code":"BknBackend.KnowledgeNetwork.Proxy.SyncFailed",
+			"description":"must not cross service boundary",
+			"error_details":"proxy-credential-secret"
+		}`), nil)
+	access := &knowledgeNetworkProxyAccess{baseURL: "http://bkn", httpClient: httpClient}
+
+	_, err := access.ResolveKnowledgeNetworkProxy(context.Background(), interfaces.TrustedProxyBinding{KNID: "kn-1"})
+	resolutionErr, ok := err.(*interfaces.KnowledgeNetworkProxyResolveError)
+	if !ok || resolutionErr.StatusCode != http.StatusServiceUnavailable ||
+		resolutionErr.Code != "BknBackend.KnowledgeNetwork.Proxy.SyncFailed" {
+		t.Fatalf("error = %#v", err)
+	}
+	if got := resolutionErr.Error(); got == "" || got == "proxy-credential-secret" {
+		t.Fatalf("unexpected sanitized error string %q", got)
+	}
+}

--- a/adp/bkn/ontology-query/server/errors/error_code.go
+++ b/adp/bkn/ontology-query/server/errors/error_code.go
@@ -25,6 +25,13 @@ const (
 
 	// Permission
 	OntologyQuery_InternalError_CheckPermissionFailed = "OntologyQuery.InternalError.CheckPermissionFailed"
+	OntologyQuery_Proxy_BindingInvalid                = "OntologyQuery.Proxy.BindingInvalid"
+	OntologyQuery_Proxy_Disabled                      = "OntologyQuery.Proxy.Disabled"
+	OntologyQuery_Proxy_MappingNotFound               = "OntologyQuery.Proxy.MappingNotFound"
+	OntologyQuery_Proxy_PermissionDenied              = "OntologyQuery.Proxy.PermissionDenied"
+	OntologyQuery_Proxy_SyncFailed                    = "OntologyQuery.Proxy.SyncFailed"
+	OntologyQuery_Proxy_SyncPending                   = "OntologyQuery.Proxy.SyncPending"
+	OntologyQuery_Proxy_Unavailable                   = "OntologyQuery.Proxy.Unavailable"
 	// OntologyQuery_InternalError_CreateResourcesFailed = "OntologyQuery.InternalError.CreateResourcesFailed"
 	// OntologyQuery_InternalError_DeleteResourcesFailed = "OntologyQuery.InternalError.DeleteResourcesFailed"
 	// OntologyQuery_InternalError_FilterResourcesFailed = "OntologyQuery.InternalError.FilterResourcesFailed"
@@ -48,6 +55,13 @@ var (
 
 		// permission
 		OntologyQuery_InternalError_CheckPermissionFailed,
+		OntologyQuery_Proxy_BindingInvalid,
+		OntologyQuery_Proxy_Disabled,
+		OntologyQuery_Proxy_MappingNotFound,
+		OntologyQuery_Proxy_PermissionDenied,
+		OntologyQuery_Proxy_SyncFailed,
+		OntologyQuery_Proxy_SyncPending,
+		OntologyQuery_Proxy_Unavailable,
 		// OntologyQuery_InternalError_CreateResourcesFailed,
 		// OntologyQuery_InternalError_DeleteResourcesFailed,
 		// OntologyQuery_InternalError_FilterResourcesFailed,

--- a/adp/bkn/ontology-query/server/interfaces/proxy_context.go
+++ b/adp/bkn/ontology-query/server/interfaces/proxy_context.go
@@ -4,7 +4,10 @@
 
 package interfaces
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 const (
 	HTTPHeaderBKNCallerID     = "x-bkn-caller-id"
@@ -20,8 +23,12 @@ const (
 
 	ProxyAccountTypeApp = "app"
 
-	ProxyLifecycleActive = "active"
-	ProxySyncReady       = "ready"
+	ProxyLifecycleActive    = "active"
+	ProxyLifecycleDisabling = "disabling"
+	ProxyLifecycleArchived  = "archived"
+	ProxySyncPending        = "pending"
+	ProxySyncReady          = "ready"
+	ProxySyncFailed         = "failed"
 
 	ProxyTargetTypeResource = "resource"
 	ProxyTargetTypeToolBox  = "tool_box"
@@ -41,6 +48,18 @@ type KnowledgeNetworkProxyAccount struct {
 	SyncStatus            string `json:"sync_status"`
 	PublishedModelVersion string `json:"published_model_version"`
 	SyncedModelVersion    string `json:"synced_model_version"`
+}
+
+// KnowledgeNetworkProxyResolveError preserves only the stable status and code
+// returned by BKN. Response descriptions and internal details are deliberately
+// not propagated across the service boundary.
+type KnowledgeNetworkProxyResolveError struct {
+	StatusCode int
+	Code       string
+}
+
+func (e *KnowledgeNetworkProxyResolveError) Error() string {
+	return fmt.Sprintf("knowledge network proxy resolution failed with status %d and code %s", e.StatusCode, e.Code)
 }
 
 // TrustedProxyBinding identifies one downstream target derived from the

--- a/adp/bkn/ontology-query/server/locale/errorcode.en-US.toml
+++ b/adp/bkn/ontology-query/server/locale/errorcode.en-US.toml
@@ -44,6 +44,41 @@ Description = "Failed to verify data-query permission"
 Solution = "Please retry. If the authorization service remains unavailable, contact technical support."
 ErrorLink = ""
 
+[OntologyQuery.Proxy.BindingInvalid]
+Description = "The published binding cannot be accessed through the knowledge-network proxy"
+Solution = "Publish a valid binding and synchronize proxy permissions before retrying."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.Disabled]
+Description = "The knowledge-network proxy account is not active"
+Solution = "Ask an administrator to restore the proxy account."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.MappingNotFound]
+Description = "The knowledge-network proxy mapping does not exist"
+Solution = "Ask an administrator to synchronize the proxy account."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.PermissionDenied]
+Description = "The knowledge-network proxy lacks permission for the published resource"
+Solution = "Ask an administrator to inspect and synchronize proxy grants."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.SyncFailed]
+Description = "Knowledge-network proxy permission synchronization failed"
+Solution = "Ask an administrator to inspect the synchronization error and retry."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.SyncPending]
+Description = "Knowledge-network proxy permissions are still synchronizing"
+Solution = "Wait for synchronization to finish or ask an administrator to retry it."
+ErrorLink = ""
+
+[OntologyQuery.Proxy.Unavailable]
+Description = "The knowledge-network proxy service is unavailable"
+Solution = "Try again later; contact an administrator if the problem persists."
+ErrorLink = ""
+
 [OntologyQuery.Metric.InvalidParameter]
 Description = "Invalid metric request parameter"
 Solution = "Please check the request body and path parameters."

--- a/adp/bkn/ontology-query/server/locale/errorcode.zh-CN.toml
+++ b/adp/bkn/ontology-query/server/locale/errorcode.zh-CN.toml
@@ -44,6 +44,41 @@ Description = "数据查询权限校验失败"
 Solution = "请重试；若授权服务持续不可用，请联系技术支持。"
 ErrorLink = ""
 
+[OntologyQuery.Proxy.BindingInvalid]
+Description = "已发布绑定无法通过知识网络代理访问"
+Solution = "请发布有效绑定并同步代理权限，然后重试。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.Disabled]
+Description = "知识网络代理账号未处于启用状态"
+Solution = "请联系管理员恢复代理账号。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.MappingNotFound]
+Description = "知识网络代理映射不存在"
+Solution = "请联系管理员同步代理账号。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.PermissionDenied]
+Description = "知识网络代理缺少已发布资源的访问权限"
+Solution = "请联系管理员检查并同步代理授权。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.SyncFailed]
+Description = "知识网络代理权限同步失败"
+Solution = "请联系管理员检查同步错误并重试。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.SyncPending]
+Description = "知识网络代理权限正在同步"
+Solution = "请等待同步完成，或联系管理员重试同步。"
+ErrorLink = ""
+
+[OntologyQuery.Proxy.Unavailable]
+Description = "知识网络代理服务不可用"
+Solution = "请稍后重试；若问题持续，请联系管理员。"
+ErrorLink = ""
+
 [OntologyQuery.Metric.InvalidParameter]
 Description = "指标请求参数无效"
 Solution = "请检查请求体与路径参数。"

--- a/adp/bkn/ontology-query/server/logics/object_type/downstream_error_code_test.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/downstream_error_code_test.go
@@ -71,3 +71,12 @@ func Test_downstreamErrorCodeIsRegisteredInEveryLanguage(t *testing.T) {
 		}
 	}
 }
+
+func Test_proxyDownstreamErrorCodeSeparatesManagedProxyPermission(t *testing.T) {
+	if got := proxyDownstreamErrorCode(http.StatusForbidden); got != oerrors.OntologyQuery_Proxy_PermissionDenied {
+		t.Fatalf("proxy 403 code = %q, want %q", got, oerrors.OntologyQuery_Proxy_PermissionDenied)
+	}
+	if got := proxyDownstreamErrorCode(http.StatusBadRequest); got != oerrors.OntologyQuery_ObjectType_InvalidParameter {
+		t.Fatalf("proxy 400 code = %q, want %q", got, oerrors.OntologyQuery_ObjectType_InvalidParameter)
+	}
+}

--- a/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/ontology-query/server/logics/object_type/object_type_service.go
@@ -110,7 +110,7 @@ func (ots *objectTypeService) GetObjectTypeSchema(ctx context.Context,
 	response, err := ots.vba.GetResourceSchema(interfaces.WithTrustedProxyContext(ctx, proxyContext), objectType.DataSource.ID)
 	if err != nil {
 		if downstream, ok := interfaces.AsVegaDownstreamError(err); ok && downstream.IsClientError() {
-			return nil, rest.NewHTTPError(ctx, downstream.StatusCode, downstreamErrorCode(downstream.StatusCode))
+			return nil, rest.NewHTTPError(ctx, downstream.StatusCode, proxyDownstreamErrorCode(downstream.StatusCode))
 		}
 		return nil, rest.NewHTTPError(ctx, http.StatusServiceUnavailable,
 			oerrors.OntologyQuery_ObjectType_InternalError_GetObjectTypesByIDFailed)
@@ -452,6 +452,16 @@ func downstreamErrorCode(statusCode int) string {
 	}
 }
 
+// proxyDownstreamErrorCode distinguishes a denied managed principal from a
+// denied business caller. Caller authorization has already succeeded before a
+// trusted proxy context reaches Vega.
+func proxyDownstreamErrorCode(statusCode int) string {
+	if statusCode == http.StatusForbidden {
+		return oerrors.OntologyQuery_Proxy_PermissionDenied
+	}
+	return downstreamErrorCode(statusCode)
+}
+
 func (ots *objectTypeService) getObjectsFromResource(ctx context.Context, query *interfaces.ObjectQueryBaseOnObjectType,
 	objectType interfaces.ObjectType, resps *interfaces.Objects, fieldPropMap map[string]string) error {
 
@@ -528,7 +538,7 @@ func (ots *objectTypeService) getObjectsFromResource(ctx context.Context, query 
 		// like service failures, preventing callers from self-correcting and sending manual investigation in the wrong direction.
 		if downstream, ok := interfaces.AsVegaDownstreamError(err); ok && downstream.IsClientError() {
 			return rest.NewHTTPError(ctx, downstream.StatusCode,
-				downstreamErrorCode(downstream.StatusCode))
+				proxyDownstreamErrorCode(downstream.StatusCode))
 		}
 		return rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			oerrors.OntologyQuery_ObjectType_InternalError_GetViewDataByIDFailed).WithErrorDetails(err.Error())

--- a/adp/bkn/ontology-query/server/logics/proxy_context/proxy_context_service.go
+++ b/adp/bkn/ontology-query/server/logics/proxy_context/proxy_context_service.go
@@ -6,6 +6,7 @@ package proxy_context
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -20,6 +21,14 @@ type proxyContextResolver struct {
 	access interfaces.KnowledgeNetworkProxyAccess
 }
 
+const (
+	bknProxyBindingInvalidCode  = "BknBackend.KnowledgeNetwork.Proxy.BindingInvalid"
+	bknProxyDisabledCode        = "BknBackend.KnowledgeNetwork.Proxy.Disabled"
+	bknProxyMappingNotFoundCode = "BknBackend.KnowledgeNetwork.Proxy.MappingNotFound"
+	bknProxySyncFailedCode      = "BknBackend.KnowledgeNetwork.Proxy.SyncFailed"
+	bknProxySyncPendingCode     = "BknBackend.KnowledgeNetwork.Proxy.SyncPending"
+)
+
 func NewProxyContextResolver(access interfaces.KnowledgeNetworkProxyAccess) interfaces.ProxyContextResolver {
 	return &proxyContextResolver{access: access}
 }
@@ -33,26 +42,40 @@ func (r *proxyContextResolver) Resolve(
 		return nil, proxyUnavailable(ctx, "request caller is unavailable")
 	}
 	if err := validateBinding(binding); err != nil {
-		return nil, proxyUnavailable(ctx, "trusted proxy binding is invalid")
+		return nil, proxyError(ctx, http.StatusForbidden, oerrors.OntologyQuery_Proxy_BindingInvalid,
+			"trusted proxy binding is invalid")
 	}
 	if r == nil || r.access == nil {
 		return nil, proxyUnavailable(ctx, "knowledge network proxy resolver is not configured")
 	}
 
 	mapping, err := r.access.ResolveKnowledgeNetworkProxy(ctx, binding)
-	if err != nil || mapping == nil {
+	if err != nil {
+		return nil, mapProxyResolutionError(ctx, err)
+	}
+	if mapping == nil {
 		return nil, proxyUnavailable(ctx, "knowledge network proxy mapping is unavailable")
+	}
+	if mapping.LifecycleStatus != interfaces.ProxyLifecycleActive {
+		return nil, proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_Disabled,
+			"knowledge network proxy is not active")
+	}
+	if mapping.SyncStatus == interfaces.ProxySyncFailed {
+		return nil, proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_SyncFailed,
+			"knowledge network proxy synchronization failed")
+	}
+	if mapping.SyncStatus != interfaces.ProxySyncReady ||
+		strings.TrimSpace(mapping.PublishedModelVersion) == "" ||
+		mapping.PublishedModelVersion != mapping.SyncedModelVersion {
+		return nil, proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_SyncPending,
+			"knowledge network proxy is not synchronized with the current published model")
 	}
 	if mapping.KNID != binding.KNID ||
 		strings.TrimSpace(mapping.ProxyAccountID) == "" ||
 		strings.TrimSpace(mapping.ProxyAccountID) != mapping.ProxyAccountID ||
 		mapping.ProxyAccountType != interfaces.ProxyAccountTypeApp ||
-		mapping.LifecycleStatus != interfaces.ProxyLifecycleActive ||
-		mapping.SyncStatus != interfaces.ProxySyncReady ||
 		mapping.Version <= 0 ||
-		strings.TrimSpace(mapping.PublishedModelVersion) == "" ||
-		strings.TrimSpace(mapping.PublishedModelVersion) != mapping.PublishedModelVersion ||
-		mapping.PublishedModelVersion != mapping.SyncedModelVersion {
+		strings.TrimSpace(mapping.PublishedModelVersion) != mapping.PublishedModelVersion {
 		return nil, proxyUnavailable(ctx, "knowledge network proxy is not ready")
 	}
 
@@ -121,6 +144,35 @@ func validateBinding(binding interfaces.TrustedProxyBinding) error {
 }
 
 func proxyUnavailable(ctx context.Context, detail string) *rest.HTTPError {
-	return rest.NewHTTPError(ctx, http.StatusServiceUnavailable,
-		oerrors.OntologyQuery_InternalError_CheckPermissionFailed).WithErrorDetails(detail)
+	return proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_Unavailable, detail)
+}
+
+func proxyError(ctx context.Context, status int, code, detail string) *rest.HTTPError {
+	return rest.NewHTTPError(ctx, status, code).WithErrorDetails(detail)
+}
+
+func mapProxyResolutionError(ctx context.Context, err error) *rest.HTTPError {
+	var resolutionErr *interfaces.KnowledgeNetworkProxyResolveError
+	if !errors.As(err, &resolutionErr) {
+		return proxyUnavailable(ctx, "knowledge network proxy mapping is unavailable")
+	}
+	switch resolutionErr.Code {
+	case bknProxyBindingInvalidCode:
+		return proxyError(ctx, http.StatusForbidden, oerrors.OntologyQuery_Proxy_BindingInvalid,
+			"target is not a current published binding")
+	case bknProxyDisabledCode:
+		return proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_Disabled,
+			"knowledge network proxy is not active")
+	case bknProxyMappingNotFoundCode:
+		return proxyError(ctx, http.StatusNotFound, oerrors.OntologyQuery_Proxy_MappingNotFound,
+			"knowledge network proxy mapping does not exist")
+	case bknProxySyncFailedCode:
+		return proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_SyncFailed,
+			"knowledge network proxy synchronization failed")
+	case bknProxySyncPendingCode:
+		return proxyError(ctx, http.StatusServiceUnavailable, oerrors.OntologyQuery_Proxy_SyncPending,
+			"knowledge network proxy synchronization is pending")
+	default:
+		return proxyUnavailable(ctx, "knowledge network proxy mapping is unavailable")
+	}
 }

--- a/adp/bkn/ontology-query/server/logics/proxy_context/proxy_context_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/proxy_context/proxy_context_service_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
+	oerrors "ontology-query/errors"
 	"ontology-query/interfaces"
 )
 
@@ -86,6 +87,53 @@ func TestResolveFailsClosedWhenMappingDependencyFails(t *testing.T) {
 	assertServiceUnavailable(t, got, err)
 }
 
+func TestResolveMapsStableBKNProxyErrors(t *testing.T) {
+	tests := map[string]struct {
+		status int
+		code   string
+		want   string
+	}{
+		"missing mapping": {
+			status: http.StatusNotFound,
+			code:   bknProxyMappingNotFoundCode,
+			want:   oerrors.OntologyQuery_Proxy_MappingNotFound,
+		},
+		"disabled": {
+			status: http.StatusServiceUnavailable,
+			code:   bknProxyDisabledCode,
+			want:   oerrors.OntologyQuery_Proxy_Disabled,
+		},
+		"sync failed": {
+			status: http.StatusServiceUnavailable,
+			code:   bknProxySyncFailedCode,
+			want:   oerrors.OntologyQuery_Proxy_SyncFailed,
+		},
+		"sync pending": {
+			status: http.StatusServiceUnavailable,
+			code:   bknProxySyncPendingCode,
+			want:   oerrors.OntologyQuery_Proxy_SyncPending,
+		},
+		"invalid binding": {
+			status: http.StatusForbidden,
+			code:   bknProxyBindingInvalidCode,
+			want:   oerrors.OntologyQuery_Proxy_BindingInvalid,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			resolver := NewProxyContextResolver(&proxyAccessStub{err: &interfaces.KnowledgeNetworkProxyResolveError{
+				StatusCode: test.status,
+				Code:       test.code,
+			}})
+			_, err := resolver.Resolve(callerContext(), validBinding())
+			httpErr, ok := err.(*rest.HTTPError)
+			if !ok || httpErr.BaseError.ErrorCode != test.want {
+				t.Fatalf("Resolve() error = %#v, want code %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestResolveRejectsMissingCallerAndForgedBinding(t *testing.T) {
 	resolver := NewProxyContextResolver(&proxyAccessStub{mapping: readyMapping()})
 	got, err := resolver.Resolve(context.Background(), validBinding())
@@ -94,17 +142,17 @@ func TestResolveRejectsMissingCallerAndForgedBinding(t *testing.T) {
 	binding := validBinding()
 	binding.TargetID = "resource-*"
 	got, err = resolver.Resolve(callerContext(), binding)
-	assertServiceUnavailable(t, got, err)
+	assertProxyError(t, got, err, http.StatusForbidden, oerrors.OntologyQuery_Proxy_BindingInvalid)
 
 	binding = validBinding()
 	binding.TargetID = "unbound/resource"
 	got, err = resolver.Resolve(callerContext(), binding)
-	assertServiceUnavailable(t, got, err)
+	assertProxyError(t, got, err, http.StatusForbidden, oerrors.OntologyQuery_Proxy_BindingInvalid)
 
 	binding = validBinding()
 	binding.Operation = interfaces.PermissionOperationExecute
 	got, err = resolver.Resolve(callerContext(), binding)
-	assertServiceUnavailable(t, got, err)
+	assertProxyError(t, got, err, http.StatusForbidden, oerrors.OntologyQuery_Proxy_BindingInvalid)
 }
 
 func assertServiceUnavailable(t *testing.T, _ *interfaces.TrustedProxyContext, err error) {
@@ -115,6 +163,14 @@ func assertServiceUnavailable(t *testing.T, _ *interfaces.TrustedProxyContext, e
 	httpErr, ok := err.(*rest.HTTPError)
 	if !ok || httpErr.HTTPCode != http.StatusServiceUnavailable {
 		t.Fatalf("expected 503 HTTPError, got %T %#v", err, err)
+	}
+}
+
+func assertProxyError(t *testing.T, _ *interfaces.TrustedProxyContext, err error, status int, code string) {
+	t.Helper()
+	httpErr, ok := err.(*rest.HTTPError)
+	if !ok || httpErr.HTTPCode != status || httpErr.BaseError.ErrorCode != code {
+		t.Fatalf("expected status %d code %q, got %T %#v", status, code, err, err)
 	}
 }
 

--- a/docs/api/bkn/proxy-accounts.yaml
+++ b/docs/api/bkn/proxy-accounts.yaml
@@ -1,9 +1,92 @@
 openapi: 3.0.3
 info:
   title: BKN Knowledge Network Managed Proxy API
-  version: 0.1.0
-  description: Cluster-internal runtime lookup and governance APIs for the environment-local knowledge-network proxy mapping.
+  version: 0.2.0
+  description: OAuth-protected governance APIs and cluster-internal runtime APIs for environment-local knowledge-network proxy mappings.
 paths:
+  /api/bkn-backend/v1/proxy-accounts:
+    get:
+      summary: List knowledge-network proxy mappings in the caller's governance scope
+      description: Returns only mappings for knowledge networks on which the OAuth caller has the authorize operation. Unauthorized mapping existence and proxy account identifiers are not disclosed.
+      security:
+        - OAuth2: []
+      responses:
+        '200':
+          description: Permission-filtered mapping list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeNetworkProxyAccountList'
+        '401': { description: OAuth authentication failed. }
+        '503': { description: Proxy mapping storage or authorization filtering is unavailable. }
+  /api/bkn-backend/v1/knowledge-networks/{kn_id}/proxy-account:
+    get:
+      summary: Get one governed knowledge-network proxy mapping
+      security:
+        - OAuth2: []
+      parameters:
+        - $ref: '#/components/parameters/KnowledgeNetworkID'
+      responses:
+        '200':
+          description: Mapping state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeNetworkProxyGovernanceView'
+        '401': { description: OAuth authentication failed. }
+        '403': { description: The caller cannot authorize this knowledge network. }
+        '404': { description: No mapping exists. }
+        '503': { description: Proxy orchestration is unavailable. }
+  /api/bkn-backend/v1/knowledge-networks/{kn_id}/proxy-account/plan:
+    get:
+      summary: Preview the published binding sources used for proxy synchronization
+      security:
+        - OAuth2: []
+      parameters:
+        - $ref: '#/components/parameters/KnowledgeNetworkID'
+      responses:
+        '200':
+          description: Side-effect-free synchronization plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxySyncPlan'
+        '401': { description: OAuth authentication failed. }
+        '403': { description: The caller cannot authorize this knowledge network. }
+  /api/bkn-backend/v1/knowledge-networks/{kn_id}/proxy-account/sync:
+    post:
+      summary: Retry proxy synchronization from the latest persisted main model
+      security:
+        - OAuth2: []
+      parameters:
+        - $ref: '#/components/parameters/KnowledgeNetworkID'
+      responses:
+        '200':
+          description: Latest synchronization state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KnowledgeNetworkProxyGovernanceView'
+        '401': { description: OAuth authentication failed. }
+        '403': { description: The caller lacks authorize or a required target operation. }
+        '409': { description: Another publication owns the per-network lease. }
+        '503': { description: Synchronization failed; the mapping remains fail-closed. }
+  /api/bkn-backend/v1/proxy-accounts/reconcile:
+    post:
+      summary: Detect and reconcile proxy authorization drift
+      description: The caller must hold authorize on every live mapped knowledge network. Authorization completes before any policy repair starts.
+      security:
+        - OAuth2: []
+      responses:
+        '200':
+          description: Reconciliation report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProxyGovernanceReconcileReport'
+        '401': { description: OAuth authentication failed. }
+        '403': { description: The caller cannot authorize every live mapped knowledge network. }
+        '503': { description: Reconciliation is unavailable. }
   /api/bkn-backend/in/v1/knowledge-networks/{kn_id}/proxy-account:
     get:
       summary: Resolve the managed runtime proxy and publication synchronization state
@@ -43,8 +126,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/KnowledgeNetworkProxyAccount'
         '403': { description: The target is not an exact current published binding. }
-        '404': { description: No mapping exists. }
-        '503': { description: Mapping or model synchronization is unavailable. }
+        '404': { description: No mapping exists (`BknBackend.KnowledgeNetwork.Proxy.MappingNotFound`). }
+        '503': { description: "Mapping is disabled, pending, failed, or unavailable; see the stable `BknBackend.KnowledgeNetwork.Proxy.*` error code." }
   /api/bkn-backend/in/v1/knowledge-networks/{kn_id}/proxy-account/sync:
     post:
       summary: Retry synchronization from the latest persisted main model
@@ -96,6 +179,9 @@ paths:
         '403': { description: The caller cannot authorize every live mapped knowledge network. }
         '503': { description: Reconciliation is unavailable. }
 components:
+  securitySchemes:
+    OAuth2:
+      $ref: '../_shared/auth.yaml#/components/securitySchemes/OAuth2'
   parameters:
     KnowledgeNetworkID:
       name: kn_id
@@ -103,6 +189,17 @@ components:
       required: true
       schema: { type: string, maxLength: 64 }
   schemas:
+    KnowledgeNetworkProxyAccountList:
+      type: object
+      required: [entries, total]
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/KnowledgeNetworkProxyGovernanceView'
+        total:
+          type: integer
+          minimum: 0
     ProxyRuntimeBinding:
       type: object
       additionalProperties: false
@@ -128,6 +225,22 @@ components:
         last_error: { type: string, maxLength: 1024 }
         created_at: { type: integer, format: int64 }
         updated_at: { type: integer, format: int64 }
+    KnowledgeNetworkProxyGovernanceView:
+      type: object
+      description: OAuth governance projection. Internal last-error, grantor, and lock details are omitted.
+      required: [kn_id, proxy_account_id, proxy_account_type, lifecycle_status, version, sync_status, published_model_version, synced_model_version, created_at, updated_at]
+      properties:
+        kn_id: { type: string }
+        proxy_account_id: { type: string, readOnly: true }
+        proxy_account_type: { type: string, enum: [app], readOnly: true }
+        lifecycle_status: { type: string, enum: [active, disabling, archived] }
+        last_error_code: { type: string, enum: [PROXY_SYNC_FAILED], description: Stable public summary; raw internal synchronization errors are omitted. }
+        version: { type: integer, format: int64 }
+        sync_status: { type: string, enum: [pending, ready, failed] }
+        published_model_version: { type: string }
+        synced_model_version: { type: string }
+        created_at: { type: integer, format: int64 }
+        updated_at: { type: integer, format: int64 }
     ProxyReconcileReport:
       type: object
       required: [missing_mappings, orphan_mappings, conflicting_proxy_accounts, authorization_drift]
@@ -150,6 +263,29 @@ components:
         errors:
           type: object
           additionalProperties: { type: string }
+    ProxyGovernanceReconcileReport:
+      type: object
+      description: Public reconciliation result. Failed network IDs are exposed without raw internal error text.
+      required: [missing_mappings, orphan_mappings, conflicting_proxy_accounts, authorization_drift]
+      properties:
+        missing_mappings:
+          type: array
+          items: { type: string }
+        orphan_mappings:
+          type: array
+          items: { type: string }
+        conflicting_proxy_accounts:
+          type: object
+          additionalProperties:
+            type: array
+            items: { type: string }
+        authorization_drift:
+          type: object
+          additionalProperties:
+            type: object
+        failed_kn_ids:
+          type: array
+          items: { type: string }
     ProxySyncPlan:
       type: object
       required: [kn_id, model_version, sources]

--- a/docs/api/bkn/proxy-accounts.yaml
+++ b/docs/api/bkn/proxy-accounts.yaml
@@ -74,7 +74,7 @@ paths:
   /api/bkn-backend/v1/proxy-accounts/reconcile:
     post:
       summary: Detect and reconcile proxy authorization drift
-      description: The caller must hold authorize on every live mapped knowledge network. Authorization completes before any policy repair starts.
+      description: The caller must hold authorize on every live main-branch knowledge network, including those without a proxy mapping. Authorization completes before any policy repair starts.
       security:
         - OAuth2: []
       responses:
@@ -85,7 +85,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProxyGovernanceReconcileReport'
         '401': { description: OAuth authentication failed. }
-        '403': { description: The caller cannot authorize every live mapped knowledge network. }
+        '403': { description: The caller cannot authorize every live main-branch knowledge network. }
         '503': { description: Reconciliation is unavailable. }
   /api/bkn-backend/in/v1/knowledge-networks/{kn_id}/proxy-account:
     get:
@@ -168,7 +168,7 @@ paths:
   /api/bkn-backend/in/v1/proxy-accounts/reconcile:
     post:
       summary: Detect mapping defects and reconcile bkn-safe authorization ledger drift
-      description: The caller must hold authorize on every live knowledge network that has a proxy mapping. Authorization is completed before any policy repair starts; orphan mappings are reported without mutation.
+      description: The caller must hold authorize on every live main-branch knowledge network, including those without a proxy mapping. Authorization is completed before any policy repair starts; orphan mappings are reported without mutation.
       responses:
         '200':
           description: Reconciliation report
@@ -176,7 +176,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProxyReconcileReport'
-        '403': { description: The caller cannot authorize every live mapped knowledge network. }
+        '403': { description: The caller cannot authorize every live main-branch knowledge network. }
         '503': { description: Reconciliation is unavailable. }
 components:
   securitySchemes:

--- a/docs/api/ontology-query/ontology-query.yaml
+++ b/docs/api/ontology-query/ontology-query.yaml
@@ -82,9 +82,9 @@ paths:
                     items:
                       type: object
                       additionalProperties: true
-        '403': { description: Caller or managed proxy lacks the required permission. }
-        '404': { description: The published object type does not exist. }
-        '503': { description: Proxy mapping or a permission dependency is unavailable. }
+        '403': { description: "Caller permission is denied, or the managed proxy lacks resource permission (`OntologyQuery.Proxy.PermissionDenied`)." }
+        '404': { description: The published object type or proxy mapping does not exist (`OntologyQuery.Proxy.MappingNotFound` for the latter). }
+        '503': { description: "Proxy binding is invalid, disabled, pending, failed, or unavailable; see the stable `OntologyQuery.Proxy.*` error code." }
   /api/ontology-query/v1/knowledge-networks/{kn_id}/object-types/{ot_id}/sample-data:
     get:
       summary: Get object-type sample data through the managed proxy
@@ -145,9 +145,9 @@ paths:
                   search_after:
                     type: array
                     items: {}
-        '403': { description: Caller or managed proxy lacks query_data. }
-        '404': { description: The published object type does not exist. }
-        '503': { description: Proxy mapping or a permission dependency is unavailable. }
+        '403': { description: "Caller query_data is denied, or the managed proxy lacks resource query_data (`OntologyQuery.Proxy.PermissionDenied`)." }
+        '404': { description: The published object type or proxy mapping does not exist (`OntologyQuery.Proxy.MappingNotFound` for the latter). }
+        '503': { description: "Proxy binding is invalid, disabled, pending, failed, or unavailable; see the stable `OntologyQuery.Proxy.*` error code." }
   /api/ontology-query/v1/knowledge-networks/{kn_id}/object-types/{ot_id}:
     summary: 检索指定对象类的对象的详细数据
     post:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add OAuth-protected knowledge-network proxy governance read, sync, plan, and reconciliation endpoints.
- [x] Preserve stable managed-proxy lifecycle, synchronization, binding, and permission error semantics across BKN Backend and Ontology Query.
- [x] Document the public governance projection and controlled object-type schema/sample-data error contract.

---

## Why

- Related Issue: [Issue #1310](https://github.com/openbkn-ai/bkn-foundry/issues/1310)
- Related Feature: [Managed identity and authorization governance #805](https://github.com/openbkn-ai/bkn-foundry/issues/805)
- Background: Studio needs a fail-closed server contract for proxy state visibility and repair without receiving proxy credentials, raw internal errors, or caller-selectable proxy targets.

---

## How

- Key implementation points:
  - Verify OAuth before every public governance operation and require the exact knowledge-network authorize operation.
  - Filter list results server-side so unauthorized mapping existence and proxy identifiers are not disclosed.
  - Return sanitized governance DTOs and stable public error codes while keeping existing internal APIs backward compatible.
  - Derive synchronization plans and runtime bindings from the persisted published model; clients cannot submit proxy accounts or arbitrary target resources.
  - Map managed-proxy permission failures separately from original-caller permission failures in Ontology Query.
- Breaking changes (API, config, database, etc.): None. Existing cluster-internal routes and response DTOs remain available.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- I18N_MODE_UT=true go test ./... in adp/bkn/bkn-backend/server
- I18N_MODE_UT=true go test ./... in adp/bkn/ontology-query/server
- I18N_MODE_UT=true go vet ./... in both affected Go modules
- golangci-lint run --new-from-rev=origin/main ./... in both affected Go modules: 0 new issues
- REDOCLY_TELEMETRY=off make api-docs-lint: passed; existing repository warnings remain

---

## Risk & Rollback

- Potential risks: Incorrect state or permission mapping could hide a governed proxy or return an overly generic failure. Focused handler, orchestration, adapter, resolver, locale, and permission tests cover these paths.
- Rollback plan: Revert this PR. No database schema, persisted-data migration, deployment configuration, or credential format changes are included.

---

## Additional Notes

- This PR contains backend and API-contract changes only. The Studio frontend is intentionally kept in a separate local worktree and is not part of this PR.
- Full golangci-lint without a baseline still reports unrelated findings already present on main; this PR introduces zero new findings relative to origin/main.

Closes #1310