### PR TITLE
fix(vega): exclude unsupported local-index fields

### DIFF
--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service.go
@@ -223,19 +223,11 @@ func validateBuildTaskKeyFields(ctx context.Context, resource *interfaces.Resour
 	}
 
 	schemaFields := make(map[string]*interfaces.Property, len(resource.SchemaDefinition))
-	unsupportedFields := make([]string, 0)
 	for _, prop := range resource.SchemaDefinition {
 		if prop == nil {
 			continue
 		}
 		schemaFields[prop.Name] = prop
-		if prop.Type == interfaces.DataType_Other {
-			unsupportedFields = append(unsupportedFields, fmt.Sprintf("%s (original_type: %s)", prop.Name, prop.OriginalType))
-		}
-	}
-	if len(unsupportedFields) > 0 {
-		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields).
-			WithErrorDetails(fmt.Sprintf("resource schema contains unsupported fields: %s", strings.Join(unsupportedFields, ", ")))
 	}
 
 	primaryKeys := make(map[string]struct{}, len(resource.IndexConfig.PrimaryKeyFields))

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -414,28 +414,17 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_StreamingUnsupported)
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
-	t.Run("rejects resources containing unsupported fields before creating a task", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockRS := mock_interfaces.NewMockResourceService(ctrl)
-		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
-		mockCS.EXPECT().CheckTaskPermission(gomock.Any(), "catalog-1", interfaces.OPERATION_TYPE_TASK_MANAGE).Return(nil)
-		service := &buildTaskService{rs: mockRS, cs: mockCS}
-
-		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
-			ID:          "resource-1",
-			CatalogID:   "catalog-1",
-			Category:    interfaces.ResourceCategoryTable,
+	t.Run("allows binary and other fields outside build keys", func(t *testing.T) {
+		resource := &interfaces.Resource{
 			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
+				{Name: "attachment", Type: interfaces.DataType_Binary, OriginalType: "bytea"},
 				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
 			},
-		}, nil)
+		}
 
-		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
-		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields)
-		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
-		assert.Contains(t, httpErr.BaseError.ErrorDetails, "interests (original_type: _text)")
+		require.NoError(t, validateBuildTaskKeyFields(context.Background(), resource))
 	})
 
 	t.Run("rejects an unsupported build key type before creating a task", func(t *testing.T) {
@@ -1267,45 +1256,16 @@ func TestBuildTaskServiceStart(t *testing.T) {
 
 		require.NoError(t, service.Start(context.Background(), "task-1", false))
 	})
-	t.Run("rejects restart when the resource contains an unsupported field", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
-		mockRS := mock_interfaces.NewMockResourceService(ctrl)
-		mockCS.EXPECT().CheckTaskPermission(gomock.Any(), "catalog-1", interfaces.OPERATION_TYPE_TASK_MANAGE).Return(nil)
-		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
-		service := &buildTaskService{cs: mockCS, rs: mockRS, bta: mockBTA}
-
-		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(&interfaces.BuildTask{
-			ID:         "task-1",
-			ResourceID: "resource-1",
-			CatalogID:  "catalog-1",
-			Status:     interfaces.BuildTaskStatusStopped,
-			IndexName:  "vega-build-test-index",
-			IndexConfig: &interfaces.BuildTaskIndexConfig{
-				IndexConfigContract: interfaces.IndexConfigContract{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
-				Features:            map[string]interfaces.BuildTaskFieldIndexFeature{},
-			},
-		}, nil)
-		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).
-			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
-		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
-		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(&interfaces.Resource{
-			ID:        "resource-1",
-			CatalogID: "catalog-1",
-			IndexConfig: &interfaces.ResourceIndexConfig{
-				PrimaryKeyFields:  []string{"id"},
-				IncrementalFields: []string{"id"},
-			},
+	t.Run("allows excluded fields outside build keys", func(t *testing.T) {
+		resource := &interfaces.Resource{
+			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "id", Type: interfaces.DataType_Integer},
 				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
 			},
-		}, nil)
+		}
 
-		err := service.Start(context.Background(), "task-1", false)
-		httpErr := requireHTTPError(t, err, verrors.VegaBackend_BuildTask_InvalidParameter_UnsupportedSchemaFields)
-		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
-		assert.Contains(t, httpErr.BaseError.ErrorDetails, "interests (original_type: _text)")
+		require.NoError(t, validateBuildTaskKeyFields(context.Background(), resource))
 	})
 	t.Run("rejects unavailable analyzer before updating status or dispatching", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/build_task/build_task_service_test.go
@@ -415,16 +415,25 @@ func TestBuildTaskServiceCreate(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, httpErr.HTTPCode)
 	})
 	t.Run("allows binary and other fields outside build keys", func(t *testing.T) {
-		resource := &interfaces.Resource{
-			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
-			SchemaDefinition: []*interfaces.Property{
-				{Name: "id", Type: interfaces.DataType_Integer},
-				{Name: "attachment", Type: interfaces.DataType_Binary, OriginalType: "bytea"},
-				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
-			},
-		}
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		mockCS.EXPECT().CheckTaskPermission(gomock.Any(), "catalog-1", interfaces.OPERATION_TYPE_TASK_MANAGE).Return(nil)
+		service := &buildTaskService{cs: mockCS, rs: mockRS, bta: mockBTA}
+		resource := buildTaskTestResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition,
+			&interfaces.Property{Name: "attachment", Type: interfaces.DataType_Binary, OriginalType: "bytea"},
+			&interfaces.Property{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
+		)
 
-		require.NoError(t, validateBuildTaskKeyFields(context.Background(), resource))
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(resource, nil)
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockBTA.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil)
+
+		_, err := service.Create(context.Background(), &interfaces.CreateBuildTaskRequest{ResourceID: "resource-1", Mode: interfaces.BuildTaskModeBatch})
+		require.NoError(t, err)
 	})
 
 	t.Run("rejects an unsupported build key type before creating a task", func(t *testing.T) {
@@ -1257,15 +1266,33 @@ func TestBuildTaskServiceStart(t *testing.T) {
 		require.NoError(t, service.Start(context.Background(), "task-1", false))
 	})
 	t.Run("allows excluded fields outside build keys", func(t *testing.T) {
-		resource := &interfaces.Resource{
-			IndexConfig: &interfaces.ResourceIndexConfig{PrimaryKeyFields: []string{"id"}, IncrementalFields: []string{"id"}},
-			SchemaDefinition: []*interfaces.Property{
-				{Name: "id", Type: interfaces.DataType_Integer},
-				{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
-			},
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockRS := mock_interfaces.NewMockResourceService(ctrl)
+		mockBTA := mock_interfaces.NewMockBuildTaskAccess(ctrl)
+		service := &buildTaskService{cs: mockCS, rs: mockRS, bta: mockBTA}
+		resource := buildTaskTestResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition,
+			&interfaces.Property{Name: "attachment", Type: interfaces.DataType_Binary, OriginalType: "bytea"},
+			&interfaces.Property{Name: "interests", Type: interfaces.DataType_Other, OriginalType: "_text"},
+		)
+		task := &interfaces.BuildTask{
+			ID:          "task-1",
+			ResourceID:  "resource-1",
+			CatalogID:   "catalog-1",
+			Status:      interfaces.BuildTaskStatusStopped,
+			IndexName:   "vega-build-test-index",
+			IndexConfig: mustBuildTaskIndexConfig(t, resource),
 		}
 
-		require.NoError(t, validateBuildTaskKeyFields(context.Background(), resource))
+		mockBTA.EXPECT().GetByID(gomock.Any(), "task-1").Return(task, nil)
+		mockCS.EXPECT().CheckTaskPermission(gomock.Any(), "catalog-1", interfaces.OPERATION_TYPE_TASK_MANAGE).Return(nil)
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", false).Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockBTA.EXPECT().InternalList(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockRS.EXPECT().GetByID(gomock.Any(), "resource-1").Return(resource, nil)
+		mockBTA.EXPECT().MarkPending(gomock.Any(), nil, "task-1", false).Return(true, nil)
+
+		require.NoError(t, service.Start(context.Background(), "task-1", false))
 	})
 	t.Run("rejects unavailable analyzer before updating status or dispatching", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/worker/build_task_common.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common.go
@@ -228,7 +228,6 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 		}
 		schema = schemaDefinition
 	}
-
 	// Legacy resources that have never been updated still contain self-references. Without normalization,
 	// dataset resources violate the ref_property restriction and keyword self-references on text fields
 	// fail ref type validation (keyword requires string), preventing build task creation. Apply this only
@@ -244,7 +243,27 @@ func buildLocalIndexSchema(buildTask *interfaces.BuildTask, resource *interfaces
 	if err := validateTaskEmbeddingFeatures(schema, buildTask); err != nil {
 		return nil, err
 	}
-	return schema, nil
+	return buildIndexableSchema(schema), nil
+}
+
+func buildIndexableSchema(schema []*interfaces.Property) []*interfaces.Property {
+	indexable := make([]*interfaces.Property, 0, len(schema))
+	for _, prop := range schema {
+		if prop == nil || prop.Type == interfaces.DataType_Binary || prop.Type == interfaces.DataType_Other {
+			continue
+		}
+		indexable = append(indexable, prop)
+	}
+	return indexable
+}
+
+func buildIndexableFieldNames(schema []*interfaces.Property) []string {
+	indexableSchema := buildIndexableSchema(schema)
+	fields := make([]string, 0, len(indexableSchema))
+	for _, prop := range indexableSchema {
+		fields = append(fields, prop.Name)
+	}
+	return fields
 }
 
 func validateBuildTaskSchemaFeatures(resourceCategory string, schema []*interfaces.Property) error {

--- a/adp/vega/vega-backend/server/worker/build_task_common_test.go
+++ b/adp/vega/vega-backend/server/worker/build_task_common_test.go
@@ -196,6 +196,38 @@ func TestBuildLocalIndexSchemaBackfillsLegacyVectorDimensionFromTaskSnapshot(t *
 	assert.Nil(t, resource.SchemaDefinition[0].Features[0].Config)
 }
 
+func TestBuildLocalIndexSchemaExcludesBinaryAndOtherFields(t *testing.T) {
+	resource := &interfaces.Resource{SchemaDefinition: []*interfaces.Property{
+		{Name: "id", Type: interfaces.DataType_Integer},
+		{Name: "attachment", Type: interfaces.DataType_Binary},
+		{Name: "metadata", Type: interfaces.DataType_Other},
+	}}
+
+	schema, err := buildLocalIndexSchema(&interfaces.BuildTask{}, resource)
+
+	require.NoError(t, err)
+	require.Len(t, schema, 1)
+	assert.Equal(t, "id", schema[0].Name)
+	assert.Equal(t, []string{"id"}, buildIndexableFieldNames(resource.SchemaDefinition))
+}
+
+func TestBuildLocalIndexSchemaRetainsFeatureTypeValidationForExcludedFields(t *testing.T) {
+	resource := &interfaces.Resource{
+		Category: interfaces.ResourceCategoryTable,
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "id", Type: interfaces.DataType_Integer},
+			{Name: "attachment", Type: interfaces.DataType_Binary, Features: []interfaces.PropertyFeature{
+				{FeatureType: interfaces.PropertyFeatureType_Fulltext},
+			}},
+		},
+	}
+
+	_, err := buildLocalIndexSchema(&interfaces.BuildTask{}, resource)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `resource schema field "attachment" type "binary" does not support feature type "fulltext"`)
+}
+
 func TestCompleteFullBuildTask(t *testing.T) {
 	t.Run("completes task and resource update atomically", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/adp/vega/vega-backend/server/worker/build_worker_batch.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch.go
@@ -349,6 +349,7 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 	embeddingConfig := buildTaskEmbeddingConfig(buildTaskInfo)
 	hasEmbedding := len(embeddingConfig) > 0
 	pipeline := &embeddingPipeline{mfs: bbw.mfs}
+	outputFields := buildIndexableFieldNames(resource.SchemaDefinition)
 
 	syncedCount := buildTaskInfo.SyncedCount
 	for {
@@ -385,9 +386,10 @@ func (bbw *batchBuildWorker) executeBuild(ctx context.Context, catalog *interfac
 		}
 
 		params := &interfaces.ResourceDataQueryParams{
-			Limit:     batchSize,
-			Sort:      sortFields,
-			NeedTotal: firstQuery,
+			Limit:        batchSize,
+			Sort:         sortFields,
+			NeedTotal:    firstQuery,
+			OutputFields: outputFields,
 		}
 
 		// Add filter condition for batch fields if we have last values

--- a/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_batch_test.go
@@ -206,6 +206,10 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 		cf := vmock.NewMockConnectorFactory(ctrl)
 		connector := vmock.NewMockTableConnector(ctrl)
 		resource := workerTestResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition,
+			&interfaces.Property{Name: "attachment", Type: interfaces.DataType_Binary},
+			&interfaces.Property{Name: "metadata", Type: interfaces.DataType_Other},
+		)
 		task := workerTestFullTask(t, resource)
 		indexName := buildIndexName(resource.ID, task.ID)
 		bbw := &batchBuildWorker{lim: lim, bts: bts, rs: rs, cf: cf}
@@ -233,7 +237,12 @@ func TestBatchBuildWorkerExecuteBuild(t *testing.T) {
 			}).Times(2)
 		cf.EXPECT().CreateConnectorInstance(gomock.Any(), "mysql", gomock.Any()).Return(connector, nil)
 		connector.EXPECT().Connect(gomock.Any()).Return(nil)
-		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).Return(&interfaces.QueryResult{Total: 0}, nil)
+		connector.EXPECT().ExecuteQuery(gomock.Any(), resource, gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.QueryResult, error) {
+				assert.Equal(t, []string{"id"}, params.OutputFields)
+				return &interfaces.QueryResult{Total: 0}, nil
+			},
+		)
 		connector.EXPECT().Close(gomock.Any()).Return(nil)
 		bts.EXPECT().InternalGetStatusByID(gomock.Any(), task.ID).Return(interfaces.BuildTaskStatusRunning, nil)
 		mockDB.ExpectBegin()

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming.go
@@ -178,12 +178,8 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 
 	logger.Infof("Started Kafka subscription for topic %s with group ID %s", topic, groupID)
 
-	fieldMap := map[string]*interfaces.Property{}
-	for _, prop := range resource.SchemaDefinition {
-		fieldMap[prop.Name] = prop
-	}
-
 	pipeline := &embeddingPipeline{mfs: sbw.mfs}
+	outputFields := buildIndexableFieldNames(resource.SchemaDefinition)
 
 	err = sbw.createKafkaConnector(ctx, catalog, resource, database, sourceIdentifier)
 	if err != nil {
@@ -316,10 +312,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 				case "r", "c":
 					// Full snapshot or create operation
 					// Create document from the after data
-					document := make(map[string]any)
-					for k, v := range after {
-						document[k] = v
-					}
+					document := filterBuildDocumentFields(after, outputFields)
 
 					kafkaKeyValues, err := getKafkaKeyValues(buildTaskInfo.IndexConfig.PrimaryKeyFields, keyMap)
 					if err != nil {
@@ -341,7 +334,7 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 					}
 				case "u":
 					// Update operation
-					if err := sbw.handleUpdateOperation(ctx, keyMap, after, indexName, buildTaskInfo, pipeline); err != nil {
+					if err := sbw.handleUpdateOperation(ctx, keyMap, after, indexName, buildTaskInfo, pipeline, outputFields); err != nil {
 						logger.Errorf("Failed to handle update operation: %v", err)
 						time.Sleep(retryInterval)
 						continue
@@ -552,7 +545,7 @@ func streamingDatabase(catalog *interfaces.Catalog) (string, error) {
 }
 
 // handleUpdateOperation handles update operations.
-func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyMap, after map[string]any, indexName string, buildTaskInfo *interfaces.BuildTask, pipeline *embeddingPipeline) error {
+func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyMap, after map[string]any, indexName string, buildTaskInfo *interfaces.BuildTask, pipeline *embeddingPipeline, outputFields []string) error {
 	documentIDFields := buildTaskInfo.IndexConfig.PrimaryKeyFields
 	kafkaKeyValues, err := getKafkaKeyValues(documentIDFields, keyMap)
 	if err != nil {
@@ -564,10 +557,7 @@ func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyM
 	}
 
 	// Create updated document from the after data
-	document := make(map[string]any)
-	for k, v := range after {
-		document[k] = v
-	}
+	document := filterBuildDocumentFields(after, outputFields)
 
 	newKeyValues, err := extractKeyValues(documentIDFields, document)
 	if err != nil {
@@ -593,6 +583,16 @@ func (sbw *streamingBuildWorker) handleUpdateOperation(ctx context.Context, keyM
 	}
 
 	return nil
+}
+
+func filterBuildDocumentFields(document map[string]any, outputFields []string) map[string]any {
+	filtered := make(map[string]any, len(outputFields))
+	for _, field := range outputFields {
+		if value, exists := document[field]; exists {
+			filtered[field] = value
+		}
+	}
+	return filtered
 }
 
 // handleDeleteOperation handles deletion operations.

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming.go
@@ -56,6 +56,8 @@ type streamingBuildWorker struct {
 	stopped     *atomic.Bool
 }
 
+var errStreamingDocumentWrite = errors.New("write streaming document")
+
 func (sbw *streamingBuildWorker) isStopping() bool {
 	return sbw.stopped != nil && sbw.stopped.Load()
 }
@@ -310,25 +312,11 @@ func (sbw *streamingBuildWorker) executeBuild(ctx context.Context, catalog *inte
 				// Determine operation type
 				switch op {
 				case "r", "c":
-					// Full snapshot or create operation
-					// Create document from the after data
-					document := filterBuildDocumentFields(after, outputFields)
-
-					kafkaKeyValues, err := getKafkaKeyValues(buildTaskInfo.IndexConfig.PrimaryKeyFields, keyMap)
-					if err != nil {
-						return fmt.Errorf("extract Kafka key values: %w", err)
-					}
-					docID, err := generateDocumentID(kafkaKeyValues)
-					if err != nil {
-						return fmt.Errorf("generate streaming document ID: %w", err)
-					}
-					if buildTaskHasEmbedding(buildTaskInfo) {
-						if err := pipeline.enrich(ctx, map[string]map[string]any{docID: document}, buildTaskEmbeddingConfig(buildTaskInfo)); err != nil {
-							return fmt.Errorf("vectorize streaming document: %w", err)
+					if err := sbw.handleCreateOperation(ctx, keyMap, after, indexName, buildTaskInfo, pipeline, outputFields); err != nil {
+						if !errors.Is(err, errStreamingDocumentWrite) {
+							return err
 						}
-					}
-					if _, err := sbw.lim.IndexDocuments(ctx, indexName, map[string]map[string]any{docID: document}); err != nil {
-						logger.Errorf("Failed to write document to local index: %v", err)
+						logger.Errorf("Failed to handle streaming create operation: %v", err)
 						time.Sleep(retryInterval)
 						continue
 					}
@@ -542,6 +530,27 @@ func streamingDatabase(catalog *interfaces.Catalog) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported streaming connector type: %s", catalog.ConnectorType)
 	}
+}
+
+func (sbw *streamingBuildWorker) handleCreateOperation(ctx context.Context, keyMap, after map[string]any, indexName string, buildTaskInfo *interfaces.BuildTask, pipeline *embeddingPipeline, outputFields []string) error {
+	document := filterBuildDocumentFields(after, outputFields)
+	kafkaKeyValues, err := getKafkaKeyValues(buildTaskInfo.IndexConfig.PrimaryKeyFields, keyMap)
+	if err != nil {
+		return fmt.Errorf("extract Kafka key values: %w", err)
+	}
+	docID, err := generateDocumentID(kafkaKeyValues)
+	if err != nil {
+		return fmt.Errorf("generate streaming document ID: %w", err)
+	}
+	if buildTaskHasEmbedding(buildTaskInfo) {
+		if err := pipeline.enrich(ctx, map[string]map[string]any{docID: document}, buildTaskEmbeddingConfig(buildTaskInfo)); err != nil {
+			return fmt.Errorf("vectorize streaming document: %w", err)
+		}
+	}
+	if _, err := sbw.lim.IndexDocuments(ctx, indexName, map[string]map[string]any{docID: document}); err != nil {
+		return fmt.Errorf("%w: %w", errStreamingDocumentWrite, err)
+	}
+	return nil
 }
 
 // handleUpdateOperation handles update operations.

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
@@ -170,6 +170,37 @@ func TestHandleUpdateOperationWritesReplacementBeforeDeletingOldDocument(t *test
 		"index-1",
 		buildTask,
 		&embeddingPipeline{},
+		[]string{"id", "title"},
+	))
+}
+
+func TestHandleUpdateOperationExcludesUnsupportedFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	lim := vmock.NewMockLocalIndexManager(ctrl)
+	worker := &streamingBuildWorker{lim: lim}
+	buildTask := &interfaces.BuildTask{
+		IndexConfig: &interfaces.BuildTaskIndexConfig{
+			IndexConfigContract: interfaces.IndexConfigContract{PrimaryKeyFields: []string{"id"}},
+		},
+	}
+	newID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 2}})
+	require.NoError(t, err)
+	oldID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 1}})
+	require.NoError(t, err)
+
+	gomock.InOrder(
+		lim.EXPECT().IndexDocuments(gomock.Any(), "index-1", map[string]map[string]any{newID: {"id": 2}}).Return(nil, nil),
+		lim.EXPECT().DeleteDocument(gomock.Any(), "index-1", oldID).Return(nil),
+	)
+
+	require.NoError(t, worker.handleUpdateOperation(
+		context.Background(),
+		map[string]any{"id": 1},
+		map[string]any{"id": 2, "attachment": []byte("blob"), "metadata": []string{"a", "b"}},
+		"index-1",
+		buildTask,
+		&embeddingPipeline{},
+		[]string{"id"},
 	))
 }
 
@@ -197,6 +228,7 @@ func TestHandleUpdateOperationKeepsOldDocumentWhenReplacementWriteFails(t *testi
 		"index-1",
 		buildTask,
 		&embeddingPipeline{},
+		[]string{"id"},
 	)
 	require.ErrorContains(t, err, "write failed")
 }

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
@@ -141,6 +141,20 @@ func TestGetKafkaKeyValuesUsesConfiguredDocumentIDFields(t *testing.T) {
 	}, values)
 }
 
+func TestFilterBuildDocumentFieldsExcludesUnsupportedFields(t *testing.T) {
+	document := filterBuildDocumentFields(
+		map[string]any{
+			"id":         2,
+			"title":      "created",
+			"attachment": []byte("blob"),
+			"metadata":   []string{"a", "b"},
+		},
+		[]string{"id", "title"},
+	)
+
+	assert.Equal(t, map[string]any{"id": 2, "title": "created"}, document)
+}
+
 func TestHandleUpdateOperationWritesReplacementBeforeDeletingOldDocument(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	lim := vmock.NewMockLocalIndexManager(ctrl)

--- a/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
+++ b/adp/vega/vega-backend/server/worker/build_worker_streaming_test.go
@@ -155,6 +155,32 @@ func TestFilterBuildDocumentFieldsExcludesUnsupportedFields(t *testing.T) {
 	assert.Equal(t, map[string]any{"id": 2, "title": "created"}, document)
 }
 
+func TestHandleCreateOperationExcludesUnsupportedFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	lim := vmock.NewMockLocalIndexManager(ctrl)
+	worker := &streamingBuildWorker{lim: lim}
+	buildTask := &interfaces.BuildTask{
+		IndexConfig: &interfaces.BuildTaskIndexConfig{
+			IndexConfigContract: interfaces.IndexConfigContract{PrimaryKeyFields: []string{"id"}},
+		},
+	}
+	docID, err := generateDocumentID([]interfaces.KeyValue{{Key: "id", Value: 2}})
+	require.NoError(t, err)
+	lim.EXPECT().IndexDocuments(gomock.Any(), "index-1", map[string]map[string]any{
+		docID: {"id": 2, "title": "created"},
+	}).Return(nil, nil)
+
+	require.NoError(t, worker.handleCreateOperation(
+		context.Background(),
+		map[string]any{"id": 2},
+		map[string]any{"id": 2, "title": "created", "attachment": []byte("blob"), "metadata": []string{"a", "b"}},
+		"index-1",
+		buildTask,
+		&embeddingPipeline{},
+		[]string{"id", "title"},
+	))
+}
+
 func TestHandleUpdateOperationWritesReplacementBeforeDeletingOldDocument(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	lim := vmock.NewMockLocalIndexManager(ctrl)


### PR DESCRIPTION
## What Changed

- [x] Allow build-task creation for resources that contain non-key `binary` or `other` fields.
- [x] Exclude those fields from local-index schema and source-query `OutputFields`.

---

## Why

- Related Issue: openbkn-ai/bkn-studio#581
- Background: unsupported source field types must be omitted without preventing valid local-index builds.

---

## How

- Retain existing primary-key, incremental-key, and feature type validation.
- Validate the complete schema before filtering unsupported fields for index creation.
- Compute `OutputFields` once before the batch loop.
- Breaking changes: none.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `go test ./worker`
- `make lint`
- `make test`

---

## Risk & Rollback

- Potential risks: a source connector must honor `OutputFields`; table connectors do so.
- Rollback plan: revert commit `561fb5ae4`.

---

## Additional Notes

- Companion Studio UI PR: openbkn-ai/bkn-studio#583.