### PR TITLE
fix(vega): preserve resumed incremental progress totals

### DIFF
--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -418,9 +418,10 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 			firstQuery = false
 			if totalRows > 0 || readRows > 0 {
 				totalCount := int64(totalRows)
-				// 增量任务从已提交 checkpoint 恢复时，连接器返回的只有剩余范围；
-				// SyncedCount 则在同一任务生命周期内持续累计。
-				if isIncremental {
+				// 从已提交 checkpoint 恢复时，连接器返回的只有剩余范围；
+				// SyncedCount 则在同一任务生命周期内持续累计。全量任务未 reset
+				// 重启时同样会恢复 checkpoint，因此不能只按任务类型判断。
+				if len(lastBatchKeyValues) > 0 {
 					totalCount += syncedCount
 				}
 				if _, err := bbw.bts.InternalSetProgress(ctx, nil, buildTaskInfo.ID,

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -418,6 +418,11 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 			firstQuery = false
 			if totalRows > 0 || readRows > 0 {
 				totalCount := int64(totalRows)
+				// 增量任务从已提交 checkpoint 恢复时，连接器返回的只有剩余范围；
+				// SyncedCount 则在同一任务生命周期内持续累计。
+				if isIncremental {
+					totalCount += syncedCount
+				}
 				if _, err := bbw.bts.InternalSetProgress(ctx, nil, buildTaskInfo.ID,
 					interfaces.BuildTaskProgress{TotalCount: &totalCount}); err != nil {
 					return fmt.Errorf("set build task total count: %w", err)

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -153,7 +153,7 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		require.NoError(t, mockDB.ExpectationsWereMet())
 	})
 
-	t.Run("incremental writes current index and advances task and resource checkpoints atomically", func(t *testing.T) {
+	t.Run("resumed incremental keeps cumulative total and advances checkpoints atomically", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)
 		bts := vmock.NewMockBuildTaskService(ctrl)
@@ -164,12 +164,13 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{Name: "payload", Type: interfaces.DataType_Json})
 		resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
 		resource.LocalIndexName = "current-index"
-		resource.SyncMark = `{"mode":"batch","cursor":[]}`
+		resource.SyncMark = `{"mode":"batch","cursor":[{"key":"id","value":8000}]}`
 		task := workerTestFullTask(t, resource)
 		task.ExecuteType = interfaces.BuildTaskExecuteTypeIncremental
 		task.IndexName = resource.LocalIndexName
 		task.Status = interfaces.BuildTaskStatusRunning
 		task.SyncedMark = resource.SyncMark
+		task.SyncedCount = 8000
 		bbw := &batchBuildWorker{lim: lim, bts: bts, rs: rs, cf: cf}
 
 		db, mockDB, err := sqlmock.New()
@@ -182,54 +183,76 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		lim.EXPECT().CheckIndexExist(gomock.Any(), "current-index").Return(true, nil)
 		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
 		connector.EXPECT().Connect(gomock.Any()).Return(nil)
-		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).DoAndReturn(
+		queryCount := 0
+		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Times(73).DoAndReturn(
 			func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
-				assert.Nil(t, params.FilterCondCfg)
-				return &interfaces.QueryResult{Total: 1, Entries: []map[string]any{{
-					"id":      int64(1),
-					"payload": `{"region":"cn"}`,
-				}}}, nil
+				queryCount++
+				if queryCount == 73 {
+					return &interfaces.QueryResult{}, nil
+				}
+				require.NotNil(t, params.FilterCondCfg)
+				assert.Equal(t, 1000, params.Limit)
+				assert.Equal(t, queryCount == 1, params.NeedTotal)
+				entries := make([]map[string]any, 1000)
+				firstID := int64(8001 + (queryCount-1)*1000)
+				for index := range entries {
+					entries[index] = map[string]any{
+						"id":      firstID + int64(index),
+						"payload": `{"region":"cn"}`,
+					}
+				}
+				result := &interfaces.QueryResult{Entries: entries}
+				if queryCount == 1 {
+					result.Total = 72000
+				}
+				return result, nil
 			})
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
-		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
+		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil).Times(73)
 		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
 			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
 				require.NotNil(t, progress.TotalCount)
-				assert.EqualValues(t, 1, *progress.TotalCount)
+				assert.EqualValues(t, 80000, *progress.TotalCount)
 				return true, nil
 			})
-		indexed := false
-		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).DoAndReturn(
+		indexedBatches := 0
+		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).Times(72).DoAndReturn(
 			func(_ context.Context, _ string, documents map[string]map[string]any) ([]string, error) {
-				require.Len(t, documents, 1)
+				require.Len(t, documents, 1000)
 				for _, document := range documents {
 					assert.Equal(t, map[string]any{"region": "cn"}, document["payload"])
 				}
-				indexed = true
+				indexedBatches++
 				return nil, nil
 			})
-		newMark := `{"mode":"batch","cursor":[{"key":"id","value":1}]}`
-		mockDB.ExpectBegin()
+		newMark := `{"mode":"batch","cursor":[{"key":"id","value":80000}]}`
+		for range 72 {
+			mockDB.ExpectBegin()
+			mockDB.ExpectCommit()
+		}
 		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
-		rs.EXPECT().InternalGetByID(gomock.Any(), txMatcher, resource.ID).DoAndReturn(
+		rs.EXPECT().InternalGetByID(gomock.Any(), txMatcher, resource.ID).AnyTimes().DoAndReturn(
 			func(context.Context, *sql.Tx, string) (*interfaces.Resource, error) {
-				require.True(t, indexed, "checkpoint transaction must start after OpenSearch write")
+				require.Positive(t, indexedBatches, "checkpoint transaction must start after OpenSearch write")
 				return resource, nil
 			})
-		bts.EXPECT().InternalSetProgress(gomock.Any(), txMatcher, task.ID, gomock.Any()).DoAndReturn(
+		var finalProgress interfaces.BuildTaskProgress
+		bts.EXPECT().InternalSetProgress(gomock.Any(), txMatcher, task.ID, gomock.Any()).Times(72).DoAndReturn(
 			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
-				require.NotNil(t, progress.SyncedMark)
-				assert.Equal(t, newMark, *progress.SyncedMark)
+				finalProgress = progress
 				return true, nil
 			})
 		rs.EXPECT().InternalUpdateLocalIndexState(gomock.Any(), txMatcher, resource.ID,
-			interfaces.ResourceLocalIndexStatusAvailable, "current-index", newMark).Return(true, nil)
-		mockDB.ExpectCommit()
+			interfaces.ResourceLocalIndexStatusAvailable, "current-index", gomock.Any()).Return(true, nil).Times(72)
 		bts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, task.ID).Return(true, nil)
 
 		err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)
 
 		require.NoError(t, err)
+		require.NotNil(t, finalProgress.SyncedMark)
+		assert.Equal(t, newMark, *finalProgress.SyncedMark)
+		require.NotNil(t, finalProgress.SyncedCount)
+		assert.EqualValues(t, 80000, *finalProgress.SyncedCount)
 		assert.Equal(t, newMark, task.SyncedMark)
 		assert.Equal(t, newMark, resource.SyncMark)
 		require.NoError(t, mockDB.ExpectationsWereMet())

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -258,6 +258,127 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		require.NoError(t, mockDB.ExpectationsWereMet())
 	})
 
+	t.Run("fresh incremental keeps connector total without a cursor", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		bts := vmock.NewMockBuildTaskService(ctrl)
+		rs := vmock.NewMockResourceService(ctrl)
+		cf := vmock.NewMockConnectorFactory(ctrl)
+		connector := vmock.NewMockTableConnector(ctrl)
+		resource := workerTestResource()
+		resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
+		resource.LocalIndexName = "current-index"
+		resource.SyncMark = `{"mode":"batch","cursor":[]}`
+		task := workerTestFullTask(t, resource)
+		task.ExecuteType = interfaces.BuildTaskExecuteTypeIncremental
+		task.IndexName = resource.LocalIndexName
+		task.Status = interfaces.BuildTaskStatusRunning
+		task.SyncedMark = resource.SyncMark
+		bbw := &batchBuildWorker{lim: lim, bts: bts, rs: rs, cf: cf}
+
+		db, mockDB, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+		oldDB := logics.DB
+		logics.DB = db
+		defer func() { logics.DB = oldDB }()
+
+		lim.EXPECT().CheckIndexExist(gomock.Any(), "current-index").Return(true, nil)
+		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
+		connector.EXPECT().Connect(gomock.Any()).Return(nil)
+		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
+				assert.Nil(t, params.FilterCondCfg)
+				return &interfaces.QueryResult{Total: 1, Entries: []map[string]any{{"id": int64(1)}}}, nil
+			})
+		connector.EXPECT().Close(gomock.Any()).Return(nil)
+		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
+		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+				require.NotNil(t, progress.TotalCount)
+				assert.EqualValues(t, 1, *progress.TotalCount)
+				return true, nil
+			})
+		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).Return(nil, nil)
+		mockDB.ExpectBegin()
+		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
+		rs.EXPECT().InternalGetByID(gomock.Any(), txMatcher, resource.ID).Return(resource, nil)
+		bts.EXPECT().InternalSetProgress(gomock.Any(), txMatcher, task.ID, gomock.Any()).Return(true, nil)
+		rs.EXPECT().InternalUpdateLocalIndexState(gomock.Any(), txMatcher, resource.ID,
+			interfaces.ResourceLocalIndexStatusAvailable, "current-index", gomock.Any()).Return(true, nil)
+		mockDB.ExpectCommit()
+		bts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, task.ID).Return(true, nil)
+
+		err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)
+
+		require.NoError(t, err)
+		require.NoError(t, mockDB.ExpectationsWereMet())
+	})
+
+	t.Run("resumed full build keeps cumulative total", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		lim := vmock.NewMockLocalIndexManager(ctrl)
+		bts := vmock.NewMockBuildTaskService(ctrl)
+		rs := vmock.NewMockResourceService(ctrl)
+		cf := vmock.NewMockConnectorFactory(ctrl)
+		connector := vmock.NewMockTableConnector(ctrl)
+		resource := workerTestResource()
+		resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
+		resource.LocalIndexName = "current-index"
+		resource.SyncMark = `{"mode":"batch","cursor":[{"key":"id","value":8}]}`
+		task := workerTestFullTask(t, resource)
+		task.IndexName = resource.LocalIndexName
+		task.Status = interfaces.BuildTaskStatusRunning
+		task.SyncedMark = resource.SyncMark
+		task.SyncedCount = 8
+		bbw := &batchBuildWorker{lim: lim, bts: bts, rs: rs, cf: cf}
+
+		db, mockDB, err := sqlmock.New()
+		require.NoError(t, err)
+		defer func() { _ = db.Close() }()
+		oldDB := logics.DB
+		logics.DB = db
+		defer func() { logics.DB = oldDB }()
+
+		lim.EXPECT().CheckIndexExist(gomock.Any(), "current-index").Return(true, nil)
+		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
+		connector.EXPECT().Connect(gomock.Any()).Return(nil)
+		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
+				require.NotNil(t, params.FilterCondCfg)
+				return &interfaces.QueryResult{Total: 2, Entries: []map[string]any{{"id": int64(9)}, {"id": int64(10)}}}, nil
+			})
+		connector.EXPECT().Close(gomock.Any()).Return(nil)
+		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
+		progressCalls := 0
+		bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).Times(2).DoAndReturn(
+			func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+				progressCalls++
+				if progressCalls == 1 {
+					require.NotNil(t, progress.TotalCount)
+					assert.EqualValues(t, 10, *progress.TotalCount)
+				} else {
+					require.NotNil(t, progress.SyncedCount)
+					assert.EqualValues(t, 10, *progress.SyncedCount)
+				}
+				return true, nil
+			})
+		lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).Return(nil, nil)
+		newMark := `{"mode":"batch","cursor":[{"key":"id","value":10}]}`
+		mockDB.ExpectBegin()
+		txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
+		rs.EXPECT().InternalGetByID(gomock.Any(), txMatcher, resource.ID).Return(resource, nil)
+		rs.EXPECT().InternalUpdateLocalIndexState(gomock.Any(), txMatcher, resource.ID,
+			interfaces.ResourceLocalIndexStatusAvailable, "current-index", newMark).Return(true, nil)
+		bts.EXPECT().InternalMarkCompleted(gomock.Any(), txMatcher, task.ID).Return(true, nil)
+		mockDB.ExpectCommit()
+
+		err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)
+
+		require.NoError(t, err)
+		require.NoError(t, mockDB.ExpectationsWereMet())
+	})
+
 	t.Run("incremental with no new rows completes with initialized checkpoint", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		lim := vmock.NewMockLocalIndexManager(ctrl)


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Fix resumed incremental task totals so cumulative synced rows and total rows share one scope.
- [x] Add a 72-batch checkpoint regression test.
- [ ] Docs/doc 1 (not needed)

---

## Why

- Related Issue: [bkn-studio#569](https://github.com/openbkn-ai/bkn-studio/issues/569)
- Related Feature: Incremental index build
- Background: Resuming a stopped task reused its cumulative numerator but reset the denominator to the remaining source range.

---

## How

- Key implementation points: Add the task cumulative synced count to the resumed connector count; verify 72 paged batches, checkpoints, and final progress.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run; no deployed dependencies used)
- [ ] Verified in test environment (not run)

Test notes: `make ci` passed.

---

## Risk & Rollback

- Potential risks: Progress totals are recalculated at resume time from the current eligible source range.
- Rollback plan: Revert this commit.

---

## Additional Notes

- Screenshots, logs, documentation links, etc.: No API contract changes.