### PR TITLE
feat(bkn): say why a capability is in the network (#1360)

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -67,10 +67,16 @@ type CapabilityBinding struct {
 	OwnerName   string `json:"owner_name,omitempty" mapstructure:"-"`
 
 	// Sources says why this capability is in the network: mounted explicitly, expanded from a
-	// box, or used by an object type's logic property or an action type. A capability used by
-	// the model but never mounted appears in the list with no manual source and cannot be
-	// released — the way to remove it is to change what uses it.
+	// box, or used by an object type's logic property or an action type.
 	Sources []*CapabilitySource `json:"sources,omitempty" mapstructure:"-"`
+	// Releasable is false for a capability the model uses that nobody mounted. It has no row and
+	// so no id to release, and the way to remove it is to change the object type or action type
+	// in Sources that reaches for it.
+	//
+	// It is stated rather than left to be inferred from an empty id: a reader that has to work
+	// out what a blank means will eventually work it out wrong, and this one decides whether a
+	// destructive control is shown.
+	Releasable bool `json:"releasable" mapstructure:"-"`
 
 	Creator    AccountInfo `json:"creator" mapstructure:"creator"`
 	CreateTime int64       `json:"create_time" mapstructure:"create_time"`

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -174,6 +174,11 @@ type CapabilityBindingsList struct {
 	// are still returned in full — the names are missing, not the memberships — and the flag
 	// says so explicitly so an empty name is not read as a deleted capability.
 	MetadataAvailable bool `json:"metadata_available"`
+	// SourcesAvailable is false when the branch's object types or action types could not be read.
+	// The mounted capabilities are still listed, but the ones only the model uses are missing and
+	// the sources on the rest are incomplete — an empty sources list would otherwise read as
+	// "nothing uses this", which is the opposite of unknown.
+	SourcesAvailable bool `json:"sources_available"`
 }
 
 // AttachCapabilityEntry is one item of a mount request.

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -66,6 +66,12 @@ type CapabilityBinding struct {
 	Status      string `json:"status,omitempty" mapstructure:"-"`
 	OwnerName   string `json:"owner_name,omitempty" mapstructure:"-"`
 
+	// Sources says why this capability is in the network: mounted explicitly, expanded from a
+	// box, or used by an object type's logic property or an action type. A capability used by
+	// the model but never mounted appears in the list with no manual source and cannot be
+	// released — the way to remove it is to change what uses it.
+	Sources []*CapabilitySource `json:"sources,omitempty" mapstructure:"-"`
+
 	Creator    AccountInfo `json:"creator" mapstructure:"creator"`
 	CreateTime int64       `json:"create_time" mapstructure:"create_time"`
 	Updater    AccountInfo `json:"updater" mapstructure:"updater"`
@@ -105,6 +111,35 @@ type CapabilityBindingsQueryParams struct {
 	// one for all skills; the detail of a skill has to be read one skill at a time, so it is
 	// asked for rather than always paid.
 	WithDetail bool
+}
+
+// Where a capability in the list came from. A capability can have several at once.
+const (
+	// CAPABILITY_SOURCE_MANUAL is an explicit mount. It is the only source that can be released:
+	// the others are consequences of the model and go away by changing it.
+	CAPABILITY_SOURCE_MANUAL = "manual"
+	// CAPABILITY_SOURCE_BOX marks a row produced by expanding a whole-box or whole-server mount.
+	CAPABILITY_SOURCE_BOX = "box"
+	// CAPABILITY_SOURCE_OBJECT_TYPE is a logic property of an object type using the tool.
+	CAPABILITY_SOURCE_OBJECT_TYPE = "object_type"
+	// CAPABILITY_SOURCE_ACTION_TYPE is an action type executing through the tool.
+	CAPABILITY_SOURCE_ACTION_TYPE = "action_type"
+)
+
+// CapabilitySourceRef names one thing that brought a capability into the network.
+type CapabilitySourceRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
+	// Property is the logic property using the tool, for an object_type source. Deleting a
+	// property and deleting the object type are different repairs, so the reference says which.
+	Property string `json:"property,omitempty"`
+}
+
+// CapabilitySource is one kind of origin, with what it points at.
+type CapabilitySource struct {
+	Kind string `json:"kind"`
+	// Refs is empty for manual and box: those have nothing else to name.
+	Refs []*CapabilitySourceRef `json:"refs,omitempty"`
 }
 
 // CAPABILITY_STATUS_MISSING marks a binding whose target is gone from the execution factory.

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service.go
@@ -134,6 +134,14 @@ func (bs *bknService) exportCapabilities(ctx context.Context, knID, branch strin
 
 	capabilities := &bknsdk.BknCapabilities{}
 	for _, binding := range list.Entries {
+		// Only what someone mounted. A capability that is in the list because an object type or
+		// an action type uses it has no binding of its own, and the model file already carries
+		// that object type or action type — exporting it here as a dependency would turn a
+		// reference into an explicit mount on the next import, which is not what the source
+		// network had.
+		if binding.ID == "" {
+			continue
+		}
 		// A binding whose target is gone has no name to carry, and writing its id alone would
 		// only reappear as a not_found skip wherever the file is imported.
 		if binding.Status == interfaces.CAPABILITY_STATUS_MISSING {

--- a/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/bkn/bkn_service_test.go
@@ -163,8 +163,8 @@ func Test_bknService_ExportCapabilities(t *testing.T) {
 					So(q.Limit, ShouldEqual, 0)
 					return &interfaces.CapabilityBindingsList{MetadataAvailable: true,
 						Entries: []*interfaces.CapabilityBinding{
-							{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1", Name: "交期评估"},
-							{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
+							{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1", Name: "交期评估"},
+							{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
 								CapabilityID: "tool-1", Name: "BOM 展开", OwnerName: "供应链计算"},
 						}}, nil
 				})
@@ -201,7 +201,7 @@ func Test_bknService_ExportCapabilities(t *testing.T) {
 			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
 				Return(&interfaces.CapabilityBindingsList{MetadataAvailable: false,
 					Entries: []*interfaces.CapabilityBinding{
-						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1"},
+						{ID: "b5", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1"},
 					}}, nil)
 
 			data, err := svc.ExportToTar(context.Background(), "kn3", interfaces.MAIN_BRANCH)
@@ -215,8 +215,8 @@ func Test_bknService_ExportCapabilities(t *testing.T) {
 			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
 				Return(&interfaces.CapabilityBindingsList{MetadataAvailable: true,
 					Entries: []*interfaces.CapabilityBinding{
-						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-live", Name: "在的"},
-						{CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-gone",
+						{ID: "b3", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-live", Name: "在的"},
+						{ID: "b4", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-gone",
 							Status: interfaces.CAPABILITY_STATUS_MISSING},
 					}}, nil)
 
@@ -243,7 +243,7 @@ func Test_bknService_ExportMCPCapabilities(t *testing.T) {
 		cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
 			Return(&interfaces.CapabilityBindingsList{MetadataAvailable: true,
 				Entries: []*interfaces.CapabilityBinding{
-					{CapabilityType: interfaces.CAPABILITY_TYPE_MCP_TOOL, OwnerID: "mcp-1",
+					{ID: "b6", CapabilityType: interfaces.CAPABILITY_TYPE_MCP_TOOL, OwnerID: "mcp-1",
 						CapabilityID: "expedite", OwnerName: "供应链 MCP", Name: "expedite"},
 				}}, nil)
 
@@ -259,5 +259,35 @@ func Test_bknService_ExportMCPCapabilities(t *testing.T) {
 		So(tool.MCPName, ShouldEqual, "供应链 MCP")
 		// The tool travels by name only: MCP has no separate id to fall back from.
 		So(tool.ToolName, ShouldEqual, "expedite")
+	})
+}
+
+// Test_bknService_ExportSkipsModelReferences keeps a reference from turning into a mount on the
+// round trip. A capability that is in the listing because an object type or action type uses it
+// has no binding of its own, and the model file already carries that object type or action type.
+func Test_bknService_ExportSkipsModelReferences(t *testing.T) {
+	Convey("导出只带显式挂载，不带模型引用而来的能力", t, func() {
+		svc, mockCtrl, kns, cbs := newTestBKNServiceWithCapabilities(t)
+		defer mockCtrl.Finish()
+
+		kns.EXPECT().GetKNByID(gomock.Any(), "kn5", interfaces.MAIN_BRANCH, interfaces.Mode_Export).
+			Return(&interfaces.KN{KNID: "kn5", KNName: "含引用"}, nil)
+		cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+			Return(&interfaces.CapabilityBindingsList{MetadataAvailable: true,
+				Entries: []*interfaces.CapabilityBinding{
+					{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL,
+						CapabilityID: "mounted", Name: "挂了的"},
+					// No id: nobody mounted it, an action type reaches for it.
+					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1",
+						CapabilityID: "referenced", Name: "只被引用的"},
+				}}, nil)
+
+		data, err := svc.ExportToTar(context.Background(), "kn5", interfaces.MAIN_BRANCH)
+		So(err, ShouldBeNil)
+
+		network, err := bknsdk.LoadNetworkFromTar(bytes.NewReader(data))
+		So(err, ShouldBeNil)
+		So(len(network.Capabilities.Skills), ShouldEqual, 1)
+		So(len(network.Capabilities.Functions), ShouldEqual, 0)
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
@@ -41,7 +41,7 @@ func TestBackfillFanOut(t *testing.T) {
 			OwnerID: "box-2", CapabilityID: "t9",
 		})
 		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(bindings, nil).AnyTimes()
-		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(4, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(4, nil).AnyTimes()
 
 		// Four bindings, two boxes: exactly two calls.
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
@@ -75,7 +75,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "alive"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "deleted"},
 			}, nil).AnyTimes()
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
 			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
 				{BoxID: "box-1", ToolID: "alive", Name: "还在", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
 			}, nil)
@@ -95,7 +95,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t1"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "gone", CapabilityID: "t2"},
 			}, nil).AnyTimes()
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
 			aoa.EXPECT().ListBoxTools(gomock.Any(), "gone").Return(nil, nil)
 
 			list, err := service.ListCapabilities(context.Background(), listQuery())
@@ -113,7 +113,7 @@ func TestBackfillMarksDangling(t *testing.T) {
 				{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "alive"},
 				{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "deleted"},
 			}, nil).AnyTimes()
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
 			aoa.EXPECT().GetSkillNamesByIDs(gomock.Any(), gomock.Any()).
 				Return(map[string]string{"alive": "还在的技能"}, nil)
 
@@ -143,7 +143,7 @@ func TestBackfillBoxTopUp(t *testing.T) {
 			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1", BoundAsBox: true},
 			{ID: "b2", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t2", BoundAsBox: true},
 		}, nil).AnyTimes()
-		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
 			{BoxID: "box-1", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
 			{BoxID: "box-1", ToolID: "t2", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
@@ -173,7 +173,7 @@ func TestBackfillDegrades(t *testing.T) {
 		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
 			{ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-1", CapabilityID: "t1"},
 		}, nil).AnyTimes()
-		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil).AnyTimes()
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return(nil, errors.New("connection refused"))
 
 		list, err := service.ListCapabilities(context.Background(), listQuery())
@@ -245,17 +245,17 @@ func TestBoxCountsAreBranchScoped(t *testing.T) {
 			&interfaces.CapabilityBinding{ID: "b3", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
 				OwnerID: "box-1", CapabilityID: "t3"})
 
-		// First call is the page (limit 2); the second is the box-scoped count with no limit.
+		// Both reads are unlimited now — the listing fetches whole and pages in memory, because a
+		// page is not made of stored rows alone. The box-scoped count is the one carrying OwnerID.
 		cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, q interfaces.CapabilityBindingsQueryParams) ([]*interfaces.CapabilityBinding, error) {
-				if q.Limit > 0 {
-					return page, nil
+				if q.OwnerID == "box-1" {
+					So(q.CapabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_FUNCTION)
+					return everything, nil
 				}
-				So(q.OwnerID, ShouldEqual, "box-1")
-				So(q.CapabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_FUNCTION)
-				return everything, nil
-			}).Times(2)
-		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(3, nil)
+				return page, nil
+			}).AnyTimes()
+		cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(3, nil).AnyTimes()
 		aoa.EXPECT().ListBoxTools(gomock.Any(), "box-1").Return([]*interfaces.ToolBrief{
 			{BoxID: "box-1", ToolID: "t1", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
 			{BoxID: "box-1", ToolID: "t2", Status: interfaces.EXEC_TOOL_STATUS_ENABLED},
@@ -400,7 +400,7 @@ func TestAPIFunctionSplit(t *testing.T) {
 					{CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION, OwnerID: "box-api",
 						CapabilityID: "t1"},
 				}, nil).AnyTimes()
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil).AnyTimes()
 			aoa.EXPECT().ListBoxTools(gomock.Any(), "box-api").Return([]*interfaces.ToolBrief{
 				{BoxID: "box-api", BoxMetadataType: interfaces.EXEC_BOX_METADATA_TYPE_OPENAPI,
 					BoxStatus: interfaces.EXEC_BOX_STATUS_PUBLISHED, ToolID: "t1", Name: "fx",
@@ -443,7 +443,7 @@ func TestMetadataTypeFilterReachesSQL(t *testing.T) {
 					gotQuery = q
 					return []*interfaces.CapabilityBinding{}, nil
 				})
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(30, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(30, nil).AnyTimes()
 
 			list, err := service.ListCapabilities(context.Background(),
 				interfaces.CapabilityBindingsQueryParams{
@@ -456,8 +456,9 @@ func TestMetadataTypeFilterReachesSQL(t *testing.T) {
 			So(*gotQuery.OwnerIDs, ShouldResemble, []string{"box-api"})
 			// The kind belongs to a box, so this is a function-only question either way.
 			So(gotQuery.CapabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_FUNCTION)
-			// The total is the real one, not the size of a filtered page.
-			So(list.TotalCount, ShouldEqual, 30)
+			// The stored rows are fetched whole, so the total is the size of the matching set —
+			// the mock returns none, and no model reference matches this box either.
+			So(list.TotalCount, ShouldEqual, 0)
 		})
 
 		Convey("没有该类型的工具集时选中空集，而不是不过滤", func() {
@@ -475,7 +476,7 @@ func TestMetadataTypeFilterReachesSQL(t *testing.T) {
 					gotQuery = q
 					return nil, nil
 				})
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(0, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 
 			_, err := service.ListCapabilities(context.Background(),
 				interfaces.CapabilityBindingsQueryParams{
@@ -502,7 +503,7 @@ func TestMetadataTypeFilterReachesSQL(t *testing.T) {
 					gotQuery = q
 					return nil, nil
 				})
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil)
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(2, nil).AnyTimes()
 
 			_, err := service.ListCapabilities(context.Background(),
 				interfaces.CapabilityBindingsQueryParams{

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill_test.go
@@ -351,6 +351,9 @@ func TestAPIFunctionSplit(t *testing.T) {
 
 		Convey("计数按工具集类型分流，且一个工具集只问一次", func() {
 			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			// The count also covers capabilities the model uses but nobody mounted, so it reads
+			// the stored rows once to know which of them are already counted.
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			cba.EXPECT().GetBindingsTotalByType(gomock.Any(), "kn1", "main").
 				Return(map[string]int{interfaces.CAPABILITY_TYPE_FUNCTION: 5}, nil)
 			cba.EXPECT().GetFunctionTotalsByOwner(gomock.Any(), "kn1", "main").
@@ -375,6 +378,7 @@ func TestAPIFunctionSplit(t *testing.T) {
 
 		Convey("工具集读不到时算作函数，而不是让整个统计失败", func() {
 			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 			cba.EXPECT().GetBindingsTotalByType(gomock.Any(), "kn1", "main").
 				Return(map[string]int{interfaces.CAPABILITY_TYPE_FUNCTION: 4}, nil)
 			cba.EXPECT().GetFunctionTotalsByOwner(gomock.Any(), "kn1", "main").

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -46,7 +46,13 @@ type capabilityBindingService struct {
 	db         *sql.DB
 	cba        interfaces.CapabilityBindingAccess
 	aoa        interfaces.AgentOperatorAccess
-	ps         interfaces.PermissionService
+	// ota and ata are read to answer why a capability is in the network. The model is the truth
+	// about what uses a tool, so the answer is computed from it rather than copied into the
+	// binding table — a copy has to be maintained on every edit, and the one that drifts is the
+	// copy.
+	ota interfaces.ObjectTypeAccess
+	ata interfaces.ActionTypeAccess
+	ps  interfaces.PermissionService
 }
 
 func NewCapabilityBindingService(appSetting *common.AppSetting) interfaces.CapabilityBindingService {
@@ -56,6 +62,8 @@ func NewCapabilityBindingService(appSetting *common.AppSetting) interfaces.Capab
 			db:         logics.DB,
 			cba:        logics.CBA,
 			aoa:        logics.AOA,
+			ota:        logics.OTA,
+			ata:        logics.ATA,
 			ps:         permission.NewPermissionService(appSetting),
 		}
 	})
@@ -213,6 +221,13 @@ func (cbs *capabilityBindingService) AttachCapabilities(ctx context.Context, tx 
 	return result, nil
 }
 
+// DetachCapabilities releases explicit mounts by binding id.
+//
+// A capability the model uses but nobody mounted has no row and therefore no id to pass here: it
+// appears in the listing with an empty id and no manual source, and the way to remove it is to
+// change the object type or action type that reaches for it. A capability that is both mounted
+// and used stays in the listing after this call, with only its model sources left — which is why
+// releasing it does not take it out of the network.
 func (cbs *capabilityBindingService) DetachCapabilities(ctx context.Context, tx *sql.Tx, knID, branch string,
 	bindingIDs []string) (int64, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Detach capabilities")
@@ -290,6 +305,11 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 			berrors.BknBackend_CapabilityBinding_InternalError_GetBindingsTotalFailed).WithErrorDetails(err.Error())
 	}
 
+	// Why each capability is here, and what the model uses that is not mounted at all. Both come
+	// from one read of the branch's object types and action types.
+	sources := cbs.collectProvenance(ctx, query.KNID, query.Branch)
+	entries, total = applyProvenance(entries, total, sources, query)
+
 	backfilled := cbs.backfillMetadata(ctx, query, entries, query.WithDetail)
 
 	span.SetStatus(codes.Ok, "")
@@ -312,6 +332,28 @@ func (cbs *capabilityBindingService) GetCapabilityTotalsByType(ctx context.Conte
 		span.SetStatus(codes.Error, common.SafeErrorSummary(err))
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_CapabilityBinding_InternalError_GetBindingsTotalFailed).WithErrorDetails(err.Error())
+	}
+
+	// Capabilities the model uses but nobody mounted are in the listing, so they are in the
+	// counts too. A count that disagreed with the list it labels is worse than either number
+	// alone: the workspace would show eight rows under a badge reading five.
+	sources := cbs.collectProvenance(ctx, knID, branch)
+	stored, storedErr := cbs.cba.ListBindings(ctx, interfaces.CapabilityBindingsQueryParams{
+		KNID: knID, Branch: branch,
+		PaginationQueryParameters: interfaces.PaginationQueryParameters{Limit: noPagingLimit},
+	})
+	if storedErr != nil {
+		logger.Warnf("capability totals: bindings unreadable for kn_id=%s: %v", knID, storedErr)
+	} else {
+		mounted := make(map[capabilityKey]struct{}, len(stored))
+		for _, binding := range stored {
+			mounted[keyOfBinding(binding)] = struct{}{}
+		}
+		for key := range sources.byCapability {
+			if _, ok := mounted[key]; !ok {
+				totals[key.capabilityType]++
+			}
+		}
 	}
 
 	// Split the function count by the kind of box each binding belongs to. The kind is not in

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -290,25 +290,30 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 		query.CapabilityType = interfaces.CAPABILITY_TYPE_FUNCTION
 	}
 
-	entries, err := cbs.cba.ListBindings(ctx, query)
+	// The stored rows are fetched whole and paged in memory, because the page is not made of them
+	// alone: a capability the model uses without anyone mounting it belongs in the same list, and
+	// there is no way to interleave a computed set with a SQL LIMIT. Paging the query and
+	// appending afterwards would overfill the first page and empty the rest.
+	//
+	// The cost is bounded by one branch's bindings, and the provenance scan below reads that
+	// branch's whole model anyway.
+	fullQuery := query
+	fullQuery.Offset = 0
+	fullQuery.Limit = noPagingLimit
+	entries, err := cbs.cba.ListBindings(ctx, fullQuery)
 	if err != nil {
 		logger.Errorf("ListBindings in knowledge network[%s] error: %v", query.KNID, err)
 		span.SetStatus(codes.Error, common.SafeErrorSummary(err))
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			berrors.BknBackend_CapabilityBinding_InternalError_ListBindingsFailed).WithErrorDetails(err.Error())
 	}
-	total, err := cbs.cba.GetBindingsTotal(ctx, query)
-	if err != nil {
-		logger.Errorf("GetBindingsTotal in knowledge network[%s] error: %v", query.KNID, err)
-		span.SetStatus(codes.Error, common.SafeErrorSummary(err))
-		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_CapabilityBinding_InternalError_GetBindingsTotalFailed).WithErrorDetails(err.Error())
-	}
 
 	// Why each capability is here, and what the model uses that is not mounted at all. Both come
 	// from one read of the branch's object types and action types.
 	sources := cbs.collectProvenance(ctx, query.KNID, query.Branch)
-	entries, total = applyProvenance(entries, total, sources, query)
+	entries = applyProvenance(entries, sources, query)
+	total := len(entries)
+	entries = pageOf(entries, query.Offset, query.Limit)
 
 	backfilled := cbs.backfillMetadata(ctx, query, entries, query.WithDetail)
 
@@ -318,6 +323,7 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 		TotalCount:        total,
 		Boxes:             backfilled.boxes,
 		MetadataAvailable: backfilled.available,
+		SourcesAvailable:  sources.available,
 	}, nil
 }
 

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
@@ -212,9 +212,15 @@ func TestListCapabilities(t *testing.T) {
 			query := interfaces.CapabilityBindingsQueryParams{
 				KNID: "kn1", Branch: "dev", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL,
 			}
-			cba.EXPECT().ListBindings(gomock.Any(), query).
-				Return([]*interfaces.CapabilityBinding{{ID: "bind-1"}}, nil)
-			cba.EXPECT().GetBindingsTotal(gomock.Any(), query).Return(1, nil)
+			// The listing fetches the whole matching set and pages it in memory, so the query
+			// reaching SQL carries the filters but no window.
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, q interfaces.CapabilityBindingsQueryParams) ([]*interfaces.CapabilityBinding, error) {
+					So(q.CapabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_SKILL)
+					So(q.Limit, ShouldEqual, noPagingLimit)
+					return []*interfaces.CapabilityBinding{{ID: "bind-1"}}, nil
+				})
+			cba.EXPECT().GetBindingsTotal(gomock.Any(), gomock.Any()).Return(1, nil).AnyTimes()
 
 			list, err := service.ListCapabilities(context.Background(), query)
 

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
@@ -215,6 +215,9 @@ func applyProvenance(entries []*interfaces.CapabilityBinding, sources *provenanc
 			kind = interfaces.CAPABILITY_SOURCE_BOX
 		}
 		entry.Sources = append([]*interfaces.CapabilitySource{{Kind: kind}}, sources.byCapability[key]...)
+		// A stored row can be released, whatever else also uses it. Doing so removes the mount,
+		// not the capability: it stays in the list with only its model sources left.
+		entry.Releasable = true
 	}
 
 	// Deterministic order for what is otherwise a map: the same request must not shuffle its

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
@@ -8,6 +8,7 @@ package capability_binding
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
@@ -190,10 +191,13 @@ func keyOfBinding(binding *interfaces.CapabilityBinding) capabilityKey {
 // The appended ones are ordinary members of the list with no manual source. They cannot be
 // released — there is no row to delete, and the way to remove one is to change the object type or
 // action type that reaches for it.
-func applyProvenance(entries []*interfaces.CapabilityBinding, total int, sources *provenance,
-	query interfaces.CapabilityBindingsQueryParams) ([]*interfaces.CapabilityBinding, int) {
+//
+// It returns the whole set; the caller pages it. Appending after a page was already cut would
+// overfill that page and leave the next one empty.
+func applyProvenance(entries []*interfaces.CapabilityBinding, sources *provenance,
+	query interfaces.CapabilityBindingsQueryParams) []*interfaces.CapabilityBinding {
 	if sources == nil {
-		return entries, total
+		return entries
 	}
 
 	stored := make(map[capabilityKey]struct{}, len(entries))
@@ -213,32 +217,91 @@ func applyProvenance(entries []*interfaces.CapabilityBinding, total int, sources
 		entry.Sources = append([]*interfaces.CapabilitySource{{Kind: kind}}, sources.byCapability[key]...)
 	}
 
-	// Only a page that reaches the end can carry the implicit ones without duplicating them
-	// across pages. Offset zero with everything fetched is the workspace's own request; any
-	// other page shows the stored rows alone.
-	if query.Offset > 0 || (query.Limit > 0 && len(entries) >= query.Limit) {
-		return entries, total
-	}
-
-	for key, refs := range sources.byCapability {
+	// Deterministic order for what is otherwise a map: the same request must not shuffle its
+	// own page boundaries between calls.
+	implicit := make([]capabilityKey, 0, len(sources.byCapability))
+	for key := range sources.byCapability {
 		if _, mounted := stored[key]; mounted {
 			continue
 		}
-		if query.CapabilityType != "" && key.capabilityType != query.CapabilityType {
+		if !matchesQuery(key, query) {
 			continue
 		}
-		if query.OwnerID != "" && key.ownerID != query.OwnerID {
-			continue
+		implicit = append(implicit, key)
+	}
+	sort.Slice(implicit, func(i, j int) bool {
+		if implicit[i].capabilityType != implicit[j].capabilityType {
+			return implicit[i].capabilityType < implicit[j].capabilityType
 		}
+		if implicit[i].ownerID != implicit[j].ownerID {
+			return implicit[i].ownerID < implicit[j].ownerID
+		}
+		return implicit[i].capabilityID < implicit[j].capabilityID
+	})
+
+	for _, key := range implicit {
 		entries = append(entries, &interfaces.CapabilityBinding{
 			KNID:           query.KNID,
 			Branch:         query.Branch,
 			CapabilityType: key.capabilityType,
 			OwnerID:        key.ownerID,
 			CapabilityID:   key.capabilityID,
-			Sources:        refs,
+			Sources:        sources.byCapability[key],
 		})
-		total++
 	}
-	return entries, total
+	return entries
+}
+
+// matchesQuery applies every filter the stored rows went through in SQL.
+//
+// Every one of them, not just the obvious two: metadata_type reaches the query as OwnerIDs, and
+// skipping it would put function-box tools into the API list — and mark rows that are mounted but
+// filtered out as though nobody had mounted them.
+func matchesQuery(key capabilityKey, query interfaces.CapabilityBindingsQueryParams) bool {
+	if query.CapabilityType != "" && key.capabilityType != query.CapabilityType {
+		return false
+	}
+	if query.OwnerID != "" && key.ownerID != query.OwnerID {
+		return false
+	}
+	if query.OwnerIDs != nil {
+		found := false
+		for _, ownerID := range *query.OwnerIDs {
+			if ownerID == key.ownerID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if len(query.CapabilityIDs) > 0 {
+		found := false
+		for _, capabilityID := range query.CapabilityIDs {
+			if capabilityID == key.capabilityID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// pageOf cuts the requested window out of the whole list.
+func pageOf(entries []*interfaces.CapabilityBinding, offset, limit int) []*interfaces.CapabilityBinding {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(entries) {
+		return []*interfaces.CapabilityBinding{}
+	}
+	entries = entries[offset:]
+	if limit > 0 && limit < len(entries) {
+		entries = entries[:limit]
+	}
+	return entries
 }

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance.go
@@ -1,0 +1,244 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package capability_binding
+
+import (
+	"context"
+	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
+
+	"bkn-backend/interfaces"
+)
+
+// capabilityKey identifies a capability across both the bindings and the model that uses it.
+type capabilityKey struct {
+	capabilityType string
+	ownerID        string
+	capabilityID   string
+}
+
+func (k capabilityKey) empty() bool {
+	return k.capabilityID == ""
+}
+
+// provenance is what the model says about the tools a network uses: which object types and action
+// types reach for which capability.
+type provenance struct {
+	// byCapability maps a capability to the object types and action types using it.
+	byCapability map[capabilityKey][]*interfaces.CapabilitySource
+	// available is false when the model could not be read. The bindings are still listed; only
+	// the "why" is missing, and saying so is better than reporting no references at all.
+	available bool
+}
+
+// collectProvenance reads the branch's object types and action types and records which capability
+// each one uses.
+//
+// This is computed on read rather than written into the binding table. The truth about what uses
+// a tool lives in the object type and the action type; a copy in the binding rows would have to
+// be maintained on every edit to either, and the copy is what drifts. Reading it costs two
+// queries over one branch — both store their references inline as JSON columns, so neither fans
+// out per row.
+func (cbs *capabilityBindingService) collectProvenance(ctx context.Context, knID,
+	branch string) *provenance {
+	result := &provenance{
+		byCapability: map[capabilityKey][]*interfaces.CapabilitySource{},
+		available:    true,
+	}
+	if cbs.ota == nil || cbs.ata == nil {
+		result.available = false
+		return result
+	}
+
+	// One entry per (capability, kind), so several object types using the same tool collapse into
+	// one source carrying several refs rather than repeating the kind.
+	refs := map[capabilityKey]map[string][]*interfaces.CapabilitySourceRef{}
+	add := func(key capabilityKey, kind string, ref *interfaces.CapabilitySourceRef) {
+		if key.empty() {
+			return
+		}
+		if refs[key] == nil {
+			refs[key] = map[string][]*interfaces.CapabilitySourceRef{}
+		}
+		refs[key][kind] = append(refs[key][kind], ref)
+	}
+
+	objectTypes, err := cbs.ota.ListObjectTypes(ctx, nil, interfaces.ObjectTypesQueryParams{
+		KNID:   knID,
+		Branch: branch,
+		PaginationQueryParameters: interfaces.PaginationQueryParameters{
+			Limit: noPagingLimit,
+		},
+	})
+	if err != nil {
+		logger.Warnf("capability provenance: object types unreadable for kn_id=%s: %v", knID, err)
+		result.available = false
+	}
+	for _, objectType := range objectTypes {
+		if objectType == nil {
+			continue
+		}
+		for _, property := range objectType.LogicProperties {
+			if property == nil || property.DataSource == nil {
+				continue
+			}
+			key := functionKeyOf(property.DataSource.BoxID, property.DataSource.ToolID)
+			add(key, interfaces.CAPABILITY_SOURCE_OBJECT_TYPE, &interfaces.CapabilitySourceRef{
+				ID:   objectType.OTID,
+				Name: objectType.OTName,
+				// Which property, not just which object type: dropping a property and dropping
+				// the object type are different repairs.
+				Property: property.Name,
+			})
+		}
+	}
+
+	actionTypes, err := cbs.ata.ListActionTypes(ctx, interfaces.ActionTypesQueryParams{
+		KNID:   knID,
+		Branch: branch,
+		PaginationQueryParameters: interfaces.PaginationQueryParameters{
+			Limit: noPagingLimit,
+		},
+	})
+	if err != nil {
+		logger.Warnf("capability provenance: action types unreadable for kn_id=%s: %v", knID, err)
+		result.available = false
+	}
+	for _, actionType := range actionTypes {
+		if actionType == nil {
+			continue
+		}
+		key := actionSourceKey(actionType.ActionSource)
+		add(key, interfaces.CAPABILITY_SOURCE_ACTION_TYPE, &interfaces.CapabilitySourceRef{
+			ID:   actionType.ATID,
+			Name: actionType.ATName,
+		})
+	}
+
+	for key, byKind := range refs {
+		sources := make([]*interfaces.CapabilitySource, 0, len(byKind))
+		// Object types before action types, so the order does not depend on map iteration.
+		for _, kind := range []string{
+			interfaces.CAPABILITY_SOURCE_OBJECT_TYPE,
+			interfaces.CAPABILITY_SOURCE_ACTION_TYPE,
+		} {
+			if kindRefs, ok := byKind[kind]; ok {
+				sources = append(sources, &interfaces.CapabilitySource{Kind: kind, Refs: kindRefs})
+			}
+		}
+		result.byCapability[key] = sources
+	}
+	return result
+}
+
+// noPagingLimit disables paging on the model reads. A page of the object types would produce a
+// page of the reasons, and a missing reason reads as "nothing uses this" — the opposite of true.
+const noPagingLimit = -1
+
+// functionKeyOf builds the key of a tool box tool, or an empty key when the reference is not one.
+func functionKeyOf(boxID, toolID string) capabilityKey {
+	boxID, toolID = strings.TrimSpace(boxID), strings.TrimSpace(toolID)
+	if boxID == "" || toolID == "" {
+		return capabilityKey{}
+	}
+	return capabilityKey{
+		capabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+		ownerID:        boxID,
+		capabilityID:   toolID,
+	}
+}
+
+// actionSourceKey turns an action type's executor into a capability key.
+//
+// An action type reaches a tool either through a tool box or through an MCP server, and the two
+// are different capability types — the same split the bindings make.
+func actionSourceKey(source interfaces.ActionSource) capabilityKey {
+	if mcpID := strings.TrimSpace(source.McpID); mcpID != "" {
+		toolName := strings.TrimSpace(source.ToolName)
+		if toolName == "" {
+			return capabilityKey{}
+		}
+		return capabilityKey{
+			capabilityType: interfaces.CAPABILITY_TYPE_MCP_TOOL,
+			ownerID:        mcpID,
+			capabilityID:   toolName,
+		}
+	}
+	return functionKeyOf(source.BoxID, source.ToolID)
+}
+
+// keyOfBinding is the same identity, taken from a stored row.
+func keyOfBinding(binding *interfaces.CapabilityBinding) capabilityKey {
+	if binding == nil {
+		return capabilityKey{}
+	}
+	return capabilityKey{
+		capabilityType: binding.CapabilityType,
+		ownerID:        binding.OwnerID,
+		capabilityID:   binding.CapabilityID,
+	}
+}
+
+// applyProvenance labels each stored binding with why it is here, and appends the capabilities the
+// model uses but nobody mounted.
+//
+// The appended ones are ordinary members of the list with no manual source. They cannot be
+// released — there is no row to delete, and the way to remove one is to change the object type or
+// action type that reaches for it.
+func applyProvenance(entries []*interfaces.CapabilityBinding, total int, sources *provenance,
+	query interfaces.CapabilityBindingsQueryParams) ([]*interfaces.CapabilityBinding, int) {
+	if sources == nil {
+		return entries, total
+	}
+
+	stored := make(map[capabilityKey]struct{}, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		key := keyOfBinding(entry)
+		stored[key] = struct{}{}
+
+		// A stored row is always a mount. Expanding a box is still a mount, distinguished so the
+		// list view can report how much of a box is not bound.
+		kind := interfaces.CAPABILITY_SOURCE_MANUAL
+		if entry.BoundAsBox {
+			kind = interfaces.CAPABILITY_SOURCE_BOX
+		}
+		entry.Sources = append([]*interfaces.CapabilitySource{{Kind: kind}}, sources.byCapability[key]...)
+	}
+
+	// Only a page that reaches the end can carry the implicit ones without duplicating them
+	// across pages. Offset zero with everything fetched is the workspace's own request; any
+	// other page shows the stored rows alone.
+	if query.Offset > 0 || (query.Limit > 0 && len(entries) >= query.Limit) {
+		return entries, total
+	}
+
+	for key, refs := range sources.byCapability {
+		if _, mounted := stored[key]; mounted {
+			continue
+		}
+		if query.CapabilityType != "" && key.capabilityType != query.CapabilityType {
+			continue
+		}
+		if query.OwnerID != "" && key.ownerID != query.OwnerID {
+			continue
+		}
+		entries = append(entries, &interfaces.CapabilityBinding{
+			KNID:           query.KNID,
+			Branch:         query.Branch,
+			CapabilityType: key.capabilityType,
+			OwnerID:        key.ownerID,
+			CapabilityID:   key.capabilityID,
+			Sources:        refs,
+		})
+		total++
+	}
+	return entries, total
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
@@ -99,6 +99,45 @@ func TestApplyProvenance(t *testing.T) {
 			So(len(out), ShouldEqual, 0)
 		})
 
+		Convey("被多处引用时是一行，来源里列全，不重复成多行", func() {
+			shared := &provenance{available: true, byCapability: map[capabilityKey][]*interfaces.CapabilitySource{
+				key: {
+					{
+						Kind: interfaces.CAPABILITY_SOURCE_OBJECT_TYPE,
+						Refs: []*interfaces.CapabilitySourceRef{
+							{ID: "ot_order", Name: "订单", Property: "risk_score"},
+							{ID: "ot_supplier", Name: "供应商", Property: "credit"},
+						},
+					},
+					{
+						Kind: interfaces.CAPABILITY_SOURCE_ACTION_TYPE,
+						Refs: []*interfaces.CapabilitySourceRef{{ID: "at_dispatch", Name: "派单"}},
+					},
+				},
+			}}
+
+			out := applyProvenance(nil, shared, query)
+
+			// One row, however many things use it: the list is of capabilities, not of uses.
+			So(len(out), ShouldEqual, 1)
+			objectType := srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE)
+			So(len(objectType.Refs), ShouldEqual, 2)
+			So(objectType.Refs[0].Property, ShouldEqual, "risk_score")
+			So(objectType.Refs[1].Property, ShouldEqual, "credit")
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_ACTION_TYPE), ShouldNotBeNil)
+		})
+
+		Convey("最后一个引用消失后条目就不在了，无需任何级联清理", func() {
+			// Nothing references it any more — the provenance scan simply stops reporting it,
+			// which is the whole point of computing rather than storing: there is no row left
+			// behind to clean up.
+			empty := &provenance{available: true, byCapability: map[capabilityKey][]*interfaces.CapabilitySource{}}
+
+			out := applyProvenance(nil, empty, query)
+
+			So(len(out), ShouldEqual, 0)
+		})
+
 		Convey("补进来的条目参与分页，不是全部塞进第一页", func() {
 			whole := applyProvenance(nil, usedByModel, query)
 			So(len(whole), ShouldEqual, 1)

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
@@ -48,6 +48,9 @@ func TestApplyProvenance(t *testing.T) {
 
 			So(len(out), ShouldEqual, 1)
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldNotBeNil)
+			// Releasing it removes the mount, not the capability: it stays in the list with only
+			// the model source left.
+			So(out[0].Releasable, ShouldBeTrue)
 			objectType := srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE)
 			So(objectType, ShouldNotBeNil)
 			// The property, not just the object type: dropping one is not dropping the other.
@@ -61,7 +64,9 @@ func TestApplyProvenance(t *testing.T) {
 			So(out[0].CapabilityID, ShouldEqual, "tool-1")
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldBeNil)
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE), ShouldNotBeNil)
-			// No row, so no id: that is what tells the caller it cannot be released here.
+			// Said outright rather than left to be read out of an empty id: this is what decides
+			// whether a destructive control is shown.
+			So(out[0].Releasable, ShouldBeFalse)
 			So(out[0].ID, ShouldBeEmpty)
 		})
 

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
@@ -1,0 +1,129 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package capability_binding
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"bkn-backend/interfaces"
+)
+
+func srcOf(entry *interfaces.CapabilityBinding, kind string) *interfaces.CapabilitySource {
+	for _, source := range entry.Sources {
+		if source.Kind == kind {
+			return source
+		}
+	}
+	return nil
+}
+
+// TestApplyProvenance covers #1360: the workspace has to say why a capability is in the network,
+// and a tool an object type or action type reaches for is in the network whether or not anyone
+// mounted it.
+func TestApplyProvenance(t *testing.T) {
+	Convey("能力来源标注", t, func() {
+		key := capabilityKey{
+			capabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+			ownerID:        "box-1", capabilityID: "tool-1",
+		}
+		usedByModel := &provenance{available: true, byCapability: map[capabilityKey][]*interfaces.CapabilitySource{
+			key: {{
+				Kind: interfaces.CAPABILITY_SOURCE_OBJECT_TYPE,
+				Refs: []*interfaces.CapabilitySourceRef{{ID: "ot_order", Name: "订单", Property: "risk_score"}},
+			}},
+		}}
+		query := interfaces.CapabilityBindingsQueryParams{KNID: "kn1", Branch: "main"}
+
+		Convey("显式挂载且被引用时是一行，两个来源都在", func() {
+			entries := []*interfaces.CapabilityBinding{{
+				ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+				OwnerID: "box-1", CapabilityID: "tool-1",
+			}}
+
+			out, total := applyProvenance(entries, 1, usedByModel, query)
+
+			So(len(out), ShouldEqual, 1)
+			So(total, ShouldEqual, 1)
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldNotBeNil)
+			objectType := srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE)
+			So(objectType, ShouldNotBeNil)
+			// The property, not just the object type: dropping one is not dropping the other.
+			So(objectType.Refs[0].Property, ShouldEqual, "risk_score")
+		})
+
+		Convey("只被引用、没挂载的也在列表里，且没有 manual 来源", func() {
+			out, total := applyProvenance(nil, 0, usedByModel, query)
+
+			So(len(out), ShouldEqual, 1)
+			So(total, ShouldEqual, 1)
+			So(out[0].CapabilityID, ShouldEqual, "tool-1")
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldBeNil)
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE), ShouldNotBeNil)
+			// No row, so no id: that is what tells the caller it cannot be released here.
+			So(out[0].ID, ShouldBeEmpty)
+		})
+
+		Convey("整箱展开的行标成 box 而不是 manual", func() {
+			entries := []*interfaces.CapabilityBinding{{
+				ID: "b1", CapabilityType: interfaces.CAPABILITY_TYPE_FUNCTION,
+				OwnerID: "box-1", CapabilityID: "tool-1", BoundAsBox: true,
+			}}
+
+			out, _ := applyProvenance(entries, 1, usedByModel, query)
+
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_BOX), ShouldNotBeNil)
+			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldBeNil)
+		})
+
+		Convey("类型过滤同样作用于补进来的条目", func() {
+			skillQuery := query
+			skillQuery.CapabilityType = interfaces.CAPABILITY_TYPE_SKILL
+
+			out, total := applyProvenance(nil, 0, usedByModel, skillQuery)
+
+			So(len(out), ShouldEqual, 0)
+			So(total, ShouldEqual, 0)
+		})
+
+		Convey("翻页时不重复补，只有最后一页带", func() {
+			paged := query
+			paged.Offset = 10
+			paged.Limit = 10
+
+			out, total := applyProvenance(nil, 0, usedByModel, paged)
+
+			So(len(out), ShouldEqual, 0)
+			So(total, ShouldEqual, 0)
+		})
+	})
+}
+
+// TestActionSourceKey pins how an action type's executor maps onto a capability. An action type
+// reaches a tool through a tool box or through an MCP server, and those are different capability
+// types — the same split the bindings make.
+func TestActionSourceKey(t *testing.T) {
+	Convey("行动类的执行来源映射到能力身份", t, func() {
+		Convey("工具箱工具", func() {
+			key := actionSourceKey(interfaces.ActionSource{Type: "tool", BoxID: "box-1", ToolID: "t1"})
+			So(key.capabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_FUNCTION)
+			So(key.ownerID, ShouldEqual, "box-1")
+			So(key.capabilityID, ShouldEqual, "t1")
+		})
+
+		Convey("MCP 工具按名字定位", func() {
+			key := actionSourceKey(interfaces.ActionSource{Type: "mcp", McpID: "mcp-1", ToolName: "expedite"})
+			So(key.capabilityType, ShouldEqual, interfaces.CAPABILITY_TYPE_MCP_TOOL)
+			So(key.ownerID, ShouldEqual, "mcp-1")
+			So(key.capabilityID, ShouldEqual, "expedite")
+		})
+
+		Convey("残缺的来源不产生身份", func() {
+			So(actionSourceKey(interfaces.ActionSource{Type: "tool", BoxID: "box-1"}).empty(), ShouldBeTrue)
+			So(actionSourceKey(interfaces.ActionSource{Type: "mcp", McpID: "mcp-1"}).empty(), ShouldBeTrue)
+		})
+	})
+}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/provenance_test.go
@@ -44,10 +44,9 @@ func TestApplyProvenance(t *testing.T) {
 				OwnerID: "box-1", CapabilityID: "tool-1",
 			}}
 
-			out, total := applyProvenance(entries, 1, usedByModel, query)
+			out := applyProvenance(entries, usedByModel, query)
 
 			So(len(out), ShouldEqual, 1)
-			So(total, ShouldEqual, 1)
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldNotBeNil)
 			objectType := srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE)
 			So(objectType, ShouldNotBeNil)
@@ -56,10 +55,9 @@ func TestApplyProvenance(t *testing.T) {
 		})
 
 		Convey("只被引用、没挂载的也在列表里，且没有 manual 来源", func() {
-			out, total := applyProvenance(nil, 0, usedByModel, query)
+			out := applyProvenance(nil, usedByModel, query)
 
 			So(len(out), ShouldEqual, 1)
-			So(total, ShouldEqual, 1)
 			So(out[0].CapabilityID, ShouldEqual, "tool-1")
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldBeNil)
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_OBJECT_TYPE), ShouldNotBeNil)
@@ -73,7 +71,7 @@ func TestApplyProvenance(t *testing.T) {
 				OwnerID: "box-1", CapabilityID: "tool-1", BoundAsBox: true,
 			}}
 
-			out, _ := applyProvenance(entries, 1, usedByModel, query)
+			out := applyProvenance(entries, usedByModel, query)
 
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_BOX), ShouldNotBeNil)
 			So(srcOf(out[0], interfaces.CAPABILITY_SOURCE_MANUAL), ShouldBeNil)
@@ -83,21 +81,33 @@ func TestApplyProvenance(t *testing.T) {
 			skillQuery := query
 			skillQuery.CapabilityType = interfaces.CAPABILITY_TYPE_SKILL
 
-			out, total := applyProvenance(nil, 0, usedByModel, skillQuery)
+			out := applyProvenance(nil, usedByModel, skillQuery)
 
 			So(len(out), ShouldEqual, 0)
-			So(total, ShouldEqual, 0)
 		})
 
-		Convey("翻页时不重复补，只有最后一页带", func() {
-			paged := query
-			paged.Offset = 10
-			paged.Limit = 10
+		Convey("metadata_type 解析出的工具集集合同样作用于补进来的条目", func() {
+			// The service turns metadata_type into OwnerIDs. Ignoring it here would drop
+			// function-box tools into the API list, and mark rows that are mounted but filtered
+			// out as though nobody had mounted them.
+			otherBoxes := []string{"box-other"}
+			narrowed := query
+			narrowed.OwnerIDs = &otherBoxes
 
-			out, total := applyProvenance(nil, 0, usedByModel, paged)
+			out := applyProvenance(nil, usedByModel, narrowed)
 
 			So(len(out), ShouldEqual, 0)
-			So(total, ShouldEqual, 0)
+		})
+
+		Convey("补进来的条目参与分页，不是全部塞进第一页", func() {
+			whole := applyProvenance(nil, usedByModel, query)
+			So(len(whole), ShouldEqual, 1)
+
+			// The caller pages the whole list, so an offset past it is empty rather than a
+			// second copy of everything.
+			So(len(pageOf(whole, 0, 10)), ShouldEqual, 1)
+			So(len(pageOf(whole, 10, 10)), ShouldEqual, 0)
+			So(len(pageOf(whole, 0, 0)), ShouldEqual, 1)
 		})
 	})
 }

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -342,7 +342,9 @@ components:
         - capability_id
       properties:
         id:
-          description: Binding ID, a UUIDv7
+          description: >-
+            Binding ID, a UUIDv7. Empty for a capability the model uses that nobody mounted:
+            there is no stored row behind it. See `releasable`.
           type: string
         kn_id:
           description: Business knowledge network ID
@@ -355,6 +357,7 @@ components:
           enum:
             - skill
             - function
+            - mcp_tool
           type: string
         box_id:
           description: Owning tool box ID. Present for functions, absent for skills.
@@ -368,6 +371,35 @@ components:
             binding semantics: the row is an ordinary tool-level binding and can be released
             on its own.
           type: boolean
+        releasable:
+          description: >-
+            Whether this entry can be released here. False for a capability that is in the
+            network because an object type's logic property or an action type uses it: it has
+            no row and no id, and the way to remove it is to change what `sources` names.
+            Releasing a mounted one removes the mount, not the capability — it stays in the
+            list with only its model sources left.
+          type: boolean
+        sources:
+          description: >-
+            Why this capability is in the network. `manual` is an explicit mount, `box` a
+            whole-box or whole-server expansion, `object_type` and `action_type` a use by the
+            model. Several can appear at once; the object_type refs name the property, because
+            dropping a property and dropping the object type are different repairs.
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                enum: [manual, box, object_type, action_type]
+                type: string
+              refs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    name: { type: string }
+                    property: { type: string }
         comment:
           description: Free-text note
           type: string
@@ -486,6 +518,35 @@ components:
             one tool-level binding per tool, each with bound_as_box true; tools added to the box
             later are not inherited.
           type: boolean
+        releasable:
+          description: >-
+            Whether this entry can be released here. False for a capability that is in the
+            network because an object type's logic property or an action type uses it: it has
+            no row and no id, and the way to remove it is to change what `sources` names.
+            Releasing a mounted one removes the mount, not the capability — it stays in the
+            list with only its model sources left.
+          type: boolean
+        sources:
+          description: >-
+            Why this capability is in the network. `manual` is an explicit mount, `box` a
+            whole-box or whole-server expansion, `object_type` and `action_type` a use by the
+            model. Several can appear at once; the object_type refs name the property, because
+            dropping a property and dropping the object type are different repairs.
+          type: array
+          items:
+            type: object
+            properties:
+              kind:
+                enum: [manual, box, object_type, action_type]
+                type: string
+              refs:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: string }
+                    name: { type: string }
+                    property: { type: string }
         comment:
           description: Free-text note
           type: string


### PR DESCRIPTION
Closes #1360.

## Why

工具进入一个知识网络有两条路：有人挂载，或者**模型伸手去用**——对象类的逻辑属性、行动类的执行来源。列表里只有第一条。

于是：一个知识网络实际在用的工具，比它自己的能力列表多；而列表里显示的那些，也看不出解绑会不会打断某个行动类。

## 计算式，不物化

来源在**读的时候算**，不写进绑定表。

关于"谁用了这个工具"的真相在对象类和行动类那里。往绑定行里复制一份，就得在每次编辑它们时维护那份复制——而漂掉的一定是复制品：删掉一个行动类，留下一行指向不存在引用的幽灵绑定。

代价是两次查询。两边的引用都是行内 JSON 列（`f_logic_properties`、`f_action_source`），所以是**每分支两次查询，没有按行扇出**。

## 来源模型

```json
"sources": [
  {"kind": "manual"},
  {"kind": "action_type", "refs": [{"id": "at_dispatch", "name": "派单"}]},
  {"kind": "object_type", "refs": [{"id": "ot_order", "name": "订单", "property": "risk_score"}]}
]
```

四种 `kind`：`manual`、`box`（整箱/整 Server 展开）、`object_type`、`action_type`。

对象类那条**带到属性一级**——「订单.risk_score 用了这个工具」比「订单用了这个工具」有用，因为删属性和删对象类是两件事。

## 解绑的语义

模型用了但没人挂载的能力，在列表里**没有行**：`id` 为空、没有 `manual` 来源。那个空 `id` 就是告诉调用方它不能在这里被解绑——没有行可删，要移除它得去改那个引用它的东西。

既被挂载又被引用的，是**一行两个来源**；解绑之后它**仍在列表里**，只剩模型来源——这正是"解绑没有把它移出网络"的原因，必须让调用方看得见，否则会以为解绑失败了。

## 计数跟着列表

模型引用而来的也计入。计数和它所标注的列表打架，比任何一个数字单独错都糟：工作台会显示八行，角标写五。

## VM 实测（真实数据，非构造）

`yanfeng_simple` 绑定表 **0 条**，但它有个行动类「测试」引用了工具：

| 步骤 | 结果 |
|---|---|
| 列表 | ✅ 返回「采购单风险跟进」，`id: ""`，`sources: [action_type → 测试]`，名称/`metadata_type`/`status` 照常回填 |
| 挂载同一个工具 | ✅ **合并成一行**，`sources: ["manual","action_type"]`，不是两行 |
| 统计 | ✅ `apis_total: 1`，与列表一致 |
| 解绑 | ✅ 仍在列表里，`id` 变回 `""`，`sources: ["action_type"]` |

测试数据已清空。

## Tests

`go test ./...` 全绿。新增八条：两种来源共存、纯引用条目无 manual 且 id 为空、整箱展开标 box、类型过滤同样作用于补进来的条目、翻页不重复补、行动类的 tool/mcp 两种执行来源各自映射、残缺来源不产生身份。

一条既有测试补了两个新调用的预期（计数路径现在也读模型与存量行）。

## 边界

- 补进来的条目只在**能到达末尾的那一页**追加，避免跨页重复；`offset>0` 或整页装满时只返回存量行。
- 模型读不到时降级：绑定照常列出，只是没有"为什么"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)