### PR TITLE
fix(vega): prevent row loss at batch cursor boundaries

### DIFF
--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -457,7 +457,8 @@ func validateIncrementalBaseline(ctx context.Context, resource *interfaces.Resou
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_IncrementalBaselineUnavailable).
 			WithErrorDetails(fmt.Sprintf("invalid incremental checkpoint: %v", err))
 	}
-	if err := sync_checkpoint.ValidateCursor(checkpoint, resource.IndexConfig.IncrementalFields, resource.SchemaDefinition); err != nil {
+	effectiveCursorFields := sync_checkpoint.EffectiveCursorFields(resource.IndexConfig.IncrementalFields, resource.IndexConfig.PrimaryKeyFields)
+	if err := sync_checkpoint.ValidateCursor(checkpoint, effectiveCursorFields, resource.SchemaDefinition); err != nil {
 		return rest.NewHTTPError(ctx, http.StatusConflict, verrors.VegaBackend_BuildTask_IncrementalBaselineUnavailable).
 			WithErrorDetails(fmt.Sprintf("invalid incremental checkpoint: %v", err))
 	}

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -948,6 +948,15 @@ func TestValidateIncrementalBaseline(t *testing.T) {
 			resource.SyncMark = validMark
 			return resource
 		}()},
+		{name: "accepts checkpoint with appended primary key", resource: func() *interfaces.Resource {
+			resource := buildTaskTestResource()
+			resource.IndexConfig.IncrementalFields = []string{"updated_at"}
+			resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{Name: "updated_at", Type: interfaces.DataType_Timestamp})
+			resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
+			resource.LocalIndexName = "resource-1-index"
+			resource.SyncMark = `{"mode":"batch","cursor":[{"key":"updated_at","value":"2026-09-08T10:00:00Z"},{"key":"id","value":1}]}`
+			return resource
+		}()},
 		{name: "rejects unavailable index", resource: func() *interfaces.Resource {
 			resource := buildTaskTestResource()
 			resource.SyncMark = validMark

--- a/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint.go
+++ b/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint.go
@@ -19,6 +19,23 @@ import (
 
 const ModeBatch = "batch"
 
+// EffectiveCursorFields appends primary key fields absent from the configured
+// incremental cursor. A declared primary key is trusted to make the cursor unique.
+func EffectiveCursorFields(incrementalFields, primaryKeyFields []string) []string {
+	fields := append([]string(nil), incrementalFields...)
+	seen := make(map[string]struct{}, len(incrementalFields)+len(primaryKeyFields))
+	for _, field := range incrementalFields {
+		seen[field] = struct{}{}
+	}
+	for _, field := range primaryKeyFields {
+		if _, exists := seen[field]; !exists {
+			fields = append(fields, field)
+			seen[field] = struct{}{}
+		}
+	}
+	return fields
+}
+
 // SyncCheckpoint is shared by Task execution progress and the Resource's
 // committed incremental baseline.
 type SyncCheckpoint struct {

--- a/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint_test.go
+++ b/adp/vega/vega-backend/server/logics/sync_checkpoint/sync_checkpoint_test.go
@@ -28,6 +28,13 @@ func TestEncodeBatch(t *testing.T) {
 	assert.Empty(t, checkpoint.Cursor)
 }
 
+func TestEffectiveCursorFields(t *testing.T) {
+	assert.Equal(t, []string{"updated_at", "tenant_id", "id"},
+		EffectiveCursorFields([]string{"updated_at", "tenant_id"}, []string{"tenant_id", "id"}))
+	assert.Equal(t, []string{"updated_at", "id", "tenant_id"},
+		EffectiveCursorFields([]string{"updated_at", "id"}, []string{"tenant_id", "id"}))
+}
+
 func TestDecodeBatch(t *testing.T) {
 	t.Run("empty mark means no checkpoint", func(t *testing.T) {
 		checkpoint, err := DecodeBatch("")

--- a/adp/vega/vega-backend/server/worker/build_task_worker.go
+++ b/adp/vega/vega-backend/server/worker/build_task_worker.go
@@ -449,8 +449,10 @@ func validateIncrementalBatchResource(resource *interfaces.Resource, task *inter
 	if err != nil {
 		return fmt.Errorf("invalid incremental checkpoint: %w", err)
 	}
+	effectiveCursorFields := sync_checkpoint.EffectiveCursorFields(
+		resource.IndexConfig.IncrementalFields, resource.IndexConfig.PrimaryKeyFields)
 	if err := sync_checkpoint.ValidateCursor(checkpoint,
-		resource.IndexConfig.IncrementalFields, resource.SchemaDefinition); err != nil {
+		effectiveCursorFields, resource.SchemaDefinition); err != nil {
 		return fmt.Errorf("invalid incremental checkpoint: %w", err)
 	}
 	return nil

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -307,13 +307,14 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 
 	primaryKeyFields := buildTaskInfo.IndexConfig.PrimaryKeyFields
 	incrementalFields := buildTaskInfo.IndexConfig.IncrementalFields
+	effectiveCursorFields := sync_checkpoint.EffectiveCursorFields(incrementalFields, primaryKeyFields)
 	var lastBatchKeyValues []interfaces.KeyValue
 	if lastSyncedMark != "" {
 		checkpoint, err := sync_checkpoint.DecodeBatch(lastSyncedMark)
 		if err != nil {
 			return fmt.Errorf("decode synced mark: %w", err)
 		}
-		if err := sync_checkpoint.ValidateCursor(checkpoint, incrementalFields, resource.SchemaDefinition); err != nil {
+		if err := sync_checkpoint.ValidateCursor(checkpoint, effectiveCursorFields, resource.SchemaDefinition); err != nil {
 			return fmt.Errorf("validate synced mark: %w", err)
 		}
 		lastBatchKeyValues = checkpoint.Cursor
@@ -338,8 +339,8 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 	}
 
 	// Build sort fields
-	sortFields := make([]*interfaces.SortField, len(incrementalFields))
-	for i, field := range incrementalFields {
+	sortFields := make([]*interfaces.SortField, len(effectiveCursorFields))
+	for i, field := range effectiveCursorFields {
 		sortFields[i] = &interfaces.SortField{
 			Field: field,
 		}
@@ -391,7 +392,7 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 
 		// Add filter condition for batch fields if we have last values
 		if len(lastBatchKeyValues) > 0 {
-			params.FilterCondCfg = buildBatchCursorFilter(incrementalFields, lastBatchKeyValues)
+			params.FilterCondCfg = buildBatchCursorFilter(effectiveCursorFields, lastBatchKeyValues)
 
 			// Convert FilterCondCfg to ActualFilterCond
 			fieldMap := map[string]*interfaces.Property{}
@@ -434,7 +435,7 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		if readRows > 0 {
 			// Update lastBatchKeyValues with the last values in this batch
 			lastItem := result.Entries[readRows-1]
-			lastBatchKeyValues, err = extractKeyValues(incrementalFields, lastItem)
+			lastBatchKeyValues, err = extractKeyValues(effectiveCursorFields, lastItem)
 			if err != nil {
 				return fmt.Errorf("extract cursor key values: %w", err)
 			}

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -18,6 +18,7 @@ import (
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 	"vega-backend/logics"
+	"vega-backend/logics/sync_checkpoint"
 )
 
 func TestBuildBatchCursorFilter(t *testing.T) {
@@ -41,6 +42,19 @@ func TestBuildBatchCursorFilter(t *testing.T) {
 			{Name: "id", Operation: "gt", ValueOptCfg: interfaces.ValueOptCfg{Value: 100, ValueFrom: interfaces.ValueFrom_Const}},
 		},
 	}, filter.SubConds[1])
+}
+
+func TestBuildBatchCursorFilterAppendsPrimaryKeyForSameIncrementalValue(t *testing.T) {
+	keys := sync_checkpoint.EffectiveCursorFields([]string{"ingested_at"}, []string{"id"})
+	filter := buildBatchCursorFilter(keys, []interfaces.KeyValue{{Key: "ingested_at", Value: "T1"}, {Key: "id", Value: int64(1000)}})
+
+	require.Equal(t, []string{"ingested_at", "id"}, keys)
+	require.Len(t, filter.SubConds, 2)
+	assert.Equal(t, "ingested_at", filter.SubConds[1].SubConds[0].Name)
+	assert.Equal(t, "==", filter.SubConds[1].SubConds[0].Operation)
+	assert.Equal(t, "id", filter.SubConds[1].SubConds[1].Name)
+	assert.Equal(t, "gt", filter.SubConds[1].SubConds[1].Operation)
+	assert.Equal(t, int64(1000), filter.SubConds[1].SubConds[1].ValueOptCfg.Value)
 }
 
 func TestBatchBuildWorkerHandleTask(t *testing.T) {

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -66,35 +66,67 @@ func TestBatchCursorReadsAllSameIncrementalValueAcrossPages(t *testing.T) {
 			filter := buildBatchCursorFilter(sync_checkpoint.EffectiveCursorFields([]string{"ingested_at"}, []string{"id"}), cursor)
 			second := make([]int64, 0, count-first)
 			for id := int64(1); id <= int64(count); id++ {
-				if id > cursor[1].Value.(int64) {
+				if matchesStringInt64CursorFilter(t, filter, map[string]any{"ingested_at": "T1", "id": id}) {
 					second = append(second, id)
 				}
 			}
-			assert.Len(t, filter.SubConds, 2)
 			assert.Len(t, second, count-first)
 			assert.Equal(t, count, first+len(second))
 		})
 	}
 
 	t.Run("999 earlier rows plus two equal boundary rows", func(t *testing.T) {
-		type cursorRow struct {
-			time string
-			id   int64
-		}
-		rows := make([]cursorRow, 0, 1001)
+		rows := make([]map[string]any, 0, 1001)
 		for id := int64(1); id <= 999; id++ {
-			rows = append(rows, cursorRow{time: "T0", id: id})
+			rows = append(rows, map[string]any{"ingested_at": "T0", "id": id})
 		}
-		rows = append(rows, cursorRow{time: "T1", id: 1000}, cursorRow{time: "T1", id: 1001})
-		cursor := rows[999]
-		remaining := make([]cursorRow, 0, 1)
+		rows = append(rows,
+			map[string]any{"ingested_at": "T1", "id": int64(1000)},
+			map[string]any{"ingested_at": "T1", "id": int64(1001)})
+		filter := buildBatchCursorFilter(
+			[]string{"ingested_at", "id"},
+			[]interfaces.KeyValue{{Key: "ingested_at", Value: "T1"}, {Key: "id", Value: int64(1000)}},
+		)
+		remaining := make([]map[string]any, 0, 1)
 		for _, row := range rows {
-			if row.time > cursor.time || row.time == cursor.time && row.id > cursor.id {
+			if matchesStringInt64CursorFilter(t, filter, row) {
 				remaining = append(remaining, row)
 			}
 		}
-		assert.Equal(t, []cursorRow{{time: "T1", id: 1001}}, remaining)
+		assert.Equal(t, []map[string]any{{"ingested_at": "T1", "id": int64(1001)}}, remaining)
 	})
+}
+
+func matchesStringInt64CursorFilter(t *testing.T, filter *interfaces.FilterCondCfg, row map[string]any) bool {
+	t.Helper()
+	require.Equal(t, "or", filter.Operation)
+	for _, branch := range filter.SubConds {
+		require.Equal(t, "and", branch.Operation)
+		matches := true
+		for _, condition := range branch.SubConds {
+			actual, exists := row[condition.Name]
+			require.True(t, exists, "row is missing cursor field %q", condition.Name)
+			switch condition.Operation {
+			case "==":
+				matches = matches && actual == condition.ValueOptCfg.Value
+			case "gt":
+				switch expected := condition.ValueOptCfg.Value.(type) {
+				case string:
+					matches = matches && actual.(string) > expected
+				case int64:
+					matches = matches && actual.(int64) > expected
+				default:
+					require.FailNow(t, "unsupported cursor value type", "%T", expected)
+				}
+			default:
+				require.FailNow(t, "unsupported cursor operation", "%s", condition.Operation)
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }
 
 func TestBatchCursorKeepsCompositePrimaryFieldsForResume(t *testing.T) {

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -55,6 +56,59 @@ func TestBuildBatchCursorFilterAppendsPrimaryKeyForSameIncrementalValue(t *testi
 	assert.Equal(t, "id", filter.SubConds[1].SubConds[1].Name)
 	assert.Equal(t, "gt", filter.SubConds[1].SubConds[1].Operation)
 	assert.Equal(t, int64(1000), filter.SubConds[1].SubConds[1].ValueOptCfg.Value)
+}
+
+func TestBatchCursorReadsAllSameIncrementalValueAcrossPages(t *testing.T) {
+	for _, count := range []int{999, 1000, 1001, 1500} {
+		t.Run(fmt.Sprintf("%d same values", count), func(t *testing.T) {
+			first := min(count, 1000)
+			cursor := []interfaces.KeyValue{{Key: "ingested_at", Value: "T1"}, {Key: "id", Value: int64(first)}}
+			filter := buildBatchCursorFilter(sync_checkpoint.EffectiveCursorFields([]string{"ingested_at"}, []string{"id"}), cursor)
+			second := make([]int64, 0, count-first)
+			for id := int64(1); id <= int64(count); id++ {
+				if id > cursor[1].Value.(int64) {
+					second = append(second, id)
+				}
+			}
+			assert.Len(t, filter.SubConds, 2)
+			assert.Len(t, second, count-first)
+			assert.Equal(t, count, first+len(second))
+		})
+	}
+
+	t.Run("999 earlier rows plus two equal boundary rows", func(t *testing.T) {
+		type cursorRow struct {
+			time string
+			id   int64
+		}
+		rows := make([]cursorRow, 0, 1001)
+		for id := int64(1); id <= 999; id++ {
+			rows = append(rows, cursorRow{time: "T0", id: id})
+		}
+		rows = append(rows, cursorRow{time: "T1", id: 1000}, cursorRow{time: "T1", id: 1001})
+		cursor := rows[999]
+		remaining := make([]cursorRow, 0, 1)
+		for _, row := range rows {
+			if row.time > cursor.time || row.time == cursor.time && row.id > cursor.id {
+				remaining = append(remaining, row)
+			}
+		}
+		assert.Equal(t, []cursorRow{{time: "T1", id: 1001}}, remaining)
+	})
+}
+
+func TestBatchCursorKeepsCompositePrimaryFieldsForResume(t *testing.T) {
+	keys := sync_checkpoint.EffectiveCursorFields(
+		[]string{"updated_at", "tenant_id"}, []string{"tenant_id", "id"},
+	)
+	cursor := []interfaces.KeyValue{{Key: "updated_at", Value: "T1"}, {Key: "tenant_id", Value: "tenant-a"}, {Key: "id", Value: int64(1000)}}
+	filter := buildBatchCursorFilter(keys, cursor)
+
+	require.Equal(t, []string{"updated_at", "tenant_id", "id"}, keys)
+	require.Len(t, filter.SubConds, 3)
+	assert.Equal(t, "id", filter.SubConds[2].SubConds[2].Name)
+	assert.Equal(t, "gt", filter.SubConds[2].SubConds[2].Operation)
+	assert.Equal(t, int64(1000), filter.SubConds[2].SubConds[2].ValueOptCfg.Value)
 }
 
 func TestBatchBuildWorkerHandleTask(t *testing.T) {
@@ -458,6 +512,117 @@ func TestBatchBuildWorkerRejectsIncrementalCheckpointWhenIndexChanged(t *testing
 
 	require.ErrorContains(t, err, "resource local index changed during incremental build")
 	assert.Equal(t, `{"mode":"batch","cursor":[]}`, resource.SyncMark)
+	require.NoError(t, mockDB.ExpectationsWereMet())
+}
+
+func TestBatchBuildWorkerReadsSameIncrementalValueAcrossPages(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	lim := vmock.NewMockLocalIndexManager(ctrl)
+	bts := vmock.NewMockBuildTaskService(ctrl)
+	rs := vmock.NewMockResourceService(ctrl)
+	cf := vmock.NewMockConnectorFactory(ctrl)
+	connector := vmock.NewMockTableConnector(ctrl)
+	resource := workerTestResource()
+	resource.SchemaDefinition = append(resource.SchemaDefinition,
+		&interfaces.Property{Name: "ingested_at", Type: interfaces.DataType_Timestamp})
+	resource.IndexConfig.IncrementalFields = []string{"ingested_at"}
+	resource.LocalIndexStatus = interfaces.ResourceLocalIndexStatusAvailable
+	resource.LocalIndexName = "current-index"
+	resource.SyncMark = `{"mode":"batch","cursor":[{"key":"ingested_at","value":"T0"},{"key":"id","value":20}]}`
+	task := workerTestFullTask(t, resource)
+	task.IndexConfig.IncrementalFields = []string{"ingested_at"}
+	task.ExecuteType = interfaces.BuildTaskExecuteTypeIncremental
+	task.IndexName = resource.LocalIndexName
+	task.Status = interfaces.BuildTaskStatusRunning
+	task.SyncedMark = resource.SyncMark
+	bbw := &batchBuildWorker{lim: lim, bts: bts, rs: rs, cf: cf}
+
+	db, mockDB, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	oldDB := logics.DB
+	logics.DB = db
+	defer func() { logics.DB = oldDB }()
+
+	lim.EXPECT().CheckIndexExist(gomock.Any(), "current-index").Return(true, nil)
+	cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
+	connector.EXPECT().Connect(gomock.Any()).Return(nil)
+	sourceRows := make([]map[string]any, 1500)
+	for i := range sourceRows {
+		sourceRows[i] = map[string]any{"id": int64(i + 21), "ingested_at": "T1"}
+	}
+	queryCount := 0
+	connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Times(2).DoAndReturn(
+		func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
+			queryCount++
+			require.Len(t, params.Sort, 2)
+			assert.Equal(t, "ingested_at", params.Sort[0].Field)
+			assert.Equal(t, "id", params.Sort[1].Field)
+			require.NotNil(t, params.FilterCondCfg)
+			if queryCount == 2 {
+				require.Len(t, params.FilterCondCfg.SubConds, 2)
+				idCondition := params.FilterCondCfg.SubConds[1].SubConds[1]
+				assert.Equal(t, "id", idCondition.Name)
+				assert.Equal(t, "gt", idCondition.Operation)
+				assert.Equal(t, int64(1020), idCondition.ValueOptCfg.Value)
+			}
+			cursorTime := params.FilterCondCfg.SubConds[0].SubConds[0].ValueOptCfg.Value.(string)
+			cursorID := params.FilterCondCfg.SubConds[1].SubConds[1].ValueOptCfg.Value.(int64)
+			entries := make([]map[string]any, 0, params.Limit)
+			for _, row := range sourceRows {
+				rowTime := row["ingested_at"].(string)
+				rowID := row["id"].(int64)
+				if rowTime > cursorTime || rowTime == cursorTime && rowID > cursorID {
+					entries = append(entries, row)
+					if len(entries) == params.Limit {
+						break
+					}
+				}
+			}
+			result := &interfaces.QueryResult{Entries: entries}
+			if queryCount == 1 {
+				result.Total = int64(len(sourceRows))
+			}
+			return result, nil
+		})
+	connector.EXPECT().Close(gomock.Any()).Return(nil)
+	bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil).Times(2)
+	bts.EXPECT().InternalSetProgress(gomock.Any(), nil, task.ID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+			require.NotNil(t, progress.TotalCount)
+			assert.EqualValues(t, 1500, *progress.TotalCount)
+			return true, nil
+		})
+	batchSizes := make([]int, 0, 2)
+	lim.EXPECT().IndexDocuments(gomock.Any(), "current-index", gomock.Any()).Times(2).DoAndReturn(
+		func(_ context.Context, _ string, documents map[string]map[string]any) ([]string, error) {
+			batchSizes = append(batchSizes, len(documents))
+			return nil, nil
+		})
+	for range 2 {
+		mockDB.ExpectBegin()
+		mockDB.ExpectCommit()
+	}
+	txMatcher := gomock.AssignableToTypeOf(&sql.Tx{})
+	rs.EXPECT().InternalGetByID(gomock.Any(), txMatcher, resource.ID).Times(2).Return(resource, nil)
+	var finalProgress interfaces.BuildTaskProgress
+	bts.EXPECT().InternalSetProgress(gomock.Any(), txMatcher, task.ID, gomock.Any()).Times(2).DoAndReturn(
+		func(_ context.Context, _ *sql.Tx, _ string, progress interfaces.BuildTaskProgress) (bool, error) {
+			finalProgress = progress
+			return true, nil
+		})
+	rs.EXPECT().InternalUpdateLocalIndexState(gomock.Any(), txMatcher, resource.ID,
+		interfaces.ResourceLocalIndexStatusAvailable, "current-index", gomock.Any()).Return(true, nil).Times(2)
+	bts.EXPECT().InternalMarkCompleted(gomock.Any(), nil, task.ID).Return(true, nil)
+
+	err = bbw.executeBuild(context.Background(), &interfaces.Catalog{ConnectorType: "mysql"}, resource, task)
+
+	require.NoError(t, err)
+	assert.Equal(t, []int{1000, 500}, batchSizes)
+	require.NotNil(t, finalProgress.SyncedCount)
+	assert.EqualValues(t, 1500, *finalProgress.SyncedCount)
+	require.NotNil(t, finalProgress.SyncedMark)
+	assert.JSONEq(t, `{"mode":"batch","cursor":[{"key":"ingested_at","value":"T1"},{"key":"id","value":1520}]}`, *finalProgress.SyncedMark)
 	require.NoError(t, mockDB.ExpectationsWereMet())
 }
 

--- a/docs/api/vega/build-task.yaml
+++ b/docs/api/vega/build-task.yaml
@@ -482,10 +482,12 @@ components:
       type: object
       properties:
         primary_key_fields:
+          description: Source row identity fields; absent fields are appended to the internal batch cursor.
           type: array
           items:
             type: string
         incremental_fields:
+          description: Ordered incremental cursor fields before any missing primary key fields are appended internally.
           type: array
           items:
             type: string

--- a/docs/api/vega/resource.yaml
+++ b/docs/api/vega/resource.yaml
@@ -785,10 +785,12 @@ components:
       type: object
       properties:
         primary_key_fields:
+          description: Must identify a unique source row. Fields absent from incremental_fields are appended to the internal batch cursor.
           type: array
           items:
             type: string
         incremental_fields:
+          description: Ordered incremental cursor fields. The service appends any missing primary_key_fields internally for batch pagination.
           type: array
           items:
             type: string


### PR DESCRIPTION
## What Changed

- [x] Append configured primary-key fields to batch incremental cursors, preserving order and removing overlaps
- [x] Use the effective cursor consistently for validation, sorting, filtering, extraction, and checkpoint persistence
- [x] Add regression coverage for boundary sizes, composite/overlapping fields, and 1,500 rows sharing one incremental value
- [x] Document the effective cursor contract in the Vega OpenAPI descriptions

---

## Why

- Related Issue: Closes #1354
- Background: A non-unique incremental cursor could skip source rows when more than 1,000 rows shared the value at a batch boundary.

---

## How

- Key implementation points:
  - Effective cursor = incremental_fields followed by primary_key_fields not already present.
  - primary_key_fields uniqueness is trusted as configured; no source-data uniqueness fallback is added.
  - Existing batch checkpoints that do not match the effective cursor shape are intentionally rejected.
- Breaking changes:
  - Existing checkpoints created with an incomplete cursor must be rebuilt; historical compatibility is intentionally out of scope.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `make ci` passed for Vega.
- Focused post-rebase tests passed:
  `go test ./logics/sync_checkpoint ./logics/build_task ./worker`
- `make api-docs-lint` passed; unrelated existing repository warnings remain.

---

## Risk & Rollback

- Potential risks: Incorrect primary-key configuration can still produce a non-unique cursor by design.
- Rollback plan: Revert this PR and rebuild affected resources from a compatible checkpoint strategy.

---

## Additional Notes

- Design and rollout plan: https://github.com/openbkn-ai/bkn-docs/commit/3fdf6bf
