### PR TITLE
fix(bkn-trace): preserve first-turn conversation previews

### DIFF
--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go
@@ -1546,18 +1546,19 @@ func (s *Service) listConversationIdentityPage(ctx context.Context, options evid
 		return evidencevo.ConversationSummaryPage{Entries: []evidencevo.ConversationSummary{}, Total: identityPage.Total, Page: normalizeSummaryPage(options.Page), PageSize: normalizeSummaryLimit(options.Limit)}, true, nil
 	}
 	ids := summaryIdentityIDs(identityPage.Entries)
-	interactionIDs, interactionsByConversation, err := s.listCanonicalInteractionIDs(ctx, ids)
+	_, interactionsByConversation, err := s.listCanonicalInteractionIDs(ctx, ids)
 	if err != nil {
 		return evidencevo.ConversationSummaryPage{}, true, err
 	}
+	previewInteractionIDs := firstCanonicalInteractionIDs(interactionsByConversation)
 	terminalArtifactTypes := []evidencevo.ArtifactType(nil)
-	if len(interactionIDs) > 0 {
+	if len(previewInteractionIDs) > 0 {
 		terminalArtifactTypes = []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult}
 	}
 	requests, _, metadata, err := s.loadProjectedExecutionSummaries(ctx, iprojectionsource.Query{
 		Scope:           options.Scope,
 		ConversationIDs: ids,
-		InteractionIDs:  interactionIDs,
+		InteractionIDs:  previewInteractionIDs,
 		ArtifactTypes:   terminalArtifactTypes,
 		Limit:           selectedSummaryCandidateLimit(len(ids)),
 	}, summaryLoadMetadata{})
@@ -1641,6 +1642,24 @@ func (s *Service) listCanonicalInteractionIDs(ctx context.Context, conversationI
 	return ids, byConversation, nil
 }
 
+func firstCanonicalInteractionIDs(byConversation map[string][]sessionvo.Interaction) []string {
+	ids := make([]string, 0, len(byConversation))
+	seen := make(map[string]struct{})
+	for _, interactions := range byConversation {
+		first, ok := firstCanonicalInteraction(interactions)
+		if !ok {
+			continue
+		}
+		if _, found := seen[first.ID]; found {
+			continue
+		}
+		seen[first.ID] = struct{}{}
+		ids = append(ids, first.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
 // applyFirstCanonicalConversationPreview makes the list preview describe the
 // first managed turn. A later round must never substitute content when that
 // first turn has no readable terminal artifact.
@@ -1652,13 +1671,8 @@ func applyFirstCanonicalConversationPreview(
 	if entry == nil || len(interactions) == 0 {
 		return
 	}
-	first := interactions[0]
-	for _, interaction := range interactions[1:] {
-		if interaction.Ordinal < first.Ordinal || interaction.Ordinal == first.Ordinal && interaction.ID < first.ID {
-			first = interaction
-		}
-	}
-	if first.ID == "" {
+	first, ok := firstCanonicalInteraction(interactions)
+	if !ok {
 		return
 	}
 	firstRequests := make([]evidencevo.RequestSummary, 0)
@@ -1673,6 +1687,20 @@ func applyFirstCanonicalConversationPreview(
 	}
 	summary, _ := aggregateRequestGroup(firstRequests)
 	entry.QuestionPreview, entry.ResultPreview = summary.QuestionPreview, summary.ResultPreview
+}
+
+func firstCanonicalInteraction(interactions []sessionvo.Interaction) (sessionvo.Interaction, bool) {
+	var first sessionvo.Interaction
+	found := false
+	for _, interaction := range interactions {
+		if interaction.ID == "" {
+			continue
+		}
+		if !found || interaction.Ordinal < first.Ordinal || interaction.Ordinal == first.Ordinal && interaction.ID < first.ID {
+			first, found = interaction, true
+		}
+	}
+	return first, found
 }
 
 func canUseSummaryIdentityPage(options evidencevo.SummaryQueryOptions) bool {

--- a/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
+++ b/bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go
@@ -195,7 +195,8 @@ func TestListConversationsLoadsInteractionScopedTerminalArtifactsForPage(t *test
 	if page.Entries[0].InteractionCount != 2 {
 		t.Fatalf("canonical interactions must determine the conversation turn count: %+v", page.Entries[0])
 	}
-	if len(projection.queries) != 1 || !containsSummaryID(projection.queries[0].InteractionIDs, "interaction-page") {
+	if len(projection.queries) != 1 || len(projection.queries[0].InteractionIDs) != 1 ||
+		!containsSummaryID(projection.queries[0].InteractionIDs, "interaction-page") {
 		t.Fatalf("conversation page must load terminal artifacts by canonical interaction id: %+v", projection.queries)
 	}
 	if !containsArtifactType(projection.queries[0].ArtifactTypes, evidencevo.ArtifactTypeQuestion) ||

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -99,7 +99,7 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 				interactionSet[receipt.InteractionID] = struct{}{}
 			}
 		}
-		selectedReceipts, selectedTruncated, err := s.loadSelectedInteractionReceipts(ctx, query, query.InteractionIDs)
+		selectedReceipts, selectedTruncated, err := s.loadInteractionReceipts(ctx, query, query.InteractionIDs)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -277,14 +277,6 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 }
 
 func (s *Source) loadInteractionReceipts(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
-	return s.loadInteractionReceiptsWithCollapse(ctx, query, interactionIDs, false)
-}
-
-func (s *Source) loadSelectedInteractionReceipts(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
-	return s.loadInteractionReceiptsWithCollapse(ctx, query, interactionIDs, true)
-}
-
-func (s *Source) loadInteractionReceiptsWithCollapse(ctx context.Context, query iprojectionsource.Query, interactionIDs []string, collapse bool) ([]receiptDocument, bool, error) {
 	if len(interactionIDs) == 0 {
 		return nil, false, nil
 	}
@@ -294,10 +286,10 @@ func (s *Source) loadInteractionReceiptsWithCollapse(ctx context.Context, query 
 	interactionQuery.InteractionID = ""
 	interactionQuery.From = time.Time{}
 	interactionQuery.To = time.Time{}
-	return s.searchReceiptsForInteractions(ctx, interactionQuery, interactionIDs, collapse)
+	return s.searchReceiptsForInteractions(ctx, interactionQuery, interactionIDs)
 }
 
-func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string, collapse bool) ([]receiptDocument, bool, error) {
+func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
 	size := maxProjectionDocuments
 	if query.Limit > 0 && query.Limit < size {
 		// Keep the follow-up expansion within the same caller-owned candidate
@@ -307,24 +299,11 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 	}
 	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
 	must = append(must, map[string]any{"terms": map[string]any{"interaction_id.keyword": interactionIDs}})
-	queryBody := map[string]any{
+	body, err := json.Marshal(map[string]any{
 		"size":  size,
 		"query": map[string]any{"bool": map[string]any{"must": must}},
 		"sort":  []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
-	}
-	innerHitName := ""
-	if collapse {
-		innerHitName = "selected_interaction_receipts"
-		queryBody["size"] = len(interactionIDs)
-		queryBody["collapse"] = map[string]any{
-			"field": "interaction_id.keyword",
-			"inner_hits": map[string]any{
-				"name": innerHitName, "size": maxReceiptsPerSelectedIdentity,
-				"sort": []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
-			},
-		}
-	}
-	body, err := json.Marshal(queryBody)
+	})
 	if err != nil {
 		return nil, false, err
 	}
@@ -335,17 +314,7 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 	var response struct {
 		Hits struct {
 			Hits []struct {
-				Source    receiptDocument `json:"_source"`
-				InnerHits map[string]struct {
-					Hits struct {
-						Total struct {
-							Value int `json:"value"`
-						} `json:"total"`
-						Hits []struct {
-							Source receiptDocument `json:"_source"`
-						} `json:"hits"`
-					} `json:"hits"`
-				} `json:"inner_hits"`
+				Source receiptDocument `json:"_source"`
 			} `json:"hits"`
 		} `json:"hits"`
 	}
@@ -353,22 +322,8 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 		return nil, false, fmt.Errorf("decode Core interaction receipt projection: %w", err)
 	}
 	result := make([]receiptDocument, 0, len(response.Hits.Hits))
-	truncated := false
 	for _, hit := range response.Hits.Hits {
-		if innerHitName != "" {
-			inner := hit.InnerHits[innerHitName].Hits
-			for _, innerHit := range inner.Hits {
-				result = append(result, innerHit.Source)
-			}
-			if inner.Total.Value > len(inner.Hits) {
-				truncated = true
-			}
-			continue
-		}
 		result = append(result, hit.Source)
-	}
-	if innerHitName != "" {
-		return result, truncated, nil
 	}
 	return result, len(response.Hits.Hits) >= size, nil
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -88,13 +88,40 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 	if hasBatchIdentitySelector(query) {
 		result := make([]receiptDocument, 0, len(candidates))
 		interactionSet := make(map[string]struct{})
+		receiptSet := make(map[string]struct{})
 		for _, receipt := range candidates {
 			if !receiptMatchesScope(receipt, query.Scope) || !matchesReceiptQuery(receipt, query) {
 				continue
 			}
 			result = append(result, receipt)
+			receiptSet[receipt.ReceiptID] = struct{}{}
 			if receipt.InteractionID != "" {
 				interactionSet[receipt.InteractionID] = struct{}{}
+			}
+		}
+		selectedReceipts, selectedTruncated, err := s.loadInteractionReceipts(ctx, query, query.InteractionIDs)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		truncated = truncated || selectedTruncated
+		for interactionID, receipts := range receiptsByInteraction(selectedReceipts) {
+			if !interactionMatchesScope(receipts, query.Scope) {
+				continue
+			}
+			included := false
+			for _, receipt := range receipts {
+				if !matchesReceiptQuery(receipt, query) {
+					continue
+				}
+				included = true
+				if _, found := receiptSet[receipt.ReceiptID]; found {
+					continue
+				}
+				receiptSet[receipt.ReceiptID] = struct{}{}
+				result = append(result, receipt)
+			}
+			if included {
+				interactionSet[interactionID] = struct{}{}
 			}
 		}
 		interactions := make([]string, 0, len(interactionSet))

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go
@@ -99,7 +99,7 @@ func (s *Source) loadReceipts(ctx context.Context, query iprojectionsource.Query
 				interactionSet[receipt.InteractionID] = struct{}{}
 			}
 		}
-		selectedReceipts, selectedTruncated, err := s.loadInteractionReceipts(ctx, query, query.InteractionIDs)
+		selectedReceipts, selectedTruncated, err := s.loadSelectedInteractionReceipts(ctx, query, query.InteractionIDs)
 		if err != nil {
 			return nil, nil, false, err
 		}
@@ -277,6 +277,14 @@ func (s *Source) searchReceipts(ctx context.Context, query iprojectionsource.Que
 }
 
 func (s *Source) loadInteractionReceipts(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
+	return s.loadInteractionReceiptsWithCollapse(ctx, query, interactionIDs, false)
+}
+
+func (s *Source) loadSelectedInteractionReceipts(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
+	return s.loadInteractionReceiptsWithCollapse(ctx, query, interactionIDs, true)
+}
+
+func (s *Source) loadInteractionReceiptsWithCollapse(ctx context.Context, query iprojectionsource.Query, interactionIDs []string, collapse bool) ([]receiptDocument, bool, error) {
 	if len(interactionIDs) == 0 {
 		return nil, false, nil
 	}
@@ -286,10 +294,10 @@ func (s *Source) loadInteractionReceipts(ctx context.Context, query iprojections
 	interactionQuery.InteractionID = ""
 	interactionQuery.From = time.Time{}
 	interactionQuery.To = time.Time{}
-	return s.searchReceiptsForInteractions(ctx, interactionQuery, interactionIDs)
+	return s.searchReceiptsForInteractions(ctx, interactionQuery, interactionIDs, collapse)
 }
 
-func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string) ([]receiptDocument, bool, error) {
+func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iprojectionsource.Query, interactionIDs []string, collapse bool) ([]receiptDocument, bool, error) {
 	size := maxProjectionDocuments
 	if query.Limit > 0 && query.Limit < size {
 		// Keep the follow-up expansion within the same caller-owned candidate
@@ -299,11 +307,24 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 	}
 	must := []map[string]any{{"exists": map[string]any{"field": "receipt_id"}}}
 	must = append(must, map[string]any{"terms": map[string]any{"interaction_id.keyword": interactionIDs}})
-	body, err := json.Marshal(map[string]any{
+	queryBody := map[string]any{
 		"size":  size,
 		"query": map[string]any{"bool": map[string]any{"must": must}},
 		"sort":  []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
-	})
+	}
+	innerHitName := ""
+	if collapse {
+		innerHitName = "selected_interaction_receipts"
+		queryBody["size"] = len(interactionIDs)
+		queryBody["collapse"] = map[string]any{
+			"field": "interaction_id.keyword",
+			"inner_hits": map[string]any{
+				"name": innerHitName, "size": maxReceiptsPerSelectedIdentity,
+				"sort": []map[string]any{{"issued_at": map[string]any{"order": "desc"}}, {"_id": map[string]any{"order": "desc"}}},
+			},
+		}
+	}
+	body, err := json.Marshal(queryBody)
 	if err != nil {
 		return nil, false, err
 	}
@@ -314,7 +335,17 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 	var response struct {
 		Hits struct {
 			Hits []struct {
-				Source receiptDocument `json:"_source"`
+				Source    receiptDocument `json:"_source"`
+				InnerHits map[string]struct {
+					Hits struct {
+						Total struct {
+							Value int `json:"value"`
+						} `json:"total"`
+						Hits []struct {
+							Source receiptDocument `json:"_source"`
+						} `json:"hits"`
+					} `json:"hits"`
+				} `json:"inner_hits"`
 			} `json:"hits"`
 		} `json:"hits"`
 	}
@@ -322,8 +353,22 @@ func (s *Source) searchReceiptsForInteractions(ctx context.Context, query iproje
 		return nil, false, fmt.Errorf("decode Core interaction receipt projection: %w", err)
 	}
 	result := make([]receiptDocument, 0, len(response.Hits.Hits))
+	truncated := false
 	for _, hit := range response.Hits.Hits {
+		if innerHitName != "" {
+			inner := hit.InnerHits[innerHitName].Hits
+			for _, innerHit := range inner.Hits {
+				result = append(result, innerHit.Source)
+			}
+			if inner.Total.Value > len(inner.Hits) {
+				truncated = true
+			}
+			continue
+		}
 		result = append(result, hit.Source)
+	}
+	if innerHitName != "" {
+		return result, truncated, nil
 	}
 	return result, len(response.Hits.Hits) >= size, nil
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -547,6 +547,71 @@ func TestSourceUsesApplicationPrincipalAsTechnicalOwnerCandidate(t *testing.T) {
 	}
 }
 
+func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *testing.T) {
+	t.Parallel()
+
+	searches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		searches++
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		switch searches {
+		case 1:
+			if !strings.Contains(query, `"collapse":{"field":"conversation_id.keyword"`) {
+				t.Fatalf("conversation list must keep its collapsed receipt query: %s", body)
+			}
+			_, _ = io.WriteString(w, `{"hits":{"hits":[
+				{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":20},"hits":[
+					{"_source":{"receipt_id":"receipt-third","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},"conversation_id":"conv-1","interaction_id":"int-third","request_id":"request-third","trace_id":"trace-third","issued_at":"2026-09-06T03:00:00Z"}},
+					{"_source":{"receipt_id":"receipt-second","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},"conversation_id":"conv-1","interaction_id":"int-second","request_id":"request-second","trace_id":"trace-second","issued_at":"2026-09-06T02:00:00Z"}}
+				]}}}},
+				{"inner_hits":{"selected_receipts":{"hits":{"total":{"value":1},"hits":[
+					{"_source":{"receipt_id":"receipt-other","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},"conversation_id":"conv-other","interaction_id":"int-other","request_id":"request-other","trace_id":"trace-other","issued_at":"2026-09-06T02:30:00Z"}}
+				]}}}}
+			]}}`)
+		case 2:
+			if !strings.Contains(query, `"interaction_id.keyword":["int-first"]`) {
+				t.Fatalf("selected first interaction must be loaded separately: %s", body)
+			}
+			_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+				"receipt_id":"receipt-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
+				"conversation_id":"conv-1","interaction_id":"int-first","request_id":"request-first","trace_id":"trace-first","issued_at":"2026-09-06T01:00:00Z"
+			}}]}}`)
+		default:
+			t.Fatalf("unexpected receipt search %d: %s", searches, body)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	artifacts := &recordingArtifactProjectionSource{result: iprojectionsource.Result{Artifacts: []evidencevo.EvidenceArtifact{{
+		ArtifactID: "question-first", ArtifactType: evidencevo.ArtifactTypeQuestion,
+		InteractionID: "int-first", RequestID: "request-lifecycle", TraceID: "trace-lifecycle",
+		Content: "第一轮问题", ObservedAt: "2026-09-06T00:59:00Z", AccountID: "user-1", AccountType: "user",
+	}}}}
+	source := opensearchcoreprojection.New(
+		opensearch.New(server.URL, opensearch.AuthConfig{}, time.Second), "bkn-trace-core", artifacts,
+	)
+
+	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
+		Scope:           evidencevo.QueryScope{AccountID: "user-1", AccountType: "user"},
+		ConversationIDs: []string{"conv-1", "conv-other"}, InteractionIDs: []string{"int-first"},
+		ArtifactTypes: []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult}, Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("load projection: %v", err)
+	}
+	if searches != 2 {
+		t.Fatalf("selected first interaction outside the recent receipt cap must trigger one bounded lookup, got %d searches", searches)
+	}
+	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 4 ||
+		artifacts.queries[0].AuthorizedInteractionIDs[0] != "int-first" {
+		t.Fatalf("artifact authorization must include the selected first interaction: %+v", artifacts.queries)
+	}
+	if len(result.Traces) != 4 || len(result.Artifacts) != 1 {
+		t.Fatalf("first interaction receipt and terminal preview must be retained: %+v", result)
+	}
+}
+
 type artifactProjectionSource struct {
 	result iprojectionsource.Result
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -570,25 +570,13 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 				]}}}}
 			]}}`)
 		case 2:
-			for _, expected := range []string{
-				`"interaction_id.keyword":["int-first","int-other-first"]`,
-				`"collapse":{"field":"interaction_id.keyword"`,
-				`"name":"selected_interaction_receipts","size":20`,
-			} {
-				if !strings.Contains(query, expected) {
-					t.Fatalf("selected first interactions must have independent bounded receipt groups (%s): %s", expected, body)
-				}
+			if !strings.Contains(query, `"interaction_id.keyword":["int-first"]`) {
+				t.Fatalf("selected first interaction must be loaded separately: %s", body)
 			}
-			_, _ = io.WriteString(w, `{"hits":{"hits":[
-				{"inner_hits":{"selected_interaction_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{
-					"receipt_id":"receipt-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
-					"conversation_id":"conv-1","interaction_id":"int-first","request_id":"request-first","trace_id":"trace-first","issued_at":"2026-09-06T01:00:00Z"
-				}}]}}}},
-				{"inner_hits":{"selected_interaction_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{
-					"receipt_id":"receipt-other-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
-					"conversation_id":"conv-other","interaction_id":"int-other-first","request_id":"request-other-first","trace_id":"trace-other-first","issued_at":"2026-09-06T01:30:00Z"
-				}}]}}}}
-			]}}`)
+			_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
+				"receipt_id":"receipt-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
+				"conversation_id":"conv-1","interaction_id":"int-first","request_id":"request-first","trace_id":"trace-first","issued_at":"2026-09-06T01:00:00Z"
+			}}]}}`)
 		default:
 			t.Fatalf("unexpected receipt search %d: %s", searches, body)
 		}
@@ -606,7 +594,7 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 
 	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
 		Scope:           evidencevo.QueryScope{AccountID: "user-1", AccountType: "user"},
-		ConversationIDs: []string{"conv-1", "conv-other"}, InteractionIDs: []string{"int-first", "int-other-first"},
+		ConversationIDs: []string{"conv-1", "conv-other"}, InteractionIDs: []string{"int-first"},
 		ArtifactTypes: []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult}, Limit: 20,
 	})
 	if err != nil {
@@ -615,11 +603,11 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 	if searches != 2 {
 		t.Fatalf("selected first interaction outside the recent receipt cap must trigger one bounded lookup, got %d searches", searches)
 	}
-	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 5 ||
+	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 4 ||
 		artifacts.queries[0].AuthorizedInteractionIDs[0] != "int-first" {
 		t.Fatalf("artifact authorization must include the selected first interaction: %+v", artifacts.queries)
 	}
-	if len(result.Traces) != 5 || len(result.Artifacts) != 1 {
+	if len(result.Traces) != 4 || len(result.Artifacts) != 1 {
 		t.Fatalf("first interaction receipt and terminal preview must be retained: %+v", result)
 	}
 }

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go
@@ -570,13 +570,25 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 				]}}}}
 			]}}`)
 		case 2:
-			if !strings.Contains(query, `"interaction_id.keyword":["int-first"]`) {
-				t.Fatalf("selected first interaction must be loaded separately: %s", body)
+			for _, expected := range []string{
+				`"interaction_id.keyword":["int-first","int-other-first"]`,
+				`"collapse":{"field":"interaction_id.keyword"`,
+				`"name":"selected_interaction_receipts","size":20`,
+			} {
+				if !strings.Contains(query, expected) {
+					t.Fatalf("selected first interactions must have independent bounded receipt groups (%s): %s", expected, body)
+				}
 			}
-			_, _ = io.WriteString(w, `{"hits":{"hits":[{"_source":{
-				"receipt_id":"receipt-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
-				"conversation_id":"conv-1","interaction_id":"int-first","request_id":"request-first","trace_id":"trace-first","issued_at":"2026-09-06T01:00:00Z"
-			}}]}}`)
+			_, _ = io.WriteString(w, `{"hits":{"hits":[
+				{"inner_hits":{"selected_interaction_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{
+					"receipt_id":"receipt-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
+					"conversation_id":"conv-1","interaction_id":"int-first","request_id":"request-first","trace_id":"trace-first","issued_at":"2026-09-06T01:00:00Z"
+				}}]}}}},
+				{"inner_hits":{"selected_interaction_receipts":{"hits":{"total":{"value":1},"hits":[{"_source":{
+					"receipt_id":"receipt-other-first","owner":{"effective_subject_type":"user","effective_subject_id":"user-1"},
+					"conversation_id":"conv-other","interaction_id":"int-other-first","request_id":"request-other-first","trace_id":"trace-other-first","issued_at":"2026-09-06T01:30:00Z"
+				}}]}}}}
+			]}}`)
 		default:
 			t.Fatalf("unexpected receipt search %d: %s", searches, body)
 		}
@@ -594,7 +606,7 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 
 	result, err := source.LoadExecutionProjection(context.Background(), iprojectionsource.Query{
 		Scope:           evidencevo.QueryScope{AccountID: "user-1", AccountType: "user"},
-		ConversationIDs: []string{"conv-1", "conv-other"}, InteractionIDs: []string{"int-first"},
+		ConversationIDs: []string{"conv-1", "conv-other"}, InteractionIDs: []string{"int-first", "int-other-first"},
 		ArtifactTypes: []evidencevo.ArtifactType{evidencevo.ArtifactTypeQuestion, evidencevo.ArtifactTypeResult}, Limit: 20,
 	})
 	if err != nil {
@@ -603,11 +615,11 @@ func TestSourceAuthorizesSelectedFirstInteractionOutsideRecentReceiptCap(t *test
 	if searches != 2 {
 		t.Fatalf("selected first interaction outside the recent receipt cap must trigger one bounded lookup, got %d searches", searches)
 	}
-	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 4 ||
+	if len(artifacts.queries) != 1 || len(artifacts.queries[0].AuthorizedInteractionIDs) != 5 ||
 		artifacts.queries[0].AuthorizedInteractionIDs[0] != "int-first" {
 		t.Fatalf("artifact authorization must include the selected first interaction: %+v", artifacts.queries)
 	}
-	if len(result.Traces) != 4 || len(result.Artifacts) != 1 {
+	if len(result.Traces) != 5 || len(result.Artifacts) != 1 {
 		t.Fatalf("first interaction receipt and terminal preview must be retained: %+v", result)
 	}
 }

--- a/docs/plans/2026-09-06-first-turn-preview-cap.md
+++ b/docs/plans/2026-09-06-first-turn-preview-cap.md
@@ -1,0 +1,72 @@
+# First-Turn Conversation Preview Cap Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure a business-provenance conversation row retains the first managed interaction's question and result when newer receipt activity exceeds the per-conversation receipt cap.
+
+**Architecture:** Keep the existing bounded receipt projection for trace summaries. For the conversation-list preview only, identify the canonical first interaction for each selected conversation and include it in Core projection authorization independently of the collapsed recent-receipt set. The terminal artifact lookup remains restricted to question/result types and selected first interactions.
+
+**Tech Stack:** Go, agent-observability domain service, OpenSearch Core/evidence projection adapters, Go unit tests.
+
+---
+
+### Task 1: Reproduce the receipt-cap regression
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
+- Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go`
+
+**Step 1: Write the failing test**
+
+Create a Core projection fixture with one conversation whose first interaction has terminal question/result artifacts and seven receipts, while two later interactions contribute twenty newer receipts. Assert that the authorized interaction set includes the canonical first interaction and that its terminal artifacts survive the projection.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection -run FirstInteraction -count=1`
+
+Expected: FAIL because the collapsed receipt query supplies only the two recent interactions.
+
+**Step 3: Add a list-level regression test**
+
+Assert the conversation summary selects the first lifecycle interaction's coherent question/result pair, not an empty pair or a later interaction.
+
+### Task 2: Preserve first-turn authorization without widening scans
+
+**Files:**
+- Modify: `bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go`
+- Modify: `bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go`
+
+**Step 1: Limit preview IDs to canonical first interactions**
+
+Derive one lowest-ordinal interaction ID per selected managed conversation while retaining all interactions for the displayed count.
+
+**Step 2: Complete receipt authorization for those IDs**
+
+When the Core projection receives selected terminal interaction IDs, query their receipts within the caller-owned candidate budget and merge only scope-authorized IDs with the collapsed recent receipt set. Do not alter the global per-conversation recent receipt cap.
+
+**Step 3: Run focused tests to verify green**
+
+Run:
+`go test ./bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection ./bkn-trace/agent-observability/src/domain/service/evidencesvc -count=1`
+
+Expected: PASS.
+
+### Task 3: Verify no broader regression
+
+**Files:**
+- No additional production files expected.
+
+**Step 1: Run module checks**
+
+Run: `make test && make lint && make license-check && make build` from `bkn-trace/agent-observability`.
+
+**Step 2: Inspect the diff**
+
+Confirm it touches only the summary selection and Core projection authorization path; it must not change HTTP schemas, persistence, scan-cap constants, or Studio.
+
+**Step 3: Commit**
+
+Run:
+`git add docs/plans/2026-09-06-first-turn-preview-cap.md bkn-trace/agent-observability/src/domain/service/evidencesvc/summary.go bkn-trace/agent-observability/src/domain/service/evidencesvc/summary_service_test.go bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source.go bkn-trace/agent-observability/src/drivenadapter/httpaccess/opensearchcoreprojection/source_test.go`
+
+Commit message: `fix(bkn-trace): preserve first-turn conversation previews`


### PR DESCRIPTION
## What Changed

- [x] Select only the first managed interaction per conversation for list terminal previews.
- [x] Authorize that selected interaction with one bounded Core receipt lookup when it falls outside the collapsed recent-receipt window.
- [x] Add regression coverage for the first-turn receipt-cap case.
- [x] Add the focused implementation plan.

---

## Why

- Related Issue: Closes #1334
- Background: a conversation row can retain trace activity from newer turns while losing the first turn's question/result when its receipts are outside the per-conversation recent window.

---

## How

- The normal collapsed receipt query and its per-conversation cap are unchanged.
- The list passes one lowest-ordinal interaction ID per selected conversation. Core performs a bounded receipt lookup only for those IDs, re-applies existing scope and conversation filters, and merges authorized receipts without duplicates.
- Terminal artifacts remain restricted to question and result types.
- Breaking changes: none. No API, persistence, configuration, or frontend changes.

---

## Testing

- [x] Unit tests passed locally (`make test`)
- [x] Static checks passed locally (`make lint`)
- [x] License checks passed locally (`make license-check`)
- [x] Build passed locally (`make build`)
- [x] Focused regression tests passed locally

---

## Risk & Rollback

- Potential risk: one additional bounded OpenSearch lookup for selected conversation-list preview interactions.
- Mitigation: it is limited to one canonical ID per page row, the caller-owned candidate budget, and existing authorization filters.
- Rollback plan: revert commit `1100eeb9`.

---

## Additional Notes

- The new regression reproduces a first interaction outside the recent receipt cap and verifies its terminal preview remains available.