### PR TITLE
fix(vega): omit binary semantic samples

### DIFF
--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -623,7 +623,7 @@ func (suts *semanticUnderstandingTaskService) attachUnmaskedSampleRows(ctx conte
 	input.SampleRows = []map[string]any{}
 	if result != nil && result.Entries != nil {
 		var truncated bool
-		input.SampleRows, truncated, err = limitSemanticUnderstandingSampleRows(result.Entries)
+		input.SampleRows, truncated, err = limitSemanticUnderstandingSampleRows(result.Entries, resource.SchemaDefinition)
 		if err != nil {
 			return fmt.Errorf("limit sample rows: %w", err)
 		}
@@ -642,7 +642,8 @@ func (suts *semanticUnderstandingTaskService) attachUnmaskedSampleRows(ctx conte
 // limitSemanticUnderstandingSampleRows keeps sample data useful for semantic
 // inference without allowing large text or binary values to exhaust the task
 // input or agent context. It never mutates connector query results.
-func limitSemanticUnderstandingSampleRows(rows []map[string]any) ([]map[string]any, bool, error) {
+func limitSemanticUnderstandingSampleRows(rows []map[string]any, schema []*interfaces.Property) ([]map[string]any, bool, error) {
+	binaryFields := semanticUnderstandingBinarySampleFields(schema)
 	limited := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		if len(limited) >= interfaces.MaxSemanticUnderstandingSampleRows {
@@ -650,6 +651,9 @@ func limitSemanticUnderstandingSampleRows(rows []map[string]any) ([]map[string]a
 		}
 		limitedRow := make(map[string]any, len(row))
 		for key, value := range row {
+			if binaryFields[key] || isSemanticUnderstandingBinarySampleValue(value) {
+				continue
+			}
 			limitedRow[key] = limitSemanticUnderstandingSampleValue(value)
 		}
 
@@ -666,27 +670,47 @@ func limitSemanticUnderstandingSampleRows(rows []map[string]any) ([]map[string]a
 	return limited, false, nil
 }
 
+func isSemanticUnderstandingBinarySampleValue(value any) bool {
+	_, ok := value.([]byte)
+	return ok
+}
+
+func semanticUnderstandingBinarySampleFields(schema []*interfaces.Property) map[string]bool {
+	binaryFields := make(map[string]bool)
+	for _, property := range schema {
+		if property == nil || property.Type != interfaces.DataType_Binary {
+			continue
+		}
+		if property.Name != "" {
+			binaryFields[property.Name] = true
+		}
+		if property.OriginalName != "" {
+			binaryFields[property.OriginalName] = true
+		}
+	}
+	return binaryFields
+}
+
 func limitSemanticUnderstandingSampleValue(value any) any {
 	switch typedValue := value.(type) {
 	case string:
-		// Table connectors convert []byte values to string before returning rows.
-		// Invalid UTF-8 therefore represents binary data in the actual query path.
-		if !utf8.ValidString(typedValue) {
-			return semanticUnderstandingBinarySampleValue(len(typedValue))
-		}
 		return truncateSemanticUnderstandingSampleString(typedValue)
-	case []byte:
-		return semanticUnderstandingBinarySampleValue(len(typedValue))
 	case map[string]any:
 		limited := make(map[string]any, len(typedValue))
 		for key, nestedValue := range typedValue {
+			if isSemanticUnderstandingBinarySampleValue(nestedValue) {
+				continue
+			}
 			limited[key] = limitSemanticUnderstandingSampleValue(nestedValue)
 		}
 		return limited
 	case []any:
-		limited := make([]any, len(typedValue))
-		for index, nestedValue := range typedValue {
-			limited[index] = limitSemanticUnderstandingSampleValue(nestedValue)
+		limited := make([]any, 0, len(typedValue))
+		for _, nestedValue := range typedValue {
+			if isSemanticUnderstandingBinarySampleValue(nestedValue) {
+				continue
+			}
+			limited = append(limited, limitSemanticUnderstandingSampleValue(nestedValue))
 		}
 		return limited
 	default:
@@ -706,10 +730,6 @@ func truncateSemanticUnderstandingSampleString(value string) string {
 		runeCount++
 	}
 	return value
-}
-
-func semanticUnderstandingBinarySampleValue(length int) string {
-	return fmt.Sprintf("[binary content omitted; original length: %d bytes]", length)
 }
 
 func normalizeCatalogSemanticUnderstandingRequest(catalog *interfaces.Catalog, resources []*interfaces.Resource, req *interfaces.CreateSemanticUnderstandingTaskRequest) (*interfaces.SemanticUnderstandingTask, error) {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service.go
@@ -606,29 +606,31 @@ func (suts *semanticUnderstandingTaskService) attachUnmaskedSampleRows(ctx conte
 	if input.Options.SamplePolicy == nil || input.Options.SamplePolicy.Masked {
 		return fmt.Errorf("unmasked sample policy is required")
 	}
+	input.SampleRows = []map[string]any{}
 	fields := make([]string, 0, len(resource.SchemaDefinition))
 	for _, property := range resource.SchemaDefinition {
-		if property != nil && property.Name != "" {
+		if !isSemanticUnderstandingExcludedSampleProperty(property) {
 			fields = append(fields, property.Name)
 		}
 	}
-	result, err := suts.rds.QueryWithPaging(ctx, resource,
-		&interfaces.ResourceDataQueryParams{
-			Limit:        input.Options.SamplePolicy.MaxRows,
-			OutputFields: fields,
-		})
-	if err != nil {
-		return fmt.Errorf("read sample rows: %w", err)
-	}
-	input.SampleRows = []map[string]any{}
-	if result != nil && result.Entries != nil {
-		var truncated bool
-		input.SampleRows, truncated, err = limitSemanticUnderstandingSampleRows(result.Entries, resource.SchemaDefinition)
+	if len(fields) > 0 {
+		result, err := suts.rds.QueryWithPaging(ctx, resource,
+			&interfaces.ResourceDataQueryParams{
+				Limit:        input.Options.SamplePolicy.MaxRows,
+				OutputFields: fields,
+			})
 		if err != nil {
-			return fmt.Errorf("limit sample rows: %w", err)
+			return fmt.Errorf("read sample rows: %w", err)
 		}
-		if truncated {
-			logger.Warnf("Semantic sample rows truncated by payload cap: resource_id=%s, category=%s, kept %d of %d rows", resource.ID, resource.Category, len(input.SampleRows), len(result.Entries))
+		if result != nil && result.Entries != nil {
+			var truncated bool
+			input.SampleRows, truncated, err = limitSemanticUnderstandingSampleRows(result.Entries, resource.SchemaDefinition)
+			if err != nil {
+				return fmt.Errorf("limit sample rows: %w", err)
+			}
+			if truncated {
+				logger.Warnf("Semantic sample rows truncated by payload cap: resource_id=%s, category=%s, kept %d of %d rows", resource.ID, resource.Category, len(input.SampleRows), len(result.Entries))
+			}
 		}
 	}
 	inputJSON, _, err := marshalSemanticUnderstandingInput(input)
@@ -643,7 +645,7 @@ func (suts *semanticUnderstandingTaskService) attachUnmaskedSampleRows(ctx conte
 // inference without allowing large text or binary values to exhaust the task
 // input or agent context. It never mutates connector query results.
 func limitSemanticUnderstandingSampleRows(rows []map[string]any, schema []*interfaces.Property) ([]map[string]any, bool, error) {
-	binaryFields := semanticUnderstandingBinarySampleFields(schema)
+	excludedFields := semanticUnderstandingExcludedSampleFields(schema)
 	limited := make([]map[string]any, 0, len(rows))
 	for _, row := range rows {
 		if len(limited) >= interfaces.MaxSemanticUnderstandingSampleRows {
@@ -651,7 +653,7 @@ func limitSemanticUnderstandingSampleRows(rows []map[string]any, schema []*inter
 		}
 		limitedRow := make(map[string]any, len(row))
 		for key, value := range row {
-			if binaryFields[key] || isSemanticUnderstandingBinarySampleValue(value) {
+			if excludedFields[key] || isSemanticUnderstandingBinarySampleValue(value) {
 				continue
 			}
 			limitedRow[key] = limitSemanticUnderstandingSampleValue(value)
@@ -675,20 +677,19 @@ func isSemanticUnderstandingBinarySampleValue(value any) bool {
 	return ok
 }
 
-func semanticUnderstandingBinarySampleFields(schema []*interfaces.Property) map[string]bool {
-	binaryFields := make(map[string]bool)
+func semanticUnderstandingExcludedSampleFields(schema []*interfaces.Property) map[string]bool {
+	excludedFields := make(map[string]bool)
 	for _, property := range schema {
-		if property == nil || property.Type != interfaces.DataType_Binary {
+		if !isSemanticUnderstandingExcludedSampleProperty(property) {
 			continue
 		}
-		if property.Name != "" {
-			binaryFields[property.Name] = true
-		}
-		if property.OriginalName != "" {
-			binaryFields[property.OriginalName] = true
-		}
+		excludedFields[property.OriginalName] = true
 	}
-	return binaryFields
+	return excludedFields
+}
+
+func isSemanticUnderstandingExcludedSampleProperty(property *interfaces.Property) bool {
+	return property.Type == interfaces.DataType_Binary || property.Type == interfaces.DataType_Other
 }
 
 func limitSemanticUnderstandingSampleValue(value any) any {

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -239,6 +239,41 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 		assert.Equal(t, inputHash, task.InputHash)
 	})
 
+	t.Run("omits binary columns from the task input after connector conversion", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		resourceDataService := mock_interfaces.NewMockResourceDataService(ctrl)
+		resource := sampleSemanticResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{
+			Name:         "attachmentBlob",
+			OriginalName: "attachment_blob",
+			OriginalType: "bytea",
+			Type:         interfaces.DataType_Binary,
+		})
+		task, err := normalizeResourceSemanticUnderstandingRequest(resource, &interfaces.CreateSemanticUnderstandingTaskRequest{
+			IncludeSampleRows: true,
+			SamplePolicy:      &interfaces.SemanticUnderstandingSamplePolicy{Masked: false, MaxRows: 2},
+		})
+		require.NoError(t, err)
+		resourceDataService.EXPECT().
+			QueryWithPaging(gomock.Any(), resource, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
+				assert.Equal(t, []string{"order_id", "attachmentBlob"}, params.OutputFields)
+				return &interfaces.ResourceDataQueryResult{Entries: []map[string]any{{
+					"order_id":        "o-1",
+					"attachment_blob": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
+				}}}, nil
+			})
+
+		service := &semanticUnderstandingTaskService{rds: resourceDataService}
+		require.NoError(t, service.attachUnmaskedSampleRows(context.Background(), resource, task))
+		var input interfaces.SemanticUnderstandingResourceAgentInput
+		require.NoError(t, sonic.Unmarshal([]byte(task.Input), &input))
+		require.Len(t, input.SampleRows, 1)
+		assert.Equal(t, "o-1", input.SampleRows[0]["order_id"])
+		assert.NotContains(t, input.SampleRows[0], "attachment_blob")
+	})
+
 	t.Run("writes an empty sample_rows array when the query has no rows", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)
@@ -421,23 +456,46 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 }
 
 func TestLimitSemanticUnderstandingSampleRows(t *testing.T) {
-	t.Run("truncates long text, binary, and nested values", func(t *testing.T) {
+	t.Run("truncates long text and nested values", func(t *testing.T) {
 		longValue := strings.Repeat("测", interfaces.MaxSemanticUnderstandingSampleValueRunes+1)
-		binaryValue := string([]byte{0xff, 0xfe, 0x01})
 		rows, truncated, err := limitSemanticUnderstandingSampleRows([]map[string]any{{
-			"text":   longValue,
-			"binary": binaryValue,
-			"nested": map[string]any{"text": longValue, "values": []any{longValue}},
-		}})
+			"text":  longValue,
+			"bytes": []byte{0x01, 0x02, 0x03},
+			"nested": map[string]any{
+				"text":   longValue,
+				"bytes":  []byte{0x01, 0x02, 0x03},
+				"values": []any{longValue, []byte{0x01, 0x02, 0x03}},
+			},
+		}}, nil)
 
 		require.NoError(t, err)
 		assert.False(t, truncated)
 		expectedText := strings.Repeat("测", interfaces.MaxSemanticUnderstandingSampleValueRunes-1) + "…"
 		assert.Equal(t, expectedText, rows[0]["text"])
-		assert.Equal(t, "[binary content omitted; original length: 3 bytes]", rows[0]["binary"])
+		assert.NotContains(t, rows[0], "bytes")
 		nested := rows[0]["nested"].(map[string]any)
 		assert.Equal(t, expectedText, nested["text"])
+		assert.NotContains(t, nested, "bytes")
 		assert.Equal(t, []any{expectedText}, nested["values"])
+	})
+
+	t.Run("omits binary schema fields regardless of their value encoding", func(t *testing.T) {
+		schema := []*interfaces.Property{
+			{Name: "attachment_blob", OriginalName: "attachment_blob", Type: interfaces.DataType_Binary},
+			{Name: "note", OriginalName: "note", Type: interfaces.DataType_Text},
+		}
+		rows, truncated, err := limitSemanticUnderstandingSampleRows([]map[string]any{
+			{"attachment_blob": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}), "note": "kept"},
+			{"attachment_blob": string([]byte{0x00, 0x01, 0xff}), "note": "kept"},
+			{"attachment_blob": []byte{0x01, 0x02, 0x03}, "note": "kept"},
+		}, schema)
+
+		require.NoError(t, err)
+		assert.False(t, truncated)
+		for _, row := range rows {
+			assert.NotContains(t, row, "attachment_blob")
+			assert.Equal(t, "kept", row["note"])
+		}
 	})
 
 	t.Run("drops trailing rows when the payload exceeds the limit", func(t *testing.T) {
@@ -449,7 +507,7 @@ func TestLimitSemanticUnderstandingSampleRows(t *testing.T) {
 			}
 		}
 
-		limited, truncated, err := limitSemanticUnderstandingSampleRows(rows)
+		limited, truncated, err := limitSemanticUnderstandingSampleRows(rows, nil)
 
 		require.NoError(t, err)
 		assert.True(t, truncated)
@@ -466,7 +524,7 @@ func TestLimitSemanticUnderstandingSampleRows(t *testing.T) {
 			rows[index] = map[string]any{"id": index}
 		}
 
-		limited, truncated, err := limitSemanticUnderstandingSampleRows(rows)
+		limited, truncated, err := limitSemanticUnderstandingSampleRows(rows, nil)
 
 		require.NoError(t, err)
 		assert.False(t, truncated)

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -249,6 +249,11 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 			OriginalName: "attachment_blob",
 			OriginalType: "bytea",
 			Type:         interfaces.DataType_Binary,
+		}, &interfaces.Property{
+			Name:         "shape",
+			OriginalName: "shape",
+			OriginalType: "geometry",
+			Type:         interfaces.DataType_Other,
 		})
 		task, err := normalizeResourceSemanticUnderstandingRequest(resource, &interfaces.CreateSemanticUnderstandingTaskRequest{
 			IncludeSampleRows: true,
@@ -258,10 +263,11 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 		resourceDataService.EXPECT().
 			QueryWithPaging(gomock.Any(), resource, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
-				assert.Equal(t, []string{"order_id", "attachmentBlob"}, params.OutputFields)
+				assert.Equal(t, []string{"order_id"}, params.OutputFields)
 				return &interfaces.ResourceDataQueryResult{Entries: []map[string]any{{
 					"order_id":        "o-1",
 					"attachment_blob": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
+					"shape":           string([]byte{0x07, 0x08, 0x09}),
 				}}}, nil
 			})
 
@@ -272,6 +278,29 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 		require.Len(t, input.SampleRows, 1)
 		assert.Equal(t, "o-1", input.SampleRows[0]["order_id"])
 		assert.NotContains(t, input.SampleRows[0], "attachment_blob")
+		assert.NotContains(t, input.SampleRows[0], "shape")
+	})
+
+	t.Run("skips sample query when every schema field is excluded", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		resourceDataService := mock_interfaces.NewMockResourceDataService(ctrl)
+		resource := sampleSemanticResource()
+		resource.SchemaDefinition = []*interfaces.Property{
+			{Name: "attachmentBlob", OriginalName: "attachment_blob", Type: interfaces.DataType_Binary},
+			{Name: "shape", OriginalName: "shape", Type: interfaces.DataType_Other},
+		}
+		task, err := normalizeResourceSemanticUnderstandingRequest(resource, &interfaces.CreateSemanticUnderstandingTaskRequest{
+			IncludeSampleRows: true,
+			SamplePolicy:      &interfaces.SemanticUnderstandingSamplePolicy{Masked: false, MaxRows: 2},
+		})
+		require.NoError(t, err)
+
+		service := &semanticUnderstandingTaskService{rds: resourceDataService}
+		require.NoError(t, service.attachUnmaskedSampleRows(context.Background(), resource, task))
+		var input interfaces.SemanticUnderstandingResourceAgentInput
+		require.NoError(t, sonic.Unmarshal([]byte(task.Input), &input))
+		assert.Empty(t, input.SampleRows)
 	})
 
 	t.Run("writes an empty sample_rows array when the query has no rows", func(t *testing.T) {
@@ -482,20 +511,40 @@ func TestLimitSemanticUnderstandingSampleRows(t *testing.T) {
 	t.Run("omits binary schema fields regardless of their value encoding", func(t *testing.T) {
 		schema := []*interfaces.Property{
 			{Name: "attachment_blob", OriginalName: "attachment_blob", Type: interfaces.DataType_Binary},
+			{Name: "legacy_blob", OriginalName: "legacy_blob", Type: interfaces.DataType_Binary},
 			{Name: "note", OriginalName: "note", Type: interfaces.DataType_Text},
 		}
 		rows, truncated, err := limitSemanticUnderstandingSampleRows([]map[string]any{
-			{"attachment_blob": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}), "note": "kept"},
-			{"attachment_blob": string([]byte{0x00, 0x01, 0xff}), "note": "kept"},
-			{"attachment_blob": []byte{0x01, 0x02, 0x03}, "note": "kept"},
+			{"attachment_blob": string([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}), "legacy_blob": []byte{0x07}, "note": "kept"},
+			{"attachment_blob": string([]byte{0x00, 0x01, 0xff}), "legacy_blob": []byte{0x08}, "note": "kept"},
+			{"attachment_blob": []byte{0x01, 0x02, 0x03}, "legacy_blob": []byte{0x09}, "note": "kept"},
 		}, schema)
 
 		require.NoError(t, err)
 		assert.False(t, truncated)
+		require.Len(t, rows, 3)
 		for _, row := range rows {
 			assert.NotContains(t, row, "attachment_blob")
+			assert.NotContains(t, row, "legacy_blob")
 			assert.Equal(t, "kept", row["note"])
 		}
+	})
+
+	t.Run("omits other schema fields", func(t *testing.T) {
+		schema := []*interfaces.Property{
+			{Name: "shape", OriginalName: "shape", OriginalType: "geometry", Type: interfaces.DataType_Other},
+			{Name: "note", OriginalType: "text", Type: interfaces.DataType_Text},
+		}
+		rows, truncated, err := limitSemanticUnderstandingSampleRows([]map[string]any{{
+			"shape": string([]byte{0x01, 0x02, 0x03}),
+			"note":  "kept",
+		}}, schema)
+
+		require.NoError(t, err)
+		assert.False(t, truncated)
+		require.Len(t, rows, 1)
+		assert.NotContains(t, rows[0], "shape")
+		assert.Equal(t, "kept", rows[0]["note"])
 	})
 
 	t.Run("drops trailing rows when the payload exceeds the limit", func(t *testing.T) {


### PR DESCRIPTION
## What Changed

- [x] Vega semantic-understanding sample sanitization
- [x] Focused regression tests
- [ ] Docs (not needed: no public API or user-facing contract change)

---

## Why

- Related Issue: [openbkn-ai/bkn-studio#565](https://github.com/openbkn-ai/bkn-studio/issues/565)
- Related Feature: Resource semantic understanding
- Background: PostgreSQL `bytea` values can be converted to valid UTF-8 strings by the connector and reach the semantic Agent sample input.

Closes openbkn-ai/bkn-studio#565

---

## How

- Key implementation points: omit schema-declared `binary` fields from `sample_rows`, matching both normalized and original column names; omit raw `[]byte` values at top level and in nested structures as a defensive fallback.
- Breaking changes (API, config, database, etc.): None. Resource schema remains in the task input; only binary sample values are removed.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run: requires deployed dependencies)
- [ ] Verified in test environment (not run)

Test notes:

- `go test ./logics/semantic_understanding_task`
- `make lint`
- `make test`

---

## Risk & Rollback

- Potential risks: Binary values no longer contribute to semantic inference; this is intentional to prevent raw binary data from reaching the Agent.
- Rollback plan: Revert commit `e19241216`.

---

## Additional Notes

- Regression coverage includes valid UTF-8 bytes, invalid UTF-8 bytes, raw `[]byte`, PostgreSQL normalized/original field-name mapping, and nested byte values.