### PR TITLE
feat(bkn): carry capability dependencies through export and import (#1264)

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/capabilities_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/capabilities_test.go
@@ -1,0 +1,91 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package bkn
+
+import (
+	"strings"
+	"testing"
+)
+
+func networkWithCapabilities() *BknNetwork {
+	return &BknNetwork{
+		BknNetworkFrontmatter: BknNetworkFrontmatter{
+			Type: "knowledge_network", ID: "kn1", Name: "供应链", Branch: "main",
+			Capabilities: &BknCapabilities{
+				Skills: []*BknCapabilitySkill{{ID: "skill-1", Name: "交期评估"}},
+				Functions: []*BknCapabilityFunction{{
+					BoxID: "box-1", ToolID: "tool-1", BoxName: "供应链计算", ToolName: "BOM 多层展开",
+				}},
+			},
+		},
+	}
+}
+
+// TestCapabilitiesRoundTrip covers the section surviving a write and a read. Both halves of each
+// identity are written: the ids match exactly in the environment that produced the file, and the
+// names are the only thing that can match anywhere else.
+func TestCapabilitiesRoundTrip(t *testing.T) {
+	text := SerializeBknNetwork(networkWithCapabilities())
+
+	parsed, err := ParseNetworkFile(text, "network.bkn")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.Capabilities == nil {
+		t.Fatal("capabilities section lost in the round trip")
+	}
+	if len(parsed.Capabilities.Skills) != 1 || parsed.Capabilities.Skills[0].Name != "交期评估" {
+		t.Fatalf("skill not round-tripped: %+v", parsed.Capabilities.Skills)
+	}
+	fn := parsed.Capabilities.Functions[0]
+	if fn.BoxID != "box-1" || fn.ToolID != "tool-1" || fn.BoxName != "供应链计算" || fn.ToolName != "BOM 多层展开" {
+		t.Fatalf("function not round-tripped: %+v", fn)
+	}
+}
+
+// TestCapabilitiesOmittedWhenEmpty keeps the section out of files that have nothing to declare,
+// so an export from a network with no bindings is byte-identical to what it was before.
+func TestCapabilitiesOmittedWhenEmpty(t *testing.T) {
+	for name, doc := range map[string]*BknNetwork{
+		"nil":   {BknNetworkFrontmatter: BknNetworkFrontmatter{Type: "knowledge_network", ID: "kn1", Name: "空"}},
+		"empty": {BknNetworkFrontmatter: BknNetworkFrontmatter{Type: "knowledge_network", ID: "kn1", Name: "空", Capabilities: &BknCapabilities{}}},
+	} {
+		if strings.Contains(SerializeBknNetwork(doc), "capabilities") {
+			t.Fatalf("%s: empty section should not be written", name)
+		}
+	}
+}
+
+// TestCapabilitiesQuotingSurvives covers the reason this block goes through yaml.Marshal instead
+// of being hand-formatted: a name containing YAML punctuation must not produce a file that no
+// longer parses.
+func TestCapabilitiesQuotingSurvives(t *testing.T) {
+	doc := networkWithCapabilities()
+	doc.Capabilities.Skills[0].Name = "评估: 交期, 含 #备注"
+
+	parsed, err := ParseNetworkFile(SerializeBknNetwork(doc), "network.bkn")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed.Capabilities.Skills[0].Name != "评估: 交期, 含 #备注" {
+		t.Fatalf("name mangled: %q", parsed.Capabilities.Skills[0].Name)
+	}
+}
+
+// TestUnknownCapabilitiesShapeIsIgnored covers forward compatibility in the other direction: a
+// section this reader cannot make sense of must not fail the import of an otherwise valid model.
+func TestUnknownCapabilitiesShapeIsIgnored(t *testing.T) {
+	text := "---\ntype: knowledge_network\nid: kn1\nname: 供应链\ncapabilities: \"not a mapping\"\n---\n\n# 供应链\n"
+
+	parsed, err := ParseNetworkFile(text, "network.bkn")
+	if err != nil {
+		t.Fatalf("a malformed section must not fail the parse: %v", err)
+	}
+	if parsed.Capabilities != nil {
+		t.Fatalf("expected the section to be dropped, got %+v", parsed.Capabilities)
+	}
+}

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
@@ -26,6 +26,37 @@ type BknNetworkFrontmatter struct {
 
 	Version string `yaml:"version,omitempty"`
 	Branch  string `yaml:"branch,omitempty"`
+
+	// Capabilities declares which Skills and ToolBox tools this network depends on. It is a
+	// dependency declaration, not a payload: the capabilities themselves travel through their own
+	// channels (a skill's package, a tool box's import/export), the way package.json names
+	// dependencies without carrying them.
+	Capabilities *BknCapabilities `yaml:"capabilities,omitempty"`
+}
+
+// BknCapabilities is the capability dependency section of a network.
+type BknCapabilities struct {
+	Skills    []*BknCapabilitySkill    `yaml:"skills,omitempty"`
+	Functions []*BknCapabilityFunction `yaml:"functions,omitempty"`
+}
+
+// BknCapabilitySkill names one skill dependency by both id and name.
+//
+// The id is generated per environment and does not survive a move between them; the name is what
+// makes a cross-environment import resolvable at all. Writing only the id would make this section
+// decoration everywhere except the environment that produced it.
+type BknCapabilitySkill struct {
+	ID   string `yaml:"id,omitempty"`
+	Name string `yaml:"name,omitempty"`
+}
+
+// BknCapabilityFunction names one tool dependency. Both halves of the identity are written twice,
+// as ids for an exact match at home and as names for a fallback elsewhere.
+type BknCapabilityFunction struct {
+	BoxID    string `yaml:"box_id,omitempty"`
+	ToolID   string `yaml:"tool_id,omitempty"`
+	BoxName  string `yaml:"box_name,omitempty"`
+	ToolName string `yaml:"tool_name,omitempty"`
 }
 
 // BknDocument is a parsed network.bkn file: frontmatter + body definitions.

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
@@ -466,12 +466,13 @@ func ParseNetworkFile(text string, sourcePath string) (*BknNetwork, error) {
 
 	network := &BknNetwork{
 		BknNetworkFrontmatter: BknNetworkFrontmatter{
-			Type:    strVal(fmData, "type"),
-			ID:      strVal(fmData, "id"),
-			Name:    strVal(fmData, "name"),
-			Tags:    strSliceVal(fmData, "tags"),
-			Version: strVal(fmData, "version"),
-			Branch:  strVal(fmData, "branch"),
+			Type:         strVal(fmData, "type"),
+			ID:           strVal(fmData, "id"),
+			Name:         strVal(fmData, "name"),
+			Tags:         strSliceVal(fmData, "tags"),
+			Version:      strVal(fmData, "version"),
+			Branch:       strVal(fmData, "branch"),
+			Capabilities: parseCapabilities(fmData),
 		},
 		Description: extractBodyDescription(text),
 		RawContent:  text,
@@ -1016,4 +1017,29 @@ func parseConceptGroupObjectTypes(sectionText string) []string {
 	}
 
 	return objectTypes
+}
+
+// parseCapabilities reads the capability dependency section out of already-parsed frontmatter.
+//
+// A malformed section yields nil rather than an error: the section is a dependency declaration,
+// and a network whose model is otherwise valid should still import — with its capabilities
+// reported as unresolvable — instead of being rejected outright. Frontmatter is read as a map, so
+// a reader that predates this section ignores it for free.
+func parseCapabilities(fmData map[string]any) *BknCapabilities {
+	raw, ok := fmData["capabilities"]
+	if !ok || raw == nil {
+		return nil
+	}
+	encoded, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	capabilities := &BknCapabilities{}
+	if err := yaml.Unmarshal(encoded, capabilities); err != nil {
+		return nil
+	}
+	if len(capabilities.Skills) == 0 && len(capabilities.Functions) == 0 {
+		return nil
+	}
+	return capabilities
 }

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
@@ -109,6 +109,9 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if doc.Branch != "" {
 		_, _ = fmt.Fprintf(&sb, "branch: %s\n", doc.Branch)
 	}
+	if block := serializeCapabilities(doc.Capabilities); block != "" {
+		_, _ = fmt.Fprint(&sb, block)
+	}
 	_, _ = fmt.Fprintf(&sb, "---\n\n")
 
 	_, _ = fmt.Fprintf(&sb, "# %s\n\n", doc.Name)
@@ -543,4 +546,20 @@ func SerializeConceptGroup(cg *BknConceptGroup, otIndex map[string]*BknObjectTyp
 	_, _ = fmt.Fprintf(&sb, "\n")
 
 	return sb.String()
+}
+
+// serializeCapabilities renders the capability dependency section of the frontmatter.
+//
+// The nested block goes through yaml.Marshal rather than being hand-formatted like the scalar
+// fields above it: nesting and quoting are exactly where hand-built YAML breaks, and a name with
+// a colon in it would silently produce a file that no longer parses.
+func serializeCapabilities(capabilities *BknCapabilities) string {
+	if capabilities == nil || (len(capabilities.Skills) == 0 && len(capabilities.Functions) == 0) {
+		return ""
+	}
+	encoded, err := yaml.Marshal(map[string]*BknCapabilities{"capabilities": capabilities})
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
 }

--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +23,10 @@ import (
 	"bkn-backend/common"
 	"bkn-backend/interfaces"
 )
+
+// execFactoryNameLookupPageSize bounds a name lookup. A name that matches more entries than this
+// is ambiguous anyway, and the import refuses to guess between them.
+const execFactoryNameLookupPageSize = 50
 
 var (
 	aoAccessOnce sync.Once
@@ -392,4 +397,94 @@ func (aoa *agentOperatorAccess) GetSkillNamesByIDs(ctx context.Context, skillIDs
 	}
 	oteltrace.AddHttpAttrs4Ok(span, respCode)
 	return names, nil
+}
+
+// FindSkillsByName resolves a skill name to every skill carrying it (GET .../skills?name=).
+//
+// The execution factory filters by substring, so the exact matches are picked out here: a model
+// asking for "交期评估" must not resolve to "交期评估（旧）" because it happens to contain it.
+func (aoa *agentOperatorAccess) FindSkillsByName(ctx context.Context, name string) ([]*interfaces.SkillBrief, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "FindSkillsByName")
+	defer span.End()
+
+	if strings.TrimSpace(name) == "" {
+		return nil, nil
+	}
+	url := fmt.Sprintf("%s/skills?name=%s&page_size=%d", aoa.agentOperatorURL, neturl.QueryEscape(name), execFactoryNameLookupPageSize)
+	respCode, result, err := aoa.httpClient.GetNoUnmarshal(ctx, url, nil, aoa.execFactoryHeaders(ctx))
+	if err != nil {
+		common.LogSafeError(ctx, "Skill name lookup request failed", err)
+		return nil, fmt.Errorf("skill name lookup failed: %w", err)
+	}
+	if respCode != http.StatusOK {
+		return nil, fmt.Errorf("skill name lookup returned HTTP %d", respCode)
+	}
+
+	var payload struct {
+		Data []struct {
+			SkillID     string `json:"skill_id"`
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Status      string `json:"status"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(result, &payload); err != nil {
+		common.LogSafeError(ctx, "Unmarshal skill list failed", err)
+		return nil, fmt.Errorf("skill name lookup failed: %w", err)
+	}
+	matches := make([]*interfaces.SkillBrief, 0, 1)
+	for _, skill := range payload.Data {
+		if skill.Name != name {
+			continue
+		}
+		matches = append(matches, &interfaces.SkillBrief{
+			SkillID:     skill.SkillID,
+			Name:        skill.Name,
+			Description: skill.Description,
+			Status:      skill.Status,
+		})
+	}
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return matches, nil
+}
+
+// FindToolBoxesByName resolves a tool box name (GET .../tool-box/list?name=), exact matches only,
+// on the same terms as FindSkillsByName.
+func (aoa *agentOperatorAccess) FindToolBoxesByName(ctx context.Context, name string) ([]*interfaces.ToolBoxBrief, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "FindToolBoxesByName")
+	defer span.End()
+
+	if strings.TrimSpace(name) == "" {
+		return nil, nil
+	}
+	url := fmt.Sprintf("%s/tool-box/list?name=%s&page_size=%d", aoa.agentOperatorURL, neturl.QueryEscape(name), execFactoryNameLookupPageSize)
+	respCode, result, err := aoa.httpClient.GetNoUnmarshal(ctx, url, nil, aoa.execFactoryHeaders(ctx))
+	if err != nil {
+		common.LogSafeError(ctx, "Tool box name lookup request failed", err)
+		return nil, fmt.Errorf("tool box name lookup failed: %w", err)
+	}
+	if respCode != http.StatusOK {
+		return nil, fmt.Errorf("tool box name lookup returned HTTP %d", respCode)
+	}
+
+	var payload struct {
+		Data []struct {
+			BoxID   string `json:"box_id"`
+			BoxName string `json:"box_name"`
+			Status  string `json:"status"`
+		} `json:"data"`
+	}
+	if err = json.Unmarshal(result, &payload); err != nil {
+		common.LogSafeError(ctx, "Unmarshal tool box list failed", err)
+		return nil, fmt.Errorf("tool box name lookup failed: %w", err)
+	}
+	matches := make([]*interfaces.ToolBoxBrief, 0, 1)
+	for _, box := range payload.Data {
+		if box.BoxName != name {
+			continue
+		}
+		matches = append(matches, &interfaces.ToolBoxBrief{BoxID: box.BoxID, Name: box.BoxName, Status: box.Status})
+	}
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return matches, nil
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -238,7 +239,15 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 	// import: a knowledge network whose capabilities are missing is still a knowledge network.
 	// What could not be resolved travels back in the response — a skip that is only logged makes
 	// an import look complete while the SKILLs list is quietly empty.
-	capabilityReport, capErr := r.cbs.ImportCapabilities(ctx, knID, branch, bknNetwork.Capabilities)
+	//
+	// detach asks for the topology without this environment's local identifiers, and a Skill or
+	// tool id is exactly that. Mounting them anyway would leave the one binding kind the caller
+	// asked to drop.
+	declaredCapabilities := bknNetwork.Capabilities
+	if bindingPolicy == bknBindingPolicyDetach {
+		declaredCapabilities = nil
+	}
+	capabilityReport, capErr := r.cbs.ImportCapabilities(ctx, knID, branch, declaredCapabilities)
 	if capErr != nil {
 		logger.Errorf("Upload BKN: capability import failed: kn_id=%s, err=%v", knID, capErr)
 		capabilityReport = &interfaces.CapabilityImportReport{
@@ -354,8 +363,14 @@ func (r *restHandler) DownloadBKN(c *gin.Context) {
 	tarData, err := r.bs.ExportToTar(ctx, kn_id, branch)
 	if err != nil {
 		logger.Errorf("Download BKN failed: %s", err.Error())
-		httpErr := rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_KnowledgeNetwork_InternalError).
-			WithErrorDetails(commonValidationDetail(ctx, "InternalRequestFailed", nil))
+		// An error the service already classified travels as it is. Flattening every failure into
+		// "internal error" hides the one the caller can act on: an export refused because the
+		// execution factory is unreachable is worth retrying, and a generic 500 does not say so.
+		var httpErr *rest.HTTPError
+		if !errors.As(err, &httpErr) {
+			httpErr = rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_KnowledgeNetwork_InternalError).
+				WithErrorDetails(commonValidationDetail(ctx, "InternalRequestFailed", nil))
+		}
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler.go
@@ -25,6 +25,7 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	"bkn-backend/logics"
+	"bkn-backend/logics/capability_binding"
 )
 
 const (
@@ -233,9 +234,24 @@ func (r *restHandler) UploadBKN(c *gin.Context) {
 	audit.NewInfoLog(audit.OPERATION, audit.CREATE, audit.TransforOperator(visitor),
 		interfaces.GenerateKNAuditObject(knID, kn.KNName), "")
 
+	// Capability declarations are resolved after the model is in place, and never fail the
+	// import: a knowledge network whose capabilities are missing is still a knowledge network.
+	// What could not be resolved travels back in the response — a skip that is only logged makes
+	// an import look complete while the SKILLs list is quietly empty.
+	capabilityReport, capErr := r.cbs.ImportCapabilities(ctx, knID, branch, bknNetwork.Capabilities)
+	if capErr != nil {
+		logger.Errorf("Upload BKN: capability import failed: kn_id=%s, err=%v", knID, capErr)
+		capabilityReport = &interfaces.CapabilityImportReport{
+			Skipped: []*interfaces.CapabilitySkip{{
+				Reason: capability_binding.CapabilitySkipUnreachable,
+				Detail: capErr.Error(),
+			}},
+		}
+	}
+
 	logger.Debugf("Upload BKN completed: kn_id=%s", knID)
 	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
-	rest.ReplyOK(c, http.StatusOK, map[string]string{"kn_id": knID})
+	rest.ReplyOK(c, http.StatusOK, map[string]any{"kn_id": knID, "capabilities": capabilityReport})
 }
 
 // detachBKNExternalBindings keeps the portable model topology while removing

--- a/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/bkn_handler_test.go
@@ -60,6 +60,27 @@ func newValidBKNTar(t *testing.T) []byte {
 	return buf.Bytes()
 }
 
+// newBKNTarWithCapabilities builds a tar whose frontmatter declares one Skill, so a test can tell
+// "the section was passed through" apart from "the file never had one".
+func newBKNTarWithCapabilities(t *testing.T) []byte {
+	net := &bknsdk.BknNetwork{
+		BknNetworkFrontmatter: bknsdk.BknNetworkFrontmatter{
+			Type:    "network",
+			ID:      "test-net",
+			Name:    "Test Network",
+			Version: "1.0.0",
+			Capabilities: &bknsdk.BknCapabilities{
+				Skills: []*bknsdk.BknCapabilitySkill{{ID: "skill-1", Name: "交期评估"}},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := bknsdk.WriteNetworkToTar(net, &buf); err != nil {
+		t.Fatalf("failed to create test BKN tar: %v", err)
+	}
+	return buf.Bytes()
+}
+
 // newMultipartRequestWithContentType builds a file-upload request with the specified Content-Type for extension-validation tests.
 func newMultipartRequestWithContentType(t *testing.T, url, filename, contentType string, content []byte) *http.Request {
 	t.Helper()
@@ -355,6 +376,58 @@ func Test_BKNRestHandler_UploadBKN_ExtensionCheck(t *testing.T) {
 			kns.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("kn1", nil)
 
 			req := newMultipartRequestWithContentType(t, url, "test.tgz", "application/gzip", newValidBKNTar(t))
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}
+
+// Test_BKNRestHandler_UploadBKN_BindingPolicyCapabilities pins the capability section to the
+// binding policy. detach asks for the topology without this environment's local identifiers, and
+// a Skill or tool id is exactly that: mounting them anyway would leave behind the one kind of
+// binding the caller asked to drop.
+func Test_BKNRestHandler_UploadBKN_BindingPolicyCapabilities(t *testing.T) {
+	Convey("导入的能力段跟随 binding_policy", t, func() {
+		test := setGinMode()
+		defer test()
+
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		as := bmock.NewMockAuthService(mockCtrl)
+		kns := bmock.NewMockKNService(mockCtrl)
+		bs := bmock.NewMockBKNService(mockCtrl)
+		cbs := bmock.NewMockCapabilityBindingService(mockCtrl)
+		as.EXPECT().VerifyToken(gomock.Any(), gomock.Any()).AnyTimes().Return(hydra.Visitor{}, nil)
+		kns.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			AnyTimes().Return("kn1", nil)
+
+		engine := gin.New()
+		engine.Use(gin.Recovery())
+		handler := &restHandler{appSetting: &common.AppSetting{}, as: as, kns: kns, bs: bs, cbs: cbs}
+		handler.RegisterPublic(engine)
+		url := "/api/bkn-backend/v1/bkns"
+
+		Convey("preserve 时把声明交给解析", func() {
+			cbs.EXPECT().ImportCapabilities(gomock.Any(), "kn1", gomock.Any(), gomock.Not(gomock.Nil())).
+				Return(&interfaces.CapabilityImportReport{}, nil)
+
+			req := newMultipartRequest(t, url+"?binding_policy=preserve", "test.tar",
+				newBKNTarWithCapabilities(t))
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("detach 时不带任何声明", func() {
+			cbs.EXPECT().ImportCapabilities(gomock.Any(), "kn1", gomock.Any(), gomock.Nil()).
+				Return(&interfaces.CapabilityImportReport{}, nil)
+
+			req := newMultipartRequest(t, url+"?binding_policy=detach", "test.tar",
+				newBKNTarWithCapabilities(t))
 			w := httptest.NewRecorder()
 			engine.ServeHTTP(w, req)
 

--- a/adp/bkn/bkn-backend/server/errors/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/errors/capability_binding.go
@@ -15,6 +15,7 @@ const (
 	BknBackend_CapabilityBinding_TargetNotAvailable                   = "BknBackend.CapabilityBinding.TargetNotAvailable"
 	BknBackend_CapabilityBinding_EmptyToolBox                         = "BknBackend.CapabilityBinding.EmptyToolBox"
 	BknBackend_CapabilityBinding_ExecutionFactoryUnavailable          = "BknBackend.CapabilityBinding.ExecutionFactoryUnavailable"
+	BknBackend_CapabilityBinding_ExportMetadataUnavailable            = "BknBackend.CapabilityBinding.ExportMetadataUnavailable"
 	BknBackend_CapabilityBinding_InternalError                        = "BknBackend.CapabilityBinding.InternalError"
 	BknBackend_CapabilityBinding_InternalError_BeginTransaction       = "BknBackend.CapabilityBinding.InternalError.BeginTransactionFailed"
 	BknBackend_CapabilityBinding_InternalError_CreateBindingsFailed   = "BknBackend.CapabilityBinding.InternalError.CreateBindingsFailed"
@@ -32,6 +33,7 @@ var CapabilityBindingErrCodeList = []string{
 	BknBackend_CapabilityBinding_TargetNotAvailable,
 	BknBackend_CapabilityBinding_EmptyToolBox,
 	BknBackend_CapabilityBinding_ExecutionFactoryUnavailable,
+	BknBackend_CapabilityBinding_ExportMetadataUnavailable,
 	BknBackend_CapabilityBinding_InternalError,
 	BknBackend_CapabilityBinding_InternalError_BeginTransaction,
 	BknBackend_CapabilityBinding_InternalError_CreateBindingsFailed,

--- a/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/agent_operator_access.go
@@ -42,6 +42,13 @@ type SkillBrief struct {
 	Status      string
 }
 
+// ToolBoxBrief identifies a tool box without its tools.
+type ToolBoxBrief struct {
+	BoxID  string
+	Name   string
+	Status string
+}
+
 // ToolBrief is one tool of a tool box, with the two lifecycle states that decide whether it can
 // be bound: its own switch and the box's publication state.
 type ToolBrief struct {
@@ -69,6 +76,12 @@ type AgentOperatorAccess interface {
 	// exist are absent from the result rather than present with an empty name, so the difference
 	// between the request and the answer is exactly the set of dangling references.
 	GetSkillNamesByIDs(ctx context.Context, skillIDs []string) (map[string]string, error)
+	// FindSkillsByName looks a skill up by exact name. It returns every match: a name is not
+	// unique in the execution factory, and an importer that picked one at random would bind a
+	// different capability than the model meant.
+	FindSkillsByName(ctx context.Context, name string) ([]*SkillBrief, error)
+	// FindToolBoxesByName looks a tool box up by exact name, with the same rule about duplicates.
+	FindToolBoxesByName(ctx context.Context, name string) ([]*ToolBoxBrief, error)
 	// ListBoxTools reads every tool of a tool box in one call, each with its status. It returns
 	// (nil, nil) when the box does not exist. The box endpoint inlines its tools, so validating
 	// and expanding a whole-box mount both cost one request per box rather than one per tool.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -165,3 +165,24 @@ type CapabilityReference struct {
 type CapabilityReferenceList struct {
 	Entries []*CapabilityReference `json:"entries"`
 }
+
+// CapabilitySkip explains why one declared capability could not be bound on import.
+type CapabilitySkip struct {
+	CapabilityType string `json:"capability_type"`
+	// Name is what the model called it — the only part a reader can act on when the ids belong
+	// to another environment.
+	Name          string `json:"name,omitempty"`
+	BoxName       string `json:"box_name,omitempty"`
+	DeclaredID    string `json:"declared_id,omitempty"`
+	DeclaredBoxID string `json:"declared_box_id,omitempty"`
+	Reason        string `json:"reason"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+// CapabilityImportReport is what an import did with the declared capabilities. It travels in the
+// import response: a skipped capability that is only logged makes an import look complete while
+// the network quietly has nothing bound.
+type CapabilityImportReport struct {
+	Bound   int               `json:"bound"`
+	Skipped []*CapabilitySkip `json:"skipped"`
+}

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding_service.go
@@ -9,6 +9,8 @@ package interfaces
 import (
 	"context"
 	"database/sql"
+
+	"bkn-backend/bkn-specification/bkn"
 )
 
 // CapabilityBindingService owns the knowledge-network side of Skill and Function binding (#1257).
@@ -30,6 +32,10 @@ type CapabilityBindingService interface {
 	// The count is the number of rows; it carries no dangling judgement, which would require
 	// calling the execution factory and does not belong on a counting path.
 	GetCapabilityTotalsByType(ctx context.Context, knID, branch string) (map[string]int, error)
+	// ImportCapabilities resolves a model file's capability declarations against this environment
+	// and mounts what resolves. It never fails the import; the report says what was skipped.
+	ImportCapabilities(ctx context.Context, knID, branch string,
+		declared *bkn.BknCapabilities) (*CapabilityImportReport, error)
 	// DeleteCapabilitiesByKnID clears the bindings of a network without a permission check,
 	// for use by knowledge-network deletion. tx must be non-nil.
 	DeleteCapabilitiesByKnID(ctx context.Context, tx *sql.Tx, knID, branch string) error

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_agent_operator_access.go
@@ -41,6 +41,36 @@ func (m *MockAgentOperatorAccess) EXPECT() *MockAgentOperatorAccessMockRecorder 
 	return m.recorder
 }
 
+// FindSkillsByName mocks base method.
+func (m *MockAgentOperatorAccess) FindSkillsByName(ctx context.Context, name string) ([]*interfaces.SkillBrief, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSkillsByName", ctx, name)
+	ret0, _ := ret[0].([]*interfaces.SkillBrief)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindSkillsByName indicates an expected call of FindSkillsByName.
+func (mr *MockAgentOperatorAccessMockRecorder) FindSkillsByName(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSkillsByName", reflect.TypeOf((*MockAgentOperatorAccess)(nil).FindSkillsByName), ctx, name)
+}
+
+// FindToolBoxesByName mocks base method.
+func (m *MockAgentOperatorAccess) FindToolBoxesByName(ctx context.Context, name string) ([]*interfaces.ToolBoxBrief, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindToolBoxesByName", ctx, name)
+	ret0, _ := ret[0].([]*interfaces.ToolBoxBrief)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindToolBoxesByName indicates an expected call of FindToolBoxesByName.
+func (mr *MockAgentOperatorAccessMockRecorder) FindToolBoxesByName(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindToolBoxesByName", reflect.TypeOf((*MockAgentOperatorAccess)(nil).FindToolBoxesByName), ctx, name)
+}
+
 // GetMcpToolByName mocks base method.
 func (m *MockAgentOperatorAccess) GetMcpToolByName(ctx context.Context, mcpID, toolName string) error {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_capability_binding_service.go
@@ -10,6 +10,7 @@
 package mock_interfaces
 
 import (
+	bkn "bkn-backend/bkn-specification/bkn"
 	interfaces "bkn-backend/interfaces"
 	context "context"
 	sql "database/sql"
@@ -99,6 +100,21 @@ func (m *MockCapabilityBindingService) GetCapabilityTotalsByType(ctx context.Con
 func (mr *MockCapabilityBindingServiceMockRecorder) GetCapabilityTotalsByType(ctx, knID, branch any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapabilityTotalsByType", reflect.TypeOf((*MockCapabilityBindingService)(nil).GetCapabilityTotalsByType), ctx, knID, branch)
+}
+
+// ImportCapabilities mocks base method.
+func (m *MockCapabilityBindingService) ImportCapabilities(ctx context.Context, knID, branch string, declared *bkn.BknCapabilities) (*interfaces.CapabilityImportReport, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ImportCapabilities", ctx, knID, branch, declared)
+	ret0, _ := ret[0].(*interfaces.CapabilityImportReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ImportCapabilities indicates an expected call of ImportCapabilities.
+func (mr *MockCapabilityBindingServiceMockRecorder) ImportCapabilities(ctx, knID, branch, declared any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportCapabilities", reflect.TypeOf((*MockCapabilityBindingService)(nil).ImportCapabilities), ctx, knID, branch, declared)
 }
 
 // ListCapabilities mocks base method.

--- a/adp/bkn/bkn-backend/server/locale/capability_binding.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/capability_binding.en-US.toml
@@ -68,3 +68,8 @@ ErrorLink = ""
 Description = "The execution factory is unreachable; no binding was written"
 Solution = "Retry later. This request produced no partial write."
 ErrorLink = ""
+
+[BknBackend.CapabilityBinding.ExportMetadataUnavailable]
+Description = "Capability names are unavailable, so the export was refused"
+Solution = "Retry once the execution factory is reachable. Nothing was exported and nothing was changed."
+ErrorLink = ""

--- a/adp/bkn/bkn-backend/server/locale/capability_binding.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/capability_binding.zh-CN.toml
@@ -68,3 +68,8 @@ ErrorLink = ""
 Description = "执行工厂不可达，未写入任何绑定"
 Solution = "请稍后重试；本次请求没有产生部分写入。"
 ErrorLink = ""
+
+[BknBackend.CapabilityBinding.ExportMetadataUnavailable]
+Description = "能力名称不可用，本次导出已被拒绝"
+Solution = "请在执行工厂恢复后重试；本次未导出任何内容，也未改动数据。"
+ErrorLink = ""

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
@@ -9,15 +9,18 @@ package bkn
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"sync"
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/otellog"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	"go.opentelemetry.io/otel/codes"
 
 	bknsdk "bkn-backend/bkn-specification/bkn"
 	"bkn-backend/common"
+	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	"bkn-backend/logics"
 	"bkn-backend/logics/capability_binding"
@@ -120,9 +123,22 @@ func (bs *bknService) exportCapabilities(ctx context.Context, knID, branch strin
 	if list == nil || len(list.Entries) == 0 {
 		return nil, nil
 	}
+	// Names are half the identity and the only half another environment can resolve. When the
+	// execution factory could not be reached they are all empty, and the section would still look
+	// well-formed while resolving to nothing on import. Failing the export says so instead.
+	if !list.MetadataAvailable {
+		return nil, rest.NewHTTPError(ctx, http.StatusServiceUnavailable,
+			berrors.BknBackend_CapabilityBinding_ExportMetadataUnavailable).
+			WithErrorDetails("capability names are unavailable, so the exported dependency section would not resolve elsewhere")
+	}
 
 	capabilities := &bknsdk.BknCapabilities{}
 	for _, binding := range list.Entries {
+		// A binding whose target is gone has no name to carry, and writing its id alone would
+		// only reappear as a not_found skip wherever the file is imported.
+		if binding.Status == interfaces.CAPABILITY_STATUS_MISSING {
+			continue
+		}
 		switch binding.CapabilityType {
 		case interfaces.CAPABILITY_TYPE_SKILL:
 			capabilities.Skills = append(capabilities.Skills, &bknsdk.BknCapabilitySkill{

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
@@ -20,6 +20,7 @@ import (
 	"bkn-backend/common"
 	"bkn-backend/interfaces"
 	"bkn-backend/logics"
+	"bkn-backend/logics/capability_binding"
 	"bkn-backend/logics/knowledge_network"
 )
 
@@ -31,6 +32,7 @@ var (
 type bknService struct {
 	appSetting *common.AppSetting
 	kns        interfaces.KNService
+	cbs        interfaces.CapabilityBindingService
 }
 
 // NewBKNService creates the BKN service.
@@ -39,6 +41,7 @@ func NewBKNService(appSetting *common.AppSetting) interfaces.BKNService {
 		bService = &bknService{
 			appSetting: appSetting,
 			kns:        knowledge_network.NewKNService(appSetting),
+			cbs:        capability_binding.NewCapabilityBindingService(appSetting),
 		}
 	})
 	return bService
@@ -77,6 +80,15 @@ func (bs *bknService) ExportToTar(ctx context.Context, knID string, branch strin
 		bknNetwork.Metrics = append(bknNetwork.Metrics, logics.ToBKNMetricDefinition(m))
 	}
 
+	// Capability bindings ride along as a dependency declaration. An export that dropped them
+	// would move a knowledge network to another environment with its Skills and functions
+	// silently unbound, and nothing in the file to say they were ever there.
+	capabilities, err := bs.exportCapabilities(ctx, knID, branch)
+	if err != nil {
+		return nil, err
+	}
+	bknNetwork.Capabilities = capabilities
+
 	var buf bytes.Buffer
 	err = bknsdk.WriteNetworkToTar(bknNetwork, &buf)
 	if err != nil {
@@ -88,4 +100,46 @@ func (bs *bknService) ExportToTar(ctx context.Context, knID string, branch strin
 	logger.Debugf("BKN ExportToTar Completed: size=%d", len(tarData))
 	span.SetStatus(codes.Ok, "")
 	return tarData, nil
+}
+
+// exportCapabilities reads the bindings of a branch and turns them into a dependency declaration.
+//
+// Both the ids and the names are written. Ids are generated per environment and match only at
+// home; names are the sole thing an import elsewhere can resolve against, and a section carrying
+// ids alone would be decoration everywhere but the environment that produced it.
+func (bs *bknService) exportCapabilities(ctx context.Context, knID, branch string) (*bknsdk.BknCapabilities, error) {
+	// No paging: the export is the whole model, and a page of the bindings would quietly ship a
+	// subset of what the network depends on.
+	list, err := bs.cbs.ListCapabilities(ctx, interfaces.CapabilityBindingsQueryParams{
+		KNID:   knID,
+		Branch: branch,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Entries) == 0 {
+		return nil, nil
+	}
+
+	capabilities := &bknsdk.BknCapabilities{}
+	for _, binding := range list.Entries {
+		switch binding.CapabilityType {
+		case interfaces.CAPABILITY_TYPE_SKILL:
+			capabilities.Skills = append(capabilities.Skills, &bknsdk.BknCapabilitySkill{
+				ID:   binding.CapabilityID,
+				Name: binding.Name,
+			})
+		case interfaces.CAPABILITY_TYPE_FUNCTION:
+			capabilities.Functions = append(capabilities.Functions, &bknsdk.BknCapabilityFunction{
+				BoxID:    binding.OwnerID,
+				ToolID:   binding.CapabilityID,
+				BoxName:  binding.OwnerName,
+				ToolName: binding.Name,
+			})
+		}
+	}
+	if len(capabilities.Skills) == 0 && len(capabilities.Functions) == 0 {
+		return nil, nil
+	}
+	return capabilities, nil
 }

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
@@ -26,13 +26,31 @@ import (
 
 func newTestBKNService(t *testing.T) (*bknService, *gomock.Controller, *bmock.MockKNService) {
 	t.Helper()
+	svc, mockCtrl, kns, cbs := newTestBKNServiceWithCapabilities(t)
+	// The cases built on this helper are about the model, not the dependency section: nothing is
+	// bound. The capability cases below set their own expectations, which is why the default
+	// lives here rather than in the shared constructor — gomock takes the first match, so a
+	// permissive default there would shadow them.
+	cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+		Return(&interfaces.CapabilityBindingsList{}, nil).AnyTimes()
+	return svc, mockCtrl, kns
+}
+
+// newTestBKNServiceWithCapabilities also hands back the capability binding service. Export reads
+// the bindings to write the dependency section, so a test that exports has to say what is bound;
+// the default here is "nothing", which is what the existing cases assume.
+func newTestBKNServiceWithCapabilities(t *testing.T) (*bknService, *gomock.Controller,
+	*bmock.MockKNService, *bmock.MockCapabilityBindingService) {
+	t.Helper()
 	mockCtrl := gomock.NewController(t)
 	kns := bmock.NewMockKNService(mockCtrl)
+	cbs := bmock.NewMockCapabilityBindingService(mockCtrl)
 	svc := &bknService{
 		appSetting: &common.AppSetting{},
 		kns:        kns,
+		cbs:        cbs,
 	}
-	return svc, mockCtrl, kns
+	return svc, mockCtrl, kns, cbs
 }
 
 func Test_bknService_ExportToTar(t *testing.T) {
@@ -123,6 +141,57 @@ func Test_bknService_ExportToTar(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(len(loaded.Metrics), ShouldEqual, 1)
 			So(loaded.Metrics[0].ID, ShouldEqual, "pod_running_count")
+		})
+	})
+}
+
+// Test_bknService_ExportCapabilities covers the dependency section riding along with the model.
+// An export that dropped it would move a network to another environment with its Skills and
+// functions silently unbound, and nothing in the file to say they were ever there.
+func Test_bknService_ExportCapabilities(t *testing.T) {
+	Convey("导出带能力依赖声明", t, func() {
+		svc, mockCtrl, kns, cbs := newTestBKNServiceWithCapabilities(t)
+		defer mockCtrl.Finish()
+
+		Convey("id 与名字双写", func() {
+			kns.EXPECT().GetKNByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH, interfaces.Mode_Export).
+				Return(&interfaces.KN{KNID: "kn1", KNName: "供应链"}, nil)
+			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, q interfaces.CapabilityBindingsQueryParams) (*interfaces.CapabilityBindingsList, error) {
+					// No paging: a page of the bindings would ship a subset of what the network
+					// depends on, with nothing to say so.
+					So(q.Limit, ShouldEqual, 0)
+					return &interfaces.CapabilityBindingsList{Entries: []*interfaces.CapabilityBinding{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1", Name: "交期评估"},
+						{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
+							CapabilityID: "tool-1", Name: "BOM 展开", OwnerName: "供应链计算"},
+					}}, nil
+				})
+
+			data, err := svc.ExportToTar(context.Background(), "kn1", interfaces.MAIN_BRANCH)
+			So(err, ShouldBeNil)
+
+			network, err := bknsdk.LoadNetworkFromTar(bytes.NewReader(data))
+			So(err, ShouldBeNil)
+			So(network.Capabilities, ShouldNotBeNil)
+			So(network.Capabilities.Skills[0].ID, ShouldEqual, "skill-1")
+			So(network.Capabilities.Skills[0].Name, ShouldEqual, "交期评估")
+			fn := network.Capabilities.Functions[0]
+			So(fn.BoxID, ShouldEqual, "box-1")
+			So(fn.ToolID, ShouldEqual, "tool-1")
+			So(fn.BoxName, ShouldEqual, "供应链计算")
+			So(fn.ToolName, ShouldEqual, "BOM 展开")
+		})
+
+		Convey("没有绑定时不写这一段", func() {
+			kns.EXPECT().GetKNByID(gomock.Any(), "kn2", interfaces.MAIN_BRANCH, interfaces.Mode_Export).
+				Return(&interfaces.KN{KNID: "kn2", KNName: "空网络"}, nil)
+			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+				Return(&interfaces.CapabilityBindingsList{}, nil)
+
+			data, err := svc.ExportToTar(context.Background(), "kn2", interfaces.MAIN_BRANCH)
+			So(err, ShouldBeNil)
+			So(string(data), ShouldNotContainSubstring, "capabilities")
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
@@ -161,11 +161,12 @@ func Test_bknService_ExportCapabilities(t *testing.T) {
 					// No paging: a page of the bindings would ship a subset of what the network
 					// depends on, with nothing to say so.
 					So(q.Limit, ShouldEqual, 0)
-					return &interfaces.CapabilityBindingsList{Entries: []*interfaces.CapabilityBinding{
-						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1", Name: "交期评估"},
-						{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
-							CapabilityID: "tool-1", Name: "BOM 展开", OwnerName: "供应链计算"},
-					}}, nil
+					return &interfaces.CapabilityBindingsList{MetadataAvailable: true,
+						Entries: []*interfaces.CapabilityBinding{
+							{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1", Name: "交期评估"},
+							{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
+								CapabilityID: "tool-1", Name: "BOM 展开", OwnerName: "供应链计算"},
+						}}, nil
 				})
 
 			data, err := svc.ExportToTar(context.Background(), "kn1", interfaces.MAIN_BRANCH)
@@ -192,6 +193,39 @@ func Test_bknService_ExportCapabilities(t *testing.T) {
 			data, err := svc.ExportToTar(context.Background(), "kn2", interfaces.MAIN_BRANCH)
 			So(err, ShouldBeNil)
 			So(string(data), ShouldNotContainSubstring, "capabilities")
+		})
+
+		Convey("执行工厂不可达时导出失败，不产出只剩 id 的段", func() {
+			kns.EXPECT().GetKNByID(gomock.Any(), "kn3", interfaces.MAIN_BRANCH, interfaces.Mode_Export).
+				Return(&interfaces.KN{KNID: "kn3", KNName: "名字缺失"}, nil)
+			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+				Return(&interfaces.CapabilityBindingsList{MetadataAvailable: false,
+					Entries: []*interfaces.CapabilityBinding{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1"},
+					}}, nil)
+
+			data, err := svc.ExportToTar(context.Background(), "kn3", interfaces.MAIN_BRANCH)
+			So(err, ShouldNotBeNil)
+			So(data, ShouldBeNil)
+		})
+
+		Convey("目标已消失的绑定不写进依赖段", func() {
+			kns.EXPECT().GetKNByID(gomock.Any(), "kn4", interfaces.MAIN_BRANCH, interfaces.Mode_Export).
+				Return(&interfaces.KN{KNID: "kn4", KNName: "含悬空绑定"}, nil)
+			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+				Return(&interfaces.CapabilityBindingsList{MetadataAvailable: true,
+					Entries: []*interfaces.CapabilityBinding{
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-live", Name: "在的"},
+						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-gone",
+							Status: interfaces.CAPABILITY_STATUS_MISSING},
+					}}, nil)
+
+			data, err := svc.ExportToTar(context.Background(), "kn4", interfaces.MAIN_BRANCH)
+			So(err, ShouldBeNil)
+			network, err := bknsdk.LoadNetworkFromTar(bytes.NewReader(data))
+			So(err, ShouldBeNil)
+			So(len(network.Capabilities.Skills), ShouldEqual, 1)
+			So(network.Capabilities.Skills[0].ID, ShouldEqual, "skill-live")
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
@@ -1,0 +1,225 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	bknsdk "bkn-backend/bkn-specification/bkn"
+	"bkn-backend/interfaces"
+)
+
+// Reasons a declared capability could not be bound. They are returned to the caller rather than
+// logged, because a silently short import is the worst outcome here: the network looks imported,
+// its SKILLs list is empty, and nothing says why.
+const (
+	CapabilitySkipNotFound    = "not_found"
+	CapabilitySkipAmbiguous   = "ambiguous_name"
+	CapabilitySkipUnusable    = "not_usable"
+	CapabilitySkipUnreachable = "execution_factory_unreachable"
+)
+
+// ImportCapabilities resolves a model file's capability declarations against this environment and
+// mounts what it can.
+//
+// Resolution order is id first, then name. Ids are exact but environment-local; names are the only
+// thing that survives a move between environments, and a model imported elsewhere would otherwise
+// arrive with everything unbound. A name matching several capabilities is not resolved at all:
+// picking one would bind something the model did not name.
+//
+// Nothing here fails the import. A knowledge network whose capabilities are missing is still a
+// knowledge network; the caller gets the list of what was skipped and why.
+func (cbs *capabilityBindingService) ImportCapabilities(ctx context.Context, knID, branch string,
+	declared *bknsdk.BknCapabilities) (*interfaces.CapabilityImportReport, error) {
+	report := &interfaces.CapabilityImportReport{Skipped: []*interfaces.CapabilitySkip{}}
+	if declared == nil {
+		return report, nil
+	}
+
+	entries := make([]*interfaces.AttachCapabilityEntry, 0,
+		len(declared.Skills)+len(declared.Functions))
+
+	for _, skill := range declared.Skills {
+		if skill == nil {
+			continue
+		}
+		resolvedID, skip := cbs.resolveSkill(ctx, skill)
+		if skip != nil {
+			report.Skipped = append(report.Skipped, skip)
+			continue
+		}
+		entries = append(entries, &interfaces.AttachCapabilityEntry{
+			CapabilityType: interfaces.CAPABILITY_TYPE_SKILL,
+			CapabilityID:   resolvedID,
+		})
+	}
+
+	for _, function := range declared.Functions {
+		if function == nil {
+			continue
+		}
+		boxID, toolID, skip := cbs.resolveFunction(ctx, function)
+		if skip != nil {
+			report.Skipped = append(report.Skipped, skip)
+			continue
+		}
+		entries = append(entries, &interfaces.AttachCapabilityEntry{
+			CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			OwnerID:        boxID,
+			CapabilityID:   toolID,
+		})
+	}
+
+	if len(entries) == 0 {
+		return report, nil
+	}
+	bound, err := cbs.AttachCapabilities(ctx, nil, knID, branch, entries)
+	if err != nil {
+		return nil, err
+	}
+	report.Bound = len(bound)
+	return report, nil
+}
+
+func (cbs *capabilityBindingService) resolveSkill(ctx context.Context,
+	declared *bknsdk.BknCapabilitySkill) (string, *interfaces.CapabilitySkip) {
+	label := declared.Name
+	if label == "" {
+		label = declared.ID
+	}
+	skip := func(reason, detail string) *interfaces.CapabilitySkip {
+		return &interfaces.CapabilitySkip{
+			CapabilityType: interfaces.CAPABILITY_TYPE_SKILL,
+			Name:           label,
+			DeclaredID:     declared.ID,
+			Reason:         reason,
+			Detail:         detail,
+		}
+	}
+
+	if id := strings.TrimSpace(declared.ID); id != "" {
+		skill, err := cbs.aoa.GetSkillByID(ctx, id)
+		if err != nil {
+			return "", skip(CapabilitySkipUnreachable, err.Error())
+		}
+		if skill != nil {
+			if !interfaces.SkillIsBindable(skill.Status) {
+				return "", skip(CapabilitySkipUnusable,
+					fmt.Sprintf("skill %s is %s", id, skill.Status))
+			}
+			return id, nil
+		}
+	}
+
+	if declared.Name == "" {
+		return "", skip(CapabilitySkipNotFound, "no skill with the declared id, and no name to fall back to")
+	}
+	matches, err := cbs.aoa.FindSkillsByName(ctx, declared.Name)
+	if err != nil {
+		return "", skip(CapabilitySkipUnreachable, err.Error())
+	}
+	switch len(matches) {
+	case 0:
+		return "", skip(CapabilitySkipNotFound, fmt.Sprintf("no skill named %q", declared.Name))
+	case 1:
+		if !interfaces.SkillIsBindable(matches[0].Status) {
+			return "", skip(CapabilitySkipUnusable,
+				fmt.Sprintf("skill %q is %s", declared.Name, matches[0].Status))
+		}
+		return matches[0].SkillID, nil
+	default:
+		return "", skip(CapabilitySkipAmbiguous,
+			fmt.Sprintf("%d skills are named %q", len(matches), declared.Name))
+	}
+}
+
+func (cbs *capabilityBindingService) resolveFunction(ctx context.Context,
+	declared *bknsdk.BknCapabilityFunction) (string, string, *interfaces.CapabilitySkip) {
+	label := declared.ToolName
+	if label == "" {
+		label = declared.ToolID
+	}
+	skip := func(reason, detail string) *interfaces.CapabilitySkip {
+		return &interfaces.CapabilitySkip{
+			CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			Name:           label,
+			BoxName:        declared.BoxName,
+			DeclaredID:     declared.ToolID,
+			DeclaredBoxID:  declared.BoxID,
+			Reason:         reason,
+			Detail:         detail,
+		}
+	}
+
+	// Exact ids first: in the environment that produced the file they identify the tool outright.
+	if declared.BoxID != "" && declared.ToolID != "" {
+		tools, err := cbs.aoa.ListBoxTools(ctx, declared.BoxID)
+		if err != nil {
+			return "", "", skip(CapabilitySkipUnreachable, err.Error())
+		}
+		if tool := findTool(tools, declared.ToolID); tool != nil {
+			if tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+				return "", "", skip(CapabilitySkipUnusable,
+					fmt.Sprintf("tool %s is %s", declared.ToolID, tool.Status))
+			}
+			return declared.BoxID, declared.ToolID, nil
+		}
+	}
+
+	if declared.BoxName == "" || declared.ToolName == "" {
+		return "", "", skip(CapabilitySkipNotFound,
+			"no tool with the declared ids, and no names to fall back to")
+	}
+	boxes, err := cbs.aoa.FindToolBoxesByName(ctx, declared.BoxName)
+	if err != nil {
+		return "", "", skip(CapabilitySkipUnreachable, err.Error())
+	}
+	switch len(boxes) {
+	case 0:
+		return "", "", skip(CapabilitySkipNotFound, fmt.Sprintf("no tool box named %q", declared.BoxName))
+	case 1:
+	default:
+		return "", "", skip(CapabilitySkipAmbiguous,
+			fmt.Sprintf("%d tool boxes are named %q", len(boxes), declared.BoxName))
+	}
+
+	tools, err := cbs.aoa.ListBoxTools(ctx, boxes[0].BoxID)
+	if err != nil {
+		return "", "", skip(CapabilitySkipUnreachable, err.Error())
+	}
+	named := make([]*interfaces.ToolBrief, 0, 1)
+	for _, tool := range tools {
+		if tool.Name == declared.ToolName {
+			named = append(named, tool)
+		}
+	}
+	switch len(named) {
+	case 0:
+		return "", "", skip(CapabilitySkipNotFound,
+			fmt.Sprintf("tool box %q has no tool named %q", declared.BoxName, declared.ToolName))
+	case 1:
+		if named[0].Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+			return "", "", skip(CapabilitySkipUnusable,
+				fmt.Sprintf("tool %q is %s", declared.ToolName, named[0].Status))
+		}
+		return boxes[0].BoxID, named[0].ToolID, nil
+	default:
+		return "", "", skip(CapabilitySkipAmbiguous,
+			fmt.Sprintf("%d tools in %q are named %q", len(named), declared.BoxName, declared.ToolName))
+	}
+}
+
+func findTool(tools []*interfaces.ToolBrief, toolID string) *interfaces.ToolBrief {
+	for _, tool := range tools {
+		if tool.ToolID == toolID {
+			return tool
+		}
+	}
+	return nil
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
@@ -165,9 +165,8 @@ func (cbs *capabilityBindingService) resolveFunction(ctx context.Context,
 			return "", "", skip(CapabilitySkipUnreachable, err.Error())
 		}
 		if tool := findTool(tools, declared.ToolID); tool != nil {
-			if tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
-				return "", "", skip(CapabilitySkipUnusable,
-					fmt.Sprintf("tool %s is %s", declared.ToolID, tool.Status))
+			if unusable := toolUnusableReason(tool); unusable != "" {
+				return "", "", skip(CapabilitySkipUnusable, unusable)
 			}
 			return declared.BoxID, declared.ToolID, nil
 		}
@@ -205,15 +204,32 @@ func (cbs *capabilityBindingService) resolveFunction(ctx context.Context,
 		return "", "", skip(CapabilitySkipNotFound,
 			fmt.Sprintf("tool box %q has no tool named %q", declared.BoxName, declared.ToolName))
 	case 1:
-		if named[0].Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
-			return "", "", skip(CapabilitySkipUnusable,
-				fmt.Sprintf("tool %q is %s", declared.ToolName, named[0].Status))
+		if unusable := toolUnusableReason(named[0]); unusable != "" {
+			return "", "", skip(CapabilitySkipUnusable, unusable)
 		}
 		return boxes[0].BoxID, named[0].ToolID, nil
 	default:
 		return "", "", skip(CapabilitySkipAmbiguous,
 			fmt.Sprintf("%d tools in %q are named %q", len(named), declared.BoxName, declared.ToolName))
 	}
+}
+
+// toolUnusableReason mirrors what validateTool rejects at mount time, and returns the empty string
+// when the tool is mountable.
+//
+// The two checks have to agree. Resolution that accepted a tool the mount then rejects does not
+// cost that one entry: AttachCapabilities validates the batch as a unit, so a single tool in an
+// unpublished box fails the whole call, and the import reports one execution_factory_unreachable
+// in place of the report — every Skill that resolved cleanly is lost with it, and the reason
+// points at the wrong thing.
+func toolUnusableReason(tool *interfaces.ToolBrief) string {
+	if !boxIsUsable(tool) {
+		return fmt.Sprintf("tool box %s is %s", tool.BoxID, tool.BoxStatus)
+	}
+	if tool.Status != interfaces.EXEC_TOOL_STATUS_ENABLED {
+		return fmt.Sprintf("tool %s is %s", tool.ToolID, tool.Status)
+	}
+	return ""
 }
 
 func findTool(tools []*interfaces.ToolBrief, toolID string) *interfaces.ToolBrief {

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/import.go
@@ -42,8 +42,9 @@ func (cbs *capabilityBindingService) ImportCapabilities(ctx context.Context, knI
 		return report, nil
 	}
 
-	entries := make([]*interfaces.AttachCapabilityEntry, 0,
-		len(declared.Skills)+len(declared.Functions))
+	// No capacity hint: the two lengths come from an uploaded file, and summing them is a
+	// tainted-arithmetic pattern for no gain on a list this short.
+	var entries []*interfaces.AttachCapabilityEntry
 
 	for _, skill := range declared.Skills {
 		if skill == nil {

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/import_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/import_test.go
@@ -164,3 +164,40 @@ func TestImportResolvesFunctionsByBoxAndToolName(t *testing.T) {
 		So(report.Skipped, ShouldBeEmpty)
 	})
 }
+
+// TestImportSkipsToolInUnpublishedBox pins resolution to the same bar the mount enforces. The
+// mount validates the batch as a unit, so a tool whose box is not published would fail the whole
+// AttachCapabilities call — every Skill that resolved cleanly would be lost with it, and the
+// import would report an execution-factory outage that never happened.
+func TestImportSkipsToolInUnpublishedBox(t *testing.T) {
+	Convey("工具箱未发布时只跳过这一条，其余照常绑定", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		aoa.EXPECT().GetSkillByID(gomock.Any(), "skill-1").
+			Return(&interfaces.SkillBrief{SkillID: "skill-1", Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}, nil).AnyTimes()
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "draft-box").Return([]*interfaces.ToolBrief{
+			{BoxID: "draft-box", BoxStatus: "unpublish", ToolID: "tool-1", Name: "BOM 展开",
+				Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil).AnyTimes()
+		cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+		cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+		report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+			&bknsdk.BknCapabilities{
+				Skills: []*bknsdk.BknCapabilitySkill{{ID: "skill-1", Name: "交期评估"}},
+				Functions: []*bknsdk.BknCapabilityFunction{{
+					BoxID: "draft-box", ToolID: "tool-1",
+					BoxName: "草稿箱", ToolName: "BOM 展开",
+				}},
+			})
+
+		So(err, ShouldBeNil)
+		So(report.Bound, ShouldEqual, 1)
+		So(len(report.Skipped), ShouldEqual, 1)
+		So(report.Skipped[0].Reason, ShouldEqual, CapabilitySkipUnusable)
+		So(report.Skipped[0].Detail, ShouldContainSubstring, "unpublish")
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/import_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/import_test.go
@@ -1,0 +1,166 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
+
+	bknsdk "bkn-backend/bkn-specification/bkn"
+	"bkn-backend/interfaces"
+)
+
+func skillDecl(id, name string) *bknsdk.BknCapabilities {
+	return &bknsdk.BknCapabilities{Skills: []*bknsdk.BknCapabilitySkill{{ID: id, Name: name}}}
+}
+
+// TestImportResolvesByIDThenName covers the resolution order. Ids are exact but belong to the
+// environment that produced the file; names are the only thing that survives the move, and a model
+// imported elsewhere would otherwise arrive with everything unbound.
+func TestImportResolvesByIDThenName(t *testing.T) {
+	Convey("导入解析:先 id 后名字", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("同环境:id 精确命中,不按名解析", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "skill-1").
+				Return(&interfaces.SkillBrief{SkillID: "skill-1", Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}, nil).Times(2)
+			// No FindSkillsByName expectation: an id hit must not cost a name lookup.
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				skillDecl("skill-1", "交期评估"))
+
+			So(err, ShouldBeNil)
+			So(report.Bound, ShouldEqual, 1)
+			So(report.Skipped, ShouldBeEmpty)
+		})
+
+		Convey("换环境:id 落空后按名解析", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "skill-from-elsewhere").Return(nil, nil)
+			aoa.EXPECT().FindSkillsByName(gomock.Any(), "交期评估").
+				Return([]*interfaces.SkillBrief{{SkillID: "local-7", Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}}, nil)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "local-7").
+				Return(&interfaces.SkillBrief{SkillID: "local-7", Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), "local-7").Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				skillDecl("skill-from-elsewhere", "交期评估"))
+
+			So(err, ShouldBeNil)
+			So(report.Bound, ShouldEqual, 1)
+		})
+	})
+}
+
+// TestImportSkipsRatherThanGuesses covers the cases that must not bind anything, and must not stay
+// silent either: a short import that looks complete is the worst outcome here.
+func TestImportSkipsRatherThanGuesses(t *testing.T) {
+	Convey("无法解析时跳过并报告", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		Convey("同名多条不猜", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), gomock.Any()).Return(nil, nil)
+			aoa.EXPECT().FindSkillsByName(gomock.Any(), "交期评估").
+				Return([]*interfaces.SkillBrief{{SkillID: "a"}, {SkillID: "b"}}, nil)
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				skillDecl("gone", "交期评估"))
+
+			So(err, ShouldBeNil)
+			So(report.Bound, ShouldEqual, 0)
+			So(report.Skipped[0].Reason, ShouldEqual, CapabilitySkipAmbiguous)
+			So(report.Skipped[0].Name, ShouldEqual, "交期评估")
+		})
+
+		Convey("目标环境没有该能力", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), gomock.Any()).Return(nil, nil)
+			aoa.EXPECT().FindSkillsByName(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				skillDecl("gone", "本环境没有的技能"))
+
+			So(err, ShouldBeNil)
+			So(report.Skipped[0].Reason, ShouldEqual, CapabilitySkipNotFound)
+		})
+
+		Convey("执行工厂不可达时整段跳过,导入不失败", func() {
+			service, _, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), gomock.Any()).Return(nil, errors.New("connection refused"))
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				skillDecl("skill-1", "交期评估"))
+
+			So(err, ShouldBeNil)
+			So(report.Skipped[0].Reason, ShouldEqual, CapabilitySkipUnreachable)
+		})
+
+		Convey("一条跳过不影响另一条挂载", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "ok").
+				Return(&interfaces.SkillBrief{SkillID: "ok", Status: interfaces.EXEC_SKILL_STATUS_PUBLISHED}, nil).Times(2)
+			aoa.EXPECT().GetSkillByID(gomock.Any(), "gone").Return(nil, nil)
+			aoa.EXPECT().FindSkillsByName(gomock.Any(), "缺失的").Return(nil, nil)
+			cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), "ok").Return(nil, nil)
+			cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+			report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+				&bknsdk.BknCapabilities{Skills: []*bknsdk.BknCapabilitySkill{
+					{ID: "ok", Name: "在的"}, {ID: "gone", Name: "缺失的"},
+				}})
+
+			So(err, ShouldBeNil)
+			So(report.Bound, ShouldEqual, 1)
+			So(len(report.Skipped), ShouldEqual, 1)
+		})
+	})
+}
+
+// TestImportResolvesFunctionsByBoxAndToolName covers the two-level fallback for tools: the box is
+// resolved by name first, then the tool inside it, because a tool id means nothing without its box.
+func TestImportResolvesFunctionsByBoxAndToolName(t *testing.T) {
+	Convey("函数按箱名 + 工具名兜底", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-from-elsewhere").Return(nil, nil)
+		aoa.EXPECT().FindToolBoxesByName(gomock.Any(), "供应链计算").
+			Return([]*interfaces.ToolBoxBrief{{BoxID: "local-box", Name: "供应链计算"}}, nil)
+		aoa.EXPECT().ListBoxTools(gomock.Any(), "local-box").Return([]*interfaces.ToolBrief{
+			{BoxID: "local-box", BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED,
+				ToolID: "local-tool", Name: "BOM 展开", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
+		}, nil).AnyTimes()
+		cba.EXPECT().GetBindingByCapability(gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any(), "local-box", "local-tool").Return(nil, nil)
+		cba.EXPECT().CreateBindings(gomock.Any(), gomock.Nil(), gomock.Len(1)).Return(nil)
+
+		report, err := service.ImportCapabilities(context.Background(), "kn1", "main",
+			&bknsdk.BknCapabilities{Functions: []*bknsdk.BknCapabilityFunction{{
+				BoxID: "box-from-elsewhere", ToolID: "tool-from-elsewhere",
+				BoxName: "供应链计算", ToolName: "BOM 展开",
+			}}})
+
+		So(err, ShouldBeNil)
+		So(report.Bound, ShouldEqual, 1)
+		So(report.Skipped, ShouldBeEmpty)
+	})
+}

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill_handler.go
@@ -41,6 +41,12 @@ func (r *skillRestHandler) RegisterPrivate(engine *gin.RouterGroup) {
 	// Batch names by skill ID. Same handler as the public face; FilterViewableIDs returns
 	// the IDs unchanged on the internal face, so callers see existence, not their own grants.
 	engine.POST("/skills/names", r.SkillHandler.QuerySkillNamesByIDs)
+	// Skill list. Registered here so bkn-backend can resolve a skill by name when importing a
+	// model from another environment, where the ids no longer match. querySkillListPage applies
+	// the per-caller view filter only on the public face, so the internal answer is the same for
+	// every caller — which is what name resolution has to be, or an import would silently skip
+	// capabilities the importer happens not to see.
+	engine.GET("/skills", r.SkillHandler.QuerySkillList)
 	// Query skill details. Registered here for bkn-backend, whose execution-factory client
 	// is pinned to internal-v1. Unlike /skills/market/:skill_id it applies no public_access
 	// filter and reports an unpublished skill through `status` instead of 404.


### PR DESCRIPTION
Closes #1264.

## What

A knowledge network's Skills and functions were invisible to the model file. Exporting a network and importing it elsewhere produced a network with an empty capability list, and nothing in the file to say the bindings had ever existed.

The network frontmatter now carries a `capabilities` section listing every bound Skill and tool by **both id and name**. Ids are exact but environment-local; names are the only half that survives a move between environments, so both are written and resolution tries them in that order.

Import resolves each declaration against the local execution factory and mounts what it can. Nothing here fails the import — a network whose capabilities are missing is still a network — so the response carries a report:

```json
{"kn_id": "...", "capabilities": {"bound": 5, "skipped": [{"capability_type": "skill", "name": "...", "reason": "ambiguous_name", "detail": "3 skills are named \"exp_session_echo\""}]}}
```

Skip reasons: `not_found`, `ambiguous_name`, `not_usable`, `execution_factory_unreachable`. A name matching several capabilities is deliberately left unresolved — picking one would bind something the model never named.

The execution factory gains `GET /skills` on its internal face, which name resolution needs to enumerate candidates.

## Verification

Run on the Parallels VM against a real execution factory (18 skills, 14 tool boxes), with the branch cross-compiled for arm64 and rolled onto isolated image copies. The 0.1.5 bkn-backend migrations (02/03/04) were applied to the VM first; the VM also needed a bkn-safe built from main, because main's import path now goes through the merged KN-proxy work.

A fixture declaring 11 capabilities:

| case | declared | result |
|---|---|---|
| skill by id | `a1fc2895…` | bound |
| skill by name, unique | `web_design_studio` | bound |
| skill by name, 3 matches | `exp_session_echo` | skipped `ambiguous_name` |
| skill by name, no match | `no_such_skill_1264` | skipped `not_found` |
| skill by id, unpublished | `49465013…` | skipped `not_usable` |
| **dead id + live name** | `dead-id-1264-0000` / `supplier_expedite` | **bound via name fallback** |
| function by ids | box `c3e7f1a2…` / tool `57d50e1e…` | bound |
| function by names | `Skill内置工具` / `builtin_skill_load` | bound |
| function, unknown box name | `不存在的工具箱1264` | skipped `not_found` |
| function, unknown tool name | box exists, tool does not | skipped `not_found` |

`bound: 5`, five skips with the expected reason on each, and all five rows confirmed in `t_kn_capability_binding`.

Round trip: exporting that imported network wrote the section back with ids **and** names for all five; re-importing the exported package under a new id bound **5/5 with no skips**.

Malformed section: a `capabilities:` whose `skills` is a string instead of a list is ignored — `bound: 0, skipped: []` — and the network still imports.

All fixtures, temporary images and the VM's original deployment images were restored afterwards; the 0.1.5 schema was left in place.

## Tests

`go test ./...` green in both modules; new cases in `capabilities_test.go`, `import_test.go` and `bkn_service_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)