### PR TITLE
fix(bkn): harden proxy governance authorization

### DIFF
--- a/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access.go
@@ -119,7 +119,9 @@ func (oma *ontologyManagerAccess) GetObjectType(ctx context.Context, knID string
 		// Log the exception.
 		otellog.LogError(ctx, fmt.Sprintf("Get object type failed: %v", httpErr), httpErr)
 
-		return emptyObjectType, false, fmt.Errorf("get object type failed: %v", httpErr.Error())
+		// Preserve the status-bearing error so the authorization layer can keep a
+		// caller denial as 401/403 instead of presenting it as a dependency outage.
+		return emptyObjectType, false, httpErr
 	}
 
 	if result == nil {

--- a/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/ontology_manager/ontology_manager_access_test.go
@@ -151,11 +151,14 @@ func Test_ontologyManagerAccess_GetObjectType(t *testing.T) {
 
 			mockHTTPClient.EXPECT().
 				GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				Return(http.StatusBadRequest, errorBytes, nil)
+				Return(http.StatusForbidden, errorBytes, nil)
 
 			result, exists, err := oma.GetObjectType(ctx, knID, branch, otID)
 
 			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusForbidden)
 			So(exists, ShouldBeFalse)
 			So(result.OTID, ShouldEqual, "")
 		})

--- a/adp/bkn/ontology-query/server/logics/query_authorization/query_authorization_service.go
+++ b/adp/bkn/ontology-query/server/logics/query_authorization/query_authorization_service.go
@@ -6,6 +6,7 @@ package query_authorization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -666,6 +667,11 @@ func invalidQuery(ctx context.Context, detail string) error {
 }
 
 func dependencyResolutionFailed(ctx context.Context, err error) error {
+	var downstream *rest.HTTPError
+	if errors.As(err, &downstream) &&
+		(downstream.HTTPCode == http.StatusUnauthorized || downstream.HTTPCode == http.StatusForbidden) {
+		return downstream
+	}
 	return rest.NewHTTPError(ctx, http.StatusServiceUnavailable,
 		oerrors.OntologyQuery_InternalError_CheckPermissionFailed).WithErrorDetails(err.Error())
 }

--- a/adp/bkn/ontology-query/server/logics/query_authorization/query_authorization_service_test.go
+++ b/adp/bkn/ontology-query/server/logics/query_authorization/query_authorization_service_test.go
@@ -216,6 +216,21 @@ func TestAuthorizeObjectTypeFailsClosedOnModelLookup(t *testing.T) {
 	assertQueryAuthHTTPStatus(t, err, http.StatusServiceUnavailable)
 }
 
+func TestAuthorizeObjectTypePreservesModelPermissionDenial(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	models := omock.NewMockOntologyManagerAccess(ctrl)
+	service := &queryAuthorizationService{
+		models:      models,
+		permissions: omock.NewMockPermissionService(ctrl),
+	}
+	models.EXPECT().GetObjectType(gomock.Any(), "kn-a", "main", "orders").Return(
+		interfaces.ObjectType{}, false,
+		rest.NewHTTPError(context.Background(), http.StatusForbidden, rest.PublicError_Forbidden))
+
+	err := service.AuthorizeObjectTypeQuery(context.Background(), "kn-a", "main", "orders")
+	assertQueryAuthHTTPStatus(t, err, http.StatusForbidden)
+}
+
 func TestAuthorizeObjectTypeScopesSameChildIDByKnowledgeNetwork(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	models := omock.NewMockOntologyManagerAccess(ctrl)

--- a/adp/vega/vega-backend/server/driveradapters/proxy_read_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/proxy_read_handler.go
@@ -90,6 +90,7 @@ func (r *restHandler) GetResourceSchemaByProxy(c *gin.Context) {
 	if !r.authorizeProxyRead(c, ctx, request, err) {
 		return
 	}
+	ctx = interfaces.WithTrustedProxyRead(ctx)
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: request.ProxyID, Type: request.ProxyType})
 
 	resource, err := r.rs.InternalGetByID(ctx, nil, request.TargetID)
@@ -127,6 +128,7 @@ func (r *restHandler) PostResourceDataByProxy(c *gin.Context) {
 	if !r.authorizeProxyRead(c, ctx, request, err) {
 		return
 	}
+	ctx = interfaces.WithTrustedProxyRead(ctx)
 	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: request.ProxyID, Type: request.ProxyType})
 	r.queryProxyResourceData(c, ctx, span)
 }

--- a/adp/vega/vega-backend/server/driveradapters/proxy_read_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/proxy_read_handler_test.go
@@ -145,6 +145,7 @@ func TestRestHandlerPostResourceDataByProxy(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
 				account := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
 				assert.Equal(t, "proxy-1", account.ID)
+				assert.True(t, interfaces.IsTrustedProxyRead(ctx))
 				assert.Equal(t, 2, params.Limit)
 				return &interfaces.ResourceDataQueryResult{Entries: []map[string]any{{"id": "row-1"}}, TotalCount: 1}, nil
 			})

--- a/adp/vega/vega-backend/server/interfaces/proxy_authorization.go
+++ b/adp/vega/vega-backend/server/interfaces/proxy_authorization.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 )
 
+type trustedProxyReadKey struct{}
+
 const (
 	HTTPHeaderBKNCallerID     = "x-bkn-caller-id"
 	HTTPHeaderBKNCallerType   = "x-bkn-caller-type"
@@ -73,4 +75,18 @@ type ProxyAuthorizationAccess interface {
 // ProxyAuthorizationService is the final PEP for Vega proxy reads.
 type ProxyAuthorizationService interface {
 	Authorize(ctx context.Context, request ProxyReadContext) error
+}
+
+// WithTrustedProxyRead marks a request whose target and operation already
+// passed the restricted proxy PEP. Only the proxy handlers may set this marker;
+// downstream metadata reads use it to avoid a second, unrelated account check.
+func WithTrustedProxyRead(ctx context.Context) context.Context {
+	return context.WithValue(ctx, trustedProxyReadKey{}, true)
+}
+
+// IsTrustedProxyRead reports whether the restricted proxy PEP authorized this
+// server-side call chain.
+func IsTrustedProxyRead(ctx context.Context) bool {
+	trusted, ok := ctx.Value(trustedProxyReadKey{}).(bool)
+	return ok && trusted
 }

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service.go
@@ -571,6 +571,10 @@ func (cs *catalogService) checkCatalogPermission(ctx context.Context, catalogID 
 }
 
 func (cs *catalogService) GetByID(ctx context.Context, id string, withSensitiveFields bool) (*interfaces.Catalog, error) {
+	if interfaces.IsTrustedProxyRead(ctx) {
+		return cs.InternalGetByID(ctx, id, withSensitiveFields)
+	}
+
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Get catalog")
 	defer span.End()
 

--- a/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
+++ b/adp/vega/vega-backend/server/logics/catalog/catalog_service_test.go
@@ -1611,6 +1611,16 @@ func TestCatalogServiceDeleteByID(t *testing.T) {
 }
 
 func TestCatalogServiceGetByID(t *testing.T) {
+	t.Run("trusted proxy read skips secondary metadata authorization", func(t *testing.T) {
+		cs, ca, _, _ := newS2SCatalogService(t)
+		want := &interfaces.Catalog{ID: "c1", Internal: false}
+		ca.EXPECT().GetByID(gomock.Any(), "c1").Return(want, nil)
+
+		got, err := cs.GetByID(interfaces.WithTrustedProxyRead(context.Background()), "c1", false)
+		require.NoError(t, err)
+		assert.Same(t, want, got)
+	})
+
 	t.Run("catalog get by ids2 sinternal bypass", func(t *testing.T) {
 		cs, ca, _, ums := newS2SCatalogService(t)
 		ca.EXPECT().GetByID(gomock.Any(), "c1").

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -540,6 +540,10 @@ func (rs *resourceService) Create(ctx context.Context, req *interfaces.ResourceR
 
 // Get retrieves a Resource by ID.
 func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.Resource, error) {
+	if interfaces.IsTrustedProxyRead(ctx) {
+		return rs.InternalGetByID(ctx, nil, id)
+	}
+
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Get resource")
 	defer span.End()
 
@@ -676,6 +680,10 @@ func (rs *resourceService) InternalGetByCatalogID(ctx context.Context, catalogID
 
 // GetByIDs retrieves Resources by IDs.
 func (rs *resourceService) GetByIDs(ctx context.Context, ids []string) ([]*interfaces.Resource, error) {
+	if interfaces.IsTrustedProxyRead(ctx) {
+		return rs.InternalGetByIDs(ctx, ids)
+	}
+
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Get resources by IDs")
 	defer span.End()
 

--- a/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service_test.go
@@ -259,6 +259,16 @@ func TestResourceServiceCheckExistByName(t *testing.T) {
 }
 
 func TestResourceServiceGetByID(t *testing.T) {
+	t.Run("trusted proxy read skips secondary metadata authorization", func(t *testing.T) {
+		rs, mockRA, _, _, _, _, _ := newTestService(t)
+		want := &interfaces.Resource{ID: "r1", CatalogID: "cat-user"}
+		mockRA.EXPECT().GetByID(gomock.Any(), nil, "r1").Return(want, nil)
+
+		got, err := rs.GetByID(interfaces.WithTrustedProxyRead(context.Background()), "r1")
+		require.NoError(t, err)
+		assert.Same(t, want, got)
+	})
+
 	t.Run("keeps resource when account name lookup fails", func(t *testing.T) {
 		rs, mockRA, mockPS, _, mockUMS, _, _ := newTestService(t)
 		mockRA.EXPECT().GetByID(gomock.Any(), nil, "r1").
@@ -353,6 +363,16 @@ func TestResourceServiceGetByID(t *testing.T) {
 }
 
 func TestResourceServiceGetByIDs(t *testing.T) {
+	t.Run("trusted proxy read skips secondary metadata authorization", func(t *testing.T) {
+		rs, mockRA, _, _, _, _, _ := newTestService(t)
+		want := []*interfaces.Resource{{ID: "r1", CatalogID: "cat-user"}}
+		mockRA.EXPECT().GetByIDs(gomock.Any(), []string{"r1"}).Return(want, nil)
+
+		got, err := rs.GetByIDs(interfaces.WithTrustedProxyRead(context.Background()), []string{"r1"})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("get by ids success", func(t *testing.T) {
 		rs, mockRA, mockPS, _, mockUMS, _, _ := newTestService(t)
 		mockRA.EXPECT().GetByIDs(gomock.Any(), []string{"r1", "r2"}).

--- a/bkn-safe/server/internal/httpapi/accesslog_test.go
+++ b/bkn-safe/server/internal/httpapi/accesslog_test.go
@@ -64,3 +64,30 @@ func TestVoluntaryLogoutRecordsAnAccessFact(t *testing.T) {
 		t.Fatalf("logout access fact = %#v, want oauth/logout/success", row)
 	}
 }
+
+func TestDisabledAccountVoluntaryLogoutRecordsAnAccessFact(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	const userID = "disabled-logout-user"
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: userID, Account: userID, Name: "Disabled Logout User", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Model(&model.User{}).Where("id = ?", userID).Update("enabled", false).Error; err != nil {
+		t.Fatalf("disable user: %v", err)
+	}
+
+	response := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/logout", nil, userID)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("disabled-account logout status = %d, want %d: %s",
+			response.Code, http.StatusNoContent, response.Body.String())
+	}
+
+	var row model.AccessLog
+	if err := db.First(&row, "actor_id = ?", userID).Error; err != nil {
+		t.Fatalf("read disabled-account logout access fact: %v", err)
+	}
+	if row.Action != "logout" || row.Outcome != "success" || row.AuthMethod != "oauth" {
+		t.Fatalf("disabled-account logout access fact = %#v, want oauth/logout/success", row)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/me_test.go
+++ b/bkn-safe/server/internal/httpapi/me_test.go
@@ -105,9 +105,9 @@ func TestMeUpdateProfile(t *testing.T) {
 	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "X"}, ""); w.Code != http.StatusUnauthorized {
 		t.Errorf("no token: want 401, got %d", w.Code)
 	}
-	// subject without a user row -> 404
-	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "X"}, "ghost"); w.Code != http.StatusNotFound {
-		t.Errorf("ghost: want 404, got %d", w.Code)
+	// subject without an active local user row -> 403
+	if w := tokReq(t, r, http.MethodPut, path, map[string]any{"name": "X"}, "ghost"); w.Code != http.StatusForbidden {
+		t.Errorf("ghost: want 403, got %d", w.Code)
 	}
 	// empty body -> 400
 	if w := tokReq(t, r, http.MethodPut, path, map[string]any{}, "u-me"); w.Code != http.StatusBadRequest {

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -337,6 +337,11 @@ func TestObjectGrantsGroupedViews(t *testing.T) {
 // who created a knowledge network (and therefore holds the creator's object
 // grant, opAuthorize included) but holds no admin-authz permission at all.
 func ownerGrantFixture(t *testing.T) (*gin.Engine, *authz.Enforcer) {
+	r, e, _ := ownerGrantFixtureWithDB(t)
+	return r, e
+}
+
+func ownerGrantFixtureWithDB(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB) {
 	t.Helper()
 	r, e, db, users := newAdminServer(t)
 	ctx := t.Context()
@@ -363,7 +368,7 @@ func ownerGrantFixture(t *testing.T) (*gin.Engine, *authz.Enforcer) {
 			t.Fatal(err)
 		}
 	}
-	return r, e
+	return r, e, db
 }
 
 // The regression: the creator of a knowledge network can share it, without any
@@ -415,6 +420,25 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 	}, "u-owner")
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("idempotent owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestObjectGrantsDisabledOwnerCannotWrite(t *testing.T) {
+	r, e, db := ownerGrantFixtureWithDB(t)
+	if err := db.Model(&model.User{}).Where("id = ?", "u-owner").Update("enabled", false).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail", "query_data"},
+	}, "u-owner")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("disabled owner share: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
+		t.Error("disabled owner wrote a grant")
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -222,10 +222,13 @@ func New(deps Deps) *gin.Engine {
 		caps := r.Group("/api/safe/v1", sharedrest.PrivateNoCacheMiddleware(), RequireUser(meVerifier))
 		registerCapabilities(caps, deps.License)
 
-		// Mutating /me (profile PUT, AppKey issue/revoke) uses the RAW verifier so
-		// a revoked/logged-out token cannot edit the profile or mint a long-lived
-		// API key within the read cache's TTL window.
-		meWrites := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier))
+		// Mutating /me (profile PUT, AppKey issue/revoke, object-grant delegation)
+		// uses the RAW verifier so a revoked/logged-out token cannot write within
+		// the read cache's TTL window. The local account check separately makes an
+		// administrator disable effective immediately even while Hydra still
+		// considers an already-issued token active.
+		meWrites := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(),
+			RequireUser(verifier), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			meWrites.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -222,6 +222,15 @@ func New(deps Deps) *gin.Engine {
 		caps := r.Group("/api/safe/v1", sharedrest.PrivateNoCacheMiddleware(), RequireUser(meVerifier))
 		registerCapabilities(caps, deps.License)
 
+		// Voluntary logout only records an access fact before the browser clears
+		// its session. Keep it on the raw verifier so a locally disabled account
+		// can still record that explicit action; it does not mutate authorization
+		// state and must not be blocked by the active-account write gate below.
+		if deps.AccessLog != nil {
+			meLogout := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier))
+			registerLogout(meLogout, deps.AccessLog, deps.Directory)
+		}
+
 		// Mutating /me (profile PUT, AppKey issue/revoke, object-grant delegation)
 		// uses the RAW verifier so a revoked/logged-out token cannot write within
 		// the read cache's TTL window. The local account check separately makes an
@@ -237,9 +246,6 @@ func New(deps Deps) *gin.Engine {
 		// belongs on the raw-verifier group with the rest of the mutating /me
 		// surface — and it must be audited like any other authorization change.
 		registerMeObjectGrants(meWrites, deps.Enforcer, deps.DB, deps.Directory)
-		if deps.AccessLog != nil && deps.Directory != nil {
-			registerLogout(meWrites, deps.AccessLog, deps.Directory)
-		}
 		// Self-service AppKey management (issue/list/revoke own keys).
 		if apiKeys != nil {
 			registerMeAPIKeys(meWrites, apiKeys)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Enforce the active local-account check on state-changing `/me` routes while keeping voluntary logout auditable for disabled accounts.
- [x] Preserve downstream 401/403 responses through ontology-query authorization instead of converting them to 503 dependency failures.
- [x] Mark proxy reads as trusted only after the restricted Vega proxy PEP succeeds, so downstream metadata reads do not perform an unrelated second account check.

---

## Why

- Related Issue: Closes #1310
- Related Feature: Follow-up hardening for #1336
- Background: Systematic verification against #1239 and #1312 found that a disabled resource owner could still delegate object grants with an already-issued token, and that ontology-query converted a downstream permission denial into a misleading 503. Proxy-mode reads also needed an explicit trusted call-chain marker after dual-principal authorization.

---

## How

- Key implementation points:
  - Add `RequireActiveAccount` to the raw-verifier `/api/safe/v1/me` write group, and mount the access-log-only logout endpoint on a separate raw-verifier group.
  - Keep status-bearing ontology-manager errors intact and preserve only downstream 401/403 responses; genuine dependency failures still return 503.
  - Add a context marker after Vega proxy authorization and use internal metadata reads only for that authorized call chain.
  - Add focused regression coverage for disabled-owner writes, propagated permission denials, and trusted proxy metadata reads.
- Breaking changes (API, config, database, etc.): None. No API schema, configuration, or database migration changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; the end-to-end scenarios were verified in the shared test environment.
- [x] Verified in test environment

Test notes:

- `bkn-safe/server`: `go test ./...`
- `bkn-safe/server`: `go vet ./...`
- `adp/bkn/ontology-query/server`: `I18N_MODE_UT=true go test -count=1 -gcflags=all=-l ./...`
- `adp/bkn/ontology-query/server`: `I18N_MODE_UT=true go vet ./...`
- `adp/bkn/ontology-query/server`: `golangci-lint run` on the two changed packages (0 issues)
- `adp/vega/vega-backend`: `make ci` (passed; total coverage 36.5%)
- Test environment: sample data returned 200 before account disablement; the same issued token returned 403 for object-grant delegation and 403 for sample-data access after disablement.
- Proxy reconciliation reported no missing mappings, orphan mappings, conflicting proxy accounts, or authorization drift.

---

## Risk & Rollback

- Potential risks: The trusted proxy-read context must remain restricted to handlers that have completed dual-principal authorization. Regression tests verify that the marker is applied only after the proxy PEP succeeds. Mutating `/me` calls for missing or disabled local accounts return 403, while voluntary logout remains available because it only records an access fact.
- Rollback plan: Revert commits `2a0028d2c` and `7a7f7d1f2`, then redeploy the previous bkn-safe, ontology-query, and Vega images.

---

## Additional Notes

- Backend-only change; no Studio frontend files are included.
- Temporary test users were removed after verification.
