### PR TITLE
fix(vega): support filtered knn vector search

### DIFF
--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition.go
@@ -1078,11 +1078,14 @@ func (c *OpenSearchConnector) ConvertFilterConditionKnnVector(condition interfac
 		},
 	}
 
-	// Add limit_key and limit_value
+	// Add limit_key and limit_value. A direct k is also accepted for compatibility
+	// with the OpenSearch DSL and takes effect only when the generic limit config is absent.
 	if limitKey, ok := cond.Cfg.RemainCfg["limit_key"].(string); ok && limitKey != "" {
 		if limitValue, ok := cond.Cfg.RemainCfg["limit_value"]; ok {
 			knnQuery[cond.FilterFieldName].(map[string]any)[limitKey] = limitValue
 		}
+	} else if k, ok := cond.Cfg.RemainCfg["k"]; ok {
+		knnQuery[cond.FilterFieldName].(map[string]any)["k"] = k
 	} else {
 		// Use the default value
 		knnQuery[cond.FilterFieldName].(map[string]any)["k"] = 10
@@ -1099,14 +1102,11 @@ func (c *OpenSearchConnector) ConvertFilterConditionKnnVector(condition interfac
 			filterQueries = append(filterQueries, subQuery)
 		}
 
-		return map[string]any{
-			"knn": knnQuery,
-			"filter": map[string]any{
-				"bool": map[string]any{
-					"must": filterQueries,
-				},
+		knnQuery[cond.FilterFieldName].(map[string]any)["filter"] = map[string]any{
+			"bool": map[string]any{
+				"must": filterQueries,
 			},
-		}, nil
+		}
 	}
 
 	return map[string]any{

--- a/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/index/opensearch/opensearch_condition_test.go
@@ -231,13 +231,37 @@ func TestOpenSearchConnectorConvertFilterCondition(t *testing.T) {
 				"embedding": map[string]any{
 					"vector": []float32{0.1, 0.2},
 					"k":      3,
+					"filter": map[string]any{
+						"bool": map[string]any{
+							"must": []map[string]any{
+								{"term": map[string]any{"is_active": true}},
+							},
+						},
+					},
 				},
 			},
-			"filter": map[string]any{
-				"bool": map[string]any{
-					"must": []map[string]any{
-						{"term": map[string]any{"is_active": true}},
-					},
+		}, got)
+	})
+
+	t.Run("uses direct k when limit key is absent", func(t *testing.T) {
+		cfg := &interfaces.FilterCondCfg{
+			Name:      "embedding",
+			Operation: filter_condition.OperationKnnVector,
+			ValueOptCfg: interfaces.ValueOptCfg{
+				ValueFrom: interfaces.ValueFrom_Const,
+				Value:     []float32{0.1, 0.2},
+			},
+			RemainCfg: map[string]any{"k": 50},
+		}
+
+		got, err := conn.ConvertFilterCondition(mustOSCondition(t, cfg), schema)
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"knn": map[string]any{
+				"embedding": map[string]any{
+					"vector": []float32{0.1, 0.2},
+					"k":      50,
 				},
 			},
 		}, got)

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_condition.go
@@ -1061,11 +1061,14 @@ func (c *logicViewDSLGenerator) ConvertFilterConditionKnnVector(ctx context.Cont
 		},
 	}
 
-	// Add limit_key and limit_value
+	// Add limit_key and limit_value. A direct k is also accepted for compatibility
+	// with the OpenSearch DSL and takes effect only when the generic limit config is absent.
 	if limitKey, ok := cond.Cfg.RemainCfg["limit_key"].(string); ok && limitKey != "" {
 		if limitValue, ok := cond.Cfg.RemainCfg["limit_value"]; ok {
 			knnQuery[cond.FilterFieldName].(map[string]any)[limitKey] = limitValue
 		}
+	} else if k, ok := cond.Cfg.RemainCfg["k"]; ok {
+		knnQuery[cond.FilterFieldName].(map[string]any)["k"] = k
 	} else {
 		// Use the default value
 		knnQuery[cond.FilterFieldName].(map[string]any)["k"] = 10
@@ -1082,14 +1085,11 @@ func (c *logicViewDSLGenerator) ConvertFilterConditionKnnVector(ctx context.Cont
 			filterQueries = append(filterQueries, subQuery)
 		}
 
-		return map[string]any{
-			"knn": knnQuery,
-			"filter": map[string]any{
-				"bool": map[string]any{
-					"must": filterQueries,
-				},
+		knnQuery[cond.FilterFieldName].(map[string]any)["filter"] = map[string]any{
+			"bool": map[string]any{
+				"must": filterQueries,
 			},
-		}, nil
+		}
 	}
 
 	return map[string]any{

--- a/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/logic_view/dsl/dsl_test.go
@@ -452,11 +452,25 @@ func TestLogicViewDSLConvertFilterCondition(t *testing.T) {
 			"knn": map[string]any{"embedding": map[string]any{
 				"vector": []float32{0.1},
 				"k":      3,
+				"filter": map[string]any{"bool": map[string]any{"must": []map[string]any{
+					{"term": map[string]any{"active": true}},
+				}}},
 			}},
-			"filter": map[string]any{"bool": map[string]any{"must": []map[string]any{
-				{"term": map[string]any{"active": true}},
-			}}},
 		}, got)
+	})
+
+	t.Run("knn vector accepts direct k", func(t *testing.T) {
+		cfg := dslConditionCfg("embedding", filter_condition.OperationKnnVector, interfaces.ValueFrom_Const, []float32{0.1, 0.2})
+		cfg.RemainCfg = map[string]any{"k": 50}
+		cond := mustDSLCondition(t, cfg, fields)
+
+		got, err := generator.ConvertFilterCondition(context.Background(), cond, fields)
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]any{"knn": map[string]any{"embedding": map[string]any{
+			"vector": []float32{0.1, 0.2},
+			"k":      50,
+		}}}, got)
 	})
 
 	fields = testDSLAdditionalFieldMap()

--- a/adp/vega/vega-backend/tests/at/resource/dataset/dataset_test.go
+++ b/adp/vega/vega-backend/tests/at/resource/dataset/dataset_test.go
@@ -1140,13 +1140,42 @@ func TestDatasetDocumentsList(t *testing.T) {
 		// 测试vector查询
 		Convey("DD102.32: vector查询 (vector)", func() {
 			testFilterQuery(map[string]any{
-				"operation":   "knn_vector",
-				"field":       "content",
-				"value":       generateVector(768),
-				"value_from":  "const",
-				"limit_key":   "k",
-				"limit_value": 3,
+				"operation":  "knn_vector",
+				"field":      "content",
+				"value":      generateVector(768),
+				"value_from": "const",
+				"k":          3,
 			}, 1)
+		})
+
+		Convey("DD102.32.1: vector查询带过滤条件", func() {
+			query := make(map[string]any)
+			for k, v := range baseQuery {
+				query[k] = v
+			}
+			query["filter_condition"] = map[string]any{
+				"operation":  "knn_vector",
+				"field":      "content",
+				"value":      generateVector(768),
+				"value_from": "const",
+				"k":          3,
+				"sub_conditions": []map[string]any{
+					{
+						"operation":  "false",
+						"field":      "active",
+						"value_from": "const",
+					},
+				},
+			}
+
+			client.SetHeader("X-HTTP-Method-Override", "GET")
+			resp := client.POST("/api/vega-backend/v1/resources/"+resourceID+"/data", query)
+			client.RemoveHeader("X-HTTP-Method-Override")
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+
+			entries := resp.Body["entries"].([]any)
+			So(entries, ShouldHaveLength, 1)
+			So(entries[0].(map[string]any)["active"], ShouldBeFalse)
 		})
 
 		// 测试AND里面嵌套OR查询


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Fix OpenSearch filtered `knn_vector` DSL nesting.
- [x] Accept direct `k` when `limit_key` / `limit_value` are absent.
- [x] Add unit and acceptance-test coverage for filtered vector search.

---

## Why

- Related Issue: Closes #1296
- Related Feature: N/A
- Background: A `filter` generated alongside `knn` was invalid OpenSearch DSL, so vector search with sub-conditions failed with HTTP 400. A direct `k` was also silently replaced by the default value.

---

## How

- Key implementation points:
  - Place the translated sub-condition filter under `knn.<vector_field>.filter`.
  - Preserve the generic limit configuration and use direct `k` as a compatible fallback.
  - Assert both the generated DSL shape and that filtered vector search returns only matching records.
- Breaking changes (API, config, database, etc.): None. Direct `k` is newly honored when generic limit configuration is absent.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `make ci` passed (lint, unit tests, coverage gate).
- The acceptance-test configuration file `tests/at/testdata/test-config.yaml` is unavailable locally, so `make test-at` was not run. The new `DD102.32.1` case should be run in a configured test environment.

---

## Risk & Rollback

- Potential risks: Filtered k-NN requires a compatible vector engine; the repository's default mapping uses Lucene, which supports native filters.
- Rollback plan: Revert commit `13abca3aa` to restore the previous DSL generation.

---

## Additional Notes

- No documentation change: the generic limit configuration remains supported; direct `k` is a backward-compatible addition.
