### PR TITLE
fix(vega): accept precise JSON vector values

### DIFF
--- a/adp/vega/vega-backend/server/logics/dataset/document_materializer.go
+++ b/adp/vega/vega-backend/server/logics/dataset/document_materializer.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -151,8 +152,11 @@ func validateVector(value any, dimension int, field string) error {
 		}
 		vector = make([]float32, len(values))
 		for i, value := range values {
-			number, ok := value.(float64)
-			if !ok || math.IsNaN(number) || math.IsInf(number, 0) {
+			number, ok := vectorElementNumber(value)
+			if !ok {
+				return fmt.Errorf("vector field %q contains a non-numeric value", field)
+			}
+			if math.IsNaN(number) || math.IsInf(number, 0) {
 				return fmt.Errorf("vector field %q contains a non-finite number", field)
 			}
 			vector[i] = float32(number)
@@ -167,6 +171,42 @@ func validateVector(value any, dimension int, field string) error {
 		}
 	}
 	return nil
+}
+
+// vectorElementNumber accepts values produced by precise JSON decoding and by
+// internal callers before they are converted to the local index representation.
+func vectorElementNumber(value any) (float64, bool) {
+	switch number := value.(type) {
+	case float64:
+		return number, true
+	case float32:
+		return float64(number), true
+	case json.Number:
+		parsed, err := number.Float64()
+		return parsed, err == nil
+	case int:
+		return float64(number), true
+	case int8:
+		return float64(number), true
+	case int16:
+		return float64(number), true
+	case int32:
+		return float64(number), true
+	case int64:
+		return float64(number), true
+	case uint:
+		return float64(number), true
+	case uint8:
+		return float64(number), true
+	case uint16:
+		return float64(number), true
+	case uint32:
+		return float64(number), true
+	case uint64:
+		return float64(number), true
+	default:
+		return 0, false
+	}
 }
 
 func invalidDocumentError(ctx context.Context, details string) error {

--- a/adp/vega/vega-backend/server/logics/dataset/document_materializer_test.go
+++ b/adp/vega/vega-backend/server/logics/dataset/document_materializer_test.go
@@ -3,12 +3,14 @@ package dataset
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"vega-backend/common"
 	"vega-backend/interfaces"
 	vmock "vega-backend/interfaces/mock"
 )
@@ -51,6 +53,36 @@ func TestMaterializeDocument(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, []any{0.1, 0.2}, document["content_vector"])
+	})
+
+	t.Run("accepts an explicit derived vector decoded with precise JSON", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mfs := vmock.NewMockModelFactoryService(ctrl)
+		ds := &datasetService{mfs: mfs}
+		var input map[string]any
+		require.NoError(t, common.DecodePreciseJSON(strings.NewReader(`{"content_vector":[0.1,0.2]}`), &input))
+
+		document, err := ds.materializeDocument(context.Background(), resource, input)
+
+		require.NoError(t, err)
+		assert.Equal(t, input["content_vector"], document["content_vector"])
+	})
+
+	t.Run("accepts a vector field decoded with precise JSON", func(t *testing.T) {
+		resource := &interfaces.Resource{
+			LocalIndexName: "vega-dataset-index",
+			SchemaDefinition: []*interfaces.Property{{
+				Name: "_vector", Type: interfaces.DataType_Vector,
+				Features: []interfaces.PropertyFeature{{FeatureType: interfaces.PropertyFeatureType_Vector, Config: map[string]any{"dimension": float64(2)}}},
+			}},
+		}
+		var input map[string]any
+		require.NoError(t, common.DecodePreciseJSON(strings.NewReader(`{"_vector":[0.1,0.2]}`), &input))
+
+		document, err := (&datasetService{}).materializeDocument(context.Background(), resource, input)
+
+		require.NoError(t, err)
+		assert.Equal(t, input["_vector"], document["_vector"])
 	})
 
 	t.Run("does not write when inference fails", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/dataset/document_materializer_test.go
+++ b/adp/vega/vega-backend/server/logics/dataset/document_materializer_test.go
@@ -2,6 +2,7 @@ package dataset
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -65,7 +66,7 @@ func TestMaterializeDocument(t *testing.T) {
 		document, err := ds.materializeDocument(context.Background(), resource, input)
 
 		require.NoError(t, err)
-		assert.Equal(t, input["content_vector"], document["content_vector"])
+		assert.Equal(t, []any{json.Number("0.1"), json.Number("0.2")}, document["content_vector"])
 	})
 
 	t.Run("accepts a vector field decoded with precise JSON", func(t *testing.T) {
@@ -82,7 +83,7 @@ func TestMaterializeDocument(t *testing.T) {
 		document, err := (&datasetService{}).materializeDocument(context.Background(), resource, input)
 
 		require.NoError(t, err)
-		assert.Equal(t, input["_vector"], document["_vector"])
+		assert.Equal(t, []any{json.Number("0.1"), json.Number("0.2")}, document["_vector"])
 	})
 
 	t.Run("does not write when inference fails", func(t *testing.T) {


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Fix VEGA Dataset vector validation for precise JSON (`json.Number`) values.
- [x] Add regression coverage for derived and direct vector fields decoded through the precise JSON decoder.
- [ ] Docs: not needed; API contract is unchanged.

---

## Why

- Related Issue: Closes #1378
- Background: `UseNumber` makes JSON vector elements `json.Number`, while the synchronous vector validator only accepted `float64`.

---

## How

- Normalize accepted numeric element types before finite-value validation.
- Distinguish non-numeric elements from non-finite values.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally (`make ci`)
- [ ] Integration tests: not required; this is a deterministic unit-level decode/validation regression.
- [ ] Verified in test environment: not run.

Test notes: direct and derived vector fields decoded with `common.DecodePreciseJSON` are both covered.

---

## Risk & Rollback

- Potential risks: malformed numeric literals remain rejected; finite vector behavior is unchanged.
- Rollback plan: revert commit `2f7b44c70`.

---

## Additional Notes

- No API, configuration, schema, or data migration changes.