### PR TITLE
feat(bkn-safe): support deny-overrides for resource permissions

### DIFF
--- a/bkn-safe/README.md
+++ b/bkn-safe/README.md
@@ -15,7 +15,8 @@ bkn-safe 是 OpenBKN 的认证、鉴权和用户目录服务。它配合**上游
 
 1. **认证** —— hydra 的 login/consent/device 验证页；用**自有用户库 + bcrypt** 验密码
    （不调 eacp/anyshare）；在 consent 时把 introspect 的 `ext` claims 注入 token session。
-2. **鉴权** —— Casbin（RBAC + 资源实例，`keyMatch`，只 allow），policy 存 GORM（gorm-adapter）。
+2. **鉴权** —— Casbin（RBAC + 资源实例，`keyMatch`，显式 deny 优先于普通 allow；
+   `super_admin` 作为恢复角色不可被 deny），policy 存 GORM（gorm-adapter）。
 3. **用户管理** —— 自建目录（users/departments/groups/roles）+ 名称解析 + LDAP 连接器（轻）。
 
 ## 目录
@@ -175,6 +176,25 @@ resolver 只能在此基础上收窄；core 会再次取最小档，不能通过
 顺序一致；未知档位、不完整的 Enterprise 结果、账号状态或授权判定不可用均失败关闭。
 该端点与其他 `/authz` 路由一样只存在于 ClusterIP S2S 边界，Helm Ingress 不暴露；
 终端业务请求不得提交或覆盖这里的 `accessor_id`。
+
+## 显式拒绝例外
+
+普通用户和普通角色遵循 `deny > allow > 默认拒绝`。例如角色持有
+`resource:* / view_detail` 时，可通过管理员对象授权接口只禁止 Alice 读取 `r-1`：
+
+```json
+{
+  "accessor_id": "alice",
+  "resource": {"type": "resource", "id": "r-1"},
+  "operations": ["view_detail"],
+  "effect": "deny"
+}
+```
+
+`effect` 不传时仍默认为 `allow`，已有调用无需修改。删除请求不传 `effect` 时清除该
+用户在对象上的全部直接规则；传 `allow` 或 `deny` 时只清除对应类型。历史
+`casbin_rule` 的空 `v3` 会在启动加载前幂等补为 `allow`。`super_admin` 是紧急恢复角色，
+任何 deny 都不会限制其成员。
 
 ## 授权档位（付费能力门控）
 

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -6,8 +6,9 @@
 // resource instances, backed by a GORM adapter (policies live in the shared DB).
 //
 // This is a clean redesign, NOT the ISF authorization contract. Kowell only
-// uses the RBAC subset (ISF's deny/condition/obligation/hierarchy/expires are
-// unused), so the model is allow-only.
+// uses the RBAC subset plus an explicit deny effect. Deny overrides ordinary
+// direct, role-derived, public and inherited allows. The seeded super-admin
+// role is handled as a recovery-path bypass before policy evaluation.
 //
 // Object format is "type:id" (e.g. "agent:probe", "agent:*"). The matcher uses
 // keyMatch — NOT keyMatch2: keyMatch2 treats ":" as a named wildcard, which
@@ -44,13 +45,13 @@ const modelConf = `
 r = sub, obj, act
 
 [policy_definition]
-p = sub, obj, act
+p = sub, obj, act, eft
 
 [role_definition]
 g = _, _
 
 [policy_effect]
-e = some(where (p.eft == allow))
+e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
 m = (g(r.sub, p.sub) || p.sub == "` + PublicAccessorID + `") && keyMatch(r.obj, p.obj) && (p.act == "*" || r.act == p.act)
@@ -61,6 +62,16 @@ m = (g(r.sub, p.sub) || p.sub == "` + PublicAccessorID + `") && keyMatch(r.obj, 
 // department id, written by e.g. execution-factory's CreateIntCompPolicyForAllUsers
 // (interfaces.AccessorRootDepartmentID) for built-in toolbox public access.
 const PublicAccessorID = "00000000-0000-0000-0000-000000000000"
+
+// SuperAdminRoleID is the immutable seeded recovery role. Explicit deny rules
+// never constrain its members, so an administrator can always repair a broken
+// authorization configuration.
+const SuperAdminRoleID = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
+
+const (
+	EffectAllow = "allow"
+	EffectDeny  = "deny"
+)
 
 // ActAll is the wildcard act: a policy with act "*" grants every operation on
 // the matched object (used for the super-admin "do everything" grant).
@@ -90,6 +101,13 @@ func New(db *gorm.DB) (*Enforcer, error) {
 	adapter, err := gormadapter.NewAdapterByDB(db)
 	if err != nil {
 		return nil, fmt.Errorf("new gorm adapter: %w", err)
+	}
+	// The old three-column model left v3 empty. Normalize those rows before the
+	// four-column model loads them; this is idempotent and keeps every historical
+	// grant effective as an explicit allow.
+	if err := db.Table("casbin_rule").Where("ptype = ? AND (v3 IS NULL OR v3 = '')", "p").
+		Update("v3", EffectAllow).Error; err != nil {
+		return nil, fmt.Errorf("normalize legacy casbin policies: %w", err)
 	}
 	m, err := model.NewModelFromString(modelConf)
 	if err != nil {
@@ -143,11 +161,21 @@ func (en *Enforcer) isManagedProxy(accessorID string) (bool, error) {
 // applying managed-proxy provenance. Delegator validation must use this raw
 // path so a source can never recursively justify itself.
 func (en *Enforcer) checkPolicy(accessorID, resourceType, resourceID, op string) (bool, error) {
-	ok, err := en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
-	if err != nil || ok {
-		return ok, err
+	idx, err := en.grantIndex(accessorID)
+	if err != nil {
+		return false, err
 	}
-	inherited, err := en.inheritedOps(accessorID, resourceType, resourceID, []string{op})
+	if idx.superAdmin {
+		return true, nil
+	}
+	direct := idx.decide(ResourceRef{Type: resourceType, ID: resourceID}, []string{op})
+	if direct[op] == EffectDeny {
+		return false, nil
+	}
+	if direct[op] == EffectAllow {
+		return true, nil
+	}
+	inherited, err := en.inheritedOpsWithIndex(idx, resourceType, resourceID, []string{op})
 	if err != nil {
 		return false, err
 	}
@@ -204,22 +232,28 @@ func (en *Enforcer) hasCurrentProxySource(proxyID, resourceType, resourceID, op 
 // the resource. Mirrors ISF resource-operation (allow_operation): the result is
 // a set; callers must not depend on order.
 func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, candidates []string) ([]string, error) {
+	idx, err := en.grantIndex(accessorID)
+	if err != nil {
+		return nil, err
+	}
+	if idx.superAdmin {
+		return append([]string(nil), candidates...), nil
+	}
 	out := make([]string, 0, len(candidates))
 	missing := make([]string, 0, len(candidates))
+	direct := idx.decide(ResourceRef{Type: resourceType, ID: resourceID}, candidates)
 	for _, op := range candidates {
-		ok, err := en.e.Enforce(accessorID, obj(resourceType, resourceID), op)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
+		if direct[op] == EffectAllow {
 			out = append(out, op)
 			continue
 		}
-		missing = append(missing, op)
+		if direct[op] != EffectDeny {
+			missing = append(missing, op)
+		}
 	}
 	// One climb for everything that missed, rather than one per operation: the
 	// ancestor chain and its operation mapping are the same for all of them.
-	inherited, err := en.inheritedOps(accessorID, resourceType, resourceID, missing)
+	inherited, err := en.inheritedOpsWithIndex(idx, resourceType, resourceID, missing)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +287,7 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(roleID, obj(resourceType, idPattern), op)
+	_, err := en.e.AddPolicy(roleID, obj(resourceType, idPattern), op, EffectAllow)
 	return err
 }
 
@@ -262,7 +296,7 @@ func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op stri
 func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.RemovePolicy(roleID, obj(resourceType, idPattern), op)
+	_, err := en.e.RemovePolicy(roleID, obj(resourceType, idPattern), op, EffectAllow)
 	return err
 }
 
@@ -272,7 +306,7 @@ func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op str
 func (en *Enforcer) Grant(sub, obj, act string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(sub, obj, act)
+	_, err := en.e.AddPolicy(sub, obj, act, EffectAllow)
 	return err
 }
 
@@ -281,7 +315,16 @@ func (en *Enforcer) Grant(sub, obj, act string) error {
 func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op)
+	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow)
+	return err
+}
+
+// DenyObjectPermission adds an explicit per-object exception. Deny overrides
+// every ordinary allow source; only membership in SuperAdminRoleID bypasses it.
+func (en *Enforcer) DenyObjectPermission(accessorID, resourceType, resourceID, op string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, EffectDeny)
 	return err
 }
 
@@ -289,7 +332,7 @@ func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, 
 func (en *Enforcer) RevokeObjectPermission(accessorID, resourceType, resourceID, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.RemovePolicy(accessorID, obj(resourceType, resourceID), op)
+	_, err := en.e.RemovePolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow)
 	return err
 }
 
@@ -342,6 +385,7 @@ type RoleGrant struct {
 	Object             string
 	Operations         []string
 	InstanceOperations []string
+	DeniedOperations   []string
 }
 
 // RolePermissions lists the policy grants whose subject is the role, grouped by
@@ -362,7 +406,7 @@ func groupGrantsByObject(rows [][]string) []RoleGrant {
 	ops := map[string][]string{}
 	order := make([]string, 0, len(rows))
 	for _, row := range rows {
-		if len(row) < 3 {
+		if len(row) < 3 || (len(row) >= 4 && row[3] == EffectDeny) {
 			continue
 		}
 		o, act := row[1], row[2]
@@ -435,11 +479,25 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		return false, nil, err
 	}
 	grouped := groupGrantsByObject(rows)
+	superAdmin, err := en.hasSuperAdminRole(accessorID)
+	if err != nil {
+		return false, nil, err
+	}
 
+	hasDeny := false
+	for _, row := range rows {
+		if policyEffect(row) == EffectDeny {
+			hasDeny = true
+			break
+		}
+	}
 	// Wildcard short-circuit — keyed on a real "*"/"*" grant, not is_admin.
+	// An ordinary wildcard holder with exceptions cannot collapse to one row;
+	// super-admin remains the only principal whose deny rows are intentionally
+	// ignored by the runtime decision.
 	for _, g := range grouped {
 		rtype, _ := splitObjectKey(g.Object)
-		if rtype == ActAll && hasOp(g.Operations, ActAll) {
+		if rtype == ActAll && hasOp(g.Operations, ActAll) && (!hasDeny || superAdmin) {
 			if q.ResourceType == "" {
 				return true, []RoleGrant{{Object: ActAll + ":" + ActAll, Operations: []string{ActAll}}}, nil
 			}
@@ -544,7 +602,51 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		// may reach this type, but only through specific objects".
 		out = append(out, RoleGrant{Object: rtype + ":*", Operations: []string{}, InstanceOperations: ops})
 	}
+
+	// Deny exceptions are additive to the legacy response shape. Keep the allow
+	// rows unchanged for old clients, while newer administration clients can
+	// explain why a concrete operation is absent from Check/operations/filter.
+	if !superAdmin && !q.TypeWideOnly {
+		byObject := make(map[string]int, len(out))
+		for i := range out {
+			byObject[out[i].Object] = i
+		}
+		for _, row := range rows {
+			if policyEffect(row) != EffectDeny || len(row) < 3 {
+				continue
+			}
+			rtype, rid := splitObjectKey(row[1])
+			if q.ResourceType != "" && rtype != q.ResourceType {
+				continue
+			}
+			if len(idFilter) > 0 && rid != "*" && !idFilter[rid] {
+				continue
+			}
+			i, ok := byObject[row[1]]
+			if !ok {
+				i = len(out)
+				byObject[row[1]] = i
+				out = append(out, RoleGrant{Object: row[1], Operations: []string{}})
+			}
+			if !hasOp(out[i].DeniedOperations, row[2]) {
+				out[i].DeniedOperations = append(out[i].DeniedOperations, row[2])
+			}
+		}
+	}
 	return false, out, nil
+}
+
+func (en *Enforcer) hasSuperAdminRole(accessorID string) (bool, error) {
+	roles, err := en.e.GetImplicitRolesForUser(accessorID)
+	if err != nil {
+		return false, err
+	}
+	for _, role := range roles {
+		if role == SuperAdminRoleID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // hasOp reports whether ops contains want.
@@ -597,10 +699,14 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
 			continue
 		}
-		if _, err := en.e.RemovePolicy(row[0], object, oldOp); err != nil {
+		effect := EffectAllow
+		if len(row) >= 4 && row[3] != "" {
+			effect = row[3]
+		}
+		if _, err := en.e.RemovePolicy(row[0], object, oldOp, effect); err != nil {
 			return moved, err
 		}
-		if _, err := en.e.AddPolicy(row[0], object, newOp); err != nil {
+		if _, err := en.e.AddPolicy(row[0], object, newOp, effect); err != nil {
 			return moved, err
 		}
 		moved++
@@ -640,21 +746,21 @@ func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp s
 	prefix := resourceType + ":"
 	var added []BackfilledGrant
 	for _, row := range rows {
-		if len(row) < 3 {
+		if len(row) < 3 || (len(row) >= 4 && row[3] == EffectDeny) {
 			continue
 		}
 		object := row[1]
 		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
 			continue
 		}
-		has, err := en.e.HasPolicy(row[0], object, impliedOp)
+		has, err := en.e.HasPolicy(row[0], object, impliedOp, EffectAllow)
 		if err != nil {
 			return added, err
 		}
 		if has {
 			continue
 		}
-		if _, err := en.e.AddPolicy(row[0], object, impliedOp); err != nil {
+		if _, err := en.e.AddPolicy(row[0], object, impliedOp, EffectAllow); err != nil {
 			return added, err
 		}
 		added = append(added, BackfilledGrant{AccessorID: row[0], ResourceID: object[len(prefix):]})
@@ -724,7 +830,21 @@ func (en *Enforcer) RemoveResourcePolicies(resourceType, resourceID string) erro
 // built on this endpoint would lose rows that Check allows — and every caller
 // keeps working unchanged instead of having to learn about the hierarchy.
 func (en *Enforcer) AccessibleResources(accessorID, resourceType, op string) ([]string, error) {
-	return en.accessibleResources(accessorID, resourceType, op, map[string]bool{})
+	ids, err := en.accessibleResources(accessorID, resourceType, op, map[string]bool{})
+	if err != nil {
+		return nil, err
+	}
+	out := ids[:0]
+	for _, id := range ids {
+		allowed, err := en.Check(accessorID, resourceType, id, op)
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			out = append(out, id)
+		}
+	}
+	return out, nil
 }
 
 // accessibleResources is AccessibleResources plus the visited-type set that
@@ -738,7 +858,7 @@ func (en *Enforcer) accessibleResources(accessorID, resourceType, op string, vis
 	seen := map[string]bool{}
 	out := make([]string, 0, len(perms))
 	for _, p := range perms {
-		if len(p) < 3 {
+		if len(p) < 3 || (len(p) >= 4 && p[3] == EffectDeny) {
 			continue
 		}
 		o, act := p[1], p[2]
@@ -771,35 +891,43 @@ func (en *Enforcer) accessibleResources(accessorID, resourceType, op string, vis
 
 // ResourcePolicy is one accessor's grant set on a single resource instance.
 type ResourcePolicy struct {
-	AccessorID string
-	Operations []string
+	AccessorID       string
+	Operations       []string
+	DeniedOperations []string
 }
 
 // ResourcePolicies lists the per-accessor grants on a concrete resource
 // instance, grouping the raw (sub, obj, act) rows by accessor. Order of
 // accessors follows first appearance; ops within an accessor follow row order.
-// Mirrors ISF list-policy for one resource (bkn-safe has no expiry/condition,
-// so callers treat entries as never-expiring allow-only).
+// Mirrors ISF list-policy for one resource (bkn-safe has no expiry/condition).
+// Allows retain the legacy Operations field; deny exceptions are additive.
 func (en *Enforcer) ResourcePolicies(resourceType, resourceID string) ([]ResourcePolicy, error) {
 	rows, err := en.e.GetFilteredPolicy(1, obj(resourceType, resourceID))
 	if err != nil {
 		return nil, err
 	}
 	bySub := map[string][]string{}
+	deniedBySub := map[string][]string{}
+	seenSub := map[string]bool{}
 	order := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if len(row) < 3 {
 			continue
 		}
 		sub, act := row[0], row[2]
-		if _, ok := bySub[sub]; !ok {
+		if !seenSub[sub] {
 			order = append(order, sub)
+			seenSub[sub] = true
 		}
-		bySub[sub] = append(bySub[sub], act)
+		if len(row) >= 4 && row[3] == EffectDeny {
+			deniedBySub[sub] = append(deniedBySub[sub], act)
+		} else {
+			bySub[sub] = append(bySub[sub], act)
+		}
 	}
 	out := make([]ResourcePolicy, 0, len(order))
 	for _, sub := range order {
-		out = append(out, ResourcePolicy{AccessorID: sub, Operations: bySub[sub]})
+		out = append(out, ResourcePolicy{AccessorID: sub, Operations: bySub[sub], DeniedOperations: deniedBySub[sub]})
 	}
 	return out, nil
 }
@@ -808,10 +936,11 @@ func (en *Enforcer) ResourcePolicies(resourceType, resourceID string) ([]Resourc
 // the cross-product cell of the object-level authorization matrix (who can do
 // what on which specific object). Powers the admin authorization overview.
 type ObjectGrant struct {
-	AccessorID   string
-	ResourceType string
-	ResourceID   string
-	Operations   []string
+	AccessorID       string
+	ResourceType     string
+	ResourceID       string
+	Operations       []string
+	DeniedOperations []string
 }
 
 // ListObjectGrants enumerates concrete per-object accessor grants across all
@@ -833,6 +962,7 @@ func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string
 	}
 	type key struct{ sub, rtype, rid string }
 	ops := map[key][]string{}
+	deniedOps := map[key][]string{}
 	seen := map[key]map[string]bool{}
 	order := make([]key, 0, len(rows))
 	for _, row := range rows {
@@ -855,37 +985,58 @@ func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string
 			order = append(order, k)
 			seen[k] = map[string]bool{}
 		}
-		if seen[k][act] {
+		effectKey := act + "\x00" + policyEffect(row)
+		if seen[k][effectKey] {
 			continue
 		}
-		seen[k][act] = true
-		ops[k] = append(ops[k], act)
+		seen[k][effectKey] = true
+		if policyEffect(row) == EffectDeny {
+			deniedOps[k] = append(deniedOps[k], act)
+		} else {
+			ops[k] = append(ops[k], act)
+		}
 	}
 	out := make([]ObjectGrant, 0, len(order))
 	for _, k := range order {
 		out = append(out, ObjectGrant{
-			AccessorID: k.sub, ResourceType: k.rtype, ResourceID: k.rid, Operations: ops[k],
+			AccessorID: k.sub, ResourceType: k.rtype, ResourceID: k.rid,
+			Operations: ops[k], DeniedOperations: deniedOps[k],
 		})
 	}
 	return out, nil
 }
 
-// SetObjectPermissions replaces an accessor's entire op set on one concrete
-// resource instance: it drops every existing (accessor, object) p-line and adds
-// one per op. The "edit a grant" write behind the admin object-grant page
-// (POST /policies only adds, never prunes). Passing no ops clears the grant.
+// SetObjectPermissions replaces an accessor's allow operation set on one
+// concrete resource instance. Deny exceptions are managed independently by
+// SetObjectPermissionsForEffect. Passing no ops clears the allow set.
 func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID string, ops []string) error {
+	return en.SetObjectPermissionsForEffect(accessorID, resourceType, resourceID, ops, EffectAllow)
+}
+
+// SetObjectPermissionsForEffect replaces only one effect's operation set. This
+// preserves deny exceptions while legacy callers update allows, and vice versa.
+func (en *Enforcer) SetObjectPermissionsForEffect(accessorID, resourceType, resourceID string, ops []string, effect string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	if _, err := en.removeAccessorResourcePolicies(accessorID, resourceType, resourceID); err != nil {
+	if effect != EffectAllow && effect != EffectDeny {
+		return fmt.Errorf("invalid policy effect %q", effect)
+	}
+	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect); err != nil {
 		return err
 	}
 	for _, op := range ops {
-		if _, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op); err != nil {
+		if _, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, effect); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func policyEffect(row []string) string {
+	if len(row) >= 4 && row[3] == EffectDeny {
+		return EffectDeny
+	}
+	return EffectAllow
 }
 
 // RemoveAccessorResourcePolicies drops every op one accessor holds on one
@@ -902,6 +1053,27 @@ func (en *Enforcer) RemoveAccessorResourcePolicies(accessorID, resourceType, res
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
 	return en.removeAccessorResourcePolicies(accessorID, resourceType, resourceID)
+}
+
+// RemoveAccessorResourcePoliciesForEffect removes only allow or deny rows,
+// allowing an administrator to clear an exception without disturbing grants.
+func (en *Enforcer) RemoveAccessorResourcePoliciesForEffect(accessorID, resourceType, resourceID, effect string) (int, error) {
+	if effect != EffectAllow && effect != EffectDeny {
+		return 0, fmt.Errorf("invalid policy effect %q", effect)
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect)
+	if err != nil {
+		return 0, err
+	}
+	if len(rows) == 0 {
+		return 0, nil
+	}
+	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
 }
 
 func (en *Enforcer) removeAccessorResourcePolicies(accessorID, resourceType, resourceID string) (int, error) {

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -834,15 +834,20 @@ func (en *Enforcer) AccessibleResources(accessorID, resourceType, op string) ([]
 	if err != nil {
 		return nil, err
 	}
-	out := ids[:0]
+	resources := make([]ResourceRef, 0, len(ids))
 	for _, id := range ids {
-		allowed, err := en.Check(accessorID, resourceType, id, op)
-		if err != nil {
-			return nil, err
-		}
-		if allowed {
-			out = append(out, id)
-		}
+		resources = append(resources, ResourceRef{Type: resourceType, ID: id})
+	}
+	// The candidate set is collected above from direct and inherited grants,
+	// then filtered in one deny-aware batch. Calling Check for every id here
+	// would turn a resource-list request into N hierarchy/proxy lookups.
+	filtered, err := en.FilterResourceOps(accessorID, resources, []string{op}, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(filtered))
+	for _, resource := range filtered {
+		out = append(out, resource.ID)
 	}
 	return out, nil
 }

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -105,6 +105,24 @@ func TestExplicitDenyOverridesOrdinaryAllows(t *testing.T) {
 	}
 }
 
+func TestAccessibleResourcesFiltersDenyInBatch(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user, role = "alice", "reader-role"
+	mustNoErr(t, e.GrantRolePermission(role, "resource", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-2", "view_detail"))
+	mustNoErr(t, e.DenyObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	got, err := e.AccessibleResources(user, "resource", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameSet(got, []string{"r-2"}) {
+		t.Fatalf("accessible resources = %v, want [r-2]", got)
+	}
+}
+
 func TestSuperAdminCannotBeDenied(t *testing.T) {
 	e := newTestEnforcer(t)
 	const user = "break-glass-admin"

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -81,6 +81,72 @@ func TestRoleGrantAndWildcard(t *testing.T) {
 	}
 }
 
+func TestExplicitDenyOverridesOrdinaryAllows(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user, role = "alice", "reader-role"
+	mustNoErr(t, e.GrantRolePermission(role, "resource", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.DenyObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	denied, err := e.Check(user, "resource", "r-1", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if denied {
+		t.Fatal("an exact user deny did not override the role's type-wide allow")
+	}
+	allowed, err := e.Check(user, "resource", "r-2", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed {
+		t.Fatal("the deny exception leaked to a sibling resource")
+	}
+}
+
+func TestSuperAdminCannotBeDenied(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user = "break-glass-admin"
+	mustNoErr(t, e.AssignRole(user, SuperAdminRoleID))
+	mustNoErr(t, e.GrantRolePermission(SuperAdminRoleID, "", "*", ActAll))
+	mustNoErr(t, e.DenyObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	allowed, err := e.Check(user, "resource", "r-1", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed {
+		t.Fatal("the seeded super-admin recovery role was constrained by deny")
+	}
+}
+
+func TestLegacyPolicyWithoutEffectIsNormalizedToAllow(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	_ = e
+	if err := db.Exec(
+		"INSERT INTO casbin_rule (ptype, v0, v1, v2, v3) VALUES (?, ?, ?, ?, '')",
+		"p", "legacy-user", "resource:r-1", "view_detail",
+	).Error; err != nil {
+		t.Fatalf("insert legacy policy: %v", err)
+	}
+	reloaded, err := New(db)
+	if err != nil {
+		t.Fatalf("reload legacy policy: %v", err)
+	}
+	allowed, err := reloaded.Check("legacy-user", "resource", "r-1", "view_detail")
+	if err != nil || !allowed {
+		t.Fatalf("legacy policy decision = %v, %v; want true", allowed, err)
+	}
+	var effect string
+	if err := db.Raw("SELECT v3 FROM casbin_rule WHERE v0 = ?", "legacy-user").Scan(&effect).Error; err != nil {
+		t.Fatal(err)
+	}
+	if effect != EffectAllow {
+		t.Fatalf("legacy effect = %q, want %q", effect, EffectAllow)
+	}
+}
+
 // TestPublicAccessorGrant covers the root-department-as-everyone convention:
 // a policy whose subject is PublicAccessorID matches ANY requesting subject,
 // scoped strictly to the granted object and op (ISF "grant to root department

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -330,3 +330,24 @@ func TestEffectivePermissionsTypeWideOnlyInstanceOnlyType(t *testing.T) {
 		t.Errorf("no synthetic type row without TypeWideOnly: %+v", grants)
 	}
 }
+
+func TestEffectivePermissionsReportsDenyExceptionsAdditively(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user, role = "alice", "reader-role"
+	mustNoErr(t, e.GrantRolePermission(role, "resource", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.DenyObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	_, grants, err := e.EffectivePermissions(user, PermQuery{})
+	mustNoErr(t, err)
+	var exception *RoleGrant
+	for i := range grants {
+		if grants[i].Object == "resource:r-1" {
+			exception = &grants[i]
+			break
+		}
+	}
+	if exception == nil || !eqOps(exception.DeniedOperations, "view_detail") {
+		t.Fatalf("deny exception missing from effective permissions: %+v", grants)
+	}
+}

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -71,9 +71,18 @@ func (en *Enforcer) filterResourceOps(accessorID string, resources []ResourceRef
 	}
 
 	decided := map[ResourceRef]map[string]bool{}
+	terminal := map[ResourceRef]map[string]bool{}
 	for _, r := range resources {
 		if _, done := decided[r]; !done {
-			decided[r] = idx.allowed(r, union)
+			decided[r] = map[string]bool{}
+			terminal[r] = map[string]bool{}
+			for op, effect := range idx.decide(r, union) {
+				if effect == EffectAllow {
+					decided[r][op] = true
+				} else if effect == EffectDeny {
+					terminal[r][op] = true
+				}
+			}
 		}
 	}
 
@@ -86,7 +95,7 @@ func (en *Enforcer) filterResourceOps(accessorID string, resources []ResourceRef
 	for r, allowed := range decided {
 		var missing []string
 		for _, op := range union {
-			if !allowed[op] {
+			if !allowed[op] && !terminal[r][op] {
 				missing = append(missing, op)
 			}
 		}
@@ -94,8 +103,8 @@ func (en *Enforcer) filterResourceOps(accessorID string, resources []ResourceRef
 			stillMissing[r] = missing
 		}
 	}
-	inherited, err := en.climb(func(node ResourceRef, ops []string) (map[string]bool, error) {
-		return idx.allowed(node, ops), nil
+	inherited, err := en.climb(func(node ResourceRef, ops []string) (map[string]string, error) {
+		return idx.decide(node, ops), nil
 	}, stillMissing)
 	if err != nil {
 		return nil, err
@@ -165,6 +174,7 @@ func (en *Enforcer) filterResourceOps(accessorID string, resources []ResourceRef
 type grantRow struct {
 	object string
 	act    string
+	effect string
 }
 
 // grantIndex is an accessor's effective grant set, split by whether the object
@@ -172,8 +182,9 @@ type grantRow struct {
 // the (few) wildcard patterns are walked per resource, which keeps a list page
 // linear in resources rather than resources x policies.
 type grantIndex struct {
-	exact    map[string][]string // object key -> acts
-	wildcard []grantRow
+	exact      map[string][]grantRow // object key -> rules
+	wildcard   []grantRow
+	superAdmin bool
 }
 
 // grantIndex collects every policy row that can satisfy the matcher's subject
@@ -196,17 +207,25 @@ func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
 		return nil, err
 	}
 
-	idx := &grantIndex{exact: make(map[string][]string, len(rows))}
+	superAdmin, err := en.hasSuperAdminRole(accessorID)
+	if err != nil {
+		return nil, err
+	}
+	idx := &grantIndex{exact: make(map[string][]grantRow, len(rows)), superAdmin: superAdmin}
 	for _, row := range append(rows, public...) {
-		if len(row) < 3 {
+		if len(row) < 4 {
 			continue
 		}
-		object, act := row[1], row[2]
+		object, act, effect := row[1], row[2], row[3]
+		if effect == "" {
+			effect = EffectAllow
+		}
+		rule := grantRow{object: object, act: act, effect: effect}
 		if hasWildcard(object) {
-			idx.wildcard = append(idx.wildcard, grantRow{object: object, act: act})
+			idx.wildcard = append(idx.wildcard, rule)
 			continue
 		}
-		idx.exact[object] = append(idx.exact[object], act)
+		idx.exact[object] = append(idx.exact[object], rule)
 	}
 	return idx, nil
 }
@@ -214,28 +233,36 @@ func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
 // allowed reports, for one resource, which of ops the grants cover. It mirrors
 // the matcher's remaining two clauses: keyMatch(r.obj, p.obj) — via the same
 // util.KeyMatch the model uses — and (p.act == "*" || r.act == p.act).
-func (idx *grantIndex) allowed(r ResourceRef, ops []string) map[string]bool {
-	out := make(map[string]bool, len(ops))
+func (idx *grantIndex) decide(r ResourceRef, ops []string) map[string]string {
+	out := make(map[string]string, len(ops))
+	if idx.superAdmin {
+		for _, op := range ops {
+			out[op] = EffectAllow
+		}
+		return out
+	}
 	object := obj(r.Type, r.ID)
-	grant := func(act string) {
-		if act == ActAll {
+	apply := func(rule grantRow) {
+		if rule.act == ActAll {
 			for _, op := range ops {
-				out[op] = true
+				if rule.effect == EffectDeny || out[op] == "" {
+					out[op] = rule.effect
+				}
 			}
 			return
 		}
 		for _, op := range ops {
-			if op == act {
-				out[op] = true
+			if op == rule.act && (rule.effect == EffectDeny || out[op] == "") {
+				out[op] = rule.effect
 			}
 		}
 	}
-	for _, act := range idx.exact[object] {
-		grant(act)
+	for _, rule := range idx.exact[object] {
+		apply(rule)
 	}
 	for _, row := range idx.wildcard {
 		if util.KeyMatch(object, row.object) {
-			grant(row.act)
+			apply(row)
 		}
 	}
 	return out

--- a/bkn-safe/server/internal/authz/filter_test.go
+++ b/bkn-safe/server/internal/authz/filter_test.go
@@ -63,6 +63,25 @@ func TestFilterResourceOpsProjection(t *testing.T) {
 	}
 }
 
+func TestFilterResourceOpsAppliesDenyExceptions(t *testing.T) {
+	e := newTestEnforcer(t)
+	const user, role = "alice", "reader-role"
+	mustNoErr(t, e.GrantRolePermission(role, "knowledge_network", "*", "view_detail"))
+	mustNoErr(t, e.AssignRole(user, role))
+	mustNoErr(t, e.DenyObjectPermission(user, "knowledge_network", "kn-1", "view_detail"))
+
+	got, err := e.FilterResourceOps(user, []ResourceRef{
+		{Type: "knowledge_network", ID: "kn-1"},
+		{Type: "knowledge_network", ID: "kn-2"},
+	}, []string{"view_detail"}, []string{"view_detail"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "kn-2" {
+		t.Fatalf("filtered resources = %#v, want only kn-2", got)
+	}
+}
+
 // TestFilterResourceOpsVisibility covers the filtering axis: resources missing
 // any visibility op are dropped entirely, not returned with an empty op set.
 func TestFilterResourceOpsVisibility(t *testing.T) {

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -46,7 +46,7 @@ type climber struct {
 // nothing inherited are absent, so a caller reads it as an overlay on what it
 // already decided.
 func (en *Enforcer) climb(
-	decide func(ResourceRef, []string) (map[string]bool, error),
+	decide func(ResourceRef, []string) (map[string]string, error),
 	want map[ResourceRef][]string,
 ) (map[ResourceRef]map[string]bool, error) {
 	if en.db == nil || len(want) == 0 {
@@ -102,7 +102,7 @@ func (en *Enforcer) climb(
 
 		// Two resources under the same catalog asking about the same operations
 		// are one decision, not two. On a list page that is the common case.
-		verdicts := map[string]map[string]bool{}
+		verdicts := map[string]map[string]string{}
 		next := make([]*climber, 0, len(active))
 		for _, c := range active {
 			parent, ok := parents[c.node]
@@ -135,16 +135,23 @@ func (en *Enforcer) climb(
 
 			ask := distinctSorted(translated)
 			key := parent.Type + "\x00" + parent.ID + "\x00" + strings.Join(ask, "\x00")
-			allowed, cached := verdicts[key]
+			decisions, cached := verdicts[key]
 			if !cached {
-				allowed, err = decide(parent, ask)
+				decisions, err = decide(parent, ask)
 				if err != nil {
 					return nil, err
 				}
-				verdicts[key] = allowed
+				verdicts[key] = decisions
 			}
 			for asked, up := range translated {
-				if !allowed[up] {
+				effect := decisions[up]
+				if effect == EffectDeny {
+					// A deny encountered anywhere on the explicit inheritance
+					// path is terminal; a broader ancestor cannot restore it.
+					delete(translated, asked)
+					continue
+				}
+				if effect != EffectAllow {
 					continue
 				}
 				if found[c.origin] == nil {
@@ -395,31 +402,25 @@ func distinctSorted(m map[string]string) []string {
 
 // enforceOn is the single-decision evaluator handed to climb: it asks casbin
 // about one ancestor node, exactly as Check asks about the resource itself.
-func (en *Enforcer) enforceOn(accessorID string) func(ResourceRef, []string) (map[string]bool, error) {
-	return func(node ResourceRef, ops []string) (map[string]bool, error) {
-		out := make(map[string]bool, len(ops))
-		for _, op := range ops {
-			ok, err := en.e.Enforce(accessorID, obj(node.Type, node.ID), op)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				out[op] = true
-			}
-		}
-		return out, nil
-	}
-}
-
 // inheritedOps reports which of the missing operations the accessor holds on an
 // ancestor of the resource. The single-resource entry point behind Check and
 // AllowedOps.
 func (en *Enforcer) inheritedOps(accessorID, resourceType, resourceID string, missing []string) (map[string]bool, error) {
+	idx, err := en.grantIndex(accessorID)
+	if err != nil {
+		return nil, err
+	}
+	return en.inheritedOpsWithIndex(idx, resourceType, resourceID, missing)
+}
+
+func (en *Enforcer) inheritedOpsWithIndex(idx *grantIndex, resourceType, resourceID string, missing []string) (map[string]bool, error) {
 	if len(missing) == 0 {
 		return nil, nil
 	}
 	r := ResourceRef{Type: resourceType, ID: resourceID}
-	found, err := en.climb(en.enforceOn(accessorID), map[ResourceRef][]string{r: missing})
+	found, err := en.climb(func(node ResourceRef, ops []string) (map[string]string, error) {
+		return idx.decide(node, ops), nil
+	}, map[ResourceRef][]string{r: missing})
 	if err != nil {
 		return nil, err
 	}
@@ -448,9 +449,8 @@ type OwnershipFlip struct {
 
 // PreviewOwnership answers "who would gain and lose what" BEFORE any ownership
 // row is written. It exists because recording ownership is the moment
-// inheritance starts applying, and there is no flag to stage that (an
-// allow-only engine has nothing to tighten), so the confirmation has to happen
-// before the write rather than after it.
+// inheritance starts applying, and there is no flag to stage that, so the
+// confirmation has to happen before the write rather than after it.
 //
 // links maps each proposed resource id to its proposed parent id. limit caps
 // the returned slice; the total is always exact, so a caller can say "3 shown

--- a/bkn-safe/server/internal/authz/hierarchy_test.go
+++ b/bkn-safe/server/internal/authz/hierarchy_test.go
@@ -82,6 +82,23 @@ func TestCheckInheritsThroughTheCatalog(t *testing.T) {
 	}
 }
 
+func TestConcreteDenyBlocksInheritedAllow(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	declareCatalogHierarchy(t, db)
+	ownedBy(t, db, "res-in", "cat-1")
+	const user = "alice"
+	mustNoErr(t, e.GrantObjectPermission(user, "catalog", "cat-1", "view_detail"))
+	mustNoErr(t, e.DenyObjectPermission(user, "resource", "res-in", "view_detail"))
+
+	allowed, err := e.Check(user, "resource", "res-in", "view_detail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed {
+		t.Fatal("a concrete deny was restored by an inherited catalog allow")
+	}
+}
+
 // TestInheritanceRefusesSameNameFallback is the escalation this design exists to
 // prevent: "modify" on a catalog means rename the catalog. If it fell back by
 // name, whoever may rename a catalog could rewrite every table in it.

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -36,16 +36,16 @@ func (tx *PolicyTransaction) Check(accessorID, resourceType, resourceID, operati
 }
 
 func (tx *PolicyTransaction) HasObjectPermission(accessorID, resourceType, resourceID, operation string) (bool, error) {
-	return tx.enforcer.e.HasPolicy(accessorID, obj(resourceType, resourceID), operation)
+	return tx.enforcer.e.HasPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
 }
 
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
-	_, err := tx.enforcer.e.AddPolicy(accessorID, obj(resourceType, resourceID), operation)
+	_, err := tx.enforcer.e.AddPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
 	return err
 }
 
 func (tx *PolicyTransaction) RevokeObjectPermission(accessorID, resourceType, resourceID, operation string) error {
-	_, err := tx.enforcer.e.RemovePolicy(accessorID, obj(resourceType, resourceID), operation)
+	_, err := tx.enforcer.e.RemovePolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
 	return err
 }
 

--- a/bkn-safe/server/internal/authz/transaction_test.go
+++ b/bkn-safe/server/internal/authz/transaction_test.go
@@ -25,7 +25,7 @@ func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
 		})
 	}()
 	<-entered
-	allowed, err := e.e.HasPolicy("proxy", obj("resource", "r-1"), "query_data")
+	allowed, err := e.e.HasPolicy("proxy", obj("resource", "r-1"), "query_data", EffectAllow)
 	if err != nil || allowed {
 		t.Fatalf("uncommitted policy was visible: allowed=%v err=%v", allowed, err)
 	}
@@ -53,7 +53,7 @@ func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
 		{"proxy", "r-1", "query_data"},
 		{"user", "r-2", "view_detail"},
 	} {
-		allowed, err := e.e.HasPolicy(check.accessor, obj("resource", check.resource), check.operation)
+		allowed, err := e.e.HasPolicy(check.accessor, obj("resource", check.resource), check.operation, EffectAllow)
 		if err != nil || !allowed {
 			t.Fatalf("Check(%q, %q, %q) = %v, %v", check.accessor, check.resource, check.operation, allowed, err)
 		}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -353,9 +353,10 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 		entries := make([]gin.H, 0, len(policies))
 		for _, p := range policies {
 			entries = append(entries, gin.H{
-				"accessor_id": p.AccessorID,
-				"resource":    gin.H{"type": rtype, "id": rid},
-				"operations":  p.Operations,
+				"accessor_id":       p.AccessorID,
+				"resource":          gin.H{"type": rtype, "id": rid},
+				"operations":        p.Operations,
+				"denied_operations": p.DeniedOperations,
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"entries": entries})
@@ -776,6 +777,9 @@ func grantsJSON(grants []authz.RoleGrant) []gin.H {
 		// every other response rather than showing up empty everywhere.
 		if len(gr.InstanceOperations) > 0 {
 			row["instance_operations"] = gr.InstanceOperations
+		}
+		if len(gr.DeniedOperations) > 0 {
+			row["denied_operations"] = gr.DeniedOperations
 		}
 		out = append(out, row)
 	}

--- a/bkn-safe/server/internal/httpapi/me.go
+++ b/bkn-safe/server/internal/httpapi/me.go
@@ -179,7 +179,19 @@ func registerMeReads(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, dir *di
 		}
 		result := make([]knowledgeNetworkGrantJSON, 0, len(grants))
 		for _, grant := range grants {
-			operations := append([]string(nil), grant.Operations...)
+			denied := make(map[string]bool, len(grant.DeniedOperations))
+			for _, operation := range grant.DeniedOperations {
+				denied[operation] = true
+			}
+			operations := make([]string, 0, len(grant.Operations))
+			for _, operation := range grant.Operations {
+				if !denied[operation] {
+					operations = append(operations, operation)
+				}
+			}
+			if len(operations) == 0 {
+				continue
+			}
 			sort.Strings(operations)
 			result = append(result, knowledgeNetworkGrantJSON{
 				KnowledgeNetworkID: grant.ResourceID,

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -259,9 +259,10 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		entries := make([]gin.H, 0, len(policies))
 		for _, p := range policies {
 			entries = append(entries, gin.H{
-				"accessor_id": p.AccessorID,
-				"resource":    gin.H{"type": resourceType, "id": resourceID},
-				"operations":  p.Operations,
+				"accessor_id":       p.AccessorID,
+				"resource":          gin.H{"type": resourceType, "id": resourceID},
+				"operations":        p.Operations,
+				"denied_operations": p.DeniedOperations,
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"entries": entries})
@@ -364,7 +365,9 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		// count — and stays far under 1024. Op ids contain no ",", so splitting the
 		// result on "," below is safe.
 		rowsSQL := "SELECT v0 AS accessor, " + rtypeExpr + " AS rtype, " + ridExpr + " AS rid, " +
-			"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
+			"COALESCE(GROUP_CONCAT(DISTINCT CASE WHEN v3 = 'deny' THEN NULL ELSE v2 END), '') AS ops, " +
+			"COALESCE(GROUP_CONCAT(DISTINCT CASE WHEN v3 = 'deny' THEN v2 ELSE NULL END), '') AS denied_ops " +
+			"FROM casbin_rule WHERE " + whereSQL +
 			" GROUP BY v0, v1 ORDER BY v0, v1"
 		rowArgs := append([]any{}, args...)
 		if _, limitSet := c.GetQuery("limit"); limitSet {
@@ -384,10 +387,11 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		}
 
 		var rows []struct {
-			Accessor string
-			Rtype    string
-			Rid      string
-			Ops      string
+			Accessor  string
+			Rtype     string
+			Rid       string
+			Ops       string
+			DeniedOps string
 		}
 		if err := qdb.Raw(rowsSQL, rowArgs...).Scan(&rows).Error; err != nil {
 			serverError(c, err)
@@ -401,9 +405,10 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 				ops = strings.Split(row.Ops, ",")
 			}
 			entries = append(entries, gin.H{
-				"accessor_id": row.Accessor,
-				"resource":    gin.H{"type": row.Rtype, "id": row.Rid},
-				"operations":  ops,
+				"accessor_id":       row.Accessor,
+				"resource":          gin.H{"type": row.Rtype, "id": row.Rid},
+				"operations":        ops,
+				"denied_operations": splitGrantOps(row.DeniedOps),
 			})
 		}
 		resp["entries"] = entries
@@ -411,9 +416,10 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		c.JSON(http.StatusOK, resp)
 	})
 
-	// POST /object-grants — set (replace) a user's exact op set on one concrete
-	// resource instance. { accessor_id, resource{type,id}, operations:[...] }
-	// Upsert semantics: the grant's ops become exactly `operations`. An empty
+	// POST /object-grants — set (replace) a user's exact allow or deny op set on
+	// one concrete resource instance. { accessor_id, resource, operations,
+	// effect?:"allow"|"deny" }. Missing effect remains allow for compatibility.
+	// Upsert semantics: that effect's ops become exactly `operations`. An empty
 	// list is rejected (use DELETE to revoke) so an accidental empty body can't
 	// silently wipe a grant.
 	g.POST("/object-grants", setObjectGrantHandler(e, db))
@@ -460,7 +466,9 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 	// the fixed operation vocabulary (a comma-free ~dozen ids), so the result
 	// stays well under group_concat_max_len and splits cleanly on ",".
 	sql := "SELECT " + keyCol + " AS k, COUNT(DISTINCT " + cntCol + ") AS cnt, " +
-		"GROUP_CONCAT(DISTINCT v2) AS ops FROM casbin_rule WHERE " + whereSQL +
+		"COALESCE(GROUP_CONCAT(DISTINCT CASE WHEN v3 = 'deny' THEN NULL ELSE v2 END), '') AS ops, " +
+		"COALESCE(GROUP_CONCAT(DISTINCT CASE WHEN v3 = 'deny' THEN v2 ELSE NULL END), '') AS denied_ops " +
+		"FROM casbin_rule WHERE " + whereSQL +
 		" GROUP BY " + keyCol + " ORDER BY " + keyCol
 	rowArgs := append([]any{}, args...)
 	if _, limitSet := c.GetQuery("limit"); limitSet {
@@ -480,9 +488,10 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 	}
 
 	var rows []struct {
-		K   string
-		Cnt int64
-		Ops string
+		K         string
+		Cnt       int64
+		Ops       string
+		DeniedOps string
 	}
 	if err := qdb.Raw(sql, rowArgs...).Scan(&rows).Error; err != nil {
 		serverError(c, err)
@@ -498,19 +507,28 @@ func listGroupedObjectGrants(c *gin.Context, qdb *gorm.DB, groupBy, whereSQL str
 		if groupBy == "object" {
 			rtype, rid, _ := strings.Cut(r.K, ":")
 			groups = append(groups, gin.H{
-				"object":        gin.H{"type": rtype, "id": rid},
-				"grantee_count": r.Cnt,
-				"operations":    ops,
+				"object":            gin.H{"type": rtype, "id": rid},
+				"grantee_count":     r.Cnt,
+				"operations":        ops,
+				"denied_operations": splitGrantOps(r.DeniedOps),
 			})
 		} else {
 			groups = append(groups, gin.H{
-				"accessor_id":  r.K,
-				"object_count": r.Cnt,
-				"operations":   ops,
+				"accessor_id":       r.K,
+				"object_count":      r.Cnt,
+				"operations":        ops,
+				"denied_operations": splitGrantOps(r.DeniedOps),
 			})
 		}
 	}
 	c.JSON(http.StatusOK, gin.H{"groups": groups, "total": total})
+}
+
+func splitGrantOps(value string) []string {
+	if value == "" {
+		return []string{}
+	}
+	return strings.Split(value, ",")
 }
 
 // isUserAccessor reports whether id is a known user row (real user or app
@@ -599,9 +617,10 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 		entries := make([]gin.H, 0, len(policies))
 		for _, policy := range policies {
 			entry := gin.H{
-				"accessor_id": policy.AccessorID,
-				"resource":    gin.H{"type": ref.Type, "id": ref.ID},
-				"operations":  policy.Operations,
+				"accessor_id":       policy.AccessorID,
+				"resource":          gin.H{"type": ref.Type, "id": ref.ID},
+				"operations":        policy.Operations,
+				"denied_operations": policy.DeniedOperations,
 			}
 			// A row whose subject is a role, or a user since deleted, resolves to
 			// nothing. It is still shown — hiding a grant that exists would be
@@ -695,6 +714,7 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			AccessorID string      `json:"accessor_id" binding:"required"`
 			Resource   resourceRef `json:"resource" binding:"required"`
 			Operations []string    `json:"operations" binding:"required"`
+			Effect     string      `json:"effect"`
 		}
 		if !bind(c, &req) {
 			return
@@ -704,6 +724,13 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		if len(req.Operations) == 0 {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if req.Effect == "" {
+			req.Effect = authz.EffectAllow
+		}
+		if req.Effect != authz.EffectAllow && req.Effect != authz.EffectDeny {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
@@ -729,6 +756,13 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		// the object named in the BODY, which middleware cannot see.
 		authority, ok := resolveGrantAuthority(c, e, "grant", req.Resource)
 		if !ok {
+			return
+		}
+		// Explicit exceptions are security administration, not delegation: an
+		// object owner may share what they hold but may not install deny rules on
+		// another account.
+		if req.Effect == authz.EffectDeny && authority != authorityAdminAuthz {
+			replyPublicError(c, http.StatusForbidden)
 			return
 		}
 		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
@@ -767,10 +801,13 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		// quietly absorbs. Upsert semantics make this self-healing: a console that
 		// clears view_detail while leaving resource_manage ticked sends a set this
 		// puts back, instead of storing a grant nothing can use.
-		ops, err := impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
-		if err != nil {
-			serverError(c, err)
-			return
+		ops := req.Operations
+		if req.Effect == authz.EffectAllow {
+			ops, err = impliedOps(db.WithContext(c.Request.Context()), req.Resource.Type, req.Operations)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
 		}
 		// Checked against the EXPANDED set, not what was asked for: the implication
 		// pass can add operations, and a delegate must not acquire one that way
@@ -788,8 +825,9 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if implied := addedOps(req.Operations, ops); len(implied) > 0 {
 			outcome["implied_operations"] = implied
 		}
+		outcome["effect"] = req.Effect
 		setAuditOutcome(c, outcome)
-		if err := e.SetObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID, ops); err != nil {
+		if err := e.SetObjectPermissionsForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect); err != nil {
 			serverError(c, err)
 			return
 		}
@@ -802,11 +840,16 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		var req struct {
 			AccessorID string      `json:"accessor_id" binding:"required"`
 			Resource   resourceRef `json:"resource" binding:"required"`
+			Effect     string      `json:"effect"`
 		}
 		if !bind(c, &req) {
 			return
 		}
 		if !isConcreteResourceID(req.Resource.ID) {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if req.Effect != "" && req.Effect != authz.EffectAllow && req.Effect != authz.EffectDeny {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
@@ -838,7 +881,12 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		removed, err := e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
+		var removed int
+		if req.Effect == "" {
+			removed, err = e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
+		} else {
+			removed, err = e.RemoveAccessorResourcePoliciesForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, req.Effect)
+		}
 		if err != nil {
 			serverError(c, err)
 			return

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -869,6 +869,15 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		if !ok {
 			return
 		}
+		// Deny exceptions are security-administration state. A delegated owner
+		// may revoke ordinary allows, but must not remove an administrator's deny
+		// rule. For a legacy request without effect, keep the owner-facing revoke
+		// behavior by limiting it to allow rows; administrators retain the old
+		// "remove every row" behavior.
+		if req.Effect == authz.EffectDeny && authority != authorityAdminAuthz {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
 		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
 			return
 		}
@@ -882,10 +891,14 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		var removed int
-		if req.Effect == "" {
+		if req.Effect == "" && authority == authorityAdminAuthz {
 			removed, err = e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
 		} else {
-			removed, err = e.RemoveAccessorResourcePoliciesForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, req.Effect)
+			effect := req.Effect
+			if effect == "" {
+				effect = authz.EffectAllow
+			}
+			removed, err = e.RemoveAccessorResourcePoliciesForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, effect)
 		}
 		if err != nil {
 			serverError(c, err)

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -489,6 +489,42 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 	}
 }
 
+func TestObjectGrantsOwnerCannotRemoveAdminDeny(t *testing.T) {
+	r, e, _ := ownerGrantFixtureWithDB(t)
+	const readerRole = "kn-reader"
+	if err := e.GrantRolePermission(readerRole, "knowledge_network", "*", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("u-mate", readerRole); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.DenyObjectPermission("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+
+	// A legacy owner revoke still removes only ordinary grants, never the
+	// administrator-installed deny exception.
+	w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+	}, "u-owner")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("legacy owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, err := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil || ok {
+		t.Fatalf("owner revoke removed admin deny: allowed=%v err=%v", ok, err)
+	}
+
+	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"effect":      "deny",
+	}, "u-owner")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("owner remove deny: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
 func TestObjectGrantsDisabledOwnerCannotWrite(t *testing.T) {
 	r, e, db := ownerGrantFixtureWithDB(t)
 	if err := db.Model(&model.User{}).Where("id = ?", "u-owner").Update("enabled", false).Error; err != nil {

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -34,7 +34,8 @@ type ogEntry struct {
 		Type string `json:"type"`
 		ID   string `json:"id"`
 	} `json:"resource"`
-	Operations []string `json:"operations"`
+	Operations       []string `json:"operations"`
+	DeniedOperations []string `json:"denied_operations"`
 }
 
 func listObjectGrants(t *testing.T, r *gin.Engine, query string) []ogEntry {
@@ -138,6 +139,71 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	}
 	if got := listObjectGrants(t, r, ""); len(got) != 0 {
 		t.Fatalf("list after revoke: %+v", got)
+	}
+}
+
+func TestAdminObjectGrantDenyIsBackwardCompatible(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: "alice", Account: "alice-deny", Name: "Alice", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+	const reader = "reader-role"
+	if err := e.GrantRolePermission(reader, "catalog", "*", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("alice", reader); err != nil {
+		t.Fatal(err)
+	}
+
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "alice",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"view_detail"},
+		"effect":      "deny",
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("deny: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, err := e.Check("alice", "catalog", "c1", "view_detail"); err != nil || ok {
+		t.Fatalf("denied check = %v, %v; want false", ok, err)
+	}
+	if ok, err := e.Check("alice", "catalog", "c2", "view_detail"); err != nil || !ok {
+		t.Fatalf("sibling check = %v, %v; want true", ok, err)
+	}
+	entries := listObjectGrants(t, r, "?accessor_id=alice&resource_type=catalog&resource_id=c1")
+	if len(entries) != 1 || len(entries[0].Operations) != 0 ||
+		len(entries[0].DeniedOperations) != 1 || entries[0].DeniedOperations[0] != "view_detail" {
+		t.Fatalf("deny-only grant listing = %+v", entries)
+	}
+
+	// A legacy request without effect still means allow and changes only allows;
+	// it must not silently erase the independently managed deny exception.
+	w = adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "alice",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"operations":  []string{"modify"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("legacy allow: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	entries = listObjectGrants(t, r, "?accessor_id=alice&resource_type=catalog&resource_id=c1")
+	if len(entries) != 1 || len(entries[0].DeniedOperations) != 1 || entries[0].DeniedOperations[0] != "view_detail" {
+		t.Fatalf("deny was not exposed separately: %+v", entries)
+	}
+
+	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "alice",
+		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+		"effect":      "deny",
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("remove deny: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, err := e.Check("alice", "catalog", "c1", "view_detail"); err != nil || !ok {
+		t.Fatalf("role allow was not restored after removing deny: %v, %v", ok, err)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -102,6 +102,55 @@ func TestAuthzCheckEndpoint(t *testing.T) {
 	}
 }
 
+func TestAuthzEndpointsApplyDenyWithoutChangingBusinessRequests(t *testing.T) {
+	r, e, db := newTestServer(t)
+	const user, role = "alice", "reader-role"
+	seedEnabledUser(t, db, user)
+	if err := db.Create(&model.Operation{ResourceTypeID: "resource", ID: "view_detail", Name: "view_detail"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission(role, "resource", "*", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole(user, role); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.DenyObjectPermission(user, "resource", "r-1", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+
+	check := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", map[string]any{
+		"accessor_id": user,
+		"resource":    map[string]string{"type": "resource", "id": "r-1"},
+		"operation":   "view_detail",
+	})
+	var decision struct {
+		Allowed bool `json:"allowed"`
+	}
+	if check.Code != http.StatusOK || json.Unmarshal(check.Body.Bytes(), &decision) != nil || decision.Allowed {
+		t.Fatalf("deny check response = %d %s", check.Code, check.Body.String())
+	}
+
+	filter := do(t, r, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+		"accessor_id":           user,
+		"resource_type":         "resource",
+		"resource_ids":          []string{"r-1", "r-2"},
+		"visibility_operations": []string{"view_detail"},
+		"candidate_operations":  []string{"view_detail"},
+	})
+	var filtered struct {
+		Resources []struct {
+			ID string `json:"resource_id"`
+		} `json:"resources"`
+	}
+	if filter.Code != http.StatusOK || json.Unmarshal(filter.Body.Bytes(), &filtered) != nil {
+		t.Fatalf("deny filter response = %d %s", filter.Code, filter.Body.String())
+	}
+	if len(filtered.Resources) != 1 || filtered.Resources[0].ID != "r-2" {
+		t.Fatalf("deny filter resources = %+v, want only r-2", filtered.Resources)
+	}
+}
+
 func TestDirectoryNamesEndpoint(t *testing.T) {
 	r, _, db := newTestServer(t)
 	db.Create(&model.User{ID: "u1", Account: "alice", Name: "Alice", Enabled: true})

--- a/docs/api/bkn-safe/authorization.yaml
+++ b/docs/api/bkn-safe/authorization.yaml
@@ -5,7 +5,7 @@
 openapi: 3.0.3
 info:
   title: bkn-safe internal authorization API
-  version: 0.3.0
+  version: 0.3.1
   description: |
     Internal service-to-service authorization contract used by BKN,
     ontology-query, context-loader, and execution-factory.
@@ -572,6 +572,14 @@ components:
         operations:
           type: array
           items: {type: string}
+        denied_operations:
+          type: array
+          items: {type: string}
+          description: |
+            Explicit deny exceptions on this accessor and resource. Omitted by
+            older servers; clients that do not inspect policy administration
+            details may ignore it. Runtime decision endpoints already apply
+            deny precedence and keep their existing request/response shapes.
     ResourceParentItem:
       type: object
       required: [resource_id, parent_id]


### PR DESCRIPTION
Add explicit deny policies for concrete resource permissions.

- Make deny override ordinary direct, role-derived, public, and inherited allows
- Keep super_admin unrestricted as the emergency recovery role
- Preserve legacy policies by treating empty v3 as allow
- Keep existing business authorization APIs and request formats unchanged
- Add effect-aware object grant management and regression coverage

Tests: go test ./... in bkn-safe/server; go test ./... in bkn-safe/contract; redocly lint docs/api/bkn-safe/authorization.yaml

# Pull Request

## What Changed

Brief description of changes:

- [x] bkn-safe：Casbin 权限模型支持 `deny-override`，显式拒绝优先于角色、直接和继承授权的允许规则
- [x] bkn-safe：`super_admin` 保持不可拒绝，保留紧急运维与权限恢复通道
- [x] bkn-safe：对象授权接口支持可选 `effect: allow|deny`，授权查询响应增加 `denied_operations`
- [x] bkn-safe：兼容历史 Casbin 策略记录，空 `v3` 自动按 `allow` 处理
- [x] Docs：更新授权 API OpenAPI 文档与 bkn-safe 使用说明
- [x] Tests：补充显式拒绝、super_admin 豁免、层级资源、批量过滤、接口兼容性等回归测试

---

## Why

- Related Issue: N/A
- Related Feature: bkn-safe 资源级显式拒绝权限
- Background:

当前角色授权会使角色成员获得其全部资源权限；当需要排除某个用户访问某个资源时，缺少“拒绝优先”的表达能力。本改造允许对用户或角色配置资源级 `deny` 规则，并确保普通用户的拒绝规则覆盖已有允许规则。

---

## How

- Key implementation points:
  - Casbin policy 从 `p, sub, obj, act` 扩展为 `p, sub, obj, act, eft`。
  - 使用 `some(allow) && !some(deny)` 的策略效果，实现普通主体的 deny-override。
  - 历史策略的 `v3` 为空时，在加载前规范化为 `allow`；复用现有 `casbin_rule.v3` 字段，不新增数据库表或字段。
  - 对资源层级、公开资源、批量资源过滤和有效权限查询统一应用最终拒绝判定。
  - `super_admin` 在授权判断与资源过滤中直接放行，不受 deny 规则影响。
  - 对象授权新增可选 `effect` 请求字段；未传时默认为 `allow`，删除接口未传 `effect` 时维持旧行为：同时删除 allow/deny 规则。
  - `denied_operations` 为响应新增字段，不影响既有字段和业务服务调用方式。

- Breaking changes (API, config, database, etc.):
  - 无破坏性变更。
  - 数据库无 schema 变更；旧策略自动兼容为 `allow`。
  - 既有授权接口请求及业务服务 Casbin 调用方式无需修改。
  - 新增 deny 配置仅允许管理员授权，避免资源所有者越权拒绝他人访问。

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `GOCACHE=/tmp/bkn-safe-go-cache go test ./...`（`bkn-safe/server`）
- `GOCACHE=/tmp/bkn-safe-contract-go-cache go test ./...`（`bkn-safe/contract`）
- `npx @redocly/cli lint --config .redocly.yaml docs/api/bkn-safe/authorization.yaml`
- `git diff --check`

覆盖场景包括：角色通配允许被用户显式拒绝覆盖、super_admin 不可拒绝、历史空 effect 策略兼容、层级资源拒绝阻断继承允许、批量资源过滤、授权接口新增/删除 deny 规则及旧请求兼容。

---

## Risk & Rollback

- Potential risks:
  - 新增 deny 规则生效后，可能使已有角色授权的用户失去指定资源访问权限。
  - 历史策略加载时会将空 effect 规范化为 `allow`，需关注数据库写入权限与执行日志。
  - 业务侧若依赖“只要存在 allow 即可访问”的非标准权限判断，可能与新语义不一致。

- Rollback plan:
  - 回滚本 PR 对应版本即可恢复原有仅 allow 的 Casbin 模型。
  - 如需紧急恢复特定用户访问，可删除对应 deny 策略；`super_admin` 始终可用于权限恢复。

---

## Additional Notes

- Commit: `1c9ea98fe feat(bkn-safe): support deny-overrides for resource permissions`
- PR 分支：`feat/bkn-safe/deny-overrides`
- bkn-safe README 与 `docs/api/bkn-safe/authorization.yaml` 已同步更新。