### PR TITLE
feat(bkn): add DataProperty masking rule contract

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/mask_rule_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/mask_rule_test.go
@@ -1,0 +1,93 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package bkn
+
+import (
+	"strings"
+	"testing"
+
+	"bkn-backend/common/maskrule"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectTypeMaskRuleRoundTrip(t *testing.T) {
+	keepStart, keepEnd := 3, 4
+	original := &BknObjectType{
+		BknObjectTypeFrontmatter: BknObjectTypeFrontmatter{Type: "object_type", ID: "customer", Name: "Customer"},
+		DataProperties: []*DataProperty{{
+			Name: "mobile", DisplayName: "Mobile", Type: "string", MappedField: "mobile",
+			MaskRule: &maskrule.Rule{Kind: maskrule.KindPartial, KeepStart: &keepStart, KeepEnd: &keepEnd, Replacement: "|"},
+		}},
+		PrimaryKeys: []string{"mobile"},
+		DisplayKey:  "mobile",
+	}
+
+	serialized := SerializeObjectType(original)
+	assert.Contains(t, serialized, "| Mask Rule |")
+	assert.Contains(t, serialized, `"replacement":"\u007c"`)
+
+	parsed, err := ParseObjectTypeFile(serialized, "customer.bkn")
+	require.NoError(t, err)
+	require.Len(t, parsed.DataProperties, 1)
+	assert.Equal(t, original.DataProperties[0].MaskRule, parsed.DataProperties[0].MaskRule)
+}
+
+func TestParseObjectTypeMaskRuleCompatibility(t *testing.T) {
+	legacy := `---
+type: object_type
+id: customer
+name: Customer
+---
+
+## ObjectType: Customer
+
+### Data Properties
+
+| Name | Display Name | Type | Description | Mapped Field |
+|------|--------------|------|-------------|--------------|
+| id | ID | string | identifier | id |
+`
+	parsed, err := ParseObjectTypeFile(legacy, "legacy.bkn")
+	require.NoError(t, err)
+	require.Len(t, parsed.DataProperties, 1)
+	assert.Nil(t, parsed.DataProperties[0].MaskRule)
+	assert.NotContains(t, SerializeObjectType(parsed), "| Mask Rule |")
+
+	invalid := strings.Replace(legacy,
+		"| Name | Display Name | Type | Description | Mapped Field |",
+		"| Name | Display Name | Type | Description | Mapped Field | Mask Rule |", 1)
+	invalid = strings.Replace(invalid,
+		"|------|--------------|------|-------------|--------------|",
+		"|------|--------------|------|-------------|--------------|-----------|", 1)
+	invalid = strings.Replace(invalid, "| id | ID | string | identifier | id |", "| id | ID | string | identifier | id | {bad-json} |", 1)
+	_, err = ParseObjectTypeFile(invalid, "invalid.bkn")
+	assert.ErrorContains(t, err, "invalid Mask Rule JSON")
+}
+
+func TestValidateNetworkChecksMaskRule(t *testing.T) {
+	keepStart, keepEnd := 1, 1
+	network := &BknNetwork{
+		BknNetworkFrontmatter: BknNetworkFrontmatter{Type: "knowledge_network", ID: "net", Name: "Net"},
+		ObjectTypes: []*BknObjectType{{
+			BknObjectTypeFrontmatter: BknObjectTypeFrontmatter{Type: "object_type", ID: "customer", Name: "Customer"},
+			HasDataPropertiesSection: true,
+			HasKeysSection:           true,
+			DataProperties: []*DataProperty{{
+				Name: "mobile", DisplayName: "Mobile", Type: "string",
+				MaskRule: &maskrule.Rule{Kind: maskrule.KindPartial, KeepStart: &keepStart, KeepEnd: &keepEnd, Replacement: "*"},
+			}},
+			PrimaryKeys: []string{"mobile"},
+			DisplayKey:  "mobile",
+		}},
+	}
+
+	assert.True(t, ValidateNetwork(network).OK())
+	network.ObjectTypes[0].DataProperties[0].Type = "vector"
+	result := ValidateNetwork(network)
+	assert.False(t, result.OK())
+	assert.Contains(t, result.Errors[0].Message, "invalid mask_rule")
+}

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
@@ -6,6 +6,8 @@
 
 package bkn
 
+import "bkn-backend/common/maskrule"
+
 // RelationType mapping types.
 const (
 	RELATION_MAPPING_TYPE_DIRECT              = "direct"
@@ -224,6 +226,7 @@ type DataProperty struct {
 	Type        string
 	Description string
 	MappedField string
+	MaskRule    *maskrule.Rule
 }
 
 // LogicProperty represents a logic property definition.

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
@@ -7,9 +7,12 @@
 package bkn
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"bkn-backend/common/maskrule"
 
 	"gopkg.in/yaml.v3"
 )
@@ -259,19 +262,27 @@ func parseDataSource(sectionText string) *ResourceInfo {
 	}
 }
 
-func parseDataProperties(sectionText string) []*DataProperty {
+func parseDataProperties(sectionText string) ([]*DataProperty, error) {
 	rows := parseTable(strings.Split(sectionText, "\n"))
 	var props []*DataProperty
 	for _, row := range rows {
-		props = append(props, &DataProperty{
+		property := &DataProperty{
 			Name:        row["Name"],
 			DisplayName: row["Display Name"],
 			Type:        row["Type"],
 			Description: row["Description"],
 			MappedField: row["Mapped Field"],
-		})
+		}
+		if rawRule := strings.TrimSpace(row["Mask Rule"]); rawRule != "" {
+			var rule maskrule.Rule
+			if err := json.Unmarshal([]byte(rawRule), &rule); err != nil {
+				return nil, fmt.Errorf("data property %q has invalid Mask Rule JSON: %w", property.Name, err)
+			}
+			property.MaskRule = &rule
+		}
+		props = append(props, property)
 	}
-	return props
+	return props, nil
 }
 
 func parseLogicProperties(sectionText string) []*LogicProperty {
@@ -510,7 +521,10 @@ func ParseObjectTypeFile(text string, sourcePath string) (*BknObjectType, error)
 		obj.DataSource = parseDataSource(s)
 	}
 	if s, ok := sections["Data Properties"]; ok {
-		obj.DataProperties = parseDataProperties(s)
+		obj.DataProperties, err = parseDataProperties(s)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if s, ok := sections["Logic Properties"]; ok {
 		obj.LogicProperties = parseLogicProperties(s)

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
@@ -8,12 +8,28 @@ package bkn
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
+	"bkn-backend/common/maskrule"
+
 	"gopkg.in/yaml.v3"
 )
+
+func serializeMaskRule(rule *maskrule.Rule) string {
+	if rule == nil {
+		return ""
+	}
+	data, err := json.Marshal(rule)
+	if err != nil {
+		return ""
+	}
+	// A literal pipe would terminate the Markdown table cell. Its JSON escape
+	// decodes to the same replacement string on the next import.
+	return strings.ReplaceAll(string(data), "|", `\u007c`)
+}
 
 // encodeMetricFormulaYAML encodes a metric formula fenced with Markdown ```yaml code blocks, matching on-disk examples.
 func encodeMetricFormulaYAML(m *MetricFormula) string {
@@ -279,12 +295,29 @@ func SerializeObjectType(ot *BknObjectType) string {
 
 	// Data Properties
 	_, _ = fmt.Fprintf(&sb, "### Data Properties\n\n")
-	_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description | Mapped Field |\n")
-	_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|--------------|\n")
+	hasMaskRule := false
+	for _, dp := range ot.DataProperties {
+		if dp.MaskRule != nil {
+			hasMaskRule = true
+			break
+		}
+	}
+	if hasMaskRule {
+		_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description | Mapped Field | Mask Rule |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|--------------|-----------|\n")
+	} else {
+		_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description | Mapped Field |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|--------------|\n")
+	}
 	if len(ot.DataProperties) > 0 {
 		for _, dp := range ot.DataProperties {
-			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
-				dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField)
+			if hasMaskRule {
+				_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s |\n",
+					dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField, serializeMaskRule(dp.MaskRule))
+			} else {
+				_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
+					dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField)
+			}
 		}
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
@@ -11,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode/utf8"
+
+	"bkn-backend/common/maskrule"
 )
 
 // Aligned with adp bkn-backend/interfaces/common.go RegexPattern_NonBuiltin_ID
@@ -86,7 +88,7 @@ var validDisplayKeyTypes = map[string]bool{
 }
 
 var validDataPropertyTypes = map[string]bool{
-	"integer": true, "unsigned integer": true, "string": true, "float": true, "decimal": true,
+	"integer": true, "unsigned integer": true, "string": true, "keyword": true, "float": true, "decimal": true,
 	"text": true, "date": true, "timestamp": true, "time": true, "datetime": true,
 	"boolean": true, "binary": true, "json": true, "vector": true, "point": true, "shape": true, "ip": true,
 }
@@ -421,6 +423,10 @@ func validateObjectTypeDeep(result *ValidationResult, table string, ot *BknObjec
 				appendError(result, table, "data_properties", "invalid_property_type",
 					fmt.Sprintf("data property %q has invalid type %q", dp.Name, dp.Type))
 			}
+		}
+		if err := maskrule.Validate(normType(dp.Type), dp.MaskRule); err != nil {
+			appendError(result, table, "data_properties", "invalid_mask_rule",
+				fmt.Sprintf("data property %q has invalid mask_rule: %s", dp.Name, err))
 		}
 		if dp.MappedField != "" && strings.TrimSpace(dp.MappedField) == "" {
 			appendError(result, table, "data_properties", "invalid_object_type", fmt.Sprintf("mapped_field for %q must not be empty when set", dp.Name))

--- a/adp/bkn/bkn-backend/server/common/maskrule/rule.go
+++ b/adp/bkn/bkn-backend/server/common/maskrule/rule.go
@@ -7,6 +7,7 @@ package maskrule
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"unicode"
@@ -126,6 +127,9 @@ var dateGranularities = map[string]map[string]bool{
 func Validate(propertyType string, rule *Rule) error {
 	if rule == nil {
 		return nil
+	}
+	if propertyType == "" {
+		return errors.New("property type is required when mask_rule is set")
 	}
 
 	switch rule.Kind {

--- a/adp/bkn/bkn-backend/server/common/maskrule/rule.go
+++ b/adp/bkn/bkn-backend/server/common/maskrule/rule.go
@@ -1,0 +1,250 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package maskrule defines and validates the DataProperty masking contract.
+package maskrule
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	KindFixed           = "fixed"
+	KindPartial         = "partial"
+	KindEmail           = "email"
+	KindRound           = "round"
+	KindDateGranularity = "date_granularity"
+
+	maxKeepCodePoints        = 64
+	maxReplacementCodePoints = 8
+)
+
+// Rule is the strongly typed wire and persistence model for a DataProperty mask_rule.
+// Fields that do not belong to the selected kind are rejected by Validate.
+type Rule struct {
+	Kind string `json:"kind" mapstructure:"kind"`
+
+	Replacement    string `json:"replacement,omitempty" mapstructure:"replacement,omitempty"`
+	KeepStart      *int   `json:"keep_start,omitempty" mapstructure:"keep_start,omitempty"`
+	KeepEnd        *int   `json:"keep_end,omitempty" mapstructure:"keep_end,omitempty"`
+	LocalKeepStart *int   `json:"local_keep_start,omitempty" mapstructure:"local_keep_start,omitempty"`
+	PreserveDomain *bool  `json:"preserve_domain,omitempty" mapstructure:"preserve_domain,omitempty"`
+
+	Step        *float64 `json:"step,omitempty" mapstructure:"step,omitempty"`
+	Granularity string   `json:"granularity,omitempty" mapstructure:"granularity,omitempty"`
+}
+
+// UnmarshalJSON keeps the REST, persistence, and .bkn representations strict:
+// misspelled or future fields must not be silently dropped during a round trip.
+func (rule *Rule) UnmarshalJSON(data []byte) error {
+	type ruleAlias Rule
+	var decoded ruleAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	allowed := map[string]bool{
+		"kind":             true,
+		"replacement":      true,
+		"keep_start":       true,
+		"keep_end":         true,
+		"local_keep_start": true,
+		"preserve_domain":  true,
+		"step":             true,
+		"granularity":      true,
+	}
+	for field := range fields {
+		if !allowed[field] {
+			return fmt.Errorf("unknown mask rule field %q", field)
+		}
+	}
+	allowedForKind := map[string]map[string]bool{
+		KindFixed:           {"kind": true, "replacement": true},
+		KindPartial:         {"kind": true, "keep_start": true, "keep_end": true, "replacement": true},
+		KindEmail:           {"kind": true, "local_keep_start": true, "preserve_domain": true, "replacement": true},
+		KindRound:           {"kind": true, "step": true},
+		KindDateGranularity: {"kind": true, "granularity": true},
+	}
+	if kindFields, knownKind := allowedForKind[decoded.Kind]; knownKind {
+		for field := range fields {
+			if !kindFields[field] {
+				return fmt.Errorf("mask rule field %q is not valid for %s", field, decoded.Kind)
+			}
+		}
+	}
+
+	*rule = Rule(decoded)
+	return nil
+}
+
+var stringPropertyTypes = map[string]bool{
+	"string":  true,
+	"text":    true,
+	"keyword": true,
+}
+
+var numberPropertyTypes = map[string]bool{
+	"integer":          true,
+	"unsigned integer": true,
+	"float":            true,
+	"decimal":          true,
+}
+
+var dateGranularities = map[string]map[string]bool{
+	"date": {
+		"year":  true,
+		"month": true,
+	},
+	"time": {
+		"hour": true,
+	},
+	"datetime": {
+		"year":  true,
+		"month": true,
+		"day":   true,
+		"hour":  true,
+	},
+	"timestamp": {
+		"year":  true,
+		"month": true,
+		"day":   true,
+		"hour":  true,
+	},
+}
+
+// Validate checks the rule kind, property-type compatibility, required parameters,
+// parameter bounds, and kind-specific parameter shape. A nil rule is valid.
+func Validate(propertyType string, rule *Rule) error {
+	if rule == nil {
+		return nil
+	}
+
+	switch rule.Kind {
+	case KindFixed:
+		if !stringPropertyTypes[propertyType] {
+			return incompatibleType(rule.Kind, propertyType)
+		}
+		if err := validateReplacement(rule.Replacement); err != nil {
+			return err
+		}
+		return rejectUnexpected(rule, true, false, false, false, false, false, false)
+	case KindPartial:
+		if !stringPropertyTypes[propertyType] {
+			return incompatibleType(rule.Kind, propertyType)
+		}
+		if err := validateReplacement(rule.Replacement); err != nil {
+			return err
+		}
+		if err := validateBoundedInt("keep_start", rule.KeepStart); err != nil {
+			return err
+		}
+		if err := validateBoundedInt("keep_end", rule.KeepEnd); err != nil {
+			return err
+		}
+		return rejectUnexpected(rule, true, true, true, false, false, false, false)
+	case KindEmail:
+		if !stringPropertyTypes[propertyType] {
+			return incompatibleType(rule.Kind, propertyType)
+		}
+		if err := validateReplacement(rule.Replacement); err != nil {
+			return err
+		}
+		if err := validateBoundedInt("local_keep_start", rule.LocalKeepStart); err != nil {
+			return err
+		}
+		if rule.PreserveDomain == nil {
+			return fmt.Errorf("preserve_domain is required for %s", rule.Kind)
+		}
+		return rejectUnexpected(rule, true, false, false, true, true, false, false)
+	case KindRound:
+		if !numberPropertyTypes[propertyType] {
+			return incompatibleType(rule.Kind, propertyType)
+		}
+		if err := validateStep(rule.Step); err != nil {
+			return err
+		}
+		return rejectUnexpected(rule, false, false, false, false, false, true, false)
+	case KindDateGranularity:
+		allowed, ok := dateGranularities[propertyType]
+		if !ok {
+			return incompatibleType(rule.Kind, propertyType)
+		}
+		if !allowed[rule.Granularity] {
+			return fmt.Errorf("granularity %q is not coarser than property type %q", rule.Granularity, propertyType)
+		}
+		return rejectUnexpected(rule, false, false, false, false, false, false, true)
+	default:
+		return fmt.Errorf("unsupported mask rule kind %q", rule.Kind)
+	}
+}
+
+func incompatibleType(kind, propertyType string) error {
+	return fmt.Errorf("mask rule kind %q does not support property type %q", kind, propertyType)
+}
+
+func validateReplacement(value string) error {
+	count := utf8.RuneCountInString(value)
+	if count < 1 || count > maxReplacementCodePoints {
+		return fmt.Errorf("replacement must contain 1 to %d Unicode code points", maxReplacementCodePoints)
+	}
+	for _, r := range value {
+		if !unicode.IsPrint(r) {
+			return fmt.Errorf("replacement must contain only printable Unicode code points")
+		}
+	}
+	return nil
+}
+
+func validateBoundedInt(name string, value *int) error {
+	if value == nil {
+		return fmt.Errorf("%s is required", name)
+	}
+	if *value < 0 || *value > maxKeepCodePoints {
+		return fmt.Errorf("%s must be between 0 and %d", name, maxKeepCodePoints)
+	}
+	return nil
+}
+
+func validateStep(value *float64) error {
+	if value == nil {
+		return fmt.Errorf("step is required")
+	}
+	if *value <= 0 || math.IsInf(*value, 0) || math.IsNaN(*value) {
+		return fmt.Errorf("step must be a finite decimal number greater than 0")
+	}
+	return nil
+}
+
+func rejectUnexpected(rule *Rule, replacement, keepStart, keepEnd, localKeepStart, preserveDomain, step, granularity bool) error {
+	if !replacement && rule.Replacement != "" {
+		return fmt.Errorf("replacement is not valid for %s", rule.Kind)
+	}
+	if !keepStart && rule.KeepStart != nil {
+		return fmt.Errorf("keep_start is not valid for %s", rule.Kind)
+	}
+	if !keepEnd && rule.KeepEnd != nil {
+		return fmt.Errorf("keep_end is not valid for %s", rule.Kind)
+	}
+	if !localKeepStart && rule.LocalKeepStart != nil {
+		return fmt.Errorf("local_keep_start is not valid for %s", rule.Kind)
+	}
+	if !preserveDomain && rule.PreserveDomain != nil {
+		return fmt.Errorf("preserve_domain is not valid for %s", rule.Kind)
+	}
+	if !step && rule.Step != nil {
+		return fmt.Errorf("step is not valid for %s", rule.Kind)
+	}
+	if !granularity && rule.Granularity != "" {
+		return fmt.Errorf("granularity is not valid for %s", rule.Kind)
+	}
+	return nil
+}

--- a/adp/bkn/bkn-backend/server/common/maskrule/rule_test.go
+++ b/adp/bkn/bkn-backend/server/common/maskrule/rule_test.go
@@ -1,0 +1,85 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package maskrule
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+func intPointer(value int) *int           { return &value }
+func boolPointer(value bool) *bool        { return &value }
+func floatPointer(value float64) *float64 { return &value }
+
+func TestValidateAcceptsSupportedRulesAndBoundaries(t *testing.T) {
+	tests := []struct {
+		name         string
+		propertyType string
+		rule         *Rule
+	}{
+		{name: "fixed unicode", propertyType: "string", rule: &Rule{Kind: KindFixed, Replacement: "保密🔒"}},
+		{name: "partial bounds", propertyType: "keyword", rule: &Rule{Kind: KindPartial, KeepStart: intPointer(0), KeepEnd: intPointer(64), Replacement: "*"}},
+		{name: "email hides domain", propertyType: "text", rule: &Rule{Kind: KindEmail, LocalKeepStart: intPointer(64), PreserveDomain: boolPointer(false), Replacement: "●"}},
+		{name: "round decimal", propertyType: "decimal", rule: &Rule{Kind: KindRound, Step: floatPointer(1e-20)}},
+		{name: "date to month", propertyType: "date", rule: &Rule{Kind: KindDateGranularity, Granularity: "month"}},
+		{name: "time to hour", propertyType: "time", rule: &Rule{Kind: KindDateGranularity, Granularity: "hour"}},
+		{name: "timestamp to day", propertyType: "timestamp", rule: &Rule{Kind: KindDateGranularity, Granularity: "day"}},
+		{name: "optional rule", propertyType: "json", rule: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.propertyType, test.rule); err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name         string
+		propertyType string
+		rule         *Rule
+	}{
+		{name: "unknown kind", propertyType: "string", rule: &Rule{Kind: "regex", Replacement: "*"}},
+		{name: "fixed type mismatch", propertyType: "boolean", rule: &Rule{Kind: KindFixed, Replacement: "*"}},
+		{name: "empty replacement", propertyType: "string", rule: &Rule{Kind: KindFixed}},
+		{name: "replacement too long", propertyType: "string", rule: &Rule{Kind: KindFixed, Replacement: "123456789"}},
+		{name: "replacement control", propertyType: "string", rule: &Rule{Kind: KindFixed, Replacement: "*\n"}},
+		{name: "partial missing start", propertyType: "string", rule: &Rule{Kind: KindPartial, KeepEnd: intPointer(1), Replacement: "*"}},
+		{name: "partial start overflow", propertyType: "string", rule: &Rule{Kind: KindPartial, KeepStart: intPointer(65), KeepEnd: intPointer(0), Replacement: "*"}},
+		{name: "email missing preserve domain", propertyType: "string", rule: &Rule{Kind: KindEmail, LocalKeepStart: intPointer(1), Replacement: "*"}},
+		{name: "round type mismatch", propertyType: "string", rule: &Rule{Kind: KindRound, Step: floatPointer(10)}},
+		{name: "round zero", propertyType: "integer", rule: &Rule{Kind: KindRound, Step: floatPointer(0)}},
+		{name: "round non finite", propertyType: "float", rule: &Rule{Kind: KindRound, Step: floatPointer(math.Inf(1))}},
+		{name: "round cross kind replacement", propertyType: "float", rule: &Rule{Kind: KindRound, Step: floatPointer(1), Replacement: "*"}},
+		{name: "date same precision", propertyType: "date", rule: &Rule{Kind: KindDateGranularity, Granularity: "day"}},
+		{name: "unsupported masked type", propertyType: "vector", rule: &Rule{Kind: KindDateGranularity, Granularity: "day"}},
+		{name: "cross kind field", propertyType: "string", rule: &Rule{Kind: KindFixed, Replacement: "*", KeepStart: intPointer(1)}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := Validate(test.propertyType, test.rule); err == nil {
+				t.Fatal("Validate() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestRuleUnmarshalJSONRejectsUnknownFields(t *testing.T) {
+	inputs := []string{
+		`{"kind":"fixed","replacement":"*","keep_strat":1}`,
+		`{"kind":"round","step":1,"replacement":""}`,
+	}
+	for _, input := range inputs {
+		var rule Rule
+		if err := json.Unmarshal([]byte(input), &rule); err == nil {
+			t.Fatalf("json.Unmarshal(%s) error = nil, want field error", input)
+		}
+	}
+}

--- a/adp/bkn/bkn-backend/server/common/maskrule/rule_test.go
+++ b/adp/bkn/bkn-backend/server/common/maskrule/rule_test.go
@@ -71,6 +71,16 @@ func TestValidateRejectsInvalidRules(t *testing.T) {
 	}
 }
 
+func TestValidateRequiresPropertyTypeForMaskRule(t *testing.T) {
+	err := Validate("", &Rule{Kind: KindFixed, Replacement: "*"})
+	if err == nil {
+		t.Fatal("Validate() error = nil, want missing property type error")
+	}
+	if got, want := err.Error(), "property type is required when mask_rule is set"; got != want {
+		t.Fatalf("Validate() error = %q, want %q", got, want)
+	}
+}
+
 func TestRuleUnmarshalJSONRejectsUnknownFields(t *testing.T) {
 	inputs := []string{
 		`{"kind":"fixed","replacement":"*","keep_strat":1}`,

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_object_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_object_type.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/i18n"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 
+	"bkn-backend/common/maskrule"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 )
@@ -425,12 +426,16 @@ func ValidateDataProperty(ctx context.Context, dataProperty *interfaces.DataProp
 			WithErrorDetails(objectTypeInvalidDetail(ctx, "DataPropertyDisplayNameTooLong", map[string]any{"property": dataProperty.Name, "limit": interfaces.OBJECT_NAME_MAX_LENGTH}))
 	}
 
-	// When data_property.type is set, it must be a supported type: integer, unsigned integer, float, decimal, string, text, date, timestamp, time, datetime, boolean, binary, json, vector, point, shape, or ip.
+	// When data_property.type is set, it must be a supported type: integer, unsigned integer, float, decimal, string, keyword, text, date, timestamp, time, datetime, boolean, binary, json, vector, point, shape, or ip.
 	if dataProperty.Type != "" {
 		if !interfaces.ValidDataPropertyTypes[dataProperty.Type] {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
 				WithErrorDetails(objectTypeInvalidDetail(ctx, "DataPropertyTypeInvalid", map[string]any{"property": dataProperty.Name, "type": dataProperty.Type}))
 		}
+	}
+	if err := maskrule.Validate(dataProperty.Type, dataProperty.MaskRule); err != nil {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
+			WithErrorDetails(objectTypeInvalidDetail(ctx, "DataPropertyMaskRuleInvalid", map[string]any{"property": dataProperty.Name, "reason": err.Error()}))
 	}
 
 	// When data_property.mapped_field is set, name is required.

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
 
+	"bkn-backend/common/maskrule"
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 )
@@ -818,6 +819,26 @@ func Test_ValidateDataProperty(t *testing.T) {
 			}
 			err := ValidateDataProperty(ctx, prop, true)
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Success with valid mask rule\n", func() {
+			prop := &interfaces.DataProperty{
+				Name:        "email",
+				Type:        "string",
+				DisplayName: "Email",
+				MaskRule:    &maskrule.Rule{Kind: maskrule.KindFixed, Replacement: "保密"},
+			}
+			So(ValidateDataProperty(ctx, prop, true), ShouldBeNil)
+		})
+
+		Convey("Failed with mask rule type mismatch\n", func() {
+			prop := &interfaces.DataProperty{
+				Name:        "payload",
+				Type:        "json",
+				DisplayName: "Payload",
+				MaskRule:    &maskrule.Rule{Kind: maskrule.KindFixed, Replacement: "*"},
+			}
+			So(ValidateDataProperty(ctx, prop, true), ShouldNotBeNil)
 		})
 
 		Convey("Failed with empty mapped field name\n", func() {

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_object_type_test.go
@@ -841,6 +841,20 @@ func Test_ValidateDataProperty(t *testing.T) {
 			So(ValidateDataProperty(ctx, prop, true), ShouldNotBeNil)
 		})
 
+		Convey("Failed with mask rule and missing property type\n", func() {
+			prop := &interfaces.DataProperty{
+				Name:        "secret",
+				DisplayName: "Secret",
+				MaskRule:    &maskrule.Rule{Kind: maskrule.KindFixed, Replacement: "*"},
+			}
+			err := ValidateDataProperty(rest.WithLanguage(ctx, rest.AmericanEnglish), prop, true)
+			So(err, ShouldNotBeNil)
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.BaseError.ErrorDetails, ShouldEqual,
+				"Data property secret has invalid mask_rule: property type is required when mask_rule is set.")
+		})
+
 		Convey("Failed with empty mapped field name\n", func() {
 			prop := &interfaces.DataProperty{
 				Name:        "prop1",

--- a/adp/bkn/bkn-backend/server/interfaces/object_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type.go
@@ -9,6 +9,7 @@ package interfaces
 import (
 	"encoding/json"
 
+	"bkn-backend/common/maskrule"
 	"bkn-backend/interfaces/data_type"
 )
 
@@ -54,11 +55,12 @@ var (
 		LOGIC_PROPERTY_TYPE_TOOL:   true,
 	}
 
-	// Valid property types are integer, unsigned integer, float, decimal, string, text, date, timestamp, time, datetime, boolean, binary, json, vector, point, shape, and ip.
+	// Valid property types are integer, unsigned integer, float, decimal, string, keyword, text, date, timestamp, time, datetime, boolean, binary, json, vector, point, shape, and ip.
 	ValidDataPropertyTypes = map[string]bool{
 		data_type.DATATYPE_INTEGER:          true,
 		data_type.DATATYPE_UNSIGNED_INTEGER: true,
 		data_type.DATATYPE_STRING:           true,
+		data_type.DATATYPE_KEYWORD:          true,
 		data_type.DATATYPE_FLOAT:            true,
 		data_type.DATATYPE_DECIMAL:          true,
 		data_type.DATATYPE_TEXT:             true,
@@ -139,7 +141,8 @@ type DataProperty struct {
 	Type        string `json:"type" mapstructure:"type"`
 	Comment     string `json:"comment" mapstructure:"comment"`
 
-	MappedField *Field `json:"mapped_field,omitempty" mapstructure:"mapped_field,omitempty"`
+	MappedField *Field         `json:"mapped_field,omitempty" mapstructure:"mapped_field,omitempty"`
+	MaskRule    *maskrule.Rule `json:"mask_rule,omitempty" mapstructure:"mask_rule,omitempty"`
 
 	ConditionOperations []string `json:"condition_operations,omitempty"` // Operations supported by string fields
 

--- a/adp/bkn/bkn-backend/server/interfaces/object_type_mask_rule_test.go
+++ b/adp/bkn/bkn-backend/server/interfaces/object_type_mask_rule_test.go
@@ -1,0 +1,49 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import (
+	"encoding/json"
+	"testing"
+
+	"bkn-backend/common/maskrule"
+)
+
+func TestDataPropertyMaskRuleJSONRoundTrip(t *testing.T) {
+	keepStart, keepEnd := 3, 4
+	original := DataProperty{
+		Name: "mobile", DisplayName: "Mobile", Type: "string",
+		MaskRule: &maskrule.Rule{Kind: maskrule.KindPartial, KeepStart: &keepStart, KeepEnd: &keepEnd, Replacement: "*"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	var decoded DataProperty
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if decoded.MaskRule == nil || decoded.MaskRule.Kind != maskrule.KindPartial || *decoded.MaskRule.KeepEnd != 4 {
+		t.Fatalf("decoded mask_rule = %#v", decoded.MaskRule)
+	}
+
+	legacy, err := json.Marshal(DataProperty{Name: "legacy", Type: "string"})
+	if err != nil {
+		t.Fatalf("json.Marshal() legacy error = %v", err)
+	}
+	if string(legacy) == "" || containsJSONField(legacy, "mask_rule") {
+		t.Fatalf("legacy JSON unexpectedly contains mask_rule: %s", legacy)
+	}
+}
+
+func containsJSONField(data []byte, field string) bool {
+	var value map[string]json.RawMessage
+	if err := json.Unmarshal(data, &value); err != nil {
+		return false
+	}
+	_, ok := value[field]
+	return ok
+}

--- a/adp/bkn/bkn-backend/server/locale/object_type.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/object_type.en-US.toml
@@ -168,6 +168,7 @@ LogicPropertyParameterPropertyNotFound = "Parameter {{.parameter}} on logic prop
 DataPropertyDisplayNameRequired = "Data property {{.property}} requires display_name."
 DataPropertyDisplayNameTooLong = "Data property {{.property}} has a display_name longer than {{.limit}} characters."
 DataPropertyTypeInvalid = "Data property {{.property}} has unsupported type {{.type}}."
+DataPropertyMaskRuleInvalid = "Data property {{.property}} has invalid mask_rule: {{.reason}}."
 DataPropertyMappedFieldRequired = "Data property {{.property}} requires mapped_field.name."
 DataPropertyIndexConfigUnsupported = "Data property {{.property}} no longer supports index_config; configure index capability on the Vega resource."
 BoundByRelationTypes = "The object type is bound by the following relation types and cannot be deleted: {{.relationTypeNames}}."

--- a/adp/bkn/bkn-backend/server/locale/object_type.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/object_type.zh-CN.toml
@@ -168,6 +168,7 @@ LogicPropertyParameterPropertyNotFound = "对象类 {{.objectType}} 的逻辑属
 DataPropertyDisplayNameRequired = "数据属性 {{.property}} 的 display_name 不能为空。"
 DataPropertyDisplayNameTooLong = "数据属性 {{.property}} 的 display_name 长度不能超过 {{.limit}} 个字符。"
 DataPropertyTypeInvalid = "数据属性 {{.property}} 的类型 {{.type}} 无效。"
+DataPropertyMaskRuleInvalid = "数据属性 {{.property}} 的 mask_rule 无效：{{.reason}}。"
 DataPropertyMappedFieldRequired = "数据属性 {{.property}} 的 mapped_field.name 不能为空。"
 DataPropertyIndexConfigUnsupported = "数据属性 {{.property}} 不再支持 index_config；请在 Vega Resource 上配置索引能力。"
 BoundByRelationTypes = "对象类被以下关系类绑定，无法删除：{{.relationTypeNames}}。"

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert.go
@@ -286,6 +286,7 @@ func ToADPObjectType(knID string, branch string, bknObj *bknsdk.BknObjectType) *
 			DisplayName: dp.DisplayName,
 			Type:        dp.Type,
 			Comment:     dp.Description,
+			MaskRule:    dp.MaskRule,
 		}
 
 		if dp.MappedField != "" {
@@ -373,6 +374,7 @@ func ToBKNObjectType(adpObj *interfaces.ObjectType) *bknsdk.BknObjectType {
 			DisplayName: adpDP.DisplayName,
 			Type:        adpDP.Type,
 			Description: adpDP.Comment,
+			MaskRule:    adpDP.MaskRule,
 		}
 
 		if adpDP.MappedField != nil {

--- a/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn_convert_test.go
@@ -13,6 +13,7 @@ import (
 
 	bknsdk "bkn-backend/bkn-specification/bkn"
 	cond "bkn-backend/common/condition"
+	"bkn-backend/common/maskrule"
 	"bkn-backend/interfaces"
 )
 
@@ -246,7 +247,7 @@ func Test_ToADPObjectType(t *testing.T) {
 				DisplayKey:     "name",
 				IncrementalKey: "ts",
 				DataProperties: []*bknsdk.DataProperty{
-					{Name: "dp1", DisplayName: "DP1", Type: "string", Description: "ddp", MappedField: "col1"},
+					{Name: "dp1", DisplayName: "DP1", Type: "string", Description: "ddp", MappedField: "col1", MaskRule: &maskrule.Rule{Kind: maskrule.KindFixed, Replacement: "*"}},
 					{Name: "dp2", Type: "int"},
 				},
 				LogicProperties: []*bknsdk.LogicProperty{
@@ -271,6 +272,7 @@ func Test_ToADPObjectType(t *testing.T) {
 			So(adp.DisplayKey, ShouldEqual, "name")
 			So(len(adp.DataProperties), ShouldEqual, 2)
 			So(adp.DataProperties[0].MappedField.Name, ShouldEqual, "col1")
+			So(adp.DataProperties[0].MaskRule.Kind, ShouldEqual, maskrule.KindFixed)
 			So(adp.DataProperties[1].MappedField, ShouldBeNil)
 			So(len(adp.LogicProperties), ShouldEqual, 2)
 			So(adp.LogicProperties[0].DataSource.ID, ShouldEqual, "ds2")
@@ -307,7 +309,7 @@ func Test_ToBKNObjectType(t *testing.T) {
 					PrimaryKeys: []string{"id"}, DisplayKey: "name", IncrementalKey: "ts",
 					DataSource: &interfaces.ResourceInfo{ID: "ds1", Type: "mysql", Name: "DS1"},
 					DataProperties: []*interfaces.DataProperty{
-						{Name: "dp1", MappedField: &interfaces.Field{Name: "col1"}},
+						{Name: "dp1", MappedField: &interfaces.Field{Name: "col1"}, MaskRule: &maskrule.Rule{Kind: maskrule.KindFixed, Replacement: "*"}},
 						{Name: "dp2"},
 					},
 					LogicProperties: []*interfaces.LogicProperty{
@@ -331,6 +333,7 @@ func Test_ToBKNObjectType(t *testing.T) {
 			So(bknObj.PrimaryKeys, ShouldResemble, []string{"id"})
 			So(len(bknObj.DataProperties), ShouldEqual, 2)
 			So(bknObj.DataProperties[0].MappedField, ShouldEqual, "col1")
+			So(bknObj.DataProperties[0].MaskRule.Kind, ShouldEqual, maskrule.KindFixed)
 			So(bknObj.DataProperties[1].MappedField, ShouldBeEmpty)
 			So(len(bknObj.LogicProperties), ShouldEqual, 2)
 			So(bknObj.LogicProperties[0].DataSource.ID, ShouldEqual, "ds2")

--- a/docs/api/bkn/object-type.yaml
+++ b/docs/api/bkn/object-type.yaml
@@ -1712,6 +1712,9 @@ components:
         mapped_field:
           $ref: "#/components/schemas/ViewField"
           description: Field name mapped to the data source
+        mask_rule:
+          $ref: "#/components/schemas/MaskRule"
+          description: Optional masking rule used when the effective property access level is masked.
         condition_operations:
           description: |
             Supported filter operations for this property. They are inferred from the property type, such as
@@ -1722,6 +1725,99 @@ components:
           type: array
           items:
             type: string
+    MaskRule:
+      description: |
+        Strongly typed masking rule for a data property. String rules keep string output, round keeps JSON number
+        output, and date_granularity keeps the original date/time string representation. This field is optional;
+        logic properties and unsupported data-property types cannot configure a masking rule.
+      oneOf:
+        - $ref: "#/components/schemas/FixedMaskRule"
+        - $ref: "#/components/schemas/PartialMaskRule"
+        - $ref: "#/components/schemas/EmailMaskRule"
+        - $ref: "#/components/schemas/RoundMaskRule"
+        - $ref: "#/components/schemas/DateGranularityMaskRule"
+      discriminator:
+        propertyName: kind
+        mapping:
+          fixed: "#/components/schemas/FixedMaskRule"
+          partial: "#/components/schemas/PartialMaskRule"
+          email: "#/components/schemas/EmailMaskRule"
+          round: "#/components/schemas/RoundMaskRule"
+          date_granularity: "#/components/schemas/DateGranularityMaskRule"
+    FixedMaskRule:
+      type: object
+      additionalProperties: false
+      required: [kind, replacement]
+      properties:
+        kind:
+          type: string
+          enum: [fixed]
+        replacement:
+          $ref: "#/components/schemas/MaskReplacement"
+    PartialMaskRule:
+      type: object
+      additionalProperties: false
+      required: [kind, keep_start, keep_end, replacement]
+      properties:
+        kind:
+          type: string
+          enum: [partial]
+        keep_start:
+          type: integer
+          minimum: 0
+          maximum: 64
+        keep_end:
+          type: integer
+          minimum: 0
+          maximum: 64
+        replacement:
+          $ref: "#/components/schemas/MaskReplacement"
+    EmailMaskRule:
+      type: object
+      additionalProperties: false
+      required: [kind, local_keep_start, preserve_domain, replacement]
+      properties:
+        kind:
+          type: string
+          enum: [email]
+        local_keep_start:
+          type: integer
+          minimum: 0
+          maximum: 64
+        preserve_domain:
+          type: boolean
+        replacement:
+          $ref: "#/components/schemas/MaskReplacement"
+    RoundMaskRule:
+      type: object
+      additionalProperties: false
+      required: [kind, step]
+      properties:
+        kind:
+          type: string
+          enum: [round]
+        step:
+          description: Finite decimal number greater than zero.
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+    DateGranularityMaskRule:
+      type: object
+      additionalProperties: false
+      required: [kind, granularity]
+      properties:
+        kind:
+          type: string
+          enum: [date_granularity]
+        granularity:
+          description: Must be coarser than the declared property precision.
+          type: string
+          enum: [year, month, day, hour]
+    MaskReplacement:
+      description: One to eight printable Unicode code points.
+      type: string
+      minLength: 1
+      maxLength: 8
     FulltextConfig:
       description: Full-text index configuration
       required:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added an optional, strongly typed DataProperty mask_rule contract for fixed, partial, email, round, and date_granularity rules.
- [x] Added write-time validation and complete REST, persisted model, published-main conversion, and .bkn import/export round trips while preserving legacy models.
- [x] Updated the ObjectType OpenAPI contract, localized validation details, and focused coverage for supported rules, boundaries, invalid inputs, and compatibility.

---

## Why

- Related Issue: Closes #1343
- Related Feature: [Property-level authorization and server-side dynamic masking](https://github.com/openbkn-ai/bkn-foundry/issues/1314)
- Background: Property-level authorization needs a stable masking-rule model before Enterprise persistence and runtime query enforcement can safely consume masked decisions.

---

## How

- Key implementation points:
  - Introduces one shared maskrule package with strict JSON field handling, property-type compatibility, required-parameter validation, Unicode bounds, finite positive rounding steps, and date/time granularity constraints.
  - Carries the optional rule through DataProperty REST JSON, internal models, published-main conversions, and the optional Mask Rule JSON column in .bkn files.
  - Escapes literal table delimiters during .bkn serialization and preserves the legacy five-column table when no rule is present.
  - Rejects invalid rules during REST writes and .bkn validation; LogicProperty remains unchanged.
- Breaking changes (API, config, database, etc.): None. The contract is additive and optional, with no database migration or configuration change. Existing object types and .bkn packages remain readable and export without the new column.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; this stage defines and validates the model contract without runtime masking or external service integration.
- [ ] Verified in test environment — N/A; no deployment or environment mutation was performed.

Test notes:

- I18N_MODE_UT=true go test -p=2 ./common/maskrule ./bkn-specification/bkn ./interfaces ./driveradapters ./logics -count=1
- I18N_MODE_UT=true go vet -p=1 ./common/maskrule ./bkn-specification/bkn ./interfaces ./driveradapters ./logics
- make api-docs-lint
- REDOCLY_TELEMETRY=off npx @redocly/cli lint --config .redocly.yaml docs/api/bkn/object-type.yaml
- git diff --check

The API descriptions validate successfully. Redocly reports pre-existing repository warnings, but no validation errors.

---

## Risk & Rollback

- Potential risks: REST, published-main, and .bkn representations must stay identical, and validation mistakes could either reject valid models or admit an unusable masking rule. Focused tests cover all five kinds, Unicode and numeric boundaries, type mismatches, unknown fields, conversion round trips, delimiter escaping, and legacy compatibility.
- Rollback plan: Revert this commit. The change has no migration or persisted-data rewrite; existing records omit the optional field and remain valid.

---

## Additional Notes

- Companion SDK PR: [openbkn-ai/bkn-sdk#99](https://github.com/openbkn-ai/bkn-sdk/pull/99).
- Runtime masking, property-grant persistence, and query enforcement remain separate follow-up work under #1314.
