### PR TITLE
feat(authz): derive KN proxy grants from builder operations

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client.go
@@ -104,6 +104,17 @@ func (c *safeClient) CheckGrant(ctx context.Context, proxyAccountID, grantorID s
 	return result, err
 }
 
+func (c *safeClient) CheckGrants(ctx context.Context, proxyAccountID, grantorID string,
+	sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantBatchCheckResult, error) {
+	var result interfaces.ProxyGrantBatchCheckResult
+	_, err := c.do(ctx, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources/check-batch", map[string]any{
+		"proxy_account_id": proxyAccountID,
+		"grantor_id":       grantorID,
+		"sources":          sources,
+	}, &result)
+	return result, err
+}
+
 func (c *safeClient) SyncGrants(ctx context.Context, proxyAccountID, grantorID string,
 	sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
 	var result interfaces.ProxyGrantSyncResult

--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
@@ -44,6 +44,32 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantCheckResult{Allowed: true})
 	})
+	mux.HandleFunc("/api/safe/in/v1/proxy-grant-sources/sync", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ProxyID string `json:"proxy_account_id"`
+			Grantor string `json:"grantor_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.ProxyID != "proxy-1" || body.Grantor != "grantor-1" {
+			t.Fatalf("sync body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantSyncResult{Transferred: 1})
+	})
+	mux.HandleFunc("/api/safe/in/v1/proxy-grant-sources/reconcile", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ProxyID     string `json:"proxy_account_id"`
+			RequestedBy string `json:"requested_by"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.ProxyID != "proxy-1" || body.RequestedBy != "operator-1" {
+			t.Fatalf("reconcile body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantReconcileResult{InvalidSources: 2})
+	})
 	mux.HandleFunc("/api/safe/in/v1/managed-proxy-accounts/proxy-1/restore", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(interfaces.ManagedProxyAccount{
 			ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive, Enabled: true,
@@ -68,6 +94,14 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 	})
 	if err != nil || !result.Allowed {
 		t.Fatalf("CheckGrant() = %#v, %v", result, err)
+	}
+	syncResult, err := client.SyncGrants(t.Context(), "proxy-1", "grantor-1", nil)
+	if err != nil || syncResult.Transferred != 1 {
+		t.Fatalf("SyncGrants() = %#v, %v", syncResult, err)
+	}
+	reconcileResult, err := client.ReconcileGrants(t.Context(), "proxy-1", "operator-1")
+	if err != nil || reconcileResult.InvalidSources != 2 {
+		t.Fatalf("ReconcileGrants() = %#v, %v", reconcileResult, err)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
@@ -44,6 +44,23 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantCheckResult{Allowed: true})
 	})
+	mux.HandleFunc("/api/safe/in/v1/proxy-grant-sources/check-batch", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			ProxyID string                            `json:"proxy_account_id"`
+			Grantor string                            `json:"grantor_id"`
+			Sources []interfaces.ProxyGrantSourceSpec `json:"sources"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.ProxyID != "proxy-1" || body.Grantor != "grantor-1" ||
+			len(body.Sources) != 1 || body.Sources[0].BindingID != "ot-1" {
+			t.Fatalf("batch check body = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantBatchCheckResult{
+			DeniedSources: body.Sources,
+		})
+	})
 	mux.HandleFunc("/api/safe/in/v1/proxy-grant-sources/sync", func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			ProxyID string `json:"proxy_account_id"`
@@ -94,6 +111,14 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 	})
 	if err != nil || !result.Allowed {
 		t.Fatalf("CheckGrant() = %#v, %v", result, err)
+	}
+	batchResult, err := client.CheckGrants(t.Context(), "proxy-1", "grantor-1", []interfaces.ProxyGrantSourceSpec{{
+		ResourceType: "resource", ResourceID: "resource-1", Operation: "query_data",
+		SourceType: interfaces.ProxyGrantSourceTypeKNBinding, SourceID: "source-1", KNID: "kn-1",
+		BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+	}})
+	if err != nil || len(batchResult.DeniedSources) != 1 || batchResult.DeniedSources[0].BindingID != "ot-1" {
+		t.Fatalf("CheckGrants() = %#v, %v", batchResult, err)
 	}
 	syncResult, err := client.SyncGrants(t.Context(), "proxy-1", "grantor-1", nil)
 	if err != nil || syncResult.Transferred != 1 {

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation.go
@@ -56,8 +56,15 @@ func (r *restHandler) updateObjectType(ctx context.Context, objectType *interfac
 }
 
 func (r *restHandler) deleteObjectTypes(ctx context.Context, knID, branch string, ids []string) error {
-	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
+	// Unbound overwrite entries are projection tombstones: they remove the
+	// deleted bindings from the preflight candidate without becoming persisted
+	// rows, because the mutation callback still performs the actual deletion.
+	entries := make([]*interfaces.ObjectType, 0, len(ids))
+	for _, id := range ids {
+		entries = append(entries, &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: id}})
+	}
+	changes := &interfaces.KN{KNID: knID, Branch: branch, ObjectTypes: entries}
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ots.DeleteObjectTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -83,8 +90,12 @@ func (r *restHandler) updateRelationType(ctx context.Context, relationType *inte
 }
 
 func (r *restHandler) deleteRelationTypes(ctx context.Context, knID, branch string, ids []string) error {
-	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
+	entries := make([]*interfaces.RelationType, 0, len(ids))
+	for _, id := range ids {
+		entries = append(entries, &interfaces.RelationType{RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{RTID: id}})
+	}
+	changes := &interfaces.KN{KNID: knID, Branch: branch, RelationTypes: entries}
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.rts.DeleteRelationTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -110,8 +121,12 @@ func (r *restHandler) updateActionType(ctx context.Context, actionType *interfac
 }
 
 func (r *restHandler) deleteActionTypes(ctx context.Context, knID, branch string, ids []string) error {
-	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
+	entries := make([]*interfaces.ActionType, 0, len(ids))
+	for _, id := range ids {
+		entries = append(entries, &interfaces.ActionType{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{ATID: id}})
+	}
+	changes := &interfaces.KN{KNID: knID, Branch: branch, ActionTypes: entries}
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ats.DeleteActionTypesByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }
@@ -137,8 +152,12 @@ func (r *restHandler) updateMetric(ctx context.Context, metric *interfaces.Metri
 }
 
 func (r *restHandler) deleteMetrics(ctx context.Context, knID, branch string, ids []string) error {
-	changes := &interfaces.KN{KNID: knID, Branch: branch}
-	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Normal, func(mutationCtx context.Context, tx *sql.Tx) error {
+	entries := make([]*interfaces.MetricDefinition, 0, len(ids))
+	for _, id := range ids {
+		entries = append(entries, &interfaces.MetricDefinition{ID: id})
+	}
+	changes := &interfaces.KN{KNID: knID, Branch: branch, Metrics: entries}
+	return r.publishKNChildMutation(ctx, changes, interfaces.ImportMode_Overwrite, func(mutationCtx context.Context, tx *sql.Tx) error {
 		return r.ms.DeleteMetricsByIDs(mutationCtx, tx, knID, branch, ids)
 	})
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/kn_proxy_mutation_test.go
@@ -148,8 +148,9 @@ func TestObjectTypeWritesUseKNProxyPublisher(t *testing.T) {
 		if err := handler.deleteObjectTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"ot-1"}); err != nil {
 			t.Fatal(err)
 		}
-		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
-			if len(changes.ObjectTypes) != 0 {
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.ObjectTypes) != 1 || changes.ObjectTypes[0].OTID != "ot-1" ||
+				changes.ObjectTypes[0].DataSource != nil {
 				t.Fatalf("delete object type changes = %#v", changes.ObjectTypes)
 			}
 		})
@@ -210,8 +211,8 @@ func TestRelationTypeWritesUseKNProxyPublisher(t *testing.T) {
 		if err := handler.deleteRelationTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"rt-1"}); err != nil {
 			t.Fatal(err)
 		}
-		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
-			if len(changes.RelationTypes) != 0 {
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.RelationTypes) != 1 || changes.RelationTypes[0].RTID != "rt-1" {
 				t.Fatalf("delete relation type changes = %#v", changes.RelationTypes)
 			}
 		})
@@ -272,8 +273,9 @@ func TestActionTypeWritesUseKNProxyPublisher(t *testing.T) {
 		if err := handler.deleteActionTypes(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"at-1"}); err != nil {
 			t.Fatal(err)
 		}
-		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
-			if len(changes.ActionTypes) != 0 {
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.ActionTypes) != 1 || changes.ActionTypes[0].ATID != "at-1" ||
+				changes.ActionTypes[0].ActionSource.Type != "" {
 				t.Fatalf("delete action type changes = %#v", changes.ActionTypes)
 			}
 		})
@@ -331,8 +333,9 @@ func TestMetricWritesUseKNProxyPublisher(t *testing.T) {
 		if err := handler.deleteMetrics(t.Context(), "kn-1", interfaces.MAIN_BRANCH, []string{"metric-1"}); err != nil {
 			t.Fatal(err)
 		}
-		assertProxyMutation(t, publisher, interfaces.ImportMode_Normal, func(changes *interfaces.KN) {
-			if len(changes.Metrics) != 0 {
+		assertProxyMutation(t, publisher, interfaces.ImportMode_Overwrite, func(changes *interfaces.KN) {
+			if len(changes.Metrics) != 1 || changes.Metrics[0].ID != "metric-1" ||
+				changes.Metrics[0].ScopeRef != "" {
 				t.Fatalf("delete metric changes = %#v", changes.Metrics)
 			}
 		})

--- a/adp/bkn/bkn-backend/server/errors/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/errors/knowledge_network.go
@@ -29,11 +29,12 @@ const (
 	BknBackend_KnowledgeNetwork_ProxyMappingNotFound = "BknBackend.KnowledgeNetwork.Proxy.MappingNotFound"
 
 	// Proxy runtime state
-	BknBackend_KnowledgeNetwork_ProxyBindingInvalid = "BknBackend.KnowledgeNetwork.Proxy.BindingInvalid"
-	BknBackend_KnowledgeNetwork_ProxyDisabled       = "BknBackend.KnowledgeNetwork.Proxy.Disabled"
-	BknBackend_KnowledgeNetwork_ProxySyncFailed     = "BknBackend.KnowledgeNetwork.Proxy.SyncFailed"
-	BknBackend_KnowledgeNetwork_ProxySyncPending    = "BknBackend.KnowledgeNetwork.Proxy.SyncPending"
-	BknBackend_KnowledgeNetwork_ProxyUnavailable    = "BknBackend.KnowledgeNetwork.Proxy.Unavailable"
+	BknBackend_KnowledgeNetwork_ProxyBindingInvalid    = "BknBackend.KnowledgeNetwork.Proxy.BindingInvalid"
+	BknBackend_KnowledgeNetwork_ProxyPermissionMissing = "BknBackend.KnowledgeNetwork.Proxy.PermissionMissing"
+	BknBackend_KnowledgeNetwork_ProxyDisabled          = "BknBackend.KnowledgeNetwork.Proxy.Disabled"
+	BknBackend_KnowledgeNetwork_ProxySyncFailed        = "BknBackend.KnowledgeNetwork.Proxy.SyncFailed"
+	BknBackend_KnowledgeNetwork_ProxySyncPending       = "BknBackend.KnowledgeNetwork.Proxy.SyncPending"
+	BknBackend_KnowledgeNetwork_ProxyUnavailable       = "BknBackend.KnowledgeNetwork.Proxy.Unavailable"
 
 	// 500
 	BknBackend_KnowledgeNetwork_InternalError                             = "BknBackend.KnowledgeNetwork.InternalError"
@@ -82,6 +83,7 @@ var (
 
 		// Proxy runtime state
 		BknBackend_KnowledgeNetwork_ProxyBindingInvalid,
+		BknBackend_KnowledgeNetwork_ProxyPermissionMissing,
 		BknBackend_KnowledgeNetwork_ProxyDisabled,
 		BknBackend_KnowledgeNetwork_ProxySyncFailed,
 		BknBackend_KnowledgeNetwork_ProxySyncPending,

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -120,6 +120,10 @@ type ProxyGrantCheckResult struct {
 	Reason  string `json:"reason,omitempty"`
 }
 
+type ProxyGrantBatchCheckResult struct {
+	DeniedSources []ProxyGrantSourceSpec `json:"denied_sources"`
+}
+
 type ProxyGrantSyncResult struct {
 	Added       int `json:"added"`
 	Transferred int `json:"transferred"`
@@ -223,6 +227,7 @@ type ManagedProxyAccess interface {
 	Disable(ctx context.Context, proxyAccountID string) (*ManagedProxyAccount, error)
 	Archive(ctx context.Context, proxyAccountID string) (*ManagedProxyAccount, error)
 	CheckGrant(ctx context.Context, proxyAccountID, grantorID string, source ProxyGrantSourceSpec) (ProxyGrantCheckResult, error)
+	CheckGrants(ctx context.Context, proxyAccountID, grantorID string, sources []ProxyGrantSourceSpec) (ProxyGrantBatchCheckResult, error)
 	SyncGrants(ctx context.Context, proxyAccountID, grantorID string, sources []ProxyGrantSourceSpec) (ProxyGrantSyncResult, error)
 	ReconcileGrants(ctx context.Context, proxyAccountID, requestedBy string) (ProxyGrantReconcileResult, error)
 }

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -121,9 +121,10 @@ type ProxyGrantCheckResult struct {
 }
 
 type ProxyGrantSyncResult struct {
-	Added     int `json:"added"`
-	Revoked   int `json:"revoked"`
-	Unchanged int `json:"unchanged"`
+	Added       int `json:"added"`
+	Transferred int `json:"transferred"`
+	Revoked     int `json:"revoked"`
+	Unchanged   int `json:"unchanged"`
 }
 
 type ProxyGrantReconcileResult struct {
@@ -132,6 +133,7 @@ type ProxyGrantReconcileResult struct {
 	MarkersCreated    int `json:"markers_created"`
 	MarkersRemoved    int `json:"markers_removed"`
 	UntrackedPolicies int `json:"untracked_policies"`
+	InvalidSources    int `json:"invalid_sources"`
 }
 
 // KNProxyReconcileReport identifies BKN mapping defects and reports any

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_kn_proxy.go
@@ -229,6 +229,21 @@ func (mr *MockManagedProxyAccessMockRecorder) CheckGrant(ctx, proxyAccountID, gr
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckGrant", reflect.TypeOf((*MockManagedProxyAccess)(nil).CheckGrant), ctx, proxyAccountID, grantorID, source)
 }
 
+// CheckGrants mocks base method.
+func (m *MockManagedProxyAccess) CheckGrants(ctx context.Context, proxyAccountID, grantorID string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantBatchCheckResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckGrants", ctx, proxyAccountID, grantorID, sources)
+	ret0, _ := ret[0].(interfaces.ProxyGrantBatchCheckResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckGrants indicates an expected call of CheckGrants.
+func (mr *MockManagedProxyAccessMockRecorder) CheckGrants(ctx, proxyAccountID, grantorID, sources any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckGrants", reflect.TypeOf((*MockManagedProxyAccess)(nil).CheckGrants), ctx, proxyAccountID, grantorID, sources)
+}
+
 // Create mocks base method.
 func (m *MockManagedProxyAccess) Create(ctx context.Context, knID, name string) (*interfaces.ManagedProxyAccount, bool, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.en-US.toml
@@ -99,6 +99,11 @@ Description = "The requested target is not a current published binding"
 Solution = "Publish the binding and synchronize the proxy permissions before retrying."
 ErrorLink = ""
 
+[BknBackend.KnowledgeNetwork.Proxy.PermissionMissing]
+Description = "The knowledge-network builder lacks one or more downstream operations required by the bindings"
+Solution = "Ask the resource owner to grant the listed operations to the builder, then retry the operation."
+ErrorLink = ""
+
 [BknBackend.KnowledgeNetwork.Proxy.Disabled]
 Description = "The knowledge-network proxy account is not active"
 Solution = "Restore the proxy account or complete the knowledge-network lifecycle operation."

--- a/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/knowledge_network.zh-CN.toml
@@ -99,6 +99,11 @@ Description = "请求的目标不是当前已发布绑定"
 Solution = "请先发布绑定并同步代理权限，然后重试。"
 ErrorLink = ""
 
+[BknBackend.KnowledgeNetwork.Proxy.PermissionMissing]
+Description = "知识网络构建者缺少绑定所需的一项或多项底层操作权限"
+Solution = "请资源负责人将列出的操作权限授给构建者，然后重试。"
+ErrorLink = ""
+
 [BknBackend.KnowledgeNetwork.Proxy.Disabled]
 Description = "知识网络代理账号未处于启用状态"
 Solution = "请恢复代理账号，或完成当前知识网络生命周期操作。"

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -29,7 +29,7 @@ const (
 
 type proxyPublishPlan struct {
 	mapping        *interfaces.KNProxyAccount
-	grantorID      string
+	delegatorID    string
 	modelVersion   string
 	lockOwner      string
 	createdMapping bool
@@ -38,6 +38,18 @@ type proxyPublishPlan struct {
 type publishedProxyBindingCacheEntry struct {
 	modelVersion string
 	sources      []interfaces.ProxyGrantSourceSpec
+}
+
+type missingProxyPermission struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+	Operation    string `json:"operation"`
+	BindingType  string `json:"binding_type"`
+	BindingID    string `json:"binding_id"`
+}
+
+type missingProxyPermissionDetails struct {
+	MissingPermissions []missingProxyPermission `json:"missing_permissions"`
 }
 
 func (kns *knowledgeNetworkService) proxyOrchestrationEnabled(branch string) bool {
@@ -71,15 +83,10 @@ func (kns *knowledgeNetworkService) prepareProxyPublishWithBaseline(ctx context.
 	}()
 
 	candidate := kn
-	var currentSources []interfaces.ProxyGrantSourceSpec
 	if mergeCurrent {
 		current, loadErr := kns.ExportKNForProjection(ctx, kn.KNID)
 		if loadErr != nil {
 			return nil, loadErr
-		}
-		currentSources, _, err = buildProxyGrantSources(current)
-		if err != nil {
-			return nil, invalidProxyTargetError(ctx, err)
 		}
 		candidate = mergeProxyMutationChanges(current, kn, mergeMode)
 	}
@@ -87,11 +94,11 @@ func (kns *knowledgeNetworkService) prepareProxyPublishWithBaseline(ctx context.
 	if err != nil {
 		return nil, invalidProxyTargetError(ctx, err)
 	}
-	preflightSources := sources
-	if mergeCurrent && !plan.createdMapping {
-		preflightSources = addedProxyGrantSources(currentSources, sources)
-	}
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, preflightSources); err != nil {
+	// Check the complete desired set, not only additions. Safe preserves a still-valid
+	// historical delegator and asks the current editor to take over only when that
+	// delegator has lost the exact downstream operation. Doing this before the
+	// business write avoids discovering an invalid retained source after commit.
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources); err != nil {
 		return nil, err
 	}
 	plan.modelVersion = version
@@ -100,10 +107,10 @@ func (kns *knowledgeNetworkService) prepareProxyPublishWithBaseline(ctx context.
 }
 
 func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *interfaces.KN,
-	createIfMissing, authorizeMissing bool) (*proxyPublishPlan, error) {
-	grantorID := accountIDFromContext(ctx)
-	if grantorID == "" {
-		return nil, proxyHTTPError(ctx, http.StatusForbidden, "proxy grantor identity is unavailable")
+	createIfMissing, checkMissingWrite bool) (*proxyPublishPlan, error) {
+	delegatorID := accountIDFromContext(ctx)
+	if delegatorID == "" {
+		return nil, proxyHTTPError(ctx, http.StatusForbidden, "proxy delegator identity is unavailable")
 	}
 
 	mapping, err := kns.kpa.Get(ctx, kn.KNID)
@@ -115,16 +122,16 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 		if !createIfMissing {
 			return nil, proxyHTTPError(ctx, http.StatusConflict, "knowledge network proxy mapping is unavailable")
 		}
-		if authorizeMissing {
+		if checkMissingWrite {
 			if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
 				Type: interfaces.RESOURCE_TYPE_KN,
 				ID:   kn.KNID,
-			}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
 				return nil, err
 			}
 		}
 		mappingKN := kn
-		if authorizeMissing && strings.TrimSpace(kn.KNName) == "" {
+		if checkMissingWrite && strings.TrimSpace(kn.KNName) == "" {
 			existingKN, loadErr := kns.kna.GetKNByID(ctx, kn.KNID, interfaces.MAIN_BRANCH)
 			if loadErr != nil || existingKN == nil {
 				return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "load knowledge network for proxy mapping")
@@ -139,11 +146,11 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 		}
 	}
 	if mapping.LifecycleStatus == interfaces.KNProxyLifecycleArchived && createIfMissing {
-		if authorizeMissing {
+		if checkMissingWrite {
 			if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
 				Type: interfaces.RESOURCE_TYPE_KN,
 				ID:   kn.KNID,
-			}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
 				return nil, err
 			}
 		}
@@ -164,7 +171,7 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 
 	lockOwner := uuid.NewString()
 	if err := kns.acquireProxyLock(ctx, kn.KNID, lockOwner); err != nil {
-		if createdMapping && !authorizeMissing {
+		if createdMapping && !checkMissingWrite {
 			kns.abortCreatedProxy(context.WithoutCancel(ctx), &proxyPublishPlan{
 				mapping: mapping, createdMapping: true,
 			})
@@ -172,7 +179,7 @@ func (kns *knowledgeNetworkService) beginProxyPublish(ctx context.Context, kn *i
 		return nil, err
 	}
 	return &proxyPublishPlan{
-		mapping: mapping, grantorID: grantorID, lockOwner: lockOwner, createdMapping: createdMapping,
+		mapping: mapping, delegatorID: delegatorID, lockOwner: lockOwner, createdMapping: createdMapping,
 	}, nil
 }
 
@@ -233,18 +240,35 @@ func (kns *knowledgeNetworkService) abortCreatedProxy(ctx context.Context, plan 
 	}
 }
 
-func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, proxyID, grantorID string,
+func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, proxyID, delegatorID string,
 	sources []interfaces.ProxyGrantSourceSpec) error {
+	missing := make([]missingProxyPermission, 0)
 	for _, source := range sources {
-		result, err := kns.mpa.CheckGrant(ctx, proxyID, grantorID, source)
+		result, err := kns.mpa.CheckGrant(ctx, proxyID, delegatorID, source)
 		if err != nil {
 			return proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
 		}
 		if !result.Allowed {
-			return proxyHTTPError(ctx, http.StatusForbidden, fmt.Sprintf(
-				"proxy permission preflight denied for %s %s on %s %s with operation %s",
-				source.BindingType, source.BindingID, source.ResourceType, source.ResourceID, source.Operation))
+			missing = append(missing, missingProxyPermission{
+				ResourceType: source.ResourceType,
+				ResourceID:   source.ResourceID,
+				Operation:    source.Operation,
+				BindingType:  source.BindingType,
+				BindingID:    source.BindingID,
+			})
 		}
+	}
+	if len(missing) > 0 {
+		sort.Slice(missing, func(i, j int) bool {
+			left := fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s", missing[i].ResourceType,
+				missing[i].ResourceID, missing[i].Operation, missing[i].BindingType, missing[i].BindingID)
+			right := fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s", missing[j].ResourceType,
+				missing[j].ResourceID, missing[j].Operation, missing[j].BindingType, missing[j].BindingID)
+			return left < right
+		})
+		return rest.NewHTTPError(ctx, http.StatusForbidden,
+			berrors.BknBackend_KnowledgeNetwork_ProxyPermissionMissing).
+			WithErrorDetails(missingProxyPermissionDetails{MissingPermissions: missing})
 	}
 	return nil
 }
@@ -280,35 +304,16 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	currentSources, currentVersion, buildErr := buildProxyGrantSources(current)
-	if buildErr != nil {
-		return invalidProxyTargetError(ctx, buildErr)
-	}
-	if plan.createdMapping {
-		if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID, currentSources); err != nil {
-			return err
-		}
-		plan.modelVersion = currentVersion
-		if err := kns.markProxyPendingInNewTransaction(ctx, plan, currentVersion); err != nil {
-			return err
-		}
-		if err := kns.finishProxyPublish(ctx, plan); err != nil {
-			return err
-		}
-	}
-
 	candidate := mergeProxyMutationChanges(current, changes, mergeMode)
 	sources, version, err := buildProxyGrantSources(candidate)
 	if err != nil {
 		return invalidProxyTargetError(ctx, err)
 	}
-	// Existing grants were already authorized when they were installed. Only
-	// additions and binding replacements require the current editor to hold
-	// AUTHORIZE plus the requested downstream operation. Removals are applied
-	// by the post-commit full sync and must remain usable as a repair path even
-	// when the old target no longer exists or is no longer delegable.
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.grantorID,
-		addedProxyGrantSources(currentSources, sources)); err != nil {
+	// Preflight the complete desired set. Safe accepts retained sources whose
+	// historical delegator is still valid, and requires this editor's exact
+	// downstream operation only for additions or an explicit delegator transfer.
+	// Removed sources are absent from the candidate and therefore need no check.
+	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources); err != nil {
 		return err
 	}
 	plan.modelVersion = version
@@ -466,7 +471,7 @@ func (kns *knowledgeNetworkService) markProxyPending(ctx context.Context, tx *sq
 	if plan == nil {
 		return nil
 	}
-	if err := kns.kpa.SetPending(ctx, tx, plan.mapping.KNID, plan.modelVersion, plan.grantorID, time.Now().UnixMilli()); err != nil {
+	if err := kns.kpa.SetPending(ctx, tx, plan.mapping.KNID, plan.modelVersion, plan.delegatorID, time.Now().UnixMilli()); err != nil {
 		return proxyHTTPError(ctx, http.StatusServiceUnavailable, "mark proxy synchronization pending")
 	}
 	return nil
@@ -492,7 +497,7 @@ func (kns *knowledgeNetworkService) finishProxyPublish(ctx context.Context, plan
 		}
 		plan.modelVersion = latestVersion
 	}
-	if _, err := kns.mpa.SyncGrants(ctx, plan.mapping.ProxyAccountID, plan.grantorID, sources); err != nil {
+	if _, err := kns.mpa.SyncGrants(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources); err != nil {
 		kns.recordProxySyncFailure(ctx, plan, latestVersion, err)
 		return proxyHTTPError(ctx, http.StatusServiceUnavailable, "synchronize latest proxy permissions")
 	}
@@ -586,7 +591,7 @@ func (kns *knowledgeNetworkService) prepareProxyDelete(ctx context.Context, knID
 	if mapping == nil {
 		return nil, nil
 	}
-	plan := &proxyPublishPlan{mapping: mapping, grantorID: grantorID, lockOwner: uuid.NewString(), modelVersion: mapping.PublishedModelVersion}
+	plan := &proxyPublishPlan{mapping: mapping, delegatorID: grantorID, lockOwner: uuid.NewString(), modelVersion: mapping.PublishedModelVersion}
 	if err := kns.acquireProxyLock(ctx, knID, plan.lockOwner); err != nil {
 		return nil, err
 	}
@@ -615,7 +620,7 @@ func (kns *knowledgeNetworkService) finalizeProxyDelete(ctx context.Context, pla
 			return proxyHTTPError(ctx, http.StatusServiceUnavailable, "record disabled knowledge network proxy")
 		}
 	}
-	if _, err := kns.mpa.SyncGrants(ctx, plan.mapping.ProxyAccountID, plan.grantorID,
+	if _, err := kns.mpa.SyncGrants(ctx, plan.mapping.ProxyAccountID, plan.delegatorID,
 		[]interfaces.ProxyGrantSourceSpec{}); err != nil {
 		kns.recordProxySyncFailure(ctx, plan, plan.mapping.PublishedModelVersion, err)
 		return proxyHTTPError(ctx, http.StatusServiceUnavailable, "clear knowledge network proxy grants")
@@ -667,7 +672,7 @@ func (kns *knowledgeNetworkService) RetryKNProxySync(ctx context.Context, knID s
 		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy orchestration is disabled")
 	}
 	if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{Type: interfaces.RESOURCE_TYPE_KN, ID: knID},
-		[]string{interfaces.OPERATION_TYPE_AUTHORIZE}); err != nil {
+		[]string{interfaces.OPERATION_TYPE_MODIFY}); err != nil {
 		return nil, err
 	}
 	latest, err := kns.ExportKNForProjection(ctx, knID)
@@ -939,7 +944,7 @@ func (kns *knowledgeNetworkService) ReconcileKNProxies(ctx context.Context, requ
 			continue
 		}
 		if result.PoliciesRestored != 0 || result.PoliciesRemoved != 0 || result.MarkersCreated != 0 ||
-			result.MarkersRemoved != 0 || result.UntrackedPolicies != 0 {
+			result.MarkersRemoved != 0 || result.UntrackedPolicies != 0 || result.InvalidSources != 0 {
 			report.AuthorizationDrift[mapping.KNID] = result
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -242,21 +242,22 @@ func (kns *knowledgeNetworkService) abortCreatedProxy(ctx context.Context, plan 
 
 func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, proxyID, delegatorID string,
 	sources []interfaces.ProxyGrantSourceSpec) error {
-	missing := make([]missingProxyPermission, 0)
-	for _, source := range sources {
-		result, err := kns.mpa.CheckGrant(ctx, proxyID, delegatorID, source)
-		if err != nil {
-			return proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
-		}
-		if !result.Allowed {
-			missing = append(missing, missingProxyPermission{
-				ResourceType: source.ResourceType,
-				ResourceID:   source.ResourceID,
-				Operation:    source.Operation,
-				BindingType:  source.BindingType,
-				BindingID:    source.BindingID,
-			})
-		}
+	if len(sources) == 0 {
+		return nil
+	}
+	result, err := kns.mpa.CheckGrants(ctx, proxyID, delegatorID, sources)
+	if err != nil {
+		return proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
+	}
+	missing := make([]missingProxyPermission, 0, len(result.DeniedSources))
+	for _, source := range result.DeniedSources {
+		missing = append(missing, missingProxyPermission{
+			ResourceType: source.ResourceType,
+			ResourceID:   source.ResourceID,
+			Operation:    source.Operation,
+			BindingType:  source.BindingType,
+			BindingID:    source.BindingID,
+		})
 	}
 	if len(missing) > 0 {
 		sort.Slice(missing, func(i, j int) bool {
@@ -295,7 +296,13 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	defer kns.releaseProxyLock(context.WithoutCancel(ctx), plan)
+	committed := false
+	defer func() {
+		if plan.createdMapping && !committed {
+			kns.abortCreatedProxy(context.WithoutCancel(ctx), plan)
+		}
+		kns.releaseProxyLock(context.WithoutCancel(ctx), plan)
+	}()
 
 	// Reload after acquiring the publication lock. This prevents a candidate
 	// assembled from a stale model from omitting targets published by a writer
@@ -353,6 +360,7 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 		cleanupCreatedAuthorization()
 		return proxyHTTPError(ctx, http.StatusInternalServerError, "commit child resource publication")
 	}
+	committed = true
 	if cleanupTrackerOwner {
 		_ = cleanupTracker.Cleanup(mutationCtx, kns.ps)
 	}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -146,6 +146,17 @@ func (s *managedProxyAccessStub) CheckGrant(_ context.Context, _, _ string, sour
 	s.checked = append(s.checked, source)
 	return interfaces.ProxyGrantCheckResult{Allowed: s.allowed && !s.deniedResources[source.ResourceID]}, nil
 }
+func (s *managedProxyAccessStub) CheckGrants(_ context.Context, _, _ string,
+	sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantBatchCheckResult, error) {
+	s.checked = append(s.checked, sources...)
+	result := interfaces.ProxyGrantBatchCheckResult{DeniedSources: []interfaces.ProxyGrantSourceSpec{}}
+	for _, source := range sources {
+		if !s.allowed || s.deniedResources[source.ResourceID] {
+			result.DeniedSources = append(result.DeniedSources, source)
+		}
+	}
+	return result, nil
+}
 func (s *managedProxyAccessStub) SyncGrants(_ context.Context, _, _ string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
 	s.syncCalls++
 	s.synced = append([]interfaces.ProxyGrantSourceSpec(nil), sources...)
@@ -885,6 +896,57 @@ func TestPublishKNChildMutationRollsBackPendingWithBusinessFailure(t *testing.T)
 	}
 	if len(mpa.synced) != 0 || !kpa.lockReleased {
 		t.Fatalf("rollback state: synced=%d lock_released=%t", len(mpa.synced), kpa.lockReleased)
+	}
+	if err := databaseMock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPublishKNChildMutationArchivesNewProxyWhenBusinessWriteFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	kna := bmock.NewMockKNAccess(ctrl)
+	cga := bmock.NewMockConceptGroupAccess(ctrl)
+	ota := bmock.NewMockObjectTypeAccess(ctrl)
+	rta := bmock.NewMockRelationTypeAccess(ctrl)
+	ata := bmock.NewMockActionTypeAccess(ctrl)
+	ma := bmock.NewMockMetricAccess(ctrl)
+	ps := bmock.NewMockPermissionService(ctrl)
+	db, databaseMock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(nil)
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return(nil, nil)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
+	databaseMock.ExpectBegin()
+	databaseMock.ExpectRollback()
+
+	kpa := &proxyAccessStub{}
+	mpa := &managedProxyAccessStub{allowed: true}
+	service := &knowledgeNetworkService{
+		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, ps: ps, kpa: kpa, mpa: mpa,
+	}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
+	wantErr := errors.New("business mutation failed")
+	err = service.PublishKNChildMutation(ctx,
+		&interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH},
+		interfaces.ImportMode_Normal,
+		func(context.Context, *sql.Tx) error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PublishKNChildMutation() error = %v, want %v", err, wantErr)
+	}
+	if !mpa.disabled || !mpa.archived || kpa.lifecycle != interfaces.KNProxyLifecycleArchived || !kpa.lockReleased {
+		t.Fatalf("compensation state: disabled=%t archived=%t lifecycle=%q lock_released=%t",
+			mpa.disabled, mpa.archived, kpa.lifecycle, kpa.lockReleased)
 	}
 	if err := databaseMock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -80,6 +80,7 @@ func (s *proxyAccessStub) ListProxyConflicts(context.Context) (map[string][]stri
 
 type managedProxyAccessStub struct {
 	allowed          bool
+	deniedResources  map[string]bool
 	createCount      int
 	disabled         bool
 	disableLifecycle string
@@ -89,6 +90,7 @@ type managedProxyAccessStub struct {
 	synced           []interfaces.ProxyGrantSourceSpec
 	syncCalls        int
 	reconciled       []string
+	reconcileResult  interfaces.ProxyGrantReconcileResult
 	syncErr          error
 	events           *[]string
 }
@@ -142,7 +144,7 @@ func (s *managedProxyAccessStub) Archive(context.Context, string) (*interfaces.M
 }
 func (s *managedProxyAccessStub) CheckGrant(_ context.Context, _, _ string, source interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantCheckResult, error) {
 	s.checked = append(s.checked, source)
-	return interfaces.ProxyGrantCheckResult{Allowed: s.allowed}, nil
+	return interfaces.ProxyGrantCheckResult{Allowed: s.allowed && !s.deniedResources[source.ResourceID]}, nil
 }
 func (s *managedProxyAccessStub) SyncGrants(_ context.Context, _, _ string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
 	s.syncCalls++
@@ -308,9 +310,17 @@ func TestPrepareProxyImportPreflightsRelationAgainstExistingBoundObject(t *testi
 		t.Fatal(err)
 	}
 	defer service.releaseProxyLock(t.Context(), plan)
-	if len(mpa.checked) != 1 || mpa.checked[0].BindingType != interfaces.MODULE_TYPE_RELATION_TYPE ||
-		mpa.checked[0].ResourceID != "resource-1" {
-		t.Fatalf("import preflight sources = %#v, want new relation grant on existing object resource", mpa.checked)
+	if len(mpa.checked) != 3 {
+		t.Fatalf("import preflight sources = %#v, want complete candidate source set", mpa.checked)
+	}
+	relationChecks := 0
+	for _, source := range mpa.checked {
+		if source.BindingType == interfaces.MODULE_TYPE_RELATION_TYPE && source.ResourceID == "resource-1" {
+			relationChecks++
+		}
+	}
+	if relationChecks != 1 {
+		t.Fatalf("import preflight sources = %#v, want relation grant plus retained object grants", mpa.checked)
 	}
 }
 
@@ -362,13 +372,13 @@ func TestPublishKNChildMutationBypassesProxyOutsideMainBranch(t *testing.T) {
 	}
 }
 
-func TestPublishKNChildMutationRejectsMissingProxyWithoutAuthorize(t *testing.T) {
+func TestPublishKNChildMutationRejectsMissingProxyWithoutModify(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ps := bmock.NewMockPermissionService(ctrl)
-	wantErr := errors.New("authorize denied")
+	wantErr := errors.New("modify denied")
 	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
 		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
-	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(wantErr)
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(wantErr)
 
 	mpa := &managedProxyAccessStub{}
 	service := &knowledgeNetworkService{ps: ps, kpa: &proxyAccessStub{}, mpa: mpa}
@@ -385,7 +395,21 @@ func TestPublishKNChildMutationRejectsMissingProxyWithoutAuthorize(t *testing.T)
 	}
 }
 
-func TestPublishKNChildMutationBackfillsMissingProxyBeforeMutation(t *testing.T) {
+func TestRetryKNProxySyncRequiresModify(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ps := bmock.NewMockPermissionService(ctrl)
+	wantErr := errors.New("modify denied")
+	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(wantErr)
+
+	service := &knowledgeNetworkService{ps: ps, kpa: &proxyAccessStub{}, mpa: &managedProxyAccessStub{}}
+	if _, err := service.RetryKNProxySync(t.Context(), "kn-1"); !errors.Is(err, wantErr) {
+		t.Fatalf("RetryKNProxySync() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestPublishKNChildMutationCreatesMissingProxyAndSyncsCandidate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	kna := bmock.NewMockKNAccess(ctrl)
 	cga := bmock.NewMockConceptGroupAccess(ctrl)
@@ -404,25 +428,23 @@ func TestPublishKNChildMutationBackfillsMissingProxyBeforeMutation(t *testing.T)
 		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
 	}}
 	base := &interfaces.KN{KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH}
-	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(4)
-	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).Return(base, nil).Times(3)
+	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	loadCount := 0
 	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).DoAndReturn(
 		func(context.Context, *sql.Tx, interfaces.ObjectTypesQueryParams) ([]*interfaces.ObjectType, error) {
 			loadCount++
-			if loadCount == 3 {
+			if loadCount == 2 {
 				return []*interfaces.ObjectType{objectType}, nil
 			}
 			return nil, nil
-		}).Times(3)
-	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
-	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
-	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(3)
+		}).Times(2)
+	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
 		Type: interfaces.RESOURCE_TYPE_KN, ID: "kn-1",
-	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
-	databaseMock.ExpectBegin()
-	databaseMock.ExpectCommit()
+	}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(nil)
 	databaseMock.ExpectBegin()
 	databaseMock.ExpectCommit()
 
@@ -443,7 +465,7 @@ func TestPublishKNChildMutationBackfillsMissingProxyBeforeMutation(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !mutationCalled || mpa.createCount != 1 || mpa.syncCalls != 2 {
+	if !mutationCalled || mpa.createCount != 1 || mpa.syncCalls != 1 {
 		t.Fatalf("backfill state: mutation=%t creates=%d syncs=%d", mutationCalled, mpa.createCount, mpa.syncCalls)
 	}
 	if kpa.mapping == nil || kpa.mapping.LifecycleStatus != interfaces.KNProxyLifecycleActive || !kpa.lockReleased {
@@ -605,8 +627,15 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	if len(mpa.synced) != 4 {
 		t.Fatalf("synchronized sources = %#v, want replacement and unchanged resource grants", mpa.synced)
 	}
-	if len(mpa.checked) != 2 || mpa.checked[0].ResourceID != "resource-new" || mpa.checked[1].ResourceID != "resource-new" {
-		t.Fatalf("preflight sources = %#v, want only replacement resource grants", mpa.checked)
+	if len(mpa.checked) != 4 {
+		t.Fatalf("preflight sources = %#v, want complete candidate source set", mpa.checked)
+	}
+	checkedByResource := map[string]int{}
+	for _, source := range mpa.checked {
+		checkedByResource[source.ResourceID]++
+	}
+	if checkedByResource["resource-new"] != 2 || checkedByResource["resource-stable"] != 2 {
+		t.Fatalf("preflight sources = %#v, want replacement and retained resource grants", mpa.checked)
 	}
 	if kpa.syncStatus != interfaces.KNProxySyncReady || kpa.syncedVersion != kpa.pendingVersion {
 		t.Fatalf("sync state = %q %q, pending version %q", kpa.syncStatus, kpa.syncedVersion, kpa.pendingVersion)
@@ -616,7 +645,7 @@ func TestPublishKNChildMutationCommitsPendingAndSyncsLatest(t *testing.T) {
 	}
 }
 
-func TestPublishKNChildMutationDeniedTargetDoesNotMutate(t *testing.T) {
+func TestPublishKNChildMutationInvalidRetainedTargetDoesNotMutate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	kna := bmock.NewMockKNAccess(ctrl)
 	cga := bmock.NewMockConceptGroupAccess(ctrl)
@@ -631,10 +660,13 @@ func TestPublishKNChildMutationDeniedTargetDoesNotMutate(t *testing.T) {
 	newObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
 		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-new"},
 	}}
+	stableObjectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-stable", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-stable"},
+	}}
 	kna.EXPECT().GetKNByID(gomock.Any(), "kn-1", interfaces.MAIN_BRANCH).
 		Return(&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}, nil)
 	cga.EXPECT().ListConceptGroups(gomock.Any(), gomock.Any()).Return(nil, nil)
-	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return([]*interfaces.ObjectType{oldObjectType}, nil)
+	ota.EXPECT().ListObjectTypes(gomock.Any(), nil, gomock.Any()).Return([]*interfaces.ObjectType{oldObjectType, stableObjectType}, nil)
 	rta.EXPECT().ListRelationTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
 	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
 	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
@@ -642,7 +674,7 @@ func TestPublishKNChildMutationDeniedTargetDoesNotMutate(t *testing.T) {
 	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
 		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
 	}}
-	mpa := &managedProxyAccessStub{allowed: false}
+	mpa := &managedProxyAccessStub{allowed: true, deniedResources: map[string]bool{"resource-stable": true}}
 	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
 	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
 	mutationCalled := false
@@ -654,15 +686,21 @@ func TestPublishKNChildMutationDeniedTargetDoesNotMutate(t *testing.T) {
 			return nil
 		})
 	httpErr, ok := err.(*rest.HTTPError)
-	if !ok || httpErr.HTTPCode != http.StatusForbidden {
+	if !ok || httpErr.HTTPCode != http.StatusForbidden ||
+		httpErr.BaseError.ErrorCode != berrors.BknBackend_KnowledgeNetwork_ProxyPermissionMissing {
 		t.Fatalf("PublishKNChildMutation() error = %#v, want HTTP 403", err)
+	}
+	details, ok := httpErr.BaseError.ErrorDetails.(missingProxyPermissionDetails)
+	if !ok || len(details.MissingPermissions) != 2 || details.MissingPermissions[0].ResourceID != "resource-stable" ||
+		details.MissingPermissions[1].ResourceID != "resource-stable" {
+		t.Fatalf("missing permission details = %#v, want retained target operations", httpErr.BaseError.ErrorDetails)
 	}
 	if mutationCalled || kpa.pendingCount != 0 || !kpa.lockReleased {
 		t.Fatalf("denied mutation state: called=%t pending=%d lock_released=%t",
 			mutationCalled, kpa.pendingCount, kpa.lockReleased)
 	}
-	if len(mpa.checked) != 1 || mpa.checked[0].ResourceID != "resource-new" {
-		t.Fatalf("denied preflight sources = %#v, want replacement target only", mpa.checked)
+	if len(mpa.checked) != 4 {
+		t.Fatalf("denied preflight sources = %#v, want complete candidate source set", mpa.checked)
 	}
 }
 
@@ -702,20 +740,20 @@ func TestPublishKNChildMutationDeleteRevokesRemovedGrantsWithLegacyUnscopedMetri
 		Return([]*interfaces.MetricDefinition{legacyMetric}, nil).Times(2)
 	databaseMock.ExpectBegin()
 	databaseMock.ExpectCommit()
-	databaseMock.ExpectBegin()
-	databaseMock.ExpectCommit()
 
 	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
 		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
 	}}
-	mpa := &managedProxyAccessStub{allowed: true}
+	mpa := &managedProxyAccessStub{allowed: true, deniedResources: map[string]bool{"resource-old": true}}
 	service := &knowledgeNetworkService{
 		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa,
 	}
 	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
 	mutationCalled := false
 	err = service.PublishKNChildMutation(ctx,
-		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH}, interfaces.ImportMode_Normal,
+		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{{
+			ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot-1"},
+		}}}, interfaces.ImportMode_Overwrite,
 		func(_ context.Context, tx *sql.Tx) error {
 			mutationCalled = true
 			if tx == nil {
@@ -729,7 +767,10 @@ func TestPublishKNChildMutationDeleteRevokesRemovedGrantsWithLegacyUnscopedMetri
 	if !mutationCalled || mpa.syncCalls != 1 || len(mpa.synced) != 0 {
 		t.Fatalf("delete synchronization: mutation=%t calls=%d grants=%#v", mutationCalled, mpa.syncCalls, mpa.synced)
 	}
-	if kpa.pendingCount != 2 || kpa.syncStatus != interfaces.KNProxySyncReady || !kpa.lockReleased {
+	if len(mpa.checked) != 0 {
+		t.Fatalf("delete preflight checked removed sources: %#v", mpa.checked)
+	}
+	if kpa.pendingCount != 1 || kpa.syncStatus != interfaces.KNProxySyncReady || !kpa.lockReleased {
 		t.Fatalf("delete proxy state: pending=%d sync=%q lock_released=%t",
 			kpa.pendingCount, kpa.syncStatus, kpa.lockReleased)
 	}
@@ -879,8 +920,8 @@ func TestFinishProxyPublishReloadsLatestMainModel(t *testing.T) {
 
 	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
 	plan := &proxyPublishPlan{
-		mapping:   &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1"},
-		grantorID: "grantor-1", modelVersion: latestVersion,
+		mapping:     &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1"},
+		delegatorID: "grantor-1", modelVersion: latestVersion,
 	}
 	if err := service.finishProxyPublish(t.Context(), plan); err != nil {
 		t.Fatal(err)
@@ -915,7 +956,7 @@ func TestFinishProxyPublishFailureRemainsFailClosed(t *testing.T) {
 	ata.EXPECT().ListActionTypes(gomock.Any(), gomock.Any()).Return(nil, nil)
 	ma.EXPECT().ListMetrics(gomock.Any(), gomock.Any()).Return(nil, nil)
 	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
-	plan := &proxyPublishPlan{mapping: &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1"}, grantorID: "grantor-1", modelVersion: version}
+	plan := &proxyPublishPlan{mapping: &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1"}, delegatorID: "grantor-1", modelVersion: version}
 
 	err = service.finishProxyPublish(t.Context(), plan)
 	if err == nil {
@@ -928,7 +969,7 @@ func TestFinishProxyPublishFailureRemainsFailClosed(t *testing.T) {
 
 func (s *managedProxyAccessStub) ReconcileGrants(_ context.Context, proxyAccountID, _ string) (interfaces.ProxyGrantReconcileResult, error) {
 	s.reconciled = append(s.reconciled, proxyAccountID)
-	return interfaces.ProxyGrantReconcileResult{}, nil
+	return s.reconcileResult, nil
 }
 
 func TestGetKNProxyResolvesMappingWithoutBusinessAuthorize(t *testing.T) {
@@ -1153,7 +1194,7 @@ func TestReconcileKNProxiesReportsMissingOrphanAndConflict(t *testing.T) {
 		Type: interfaces.RESOURCE_TYPE_KN,
 		ID:   "kn-mapped",
 	}, []string{interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
-	mpa := &managedProxyAccessStub{}
+	mpa := &managedProxyAccessStub{reconcileResult: interfaces.ProxyGrantReconcileResult{InvalidSources: 2}}
 	service := &knowledgeNetworkService{kna: kna, kpa: kpa, mpa: mpa, ps: permissionService}
 
 	report, err := service.ReconcileKNProxies(t.Context(), "admin-1")
@@ -1171,6 +1212,9 @@ func TestReconcileKNProxiesReportsMissingOrphanAndConflict(t *testing.T) {
 	}
 	if !reflect.DeepEqual(mpa.reconciled, []string{"proxy-mapped"}) {
 		t.Fatalf("reconciled proxies = %#v, want live authorized mapping only", mpa.reconciled)
+	}
+	if report.AuthorizationDrift["kn-mapped"].InvalidSources != 2 {
+		t.Fatalf("authorization drift = %#v, want invalid sources reported", report.AuthorizationDrift)
 	}
 }
 
@@ -1284,8 +1328,8 @@ func TestFinalizeProxyDeleteRepairsAlreadyArchivedManagedProxy(t *testing.T) {
 	}
 	service := &knowledgeNetworkService{kpa: kpa, mpa: mpa, ps: permissionService}
 	plan := &proxyPublishPlan{
-		mapping:   &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleDisabling},
-		grantorID: "grantor-1",
+		mapping:     &interfaces.KNProxyAccount{KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleDisabling},
+		delegatorID: "grantor-1",
 	}
 
 	if err := service.finalizeProxyDelete(t.Context(), plan); err != nil {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
@@ -256,25 +256,3 @@ func stableProxySourceID(knID, bindingType, bindingID string) string {
 	digest := sha256.Sum256([]byte(strings.Join([]string{knID, bindingType, bindingID}, "\x00")))
 	return hex.EncodeToString(digest[:])
 }
-
-func addedProxyGrantSources(current, candidate []interfaces.ProxyGrantSourceSpec) []interfaces.ProxyGrantSourceSpec {
-	currentKeys := make(map[string]struct{}, len(current))
-	for _, source := range current {
-		currentKeys[proxyGrantSourceKey(source)] = struct{}{}
-	}
-	added := make([]interfaces.ProxyGrantSourceSpec, 0, len(candidate))
-	for _, source := range candidate {
-		if _, exists := currentKeys[proxyGrantSourceKey(source)]; !exists {
-			added = append(added, source)
-		}
-	}
-	return added
-}
-
-func proxyGrantSourceKey(source interfaces.ProxyGrantSourceSpec) string {
-	return strings.Join([]string{
-		source.ResourceType, source.ResourceID, source.Operation,
-		source.SourceType, source.SourceID, source.KNID,
-		source.BindingType, source.BindingID,
-	}, "\x00")
-}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
@@ -204,18 +204,3 @@ func TestBuildProxyGrantSourcesIncludesBoundLogicPropertyTool(t *testing.T) {
 		t.Fatalf("logic property sources = %#v", sources)
 	}
 }
-
-func TestAddedProxyGrantSourcesReturnsOnlyNewTargets(t *testing.T) {
-	current := []interfaces.ProxyGrantSourceSpec{
-		{ResourceType: "resource", ResourceID: "resource-stable", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "stable"},
-		{ResourceType: "resource", ResourceID: "resource-old", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "changed"},
-	}
-	candidate := []interfaces.ProxyGrantSourceSpec{
-		{ResourceType: "resource", ResourceID: "resource-stable", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "stable"},
-		{ResourceType: "resource", ResourceID: "resource-new", Operation: "query_data", SourceType: "kn_proxy_binding", SourceID: "changed"},
-	}
-	added := addedProxyGrantSources(current, candidate)
-	if len(added) != 1 || added[0].ResourceID != "resource-new" {
-		t.Fatalf("added sources = %#v, want replacement target only", added)
-	}
-}

--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -105,7 +105,10 @@ VS Code / Cursor：打开 `bkn-safe` 根目录，选 **Run and Debug → bkn-saf
   AppKeys, be managed as regular users, or receive grants through the generic Policy API
 - Proxy grant sources (ClusterIP-internal surface) `/api/safe/in/v1/proxy-grant-sources`:
   create and revoke sources, preflight authorization, synchronize the complete published-model
-  source set, and reconcile Casbin Allow policies; the source ledger and policies update atomically
+  source set, and reconcile Casbin Allow policies. A knowledge-network binding derives from the
+  recorded delegator's exact downstream operation (target `authorize` is not required), and a
+  managed proxy decision remains effective only while at least one exact active source is valid;
+  the source ledger and policies update atomically
 - 目录 `/api/safe/v1/directory`：`GET /users/:id`、`POST /names`、`GET /departments`、
   `GET /groups/:id/members`、`POST /search-org`、`POST /users`、`PUT /users/:id/password`
 - 健康：`GET /health/ready`、`/health/alive`

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -235,13 +235,13 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 	if err != nil || !managed {
 		return out, err
 	}
+	currentPermissions, err := en.currentProxyPermissions(accessorID)
+	if err != nil {
+		return nil, err
+	}
 	current := out[:0]
 	for _, op := range out {
-		valid, err := en.hasCurrentProxySource(accessorID, resourceType, resourceID, op)
-		if err != nil {
-			return nil, err
-		}
-		if valid {
+		if currentPermissions[proxyPermission{ResourceType: resourceType, ResourceID: resourceID, Operation: op}] {
 			current = append(current, op)
 		}
 	}

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -116,6 +116,33 @@ func obj(resourceType, id string) string { return resourceType + ":" + id }
 // mapping. With no ownership row recorded the second step finds nothing, which
 // is exactly the pre-#800 decision (#800).
 func (en *Enforcer) Check(accessorID, resourceType, resourceID, op string) (bool, error) {
+	ok, err := en.checkPolicy(accessorID, resourceType, resourceID, op)
+	if err != nil || !ok || en.db == nil {
+		return ok, err
+	}
+	managed, err := en.isManagedProxy(accessorID)
+	if err != nil {
+		return false, err
+	}
+	if !managed {
+		return true, nil
+	}
+	return en.hasCurrentProxySource(accessorID, resourceType, resourceID, op)
+}
+
+func (en *Enforcer) isManagedProxy(accessorID string) (bool, error) {
+	var managed int64
+	if err := en.db.Model(&safemodel.ManagedProxyAccount{}).
+		Where("proxy_account_id = ?", accessorID).Count(&managed).Error; err != nil {
+		return false, err
+	}
+	return managed > 0, nil
+}
+
+// checkPolicy evaluates the current direct, role and hierarchy policy without
+// applying managed-proxy provenance. Delegator validation must use this raw
+// path so a source can never recursively justify itself.
+func (en *Enforcer) checkPolicy(accessorID, resourceType, resourceID, op string) (bool, error) {
 	ok, err := en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
 	if err != nil || ok {
 		return ok, err
@@ -125,6 +152,52 @@ func (en *Enforcer) Check(accessorID, resourceType, resourceID, op string) (bool
 		return false, err
 	}
 	return inherited[op], nil
+}
+
+// hasCurrentProxySource makes the source ledger part of every managed-proxy
+// decision. A historical Casbin Allow is necessary but not sufficient: KN
+// binding sources also depend on their recorded delegator still holding the
+// exact downstream operation. Manual and administrator sources follow their
+// own explicit lifecycle and remain valid while active.
+func (en *Enforcer) hasCurrentProxySource(proxyID, resourceType, resourceID, op string) (bool, error) {
+	var sources []safemodel.ProxyGrantSource
+	if err := en.db.Where(
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ? AND lifecycle_status = ?",
+		proxyID, resourceType, resourceID, op, safemodel.ProxyGrantSourceStatusActive,
+	).Find(&sources).Error; err != nil {
+		return false, err
+	}
+	for _, source := range sources {
+		switch source.SourceType {
+		case safemodel.ProxyGrantSourceTypeManual, safemodel.ProxyGrantSourceTypeAdmin:
+			return true, nil
+		case safemodel.ProxyGrantSourceTypeKNBinding:
+			var registered int64
+			if err := en.db.Model(&safemodel.Operation{}).
+				Where("resource_type_id = ? AND id = ?", resourceType, op).Count(&registered).Error; err != nil {
+				return false, err
+			}
+			if registered == 0 {
+				continue
+			}
+			var active int64
+			if err := en.db.Model(&safemodel.User{}).
+				Where("id = ? AND enabled = ?", source.GrantedBy, true).Count(&active).Error; err != nil {
+				return false, err
+			}
+			if active == 0 {
+				continue
+			}
+			allowed, err := en.checkPolicy(source.GrantedBy, resourceType, resourceID, op)
+			if err != nil {
+				return false, err
+			}
+			if allowed {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 // AllowedOps returns, from the candidate ops, those the accessor may perform on
@@ -155,7 +228,24 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 			out = append(out, op)
 		}
 	}
-	return out, nil
+	if len(out) == 0 || en.db == nil {
+		return out, nil
+	}
+	managed, err := en.isManagedProxy(accessorID)
+	if err != nil || !managed {
+		return out, err
+	}
+	current := out[:0]
+	for _, op := range out {
+		valid, err := en.hasCurrentProxySource(accessorID, resourceType, resourceID, op)
+		if err != nil {
+			return nil, err
+		}
+		if valid {
+			current = append(current, op)
+		}
+	}
+	return current, nil
 }
 
 // GrantRolePermission grants a role an op over a resource-type instance pattern

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -97,6 +97,32 @@ func (en *Enforcer) FilterResourceOps(accessorID string, resources []ResourceRef
 		}
 	}
 
+	// Managed proxies have a second, provenance-aware condition that is not
+	// represented in Casbin: an exact active source must still be valid. Apply
+	// it after the batched raw-policy calculation so list/filter decisions stay
+	// identical to Check. Human and ordinary app accessors keep the optimized
+	// path above without per-decision source lookups.
+	if en.db != nil {
+		managed, err := en.isManagedProxy(accessorID)
+		if err != nil {
+			return nil, err
+		}
+		if managed {
+			for resource, allowed := range decided {
+				for operation, rawAllowed := range allowed {
+					if !rawAllowed {
+						continue
+					}
+					current, err := en.hasCurrentProxySource(accessorID, resource.Type, resource.ID, operation)
+					if err != nil {
+						return nil, err
+					}
+					allowed[operation] = current
+				}
+			}
+		}
+	}
+
 	out := make([]FilteredResource, 0, len(resources))
 	for _, r := range resources {
 		allowed := decided[r]

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -45,6 +45,15 @@ type FilteredResource struct {
 // (#357). Instead the accessor's grants are resolved once and projected onto
 // each resource; TestFilterResourceOpsMatchesCheck pins the two paths together.
 func (en *Enforcer) FilterResourceOps(accessorID string, resources []ResourceRef, visibility, candidates []string) ([]FilteredResource, error) {
+	return en.filterResourceOps(accessorID, resources, visibility, candidates, true)
+}
+
+// filterResourceOps performs the batched Casbin and hierarchy projection. The
+// provenance flag is disabled only while validating the human delegators that
+// back a managed proxy source; those checks must never recurse through proxy
+// provenance.
+func (en *Enforcer) filterResourceOps(accessorID string, resources []ResourceRef, visibility, candidates []string,
+	validateProvenance bool) ([]FilteredResource, error) {
 	idx, err := en.grantIndex(accessorID)
 	if err != nil {
 		return nil, err
@@ -102,22 +111,26 @@ func (en *Enforcer) FilterResourceOps(accessorID string, resources []ResourceRef
 	// it after the batched raw-policy calculation so list/filter decisions stay
 	// identical to Check. Human and ordinary app accessors keep the optimized
 	// path above without per-decision source lookups.
-	if en.db != nil {
+	if validateProvenance && en.db != nil {
 		managed, err := en.isManagedProxy(accessorID)
 		if err != nil {
 			return nil, err
 		}
 		if managed {
+			current, err := en.currentProxyPermissions(accessorID)
+			if err != nil {
+				return nil, err
+			}
 			for resource, allowed := range decided {
 				for operation, rawAllowed := range allowed {
 					if !rawAllowed {
 						continue
 					}
-					current, err := en.hasCurrentProxySource(accessorID, resource.Type, resource.ID, operation)
-					if err != nil {
-						return nil, err
-					}
-					allowed[operation] = current
+					allowed[operation] = current[proxyPermission{
+						ResourceType: resource.Type,
+						ResourceID:   resource.ID,
+						Operation:    operation,
+					}]
 				}
 			}
 		}

--- a/bkn-safe/server/internal/authz/proxy_source.go
+++ b/bkn-safe/server/internal/authz/proxy_source.go
@@ -1,0 +1,187 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"sort"
+	"strings"
+
+	safemodel "github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+type proxyPermission struct {
+	ResourceType string
+	ResourceID   string
+	Operation    string
+}
+
+// currentProxyPermissions resolves all currently effective source-backed
+// permissions for one managed proxy with a bounded number of database reads.
+// Delegator policy and hierarchy checks are grouped by delegator instead of by
+// source, which keeps list filtering proportional to the number of delegators.
+func (en *Enforcer) currentProxyPermissions(proxyID string) (map[proxyPermission]bool, error) {
+	sources, valid, err := en.currentProxySourceIDs(proxyID)
+	if err != nil {
+		return nil, err
+	}
+	permissions := make(map[proxyPermission]bool, len(valid))
+	for _, source := range sources {
+		if !valid[source.ID] {
+			continue
+		}
+		permissions[proxyPermission{
+			ResourceType: source.ResourceType,
+			ResourceID:   source.ResourceID,
+			Operation:    source.Operation,
+		}] = true
+	}
+	return permissions, nil
+}
+
+// currentProxySourceIDs returns the active source rows and the subset whose
+// lifecycle and delegator authority are still valid.
+func (en *Enforcer) currentProxySourceIDs(proxyID string) ([]safemodel.ProxyGrantSource, map[string]bool, error) {
+	var sources []safemodel.ProxyGrantSource
+	if err := en.db.Where("proxy_account_id = ? AND lifecycle_status = ?",
+		proxyID, safemodel.ProxyGrantSourceStatusActive).Find(&sources).Error; err != nil {
+		return nil, nil, err
+	}
+	valid, err := en.validProxySourceIDs(sources)
+	return sources, valid, err
+}
+
+// CurrentProxySourceIDs exposes the batched validity projection to provenance
+// services already running inside the same authorization transaction.
+func (tx *PolicyTransaction) CurrentProxySourceIDs(proxyID string) (map[string]bool, error) {
+	_, valid, err := tx.enforcer.currentProxySourceIDs(proxyID)
+	return valid, err
+}
+
+// FilterResourceOpsRaw evaluates a non-managed delegator without applying
+// managed-proxy provenance. Callers must validate that the accessor is an
+// enabled, non-managed identity before using it.
+func (tx *PolicyTransaction) FilterResourceOpsRaw(accessorID string, resources []ResourceRef,
+	candidates []string) ([]FilteredResource, error) {
+	return tx.enforcer.filterResourceOps(accessorID, resources, nil, candidates, false)
+}
+
+func (en *Enforcer) validProxySourceIDs(sources []safemodel.ProxyGrantSource) (map[string]bool, error) {
+	valid := make(map[string]bool, len(sources))
+	byDelegator := map[string][]safemodel.ProxyGrantSource{}
+	resourceTypes := map[string]bool{}
+	operations := map[string]bool{}
+	delegators := map[string]bool{}
+	for _, source := range sources {
+		switch source.SourceType {
+		case safemodel.ProxyGrantSourceTypeManual, safemodel.ProxyGrantSourceTypeAdmin:
+			valid[source.ID] = true
+		case safemodel.ProxyGrantSourceTypeKNBinding:
+			delegator := strings.TrimSpace(source.GrantedBy)
+			if delegator == "" {
+				continue
+			}
+			byDelegator[delegator] = append(byDelegator[delegator], source)
+			resourceTypes[source.ResourceType] = true
+			operations[source.Operation] = true
+			delegators[delegator] = true
+		}
+	}
+	if len(byDelegator) == 0 {
+		return valid, nil
+	}
+
+	type operationKey struct {
+		ResourceType string
+		Operation    string
+	}
+	var registeredRows []safemodel.Operation
+	if err := en.db.Where("resource_type_id IN ? AND id IN ?", sortedKeys(resourceTypes), sortedKeys(operations)).
+		Find(&registeredRows).Error; err != nil {
+		return nil, err
+	}
+	registered := make(map[operationKey]bool, len(registeredRows))
+	for _, operation := range registeredRows {
+		registered[operationKey{ResourceType: operation.ResourceTypeID, Operation: operation.ID}] = true
+	}
+
+	delegatorIDs := sortedKeys(delegators)
+	var users []safemodel.User
+	if err := en.db.Where("id IN ? AND enabled = ?", delegatorIDs, true).Find(&users).Error; err != nil {
+		return nil, err
+	}
+	enabled := make(map[string]bool, len(users))
+	for _, user := range users {
+		enabled[user.ID] = true
+	}
+	var managed []safemodel.ManagedProxyAccount
+	if err := en.db.Where("proxy_account_id IN ?", delegatorIDs).Find(&managed).Error; err != nil {
+		return nil, err
+	}
+	for _, account := range managed {
+		delete(enabled, account.ProxyAccountID)
+	}
+
+	for delegator, delegatedSources := range byDelegator {
+		if !enabled[delegator] {
+			continue
+		}
+		resourceSet := map[ResourceRef]bool{}
+		candidateSet := map[string]bool{}
+		for _, source := range delegatedSources {
+			if !registered[operationKey{ResourceType: source.ResourceType, Operation: source.Operation}] {
+				continue
+			}
+			resourceSet[ResourceRef{Type: source.ResourceType, ID: source.ResourceID}] = true
+			candidateSet[source.Operation] = true
+		}
+		resources := sortedResourceRefs(resourceSet)
+		if len(resources) == 0 {
+			continue
+		}
+		allowed, err := en.filterResourceOps(delegator, resources, nil, sortedKeys(candidateSet), false)
+		if err != nil {
+			return nil, err
+		}
+		allowedSet := map[proxyPermission]bool{}
+		for _, resource := range allowed {
+			for _, operation := range resource.Operations {
+				allowedSet[proxyPermission{
+					ResourceType: resource.Type,
+					ResourceID:   resource.ID,
+					Operation:    operation,
+				}] = true
+			}
+		}
+		for _, source := range delegatedSources {
+			if allowedSet[proxyPermission{source.ResourceType, source.ResourceID, source.Operation}] {
+				valid[source.ID] = true
+			}
+		}
+	}
+	return valid, nil
+}
+
+func sortedKeys(values map[string]bool) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedResourceRefs(values map[ResourceRef]bool) []ResourceRef {
+	out := make([]ResourceRef, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -74,7 +74,7 @@ func TestManagedProxyAccountLifecycleAPI(t *testing.T) {
 }
 
 func TestManagedProxyStatusControlsAuthorizationDecisions(t *testing.T) {
-	r, enforcer, _ := newTestServer(t)
+	r, enforcer, db := newTestServer(t)
 	w := do(t, r, http.MethodPost, "/api/safe/in/v1/managed-proxy-accounts", map[string]any{
 		"managed_resource_type": managedproxy.ResourceKnowledgeNetwork,
 		"managed_resource_id":   "kn-pep",
@@ -82,6 +82,13 @@ func TestManagedProxyStatusControlsAuthorizationDecisions(t *testing.T) {
 	var account managedproxy.Account
 	_ = json.Unmarshal(w.Body.Bytes(), &account)
 	if err := enforcer.GrantObjectPermission(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ProxyGrantSource{
+		ID: "source-pep", ProxyAccountID: account.ProxyAccountID, ResourceType: "resource", ResourceID: "r-1",
+		Operation: "query_data", SourceType: model.ProxyGrantSourceTypeManual, SourceID: "manual-pep",
+		LifecycleStatus: model.ProxyGrantSourceStatusActive,
+	}).Error; err != nil {
 		t.Fatal(err)
 	}
 	check := map[string]any{
@@ -194,6 +201,13 @@ func TestGenericRevokeAndRoleUnbindCannotMutateManagedProxy(t *testing.T) {
 	}
 	seedCatalogOps(t, db, "resource", "query_data")
 	if err := enforcer.GrantObjectPermission(account.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ProxyGrantSource{
+		ID: "source-protected", ProxyAccountID: account.ProxyAccountID, ResourceType: "resource", ResourceID: "r-1",
+		Operation: "query_data", SourceType: model.ProxyGrantSourceTypeManual, SourceID: "manual-protected",
+		LifecycleStatus: model.ProxyGrantSourceStatusActive,
+	}).Error; err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Create(&model.Role{ID: "proxy-role", Name: "proxy-role", Source: model.RoleSourceCustom}).Error; err != nil {

--- a/bkn-safe/server/internal/httpapi/proxygrant.go
+++ b/bkn-safe/server/internal/httpapi/proxygrant.go
@@ -58,6 +58,18 @@ func registerProxyGrantSources(r *gin.Engine, service *proxygrant.Service) {
 		c.JSON(http.StatusOK, result)
 	})
 
+	group.POST("/check-batch", func(c *gin.Context) {
+		var req proxygrant.BatchCheckRequest
+		if !bind(c, &req) {
+			return
+		}
+		result, err := service.CheckMany(c.Request.Context(), req)
+		if writeProxyGrantError(c, err) {
+			return
+		}
+		c.JSON(http.StatusOK, result)
+	})
+
 	group.POST("/sync", func(c *gin.Context) {
 		var req proxygrant.SyncRequest
 		if !bind(c, &req) {

--- a/bkn-safe/server/internal/httpapi/proxygrant_test.go
+++ b/bkn-safe/server/internal/httpapi/proxygrant_test.go
@@ -141,6 +141,21 @@ func TestProxyGrantCheckAndReconcileAPI(t *testing.T) {
 	if w.Code != http.StatusOK || !jsonBool(t, w.Body.Bytes(), "allowed") {
 		t.Fatalf("check = %d body=%s", w.Code, w.Body.String())
 	}
+	w = do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources/check-batch", map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"grantor_id":       "grantor-check",
+		"sources":          []any{body["source"]},
+	})
+	var batchResult proxygrant.BatchCheckResult
+	if w.Code != http.StatusOK {
+		t.Fatalf("batch check = %d body=%s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &batchResult); err != nil {
+		t.Fatal(err)
+	}
+	if len(batchResult.DeniedSources) != 0 {
+		t.Fatalf("batch denied sources = %#v, want none", batchResult.DeniedSources)
+	}
 
 	w = do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources/reconcile", map[string]any{
 		"proxy_account_id": proxy.ProxyAccountID,

--- a/bkn-safe/server/internal/httpapi/proxygrant_test.go
+++ b/bkn-safe/server/internal/httpapi/proxygrant_test.go
@@ -151,6 +151,49 @@ func TestProxyGrantCheckAndReconcileAPI(t *testing.T) {
 	}
 }
 
+func TestManagedProxyAuthzCheckFollowsKNBindingDelegatorPermission(t *testing.T) {
+	r, enforcer, db := newTestServer(t)
+	proxy, _, err := managedproxy.New(db).Create(t.Context(), managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-api-runtime",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedEnabledUser(t, db, "builder-runtime")
+	seedCatalogOps(t, db, "resource", "query_data")
+	if err := enforcer.GrantObjectPermission("builder-runtime", "resource", "r-runtime", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	grant := map[string]any{
+		"proxy_account_id": proxy.ProxyAccountID,
+		"grantor_id":       "builder-runtime",
+		"source": map[string]any{
+			"resource_type": "resource", "resource_id": "r-runtime", "operation": "query_data",
+			"source_id": "source-runtime", "kn_id": "kn-api-runtime",
+			"binding_type": "object_type", "binding_id": "ot-runtime",
+		},
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/in/v1/proxy-grant-sources", grant); w.Code != http.StatusCreated {
+		t.Fatalf("create = %d body=%s", w.Code, w.Body.String())
+	}
+	check := map[string]any{
+		"accessor_id": proxy.ProxyAccountID,
+		"resource":    map[string]any{"type": "resource", "id": "r-runtime"},
+		"operation":   "query_data",
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", check); w.Code != http.StatusOK || !jsonBool(t, w.Body.Bytes(), "allowed") {
+		t.Fatalf("initial check = %d body=%s", w.Code, w.Body.String())
+	}
+
+	if err := enforcer.RevokeObjectPermission("builder-runtime", "resource", "r-runtime", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", check); w.Code != http.StatusOK || jsonBool(t, w.Body.Bytes(), "allowed") {
+		t.Fatalf("check after delegator revoke = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func jsonBool(t *testing.T, body []byte, field string) bool {
 	t.Helper()
 	var value map[string]any

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -72,6 +72,14 @@ type ManagedProxyAccount struct {
 	UpdatedAt           time.Time
 }
 
+const (
+	ProxyGrantSourceTypeKNBinding = "kn_proxy_binding"
+	ProxyGrantSourceTypeManual    = "manual"
+	ProxyGrantSourceTypeAdmin     = "admin"
+	ProxyGrantSourceStatusActive  = "active"
+	ProxyGrantSourceStatusRevoked = "revoked"
+)
+
 // ProxyGrantSource is the durable provenance ledger for one direct permission
 // required by a managed BKN proxy. A binding may require several permissions,
 // and several bindings may require the same permission, so the source identity

--- a/bkn-safe/server/internal/proxygrant/service.go
+++ b/bkn-safe/server/internal/proxygrant/service.go
@@ -68,6 +68,12 @@ type SyncRequest struct {
 	Sources        []SourceSpec `json:"sources"`
 }
 
+type BatchCheckRequest struct {
+	ProxyAccountID string       `json:"proxy_account_id"`
+	GrantorID      string       `json:"grantor_id"`
+	Sources        []SourceSpec `json:"sources"`
+}
+
 type ReconcileRequest struct {
 	ProxyAccountID string `json:"proxy_account_id"`
 	RequestedBy    string `json:"requested_by"`
@@ -76,6 +82,10 @@ type ReconcileRequest struct {
 type CheckResult struct {
 	Allowed bool   `json:"allowed"`
 	Reason  string `json:"reason,omitempty"`
+}
+
+type BatchCheckResult struct {
+	DeniedSources []SourceSpec `json:"denied_sources"`
 }
 
 type SyncResult struct {
@@ -248,6 +258,162 @@ func (s *Service) Check(ctx context.Context, req GrantRequest) (CheckResult, err
 	})
 	if err != nil {
 		return CheckResult{}, err
+	}
+	return result, nil
+}
+
+// CheckMany validates a complete KN binding source set in one request. Existing
+// source and delegator state is loaded in batches; only sources that need a new
+// or replacement delegator are checked against the current actor.
+func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCheckResult, error) {
+	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
+	req.GrantorID = strings.TrimSpace(req.GrantorID)
+	if req.ProxyAccountID == "" || req.GrantorID == "" ||
+		len(req.ProxyAccountID) > 64 || len(req.GrantorID) > 64 {
+		return BatchCheckResult{}, ErrInvalidRequest
+	}
+	sources := make([]SourceSpec, 0, len(req.Sources))
+	desired := make(map[sourceKey]SourceSpec, len(req.Sources))
+	for _, raw := range req.Sources {
+		spec, err := normalizeSpec(raw)
+		if err != nil || spec.SourceType != SourceTypeKNProxyBinding {
+			return BatchCheckResult{}, ErrInvalidRequest
+		}
+		key := keyForSpec(spec)
+		if previous, exists := desired[key]; exists {
+			if !sameBinding(previous, spec) {
+				return BatchCheckResult{}, ErrInvalidRequest
+			}
+			continue
+		}
+		desired[key] = spec
+		sources = append(sources, spec)
+	}
+
+	result := BatchCheckResult{DeniedSources: []SourceSpec{}}
+	err := s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
+		mapping, mappingErr := loadProxy(tx.DB(), req.ProxyAccountID)
+		if mappingErr != nil && !errors.Is(mappingErr, ErrProxyInactive) &&
+			!errors.Is(mappingErr, ErrNotFound) && !errors.Is(mappingErr, ErrForbidden) {
+			return mappingErr
+		}
+		if mappingErr == nil && mapping.LifecycleStatus != managedproxy.StatusActive {
+			mappingErr = ErrProxyInactive
+		}
+
+		var rows []model.ProxyGrantSource
+		if mappingErr == nil {
+			if err := tx.DB().Where("proxy_account_id = ? AND source_type = ?",
+				req.ProxyAccountID, SourceTypeKNProxyBinding).Find(&rows).Error; err != nil {
+				return err
+			}
+		}
+		current := make(map[sourceKey]model.ProxyGrantSource, len(rows))
+		for _, row := range rows {
+			current[keyForModel(row)] = row
+		}
+		validCurrent := map[string]bool{}
+		if mappingErr == nil {
+			var err error
+			validCurrent, err = tx.CurrentProxySourceIDs(req.ProxyAccountID)
+			if err != nil {
+				return err
+			}
+		}
+
+		needsActor := make([]SourceSpec, 0, len(sources))
+		allowed := make(map[sourceKey]bool, len(sources))
+		for _, spec := range sources {
+			key := keyForSpec(spec)
+			if mappingErr != nil || spec.KNID != mapping.ManagedResourceID {
+				continue
+			}
+			if row, exists := current[key]; exists {
+				if !sameBinding(specFromModel(row), spec) {
+					return ErrInvalidRequest
+				}
+				if row.LifecycleStatus == StatusActive && validCurrent[row.ID] {
+					allowed[key] = true
+					continue
+				}
+			}
+			needsActor = append(needsActor, spec)
+		}
+
+		actorEligible := len(needsActor) > 0
+		if actorEligible {
+			if err := validateGrantorIdentity(tx.DB(), req.GrantorID); err != nil {
+				if !errors.Is(err, ErrForbidden) {
+					return err
+				}
+				actorEligible = false
+			}
+		}
+		if actorEligible {
+			if err := validateRegisteredOperations(tx.DB(), needsActor); err != nil {
+				return err
+			}
+			resourceSet := map[authz.ResourceRef]bool{}
+			operationSet := map[string]bool{}
+			for _, spec := range needsActor {
+				resourceSet[authz.ResourceRef{Type: spec.ResourceType, ID: spec.ResourceID}] = true
+				operationSet[spec.Operation] = true
+			}
+			resources := make([]authz.ResourceRef, 0, len(resourceSet))
+			for resource := range resourceSet {
+				resources = append(resources, resource)
+			}
+			operations := make([]string, 0, len(operationSet))
+			for operation := range operationSet {
+				operations = append(operations, operation)
+			}
+			filtered, err := tx.FilterResourceOpsRaw(req.GrantorID, resources, operations)
+			if err != nil {
+				return err
+			}
+			actorPermissions := map[permissionKey]bool{}
+			for _, resource := range filtered {
+				for _, operation := range resource.Operations {
+					actorPermissions[permissionKey{
+						ResourceType: resource.Type,
+						ResourceID:   resource.ID,
+						Operation:    operation,
+					}] = true
+				}
+			}
+			for _, spec := range needsActor {
+				if actorPermissions[permissionKey{
+					ResourceType: spec.ResourceType,
+					ResourceID:   spec.ResourceID,
+					Operation:    spec.Operation,
+				}] {
+					allowed[keyForSpec(spec)] = true
+				}
+			}
+		}
+
+		audits := make([]model.ProxyGrantAuditLog, 0, len(sources))
+		for _, spec := range sources {
+			decision := "allow"
+			reason := "actor or retained delegator holds the required operation"
+			if !allowed[keyForSpec(spec)] {
+				decision = "deny"
+				reason = ErrForbidden.Error()
+				result.DeniedSources = append(result.DeniedSources, spec)
+			}
+			audit, err := newAudit("check", decision, reason, req.GrantorID, req.ProxyAccountID, spec)
+			if err != nil {
+				return err
+			}
+			audits = append(audits, audit)
+		}
+		if len(audits) > 0 {
+			return tx.DB().Create(&audits).Error
+		}
+		return nil
+	})
+	if err != nil {
+		return BatchCheckResult{}, err
 	}
 	return result, nil
 }
@@ -600,6 +766,38 @@ func validateRegisteredOperation(db *gorm.DB, spec SourceSpec) error {
 	return nil
 }
 
+func validateRegisteredOperations(db *gorm.DB, specs []SourceSpec) error {
+	resourceTypes := map[string]bool{}
+	operationIDs := map[string]bool{}
+	for _, spec := range specs {
+		resourceTypes[spec.ResourceType] = true
+		operationIDs[spec.Operation] = true
+	}
+	resourceTypeValues := make([]string, 0, len(resourceTypes))
+	for value := range resourceTypes {
+		resourceTypeValues = append(resourceTypeValues, value)
+	}
+	operationValues := make([]string, 0, len(operationIDs))
+	for value := range operationIDs {
+		operationValues = append(operationValues, value)
+	}
+	var registered []model.Operation
+	if err := db.Where("resource_type_id IN ? AND id IN ?", resourceTypeValues, operationValues).
+		Find(&registered).Error; err != nil {
+		return err
+	}
+	available := map[string]bool{}
+	for _, operation := range registered {
+		available[operation.ResourceTypeID+"\x00"+operation.ID] = true
+	}
+	for _, spec := range specs {
+		if !available[spec.ResourceType+"\x00"+spec.Operation] {
+			return ErrInvalidRequest
+		}
+	}
+	return nil
+}
+
 func sourceCurrentlyValid(tx *authz.PolicyTransaction, source model.ProxyGrantSource) (bool, error) {
 	switch source.SourceType {
 	case SourceTypeManual, SourceTypeAdmin:
@@ -902,18 +1100,27 @@ func reconcileProxyIDs(db *gorm.DB, only string) ([]string, error) {
 }
 
 func recordAudit(db *gorm.DB, action, decision, reason, grantorID, proxyID string, spec SourceSpec) error {
+	audit, err := newAudit(action, decision, reason, grantorID, proxyID, spec)
+	if err != nil {
+		return err
+	}
+	return db.Create(&audit).Error
+}
+
+func newAudit(action, decision, reason, grantorID, proxyID string,
+	spec SourceSpec) (model.ProxyGrantAuditLog, error) {
 	if len(reason) > 255 {
 		reason = reason[:255]
 	}
 	id, err := newID()
 	if err != nil {
-		return fmt.Errorf("generate proxy grant audit id: %w", err)
+		return model.ProxyGrantAuditLog{}, fmt.Errorf("generate proxy grant audit id: %w", err)
 	}
-	return db.Create(&model.ProxyGrantAuditLog{
+	return model.ProxyGrantAuditLog{
 		ID: id, Action: action, Decision: decision, Reason: reason, GrantorID: grantorID,
 		ProxyAccountID: proxyID, ResourceType: spec.ResourceType, ResourceID: spec.ResourceID,
 		Operation: spec.Operation, SourceType: spec.SourceType, SourceID: spec.SourceID,
-	}).Error
+	}, nil
 }
 
 func (s *Service) recordDenied(ctx context.Context, action, grantorID, proxyID string, spec SourceSpec, decisionErr error) {

--- a/bkn-safe/server/internal/proxygrant/service.go
+++ b/bkn-safe/server/internal/proxygrant/service.go
@@ -26,11 +26,11 @@ import (
 )
 
 const (
-	SourceTypeKNProxyBinding = "kn_proxy_binding"
-	SourceTypeManual         = "manual"
-	SourceTypeAdmin          = "admin"
-	StatusActive             = "active"
-	StatusRevoked            = "revoked"
+	SourceTypeKNProxyBinding = model.ProxyGrantSourceTypeKNBinding
+	SourceTypeManual         = model.ProxyGrantSourceTypeManual
+	SourceTypeAdmin          = model.ProxyGrantSourceTypeAdmin
+	StatusActive             = model.ProxyGrantSourceStatusActive
+	StatusRevoked            = model.ProxyGrantSourceStatusRevoked
 )
 
 var (
@@ -79,10 +79,11 @@ type CheckResult struct {
 }
 
 type SyncResult struct {
-	Added     int                      `json:"added"`
-	Revoked   int                      `json:"revoked"`
-	Unchanged int                      `json:"unchanged"`
-	Sources   []model.ProxyGrantSource `json:"sources"`
+	Added       int                      `json:"added"`
+	Transferred int                      `json:"transferred"`
+	Revoked     int                      `json:"revoked"`
+	Unchanged   int                      `json:"unchanged"`
+	Sources     []model.ProxyGrantSource `json:"sources"`
 }
 
 type ReconcileResult struct {
@@ -91,6 +92,7 @@ type ReconcileResult struct {
 	MarkersCreated    int `json:"markers_created"`
 	MarkersRemoved    int `json:"markers_removed"`
 	UntrackedPolicies int `json:"untracked_policies"`
+	InvalidSources    int `json:"invalid_sources"`
 }
 
 type Service struct {
@@ -102,9 +104,10 @@ func New(db *gorm.DB, enforcer *authz.Enforcer) *Service {
 	return &Service{db: db, enforcer: enforcer}
 }
 
-// Grant adds or reactivates one source. Replaying the same source tuple is a
-// successful no-op. The source, materialization marker, audit row and Casbin
-// policy share the adapter's database transaction.
+// Grant adds or reactivates one source. Replaying a currently valid source tuple
+// is a successful no-op; an invalid KN-binding delegator may be replaced by the
+// current actor. The source, materialization marker, audit row and Casbin policy
+// share the adapter's database transaction.
 func (s *Service) Grant(ctx context.Context, req GrantRequest) (*model.ProxyGrantSource, bool, error) {
 	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
 	req.GrantorID = strings.TrimSpace(req.GrantorID)
@@ -121,7 +124,7 @@ func (s *Service) Grant(ctx context.Context, req GrantRequest) (*model.ProxyGran
 		if err := validateProxy(tx.DB(), req.ProxyAccountID, spec.KNID, true); err != nil {
 			return err
 		}
-		if err := validateAuthority(tx, req.GrantorID, spec); err != nil {
+		if err := validatePreflightAuthority(tx, req.ProxyAccountID, req.GrantorID, spec); err != nil {
 			return err
 		}
 		row, created, err := grantInTransaction(tx, req.ProxyAccountID, req.GrantorID, spec)
@@ -132,6 +135,20 @@ func (s *Service) Grant(ctx context.Context, req GrantRequest) (*model.ProxyGran
 		reason := "created"
 		if !created {
 			reason = "idempotent replay"
+			if spec.SourceType == SourceTypeKNProxyBinding {
+				valid, validErr := sourceCurrentlyValid(tx, row)
+				if validErr != nil {
+					return validErr
+				}
+				if !valid {
+					if err := tx.DB().Model(&row).Update("granted_by", req.GrantorID).Error; err != nil {
+						return err
+					}
+					row.GrantedBy = req.GrantorID
+					result, changed = row, true
+					reason = "invalid delegator replaced by grant actor"
+				}
+			}
 		}
 		return recordAudit(tx.DB(), "grant", "allow", reason, req.GrantorID, req.ProxyAccountID, spec)
 	})
@@ -194,9 +211,11 @@ func (s *Service) Revoke(ctx context.Context, id string, req RevokeRequest) (*mo
 	return &result, changed, nil
 }
 
-// Check verifies whether the named grantor may create a source without
-// changing policy state. Denials are returned as a normal decision payload and
-// are persisted in the proxy-grant audit log.
+// Check verifies whether the named actor may create or take over a source
+// without changing policy state. A retained KN binding remains valid through
+// its recorded delegator, so another KN editor need not hold that downstream
+// operation unless a new source or delegator transfer is required. Denials are
+// returned as a normal decision payload and persisted in the audit log.
 func (s *Service) Check(ctx context.Context, req GrantRequest) (CheckResult, error) {
 	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
 	req.GrantorID = strings.TrimSpace(req.GrantorID)
@@ -208,10 +227,10 @@ func (s *Service) Check(ctx context.Context, req GrantRequest) (CheckResult, err
 	result := CheckResult{Allowed: true}
 	err = s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
 		decision := "allow"
-		reason := "grantor holds authorize and requested operation"
+		reason := "actor holds the authority required by the source type"
 		decisionErr := validateProxy(tx.DB(), req.ProxyAccountID, spec.KNID, true)
 		if decisionErr == nil {
-			decisionErr = validateAuthority(tx, req.GrantorID, spec)
+			decisionErr = validatePreflightAuthority(tx, req.ProxyAccountID, req.GrantorID, spec)
 		}
 		if decisionErr != nil {
 			if !errors.Is(decisionErr, ErrForbidden) && !errors.Is(decisionErr, ErrProxyInactive) &&
@@ -234,8 +253,9 @@ func (s *Service) Check(ctx context.Context, req GrantRequest) (CheckResult, err
 }
 
 // Sync replaces the active KN binding source set for one proxy with the latest
-// published-model set. All additions are authorized before any row changes, so
-// one unauthorized target rejects the complete synchronization.
+// published-model set. All additions and required delegator transfers are
+// authorized before any row changes, so one unauthorized target rejects the
+// complete synchronization.
 func (s *Service) Sync(ctx context.Context, req SyncRequest) (SyncResult, error) {
 	req.ProxyAccountID = strings.TrimSpace(req.ProxyAccountID)
 	req.GrantorID = strings.TrimSpace(req.GrantorID)
@@ -273,6 +293,9 @@ func (s *Service) Sync(ctx context.Context, req SyncRequest) (SyncResult, error)
 				return ErrForbidden
 			}
 		}
+		if len(desired) > 0 && mapping.LifecycleStatus != managedproxy.StatusActive {
+			return ErrProxyInactive
+		}
 
 		var rows []model.ProxyGrantSource
 		if err := tx.DB().Where("proxy_account_id = ? AND source_type = ?", req.ProxyAccountID, SourceTypeKNProxyBinding).
@@ -284,25 +307,51 @@ func (s *Service) Sync(ctx context.Context, req SyncRequest) (SyncResult, error)
 			current[keyForModel(row)] = row
 		}
 
-		// Preflight every addition before applying any mutation.
+		// Preflight every addition and every invalid historical delegator before
+		// applying any mutation. A still-valid historical source keeps its original
+		// delegator; an invalid one may be explicitly taken over by this sync actor.
+		transfers := make(map[sourceKey]bool)
 		for key, spec := range desired {
 			if row, ok := current[key]; ok && row.LifecycleStatus == StatusActive {
 				if !sameBinding(specFromModel(row), spec) {
 					return ErrInvalidRequest
 				}
+				valid, err := sourceCurrentlyValid(tx, row)
+				if err != nil {
+					return err
+				}
+				if valid {
+					continue
+				}
+				if err := validateDelegatorOperation(tx, req.GrantorID, spec); err != nil {
+					return err
+				}
+				transfers[key] = true
 				continue
 			}
-			if mapping.LifecycleStatus != managedproxy.StatusActive {
-				return ErrProxyInactive
-			}
-			if err := validateAuthority(tx, req.GrantorID, spec); err != nil {
+			if err := validateDelegatorOperation(tx, req.GrantorID, spec); err != nil {
 				return err
 			}
 		}
 
 		for key, spec := range desired {
 			if row, ok := current[key]; ok && row.LifecycleStatus == StatusActive {
-				result.Unchanged++
+				if transfers[key] {
+					if err := tx.DB().Model(&row).Update("granted_by", req.GrantorID).Error; err != nil {
+						return err
+					}
+					row.GrantedBy = req.GrantorID
+					result.Transferred++
+					if err := recordAudit(tx.DB(), "sync_transfer", "allow", "invalid delegator replaced by sync actor",
+						req.GrantorID, req.ProxyAccountID, spec); err != nil {
+						return err
+					}
+				} else {
+					result.Unchanged++
+				}
+				if err := ensureMaterialized(tx, req.ProxyAccountID, spec); err != nil {
+					return err
+				}
 				continue
 			}
 			row, changed, err := grantInTransaction(tx, req.ProxyAccountID, req.GrantorID, spec)
@@ -466,17 +515,64 @@ func loadProxy(db *gorm.DB, proxyID string) (model.ManagedProxyAccount, error) {
 	return mapping, nil
 }
 
-func validateAuthority(tx *authz.PolicyTransaction, grantorID string, spec SourceSpec) error {
+func validateSourceAuthority(tx *authz.PolicyTransaction, actorID string, spec SourceSpec) error {
+	if spec.SourceType == SourceTypeKNProxyBinding {
+		return validateDelegatorOperation(tx, actorID, spec)
+	}
+	return validateAdministrativeAuthority(tx, actorID, spec)
+}
+
+func validatePreflightAuthority(tx *authz.PolicyTransaction, proxyID, actorID string, spec SourceSpec) error {
+	if spec.SourceType != SourceTypeKNProxyBinding {
+		return validateSourceAuthority(tx, actorID, spec)
+	}
+	var row model.ProxyGrantSource
+	err := tx.DB().Where(
+		"proxy_account_id = ? AND resource_type = ? AND resource_id = ? AND operation = ? AND source_type = ? AND source_id = ?",
+		proxyID, spec.ResourceType, spec.ResourceID, spec.Operation, spec.SourceType, spec.SourceID,
+	).First(&row).Error
+	if err == nil {
+		if !sameBinding(specFromModel(row), spec) {
+			return ErrInvalidRequest
+		}
+		if row.LifecycleStatus == StatusActive {
+			valid, validErr := sourceCurrentlyValid(tx, row)
+			if validErr != nil {
+				return validErr
+			}
+			if valid {
+				return nil
+			}
+		}
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	return validateDelegatorOperation(tx, actorID, spec)
+}
+
+func validateDelegatorOperation(tx *authz.PolicyTransaction, delegatorID string, spec SourceSpec) error {
+	if err := validateGrantorIdentity(tx.DB(), delegatorID); err != nil {
+		return err
+	}
+	if err := validateRegisteredOperation(tx.DB(), spec); err != nil {
+		return err
+	}
+	operation, err := tx.Check(delegatorID, spec.ResourceType, spec.ResourceID, spec.Operation)
+	if err != nil {
+		return err
+	}
+	if !operation {
+		return ErrForbidden
+	}
+	return nil
+}
+
+func validateAdministrativeAuthority(tx *authz.PolicyTransaction, grantorID string, spec SourceSpec) error {
 	if err := validateGrantorIdentity(tx.DB(), grantorID); err != nil {
 		return err
 	}
-	var registered int64
-	if err := tx.DB().Model(&model.Operation{}).
-		Where("resource_type_id = ? AND id = ?", spec.ResourceType, spec.Operation).Count(&registered).Error; err != nil {
+	if err := validateRegisteredOperation(tx.DB(), spec); err != nil {
 		return err
-	}
-	if registered == 0 {
-		return ErrInvalidRequest
 	}
 	authorize, err := tx.Check(grantorID, spec.ResourceType, spec.ResourceID, "authorize")
 	if err != nil {
@@ -490,6 +586,36 @@ func validateAuthority(tx *authz.PolicyTransaction, grantorID string, spec Sourc
 		return ErrForbidden
 	}
 	return nil
+}
+
+func validateRegisteredOperation(db *gorm.DB, spec SourceSpec) error {
+	var registered int64
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", spec.ResourceType, spec.Operation).Count(&registered).Error; err != nil {
+		return err
+	}
+	if registered == 0 {
+		return ErrInvalidRequest
+	}
+	return nil
+}
+
+func sourceCurrentlyValid(tx *authz.PolicyTransaction, source model.ProxyGrantSource) (bool, error) {
+	switch source.SourceType {
+	case SourceTypeManual, SourceTypeAdmin:
+		return source.LifecycleStatus == StatusActive, nil
+	case SourceTypeKNProxyBinding:
+		if source.LifecycleStatus != StatusActive || strings.TrimSpace(source.GrantedBy) == "" {
+			return false, nil
+		}
+		err := validateDelegatorOperation(tx, source.GrantedBy, specFromModel(source))
+		if errors.Is(err, ErrForbidden) || errors.Is(err, ErrInvalidRequest) {
+			return false, nil
+		}
+		return err == nil, err
+	default:
+		return false, nil
+	}
 }
 
 func validateGrantorIdentity(db *gorm.DB, grantorID string) error {
@@ -649,6 +775,18 @@ func reconcileProxy(tx *authz.PolicyTransaction, proxyID, requestedBy string, re
 	}
 	activeByPermission := make(map[permissionKey]model.ProxyGrantSource, len(active))
 	for _, source := range active {
+		valid, err := sourceCurrentlyValid(tx, source)
+		if err != nil {
+			return err
+		}
+		if !valid {
+			result.InvalidSources++
+			if err := recordAudit(tx.DB(), "reconcile_invalid", "deny", "active source has no current delegation authority",
+				requestedBy, proxyID, specFromModel(source)); err != nil {
+				return err
+			}
+			continue
+		}
 		key := permissionForModel(source)
 		if _, exists := activeByPermission[key]; !exists {
 			activeByPermission[key] = source

--- a/bkn-safe/server/internal/proxygrant/service_test.go
+++ b/bkn-safe/server/internal/proxygrant/service_test.go
@@ -77,6 +77,19 @@ func (f fixture) authorize(t *testing.T, resourceID string, operations ...string
 	}
 }
 
+func (f fixture) grantOperations(t *testing.T, accessorID, resourceID string, operations ...string) {
+	f.grantTypedOperations(t, accessorID, "resource", resourceID, operations...)
+}
+
+func (f fixture) grantTypedOperations(t *testing.T, accessorID, resourceType, resourceID string, operations ...string) {
+	t.Helper()
+	for _, operation := range operations {
+		if err := f.enforcer.GrantObjectPermission(accessorID, resourceType, resourceID, operation); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func (f fixture) request(sourceID, bindingID, resourceID string) proxygrant.GrantRequest {
 	return proxygrant.GrantRequest{
 		ProxyAccountID: f.proxyID,
@@ -158,7 +171,7 @@ func TestSourceIdentityCollisionIsRejected(t *testing.T) {
 	}
 }
 
-func TestRevokingLastSourcePreservesPreexistingManualPolicy(t *testing.T) {
+func TestRevokingLastSourcePreservesButDoesNotTrustUntrackedPolicy(t *testing.T) {
 	f := newFixture(t)
 	f.authorize(t, "r-1", "query_data")
 	if err := f.enforcer.GrantObjectPermission(f.proxyID, "resource", "r-1", "query_data"); err != nil {
@@ -171,11 +184,352 @@ func TestRevokingLastSourcePreservesPreexistingManualPolicy(t *testing.T) {
 	if _, _, err := f.service.Revoke(t.Context(), source.ID, proxygrant.RevokeRequest{GrantorID: f.grantor}); err != nil {
 		t.Fatal(err)
 	}
-	assertAllowed(t, f, true)
+	assertAllowed(t, f, false)
 	var markers int64
 	if err := f.db.Model(&model.ProxyGrantPolicy{}).Count(&markers).Error; err != nil || markers != 0 {
 		t.Fatalf("markers = %d err=%v, want 0", markers, err)
 	}
+}
+
+func TestKNBindingDerivesFromOperationWithoutAuthorize(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+
+	result, err := f.service.Check(t.Context(), f.request("source-operation", "ot-operation", "r-1"))
+	if err != nil || !result.Allowed {
+		t.Fatalf("operation-only Check() = (%+v, %v), want allowed", result, err)
+	}
+	source, changed, err := f.service.Grant(t.Context(), f.request("source-operation", "ot-operation", "r-1"))
+	if err != nil || !changed || source.GrantedBy != f.grantor {
+		t.Fatalf("operation-only Grant() = (%+v, %v, %v)", source, changed, err)
+	}
+	assertAllowed(t, f, true)
+}
+
+func TestKNBindingDerivesExecuteOperationsWithoutAuthorize(t *testing.T) {
+	f := newFixture(t)
+	for _, resourceType := range []string{"tool_box", "mcp"} {
+		if err := f.db.Create(&model.ResourceType{ID: resourceType, Name: resourceType}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := f.db.Create(&model.Operation{ResourceTypeID: resourceType, ID: "execute", Name: "execute"}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, test := range []struct {
+		resourceType string
+		resourceID   string
+	}{
+		{resourceType: "tool_box", resourceID: "box-1"},
+		{resourceType: "mcp", resourceID: "mcp-1"},
+	} {
+		t.Run(test.resourceType, func(t *testing.T) {
+			f.grantTypedOperations(t, f.grantor, test.resourceType, test.resourceID, "execute")
+			request := f.request("source-"+test.resourceType, "binding-"+test.resourceType, test.resourceID)
+			request.Source.ResourceType = test.resourceType
+			request.Source.Operation = "execute"
+			request.Source.BindingType = "action_type"
+			decision, err := f.service.Check(t.Context(), request)
+			if err != nil || !decision.Allowed {
+				t.Fatalf("operation-only Check() = (%+v, %v), want allowed", decision, err)
+			}
+			if _, changed, err := f.service.Grant(t.Context(), request); err != nil || !changed {
+				t.Fatalf("operation-only Grant() = changed %v, err %v", changed, err)
+			}
+			allowed, err := f.enforcer.Check(f.proxyID, test.resourceType, test.resourceID, "execute")
+			if err != nil || !allowed {
+				t.Fatalf("proxy execute = %v, err %v", allowed, err)
+			}
+		})
+	}
+}
+
+func TestKNBindingRejectsAuthorizeWithoutOperation(t *testing.T) {
+	f := newFixture(t)
+	f.authorize(t, "r-1")
+
+	result, err := f.service.Check(t.Context(), f.request("source-no-operation", "ot-no-operation", "r-1"))
+	if err != nil || result.Allowed {
+		t.Fatalf("authorize-only Check() = (%+v, %v), want denied", result, err)
+	}
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-no-operation", "ot-no-operation", "r-1")); !errors.Is(err, proxygrant.ErrForbidden) {
+		t.Fatalf("authorize-only Grant() error = %v, want forbidden", err)
+	}
+}
+
+func TestKNBindingFollowsCurrentDelegatorPermission(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-current", "ot-current", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+
+	if err := f.enforcer.RevokeObjectPermission(f.grantor, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+	var source model.ProxyGrantSource
+	if err := f.db.First(&source, "source_id = ?", request.Source.SourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if source.LifecycleStatus != proxygrant.StatusActive {
+		t.Fatalf("source status = %q, want active model binding", source.LifecycleStatus)
+	}
+
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	assertAllowed(t, f, true)
+}
+
+func TestKNBindingRemainsAllowedWhileAnotherDelegatorIsValid(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-a", "ot-a", "r-1")); err != nil {
+		t.Fatal(err)
+	}
+
+	const second = "builder-2"
+	if err := f.db.Create(&model.User{ID: second, Account: second, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	f.grantOperations(t, second, "r-1", "query_data")
+	secondRequest := f.request("source-b", "ot-b", "r-1")
+	secondRequest.GrantorID = second
+	if _, _, err := f.service.Grant(t.Context(), secondRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.enforcer.RevokeObjectPermission(f.grantor, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+	if err := f.enforcer.RevokeObjectPermission(second, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestKNBindingTracksRoleAndAccountState(t *testing.T) {
+	f := newFixture(t)
+	const role = "resource-reader"
+	if err := f.enforcer.GrantRolePermission(role, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.enforcer.AssignRole(f.grantor, role); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-role", "ot-role", "r-1")); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+
+	if err := f.enforcer.RemoveRole(f.grantor, role); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+	if err := f.enforcer.AssignRole(f.grantor, role); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+
+	if err := f.db.Model(&model.User{}).Where("id = ?", f.grantor).Update("enabled", false).Error; err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestKNBindingTracksInheritedOperation(t *testing.T) {
+	f := newFixture(t)
+	if err := f.db.Create(&model.ResourceType{ID: "catalog", Name: "Catalog"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Create(&model.Operation{ResourceTypeID: "catalog", ID: "query_data", Name: "query_data"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Model(&model.ResourceType{}).Where("id = ?", "resource").Update("parent_type_id", "catalog").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "resource", "query_data").
+		Update("parent_operation_id", "query_data").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.db.Create(&model.ResourceParent{
+		ResourceTypeID: "resource", ResourceID: "r-1", ParentTypeID: "catalog", ParentID: "catalog-1",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := f.enforcer.GrantObjectPermission(f.grantor, "catalog", "catalog-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-inherited", "ot-inherited", "r-1")); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+
+	if err := f.db.Where("resource_type_id = ? AND resource_id = ?", "resource", "r-1").
+		Delete(&model.ResourceParent{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestKNBindingTracksOperationRegistration(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	if _, _, err := f.service.Grant(t.Context(), f.request("source-operation-catalog", "ot-operation-catalog", "r-1")); err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, true)
+
+	if err := f.db.Where("resource_type_id = ? AND id = ?", "resource", "query_data").
+		Delete(&model.Operation{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	assertAllowed(t, f, false)
+}
+
+func TestSyncTransfersInvalidHistoricalDelegator(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-transfer", "ot-transfer", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.enforcer.RevokeObjectPermission(f.grantor, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+
+	const replacement = "builder-2"
+	if err := f.db.Create(&model.User{ID: replacement, Account: replacement, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	f.grantOperations(t, replacement, "r-1", "query_data")
+	preflight := request
+	preflight.GrantorID = replacement
+	decision, err := f.service.Check(t.Context(), preflight)
+	if err != nil || !decision.Allowed {
+		t.Fatalf("replacement Check() = (%+v, %v), want allowed", decision, err)
+	}
+	result, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: replacement, Sources: []proxygrant.SourceSpec{request.Source},
+	})
+	if err != nil || result.Transferred != 1 || result.Unchanged != 0 {
+		t.Fatalf("replacement Sync() = (%+v, %v)", result, err)
+	}
+	var source model.ProxyGrantSource
+	if err := f.db.First(&source, "source_id = ?", request.Source.SourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if source.GrantedBy != replacement {
+		t.Fatalf("source delegator = %q, want %q", source.GrantedBy, replacement)
+	}
+	assertAllowed(t, f, true)
+}
+
+func TestSyncPreservesValidHistoricalDelegator(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-preserve", "ot-preserve", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	const editor = "builder-without-data"
+	if err := f.db.Create(&model.User{ID: editor, Account: editor, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	preflight := request
+	preflight.GrantorID = editor
+	decision, err := f.service.Check(t.Context(), preflight)
+	if err != nil || !decision.Allowed {
+		t.Fatalf("historical Check() = (%+v, %v), want allowed", decision, err)
+	}
+	result, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: editor, Sources: []proxygrant.SourceSpec{request.Source},
+	})
+	if err != nil || result.Unchanged != 1 || result.Transferred != 0 {
+		t.Fatalf("historical Sync() = (%+v, %v)", result, err)
+	}
+	var source model.ProxyGrantSource
+	if err := f.db.First(&source, "source_id = ?", request.Source.SourceID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if source.GrantedBy != f.grantor {
+		t.Fatalf("source delegator = %q, want original %q", source.GrantedBy, f.grantor)
+	}
+}
+
+func TestGrantTransfersInvalidHistoricalDelegator(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-grant-transfer", "ot-grant-transfer", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.enforcer.RevokeObjectPermission(f.grantor, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+
+	const replacement = "builder-grant-replacement"
+	if err := f.db.Create(&model.User{ID: replacement, Account: replacement, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	f.grantOperations(t, replacement, "r-1", "query_data")
+	request.GrantorID = replacement
+	source, changed, err := f.service.Grant(t.Context(), request)
+	if err != nil || !changed || source.GrantedBy != replacement {
+		t.Fatalf("replacement Grant() = (%+v, %v, %v)", source, changed, err)
+	}
+	assertAllowed(t, f, true)
+}
+
+func TestGrantPreservesValidHistoricalDelegator(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-grant-preserve", "ot-grant-preserve", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+
+	const editor = "builder-grant-without-data"
+	if err := f.db.Create(&model.User{ID: editor, Account: editor, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	request.GrantorID = editor
+	source, changed, err := f.service.Grant(t.Context(), request)
+	if err != nil || changed || source.GrantedBy != f.grantor {
+		t.Fatalf("historical Grant() = (%+v, %v, %v)", source, changed, err)
+	}
+}
+
+func TestReconcileReportsInvalidSourceAndSyncRestoresMaterialization(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	request := f.request("source-reconcile-invalid", "ot-reconcile-invalid", "r-1")
+	if _, _, err := f.service.Grant(t.Context(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.enforcer.RevokeObjectPermission(f.grantor, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	result, err := f.service.Reconcile(t.Context(), proxygrant.ReconcileRequest{
+		ProxyAccountID: f.proxyID, RequestedBy: "system:reconcile",
+	})
+	if err != nil || result.InvalidSources != 1 || result.PoliciesRemoved != 1 {
+		t.Fatalf("invalid Reconcile() = (%+v, %v)", result, err)
+	}
+	assertAllowed(t, f, false)
+
+	f.grantOperations(t, f.grantor, "r-1", "query_data")
+	syncResult, err := f.service.Sync(t.Context(), proxygrant.SyncRequest{
+		ProxyAccountID: f.proxyID, GrantorID: f.grantor, Sources: []proxygrant.SourceSpec{request.Source},
+	})
+	if err != nil || syncResult.Unchanged != 1 {
+		t.Fatalf("restoring Sync() = (%+v, %v)", syncResult, err)
+	}
+	assertAllowed(t, f, true)
 }
 
 func TestRevokingBindingPreservesActiveManualSource(t *testing.T) {
@@ -443,6 +797,17 @@ func assertAllowed(t *testing.T, f fixture, want bool) {
 	allowed, err := f.enforcer.Check(f.proxyID, "resource", "r-1", "query_data")
 	if err != nil || allowed != want {
 		t.Fatalf("proxy allowed = %v err=%v, want %v", allowed, err, want)
+	}
+	operations, err := f.enforcer.AllowedOps(f.proxyID, "resource", "r-1", []string{"query_data"})
+	listed := len(operations) == 1 && operations[0] == "query_data"
+	if err != nil || listed != want {
+		t.Fatalf("proxy operations = %v err=%v, want query_data listed=%v", operations, err, want)
+	}
+	filtered, err := f.enforcer.FilterResourceOps(f.proxyID,
+		[]authz.ResourceRef{{Type: "resource", ID: "r-1"}}, []string{"query_data"}, []string{"query_data"})
+	visible := len(filtered) == 1 && len(filtered[0].Operations) == 1 && filtered[0].Operations[0] == "query_data"
+	if err != nil || visible != want {
+		t.Fatalf("proxy filtered resources = %v err=%v, want visible=%v", filtered, err, want)
 	}
 }
 

--- a/bkn-safe/server/internal/proxygrant/service_test.go
+++ b/bkn-safe/server/internal/proxygrant/service_test.go
@@ -6,7 +6,9 @@ package proxygrant_test
 
 import (
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/glebarez/sqlite"
@@ -427,6 +429,73 @@ func TestSyncTransfersInvalidHistoricalDelegator(t *testing.T) {
 		t.Fatalf("source delegator = %q, want %q", source.GrantedBy, replacement)
 	}
 	assertAllowed(t, f, true)
+}
+
+func TestCheckManyPreservesValidDelegatorAndReturnsAllDeniedSources(t *testing.T) {
+	f := newFixture(t)
+	f.grantOperations(t, f.grantor, "r-retained", "query_data")
+	retained := f.request("source-retained", "ot-retained", "r-retained")
+	if _, _, err := f.service.Grant(t.Context(), retained); err != nil {
+		t.Fatal(err)
+	}
+
+	const editor = "builder-batch"
+	if err := f.db.Create(&model.User{ID: editor, Account: editor, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	f.grantOperations(t, editor, "r-new", "query_data")
+	newSource := f.request("source-new", "ot-new", "r-new").Source
+	deniedA := f.request("source-denied-a", "ot-denied-a", "r-denied-a").Source
+	deniedB := f.request("source-denied-b", "ot-denied-b", "r-denied-b").Source
+
+	result, err := f.service.CheckMany(t.Context(), proxygrant.BatchCheckRequest{
+		ProxyAccountID: f.proxyID,
+		GrantorID:      editor,
+		Sources:        []proxygrant.SourceSpec{retained.Source, newSource, deniedA, deniedB},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.DeniedSources) != 2 || result.DeniedSources[0].SourceID != deniedA.SourceID ||
+		result.DeniedSources[1].SourceID != deniedB.SourceID {
+		t.Fatalf("denied sources = %#v, want both unavailable sources", result.DeniedSources)
+	}
+}
+
+func TestManagedProxyFilterBatchesSourceValidityQueries(t *testing.T) {
+	f := newFixture(t)
+	const sourceCount = 20
+	refs := make([]authz.ResourceRef, 0, sourceCount)
+	for i := 0; i < sourceCount; i++ {
+		resourceID := fmt.Sprintf("r-batch-%02d", i)
+		f.grantOperations(t, f.grantor, resourceID, "query_data")
+		if _, _, err := f.service.Grant(t.Context(), f.request(
+			fmt.Sprintf("source-batch-%02d", i), fmt.Sprintf("ot-batch-%02d", i), resourceID)); err != nil {
+			t.Fatal(err)
+		}
+		refs = append(refs, authz.ResourceRef{Type: "resource", ID: resourceID})
+	}
+
+	var queryCount atomic.Int64
+	callbackName := "test:count-batched-proxy-filter"
+	if err := f.db.Callback().Query().Before("gorm:query").Register(callbackName, func(*gorm.DB) {
+		queryCount.Add(1)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.db.Callback().Query().Remove(callbackName) })
+
+	filtered, err := f.enforcer.FilterResourceOps(f.proxyID, refs,
+		[]string{"query_data"}, []string{"query_data"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != sourceCount {
+		t.Fatalf("filtered resources = %d, want %d", len(filtered), sourceCount)
+	}
+	if got := queryCount.Load(); got > 6 {
+		t.Fatalf("filter query count = %d, want a bounded batch independent of source count", got)
+	}
 }
 
 func TestSyncPreservesValidHistoricalDelegator(t *testing.T) {

--- a/docs/api/bkn-safe/proxy-grants.yaml
+++ b/docs/api/bkn-safe/proxy-grants.yaml
@@ -129,6 +129,32 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalError'
+  /proxy-grant-sources/check-batch:
+    post:
+      tags: [Proxy grant sources]
+      operationId: checkProxyGrantSourceAuthorities
+      summary: Check a complete set of KN binding sources
+      description: |
+        Applies the same retained-delegator and replacement rules as the single-source check,
+        but loads source, operation, user, and delegator state in batches. Insufficient authority
+        is returned in `denied_sources`; the request does not change source or policy state.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCheckRequest'
+      responses:
+        '200':
+          description: The check completed; an empty denied_sources array means every source is allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchCheckResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /proxy-grant-sources/sync:
     post:
       tags: [Proxy grant sources]
@@ -244,6 +270,23 @@ components:
           description: Compatibility field naming the current actor; stored as `granted_by` when the actor creates, reactivates, or takes over a source.
         source:
           $ref: '#/components/schemas/SourceSpec'
+    BatchCheckRequest:
+      type: object
+      additionalProperties: false
+      required: [proxy_account_id, grantor_id, sources]
+      properties:
+        proxy_account_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        grantor_id:
+          type: string
+          minLength: 1
+          maxLength: 64
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/SourceSpec'
     RevokeRequest:
       type: object
       additionalProperties: false
@@ -394,6 +437,16 @@ components:
         reason:
           type: string
           description: Returned only when `allowed=false`; it does not contain target connection details.
+    BatchCheckResult:
+      type: object
+      additionalProperties: false
+      required: [denied_sources]
+      properties:
+        denied_sources:
+          type: array
+          description: Sources that need the current actor to hold the operation but failed that check.
+          items:
+            $ref: '#/components/schemas/SourceSpec'
     SyncResult:
       type: object
       additionalProperties: false

--- a/docs/api/bkn-safe/proxy-grants.yaml
+++ b/docs/api/bkn-safe/proxy-grants.yaml
@@ -13,9 +13,13 @@ info:
 
     Source records, materialization markers, authorization audit entries, and Casbin Allow
     policies are updated in one database transaction. Replaying the same source is idempotent;
-    multiple sources may share one Allow policy; the policy is removed only when its last active
-    source is revoked and the source service owns that policy. Manual or legacy Allow policies
-    that predate the source are preserved and reported as untracked during reconciliation.
+    multiple sources may share one Allow policy. At runtime, a managed proxy Allow is effective
+    only while at least one active source for the exact permission is currently valid. A
+    `kn_proxy_binding` source is valid while its recorded delegator remains enabled and still has
+    the exact downstream operation; `manual` and `admin` sources follow their explicit lifecycle.
+    Manual or legacy Allow policies that predate the source are preserved and reported as
+    untracked during reconciliation, but an untracked policy alone does not authorize a managed
+    proxy.
 servers:
   - url: /api/safe/in/v1
 security: []
@@ -26,9 +30,12 @@ paths:
       operationId: createProxyGrantSource
       summary: Create or reactivate a proxy grant source
       description: |
-        The grantor must be an enabled, non-managed account and must hold both `authorize` and
-        the operation being delegated on the target. The first creation returns 201; replaying
-        the same source returns 200.
+        For `kn_proxy_binding`, the actor must be enabled, non-managed, and hold the exact operation
+        being delegated; target `authorize` is not required. Replaying an active binding keeps its
+        still-valid historical delegator. If that delegator is no longer valid, an actor holding
+        the exact operation takes over the source. `manual` and `admin` sources continue to require
+        both `authorize` and the delegated operation. The first creation or a delegator transfer
+        returns 201; an unchanged replay returns 200.
       requestBody:
         required: true
         content:
@@ -99,7 +106,12 @@ paths:
     post:
       tags: [Proxy grant sources]
       operationId: checkProxyGrantSourceAuthority
-      summary: Check whether a grantor may establish a source
+      summary: Check whether an actor may establish or retain a source
+      description: |
+        Applies the same source-type rules as creation. A retained `kn_proxy_binding` is allowed
+        when its recorded delegator is still valid even if the current knowledge-network editor
+        does not hold the downstream operation. If the historical delegator is invalid, the
+        current actor must hold that exact operation so synchronization can transfer the source.
       requestBody:
         required: true
         content:
@@ -124,9 +136,11 @@ paths:
       summary: Synchronize the complete source set from the latest published model
       description: |
         `sources` is the proxy account's complete current set of `kn_proxy_binding` sources.
-        Every new source is checked before any mutation. If one source is unauthorized, the
-        entire synchronization is rejected without changing sources or policies. Removed entries
-        do not affect manual sources or other active sources.
+        Every new source and invalid historical delegator is checked before any mutation. A valid
+        historical delegator is preserved; an invalid one is transferred to the sync actor only
+        when that actor holds the exact downstream operation. If one source cannot be established
+        or transferred, the entire synchronization is rejected without changing sources or
+        policies. Removed entries do not affect manual sources or other active sources.
       requestBody:
         required: true
         content:
@@ -156,10 +170,12 @@ paths:
       operationId: reconcileProxyGrantSources
       summary: Repair drift between the source ledger and Casbin Allow policies
       description: |
-        Restores Allow policies missing for active sources and removes source-owned Allow policies
-        that have no active source. Existing policies without a materialization marker are reported
+        Restores Allow policies missing for currently valid active sources and removes source-owned
+        Allow policies that have no currently valid active source. Invalid `kn_proxy_binding`
+        sources remain active as model-binding facts, are counted in `invalid_sources`, and do not
+        authorize runtime access. Existing policies without a materialization marker are reported
         in `untracked_policies` instead of being deleted, avoiding accidental removal of historical
-        manual grants.
+        manual grants; they do not authorize a managed proxy without a valid source.
       requestBody:
         required: true
         content:
@@ -188,7 +204,7 @@ components:
           schema:
             $ref: '../_shared/errors.yaml#/components/schemas/Error'
     Forbidden:
-      description: The grantor lacks `authorize` or the delegated operation on the target, or the source belongs to a different knowledge network
+      description: The source belongs to another knowledge network, or the actor lacks the authority required by the source type (`kn_proxy_binding` requires the exact delegated operation; `manual` and `admin` also require `authorize`)
       content:
         application/json:
           schema:
@@ -225,6 +241,7 @@ components:
           type: string
           minLength: 1
           maxLength: 64
+          description: Compatibility field naming the current actor; stored as `granted_by` when the actor creates, reactivates, or takes over a source.
         source:
           $ref: '#/components/schemas/SourceSpec'
     RevokeRequest:
@@ -236,6 +253,7 @@ components:
           type: string
           minLength: 1
           maxLength: 64
+          description: Compatibility field naming the actor requesting synchronization.
     SyncRequest:
       type: object
       additionalProperties: false
@@ -379,11 +397,15 @@ components:
     SyncResult:
       type: object
       additionalProperties: false
-      required: [added, revoked, unchanged, sources]
+      required: [added, transferred, revoked, unchanged, sources]
       properties:
         added:
           type: integer
           minimum: 0
+        transferred:
+          type: integer
+          minimum: 0
+          description: Active bindings whose invalid historical delegator was replaced by the sync actor.
         revoked:
           type: integer
           minimum: 0
@@ -403,6 +425,7 @@ components:
         - markers_created
         - markers_removed
         - untracked_policies
+        - invalid_sources
       properties:
         policies_restored:
           type: integer
@@ -419,3 +442,7 @@ components:
         untracked_policies:
           type: integer
           minimum: 0
+        invalid_sources:
+          type: integer
+          minimum: 0
+          description: Active binding-source rows whose recorded delegator no longer has the exact downstream operation.


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Derive knowledge network proxy grants from the builder exact downstream operation without requiring downstream authorize
- [x] Preserve valid historical delegators, transfer invalid sources explicitly, and fail closed when no current source remains
- [x] Preflight complete publish, import, and incremental mutation candidates and return aggregated permission details
- [x] Batch complete-source preflight into one bkn-safe request and group runtime source validation by delegator
- [x] Compensate newly created proxy mappings when an incremental business transaction fails before commit
- [x] Keep deletion and repair paths usable through projection tombstones
- [x] Apply provenance checks consistently to check, operations, and resource-filter authorization paths
- [x] Update the internal Safe OpenAPI contract and focused tests

---

## Why

- Related Issue: Closes #1339
- Related Feature: #805
- Documentation: openbkn-ai/bkn-docs#102
- Background: Resource owners should grant ordinary downstream operations to knowledge network builders. Builders can then bind those resources into a knowledge network while BKN derives the minimum managed-proxy permissions. Resource owners do not need to discover or directly authorize internal proxy identities.

---

## How

- Key implementation points:
  - Interpret grantor_id as the current delegator actor for knowledge network binding sources while preserving the compatibility field name
  - Require only the exact downstream operation for kn_proxy_binding sources; manual and admin sources retain the authorize plus operation contract
  - Preserve a valid historical delegator and transfer an invalid source only when the current builder holds the same operation
  - Batch full-candidate preflight over a single internal HTTP request and return every denied source
  - Load active proxy sources, registered operations, enabled users, and managed-account exclusions in batches, then evaluate policy and hierarchy once per distinct delegator
  - Batch audit inserts for full-source preflight
  - Archive a proxy mapping created by an incremental write when that write fails before transaction commit; retain pending or failed state after commit so retry remains possible
  - Reconcile only currently valid sources and report invalid_sources; synchronization reports transferred sources
  - Preflight the complete candidate source set before the BKN business transaction and aggregate all missing permissions under a stable error code
- Breaking changes: Intentional authorization tightening for managed proxy accounts. Internal response schemas add backward-compatible transferred and invalid_sources counters, plus a new internal batch-check endpoint. No database column or public API change.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; cross-service E2E remains tracked by #1312
- [ ] Verified in test environment — not run

Test notes:

- go test ./internal/authz ./internal/proxygrant ./internal/httpapi
- I18N_MODE_UT=true go test ./logics/knowledge_network ./driveradapters ./drivenadapters/kn_proxy
- Added a regression test proving 20 managed-proxy sources use a bounded number of database queries during resource filtering
- Added a regression test proving a newly created proxy is archived when its incremental business write rolls back
- go vet on all changed Safe and BKN packages
- golangci-lint --new-from-rev=origin/main on all changed Safe and BKN packages: 0 issues
- Redocly validation passed for docs/api/bkn-safe/proxy-grants.yaml
- git diff --check passed

---

## Risk & Rollback

- Potential risks: Incorrect source validation could deny legitimate proxy access or retain an invalid source. Runtime provenance reads are now batched and policy evaluation scales with distinct delegators rather than the resource-operation result size. Permission and cross-service impact was confirmed through the owner-confirmed gate on #1339.
- Rollback plan: Revert the three commits in this PR and disable the proxy feature flag. This change performs no production migration and adds no destructive schema change.

---

## Additional Notes

- Existing early 0.1.5 preview environments should run proxy reconciliation before rollout and inspect invalid_sources. A formal 0.1.4 deployment has no historical proxy-source ledger to migrate.
- Automatic permission application, approval, notification, and retry are out of scope and remain tracked by #1337.
- Cross-service E2E coverage remains tracked by #1312.
- This PR does not modify production data or configuration.