### PR TITLE
feat(vega): map MariaDB and PostgreSQL enum columns to string

### DIFF
--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/type_mapping.go
@@ -47,6 +47,8 @@ var TypeMapping = map[string]string{
 	// String types
 	"char":    interfaces.DataType_String,
 	"varchar": interfaces.DataType_String,
+	"enum":    interfaces.DataType_String,
+	"set":     interfaces.DataType_String,
 
 	// Text types
 	"tinytext":   interfaces.DataType_Text,

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/type_mapping_test.go
@@ -38,6 +38,16 @@ func TestMariaDBConnectorMapType(t *testing.T) {
 			want:       interfaces.DataType_String,
 		},
 		{
+			name:       "enum with labels",
+			nativeType: "enum('pending','completed')",
+			want:       interfaces.DataType_String,
+		},
+		{
+			name:       "set with labels",
+			nativeType: "set('red','blue')",
+			want:       interfaces.DataType_String,
+		},
+		{
 			name:       "normalizes case and whitespace",
 			nativeType: "  DATETIME  ",
 			want:       interfaces.DataType_Datetime,

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
@@ -426,7 +426,8 @@ ORDER BY a.attnum`, relKinds)
 		if pkSet[raw.name.String] {
 			column.ColumnKey = "PRI"
 		}
-		if raw.typeKind.String == "d" {
+		switch raw.typeKind.String {
+		case "d":
 			domain, ok := domains[raw.typeOID.Int64]
 			if ok {
 				column.AliasType = raw.typeName.String
@@ -438,6 +439,9 @@ ORDER BY a.attnum`, relKinds)
 				}
 				typeModifier = domain.BaseTypmod
 			}
+		case "e":
+			column.AliasType = raw.typeName.String
+			column.Type = "enum"
 		}
 		switch column.Type {
 		case "bpchar", "varchar":

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover.go
@@ -24,6 +24,7 @@ var postgresqlTableRelKinds = []string{"r", "v", "f", "m", "p"}
 
 type postgresqlDomainMetadata struct {
 	BaseType        string
+	BaseTypeKind    string
 	BaseTypmod      int64
 	NotNull         bool
 	DefaultValue    sql.NullString
@@ -87,6 +88,7 @@ domain_checks AS (
 )
 SELECT root.oid AS domain_oid,
        base_type.typname AS base_type,
+       base_type.typtype::text AS base_type_kind,
        resolved.base_typmod,
        resolved.domain_not_null,
        COALESCE(pg_catalog.pg_get_expr(root.typdefaultbin, 0), root.typdefault) AS domain_default,
@@ -105,11 +107,12 @@ ORDER BY root.oid`, strings.Join(placeholders, ", "))
 
 	for rows.Next() {
 		var domainOID, baseTypmod sql.NullInt64
-		var baseType, defaultValue, checkConstraint sql.NullString
+		var baseType, baseTypeKind, defaultValue, checkConstraint sql.NullString
 		var notNull sql.NullBool
 		if err := rows.Scan(
 			&domainOID,
 			&baseType,
+			&baseTypeKind,
 			&baseTypmod,
 			&notNull,
 			&defaultValue,
@@ -117,12 +120,13 @@ ORDER BY root.oid`, strings.Join(placeholders, ", "))
 		); err != nil {
 			return nil, fmt.Errorf("failed to scan PostgreSQL domain metadata: %w", err)
 		}
-		if !domainOID.Valid || !baseType.Valid || !baseTypmod.Valid ||
+		if !domainOID.Valid || !baseType.Valid || !baseTypeKind.Valid || !baseTypmod.Valid ||
 			!notNull.Valid || !checkConstraint.Valid {
 			return nil, fmt.Errorf("required PostgreSQL domain metadata contains NULL")
 		}
 		metadata[domainOID.Int64] = postgresqlDomainMetadata{
 			BaseType:        baseType.String,
+			BaseTypeKind:    baseTypeKind.String,
 			BaseTypmod:      baseTypmod.Int64,
 			NotNull:         notNull.Bool,
 			DefaultValue:    defaultValue,
@@ -438,6 +442,9 @@ ORDER BY a.attnum`, relKinds)
 					column.DefaultValue = domain.DefaultValue.String
 				}
 				typeModifier = domain.BaseTypmod
+				if domain.BaseTypeKind == "e" {
+					column.Type = "enum"
+				}
 			}
 		case "e":
 			column.AliasType = raw.typeName.String

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover_test.go
@@ -117,13 +117,15 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 			AddRow("amount", 1700, "b", "numeric", int64((10<<16)|2)+4, false, nil, "", 4, "").
 			AddRow("occurred_at", 1114, "b", "timestamp", 3, false, nil, "", 5, "").
 			AddRow("legacy_code", 9200, "d", "legacy_code_domain", -1, false, nil, "", 6, "").
-			AddRow("status", 9300, "e", "order_status", -1, false, nil, "", 7, "order state"))
-	mock.ExpectQuery(`(?s)WITH RECURSIVE domain_chain.*root\.oid IN \(\$1, \$2\).*pg_catalog\.pg_constraint`).
-		WithArgs(int64(9100), int64(9200)).
+			AddRow("status", 9300, "e", "order_status", -1, false, nil, "", 7, "order state").
+			AddRow("state", 9400, "d", "order_state_domain", -1, false, nil, "", 8, "state domain"))
+	mock.ExpectQuery(`(?s)WITH RECURSIVE domain_chain.*root\.oid IN \(\$1, \$2, \$3\).*pg_catalog\.pg_constraint`).
+		WithArgs(int64(9100), int64(9200), int64(9400)).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"domain_oid", "base_type", "base_typmod", "domain_not_null", "domain_default", "check_constraint",
+			"domain_oid", "base_type", "base_type_kind", "base_typmod", "domain_not_null", "domain_default", "check_constraint",
 		}).
-			AddRow(9100, "int4", -1, true, "42", "CHECK ((VALUE > 0)); CHECK ((VALUE < 1000))"))
+			AddRow(9100, "int4", "b", -1, true, "42", "CHECK ((VALUE > 0)); CHECK ((VALUE < 1000))").
+			AddRow(9400, "order_status", "e", -1, false, nil, ""))
 	mock.ExpectQuery("SELECT kcu.column_name").
 		WithArgs("appdb", "public", "orders").
 		WillReturnRows(sqlmock.NewRows([]string{"column_name"}).AddRow("id"))
@@ -132,8 +134,8 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 	if err := connector.fetchColumns(context.Background(), table); err != nil {
 		t.Fatalf("fetchColumns returned error: %v", err)
 	}
-	if len(table.Columns) != 7 {
-		t.Fatalf("expected 7 columns, got %d", len(table.Columns))
+	if len(table.Columns) != 8 {
+		t.Fatalf("expected 8 columns, got %d", len(table.Columns))
 	}
 	column := table.Columns[0]
 	if column.Name != "id" || column.DefaultValue != "" || column.Description != "" || column.Collation != "" {
@@ -164,6 +166,10 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 	assert.Equal(t, "order_status", enumColumn.AliasType)
 	assert.Equal(t, "order state", enumColumn.Description)
 	assert.Equal(t, interfaces.DataType_String, connector.MapType(enumColumn.Type))
+	domainEnumColumn := table.Columns[7]
+	assert.Equal(t, "enum", domainEnumColumn.Type)
+	assert.Equal(t, "order_state_domain", domainEnumColumn.AliasType)
+	assert.Equal(t, interfaces.DataType_String, connector.MapType(domainEnumColumn.Type))
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sqlmock expectations were not met: %v", err)
 	}
@@ -179,9 +185,9 @@ func TestPostgresqlConnectorFetchDomainMetadata(t *testing.T) {
 	})
 
 	rows := sqlmock.NewRows([]string{
-		"domain_oid", "base_type", "base_typmod", "domain_not_null", "domain_default", "check_constraint",
+		"domain_oid", "base_type", "base_type_kind", "base_typmod", "domain_not_null", "domain_default", "check_constraint",
 	}).
-		AddRow(9100, "int4", -1, true, "42",
+		AddRow(9100, "int4", "b", -1, true, "42",
 			"CHECK ((VALUE > 0)); CHECK (((VALUE)::integer < 1000))")
 
 	mock.ExpectQuery(`(?s)WITH RECURSIVE domain_chain.*root\.oid IN \(\$1\).*pg_catalog\.pg_constraint`).
@@ -195,6 +201,7 @@ func TestPostgresqlConnectorFetchDomainMetadata(t *testing.T) {
 
 	domain := metadata[9100]
 	assert.Equal(t, "int4", domain.BaseType)
+	assert.Equal(t, "b", domain.BaseTypeKind)
 	assert.Equal(t, int64(-1), domain.BaseTypmod)
 	assert.True(t, domain.NotNull)
 	require.True(t, domain.DefaultValue.Valid)

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_discover_test.go
@@ -116,7 +116,8 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 			AddRow("code", 1043, "b", "varchar", 68, false, nil, "C", 3, "").
 			AddRow("amount", 1700, "b", "numeric", int64((10<<16)|2)+4, false, nil, "", 4, "").
 			AddRow("occurred_at", 1114, "b", "timestamp", 3, false, nil, "", 5, "").
-			AddRow("legacy_code", 9200, "d", "legacy_code_domain", -1, false, nil, "", 6, ""))
+			AddRow("legacy_code", 9200, "d", "legacy_code_domain", -1, false, nil, "", 6, "").
+			AddRow("status", 9300, "e", "order_status", -1, false, nil, "", 7, "order state"))
 	mock.ExpectQuery(`(?s)WITH RECURSIVE domain_chain.*root\.oid IN \(\$1, \$2\).*pg_catalog\.pg_constraint`).
 		WithArgs(int64(9100), int64(9200)).
 		WillReturnRows(sqlmock.NewRows([]string{
@@ -131,8 +132,8 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 	if err := connector.fetchColumns(context.Background(), table); err != nil {
 		t.Fatalf("fetchColumns returned error: %v", err)
 	}
-	if len(table.Columns) != 6 {
-		t.Fatalf("expected 6 columns, got %d", len(table.Columns))
+	if len(table.Columns) != 7 {
+		t.Fatalf("expected 7 columns, got %d", len(table.Columns))
 	}
 	column := table.Columns[0]
 	if column.Name != "id" || column.DefaultValue != "" || column.Description != "" || column.Collation != "" {
@@ -157,6 +158,12 @@ func TestPostgresqlConnectorFetchColumns(t *testing.T) {
 	assert.Equal(t, "legacy_code_domain", table.Columns[5].Type)
 	assert.Empty(t, table.Columns[5].AliasType)
 	assert.True(t, table.Columns[5].Nullable)
+	enumColumn := table.Columns[6]
+	assert.Equal(t, "status", enumColumn.Name)
+	assert.Equal(t, "enum", enumColumn.Type)
+	assert.Equal(t, "order_status", enumColumn.AliasType)
+	assert.Equal(t, "order state", enumColumn.Description)
+	assert.Equal(t, interfaces.DataType_String, connector.MapType(enumColumn.Type))
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("sqlmock expectations were not met: %v", err)
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/type_mapping.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/type_mapping.go
@@ -48,6 +48,7 @@ var TypeMapping = map[string]string{
 	"character":         interfaces.DataType_String,
 	"interval":          interfaces.DataType_String,
 	"character varying": interfaces.DataType_String,
+	"enum":              interfaces.DataType_String,
 	"inet":              interfaces.DataType_Ip,
 	"cidr":              interfaces.DataType_Ip,
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/type_mapping_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/type_mapping_test.go
@@ -26,6 +26,7 @@ func TestPostgresqlMapType(t *testing.T) {
 		{"INT4", interfaces.DataType_Integer},
 		{"  text  ", interfaces.DataType_Text},
 		{"jsonb", interfaces.DataType_Json},
+		{"enum", interfaces.DataType_String},
 		// 数组类型：udt_name 形式（带下划线前缀）—— 不识别
 		{"_int4", interfaces.DataType_Other},
 		{"_text", interfaces.DataType_Other},

--- a/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
+++ b/adp/vega/vega-backend/server/logics/semantic_understanding_task/semantic_understanding_task_service_test.go
@@ -281,6 +281,36 @@ func TestSemanticUnderstandingTaskSampleRows(t *testing.T) {
 		assert.NotContains(t, input.SampleRows[0], "shape")
 	})
 
+	t.Run("includes enum columns mapped to string in the task input", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		resourceDataService := mock_interfaces.NewMockResourceDataService(ctrl)
+		resource := sampleSemanticResource()
+		resource.SchemaDefinition = append(resource.SchemaDefinition, &interfaces.Property{
+			Name:         "status",
+			OriginalName: "status",
+			OriginalType: "enum",
+			Type:         interfaces.DataType_String,
+		})
+		task, err := normalizeResourceSemanticUnderstandingRequest(resource, &interfaces.CreateSemanticUnderstandingTaskRequest{
+			IncludeSampleRows: true,
+			SamplePolicy:      &interfaces.SemanticUnderstandingSamplePolicy{Masked: false, MaxRows: 2},
+		})
+		require.NoError(t, err)
+		resourceDataService.EXPECT().
+			QueryWithPaging(gomock.Any(), resource, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
+				assert.Equal(t, []string{"order_id", "status"}, params.OutputFields)
+				return &interfaces.ResourceDataQueryResult{Entries: []map[string]any{{"order_id": "o-1", "status": "pending"}}}, nil
+			})
+
+		service := &semanticUnderstandingTaskService{rds: resourceDataService}
+		require.NoError(t, service.attachUnmaskedSampleRows(context.Background(), resource, task))
+		var input interfaces.SemanticUnderstandingResourceAgentInput
+		require.NoError(t, sonic.Unmarshal([]byte(task.Input), &input))
+		assert.Equal(t, []map[string]any{{"order_id": "o-1", "status": "pending"}}, input.SampleRows)
+	})
+
 	t.Run("skips sample query when every schema field is excluded", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		t.Cleanup(ctrl.Finish)

--- a/adp/vega/vega-backend/server/worker/discover_table_test.go
+++ b/adp/vega/vega-backend/server/worker/discover_table_test.go
@@ -276,6 +276,37 @@ func TestEnrichTableMetadataPreservesBusinessMetadata(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestEnrichTableMetadataUsesNormalizedEnumType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	rs := vmock.NewMockResourceService(ctrl)
+	dh := &DiscoverTaskWorker{rs: rs}
+	resource := &interfaces.Resource{ID: "r1", SourceIdentifier: "public.orders"}
+	connector := vmock.NewMockTableConnector(ctrl)
+	connector.EXPECT().
+		GetTableMeta(gomock.Any(), &interfaces.TableMeta{Name: "orders", Schema: "public"}).
+		DoAndReturn(func(_ context.Context, table *interfaces.TableMeta) error {
+			table.Columns = []interfaces.TableColumnMeta{{
+				Name: "status", Type: "enum", AliasType: "order_status",
+			}}
+			return nil
+		})
+	connector.EXPECT().MapType("enum").Return(interfaces.DataType_String)
+	rs.EXPECT().InternalUpdateDiscoveryMetadata(gomock.Any(), nil, gomock.AssignableToTypeOf(&interfaces.Resource{}), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ *sql.Tx, updated *interfaces.Resource, _ int64) error {
+			require.Len(t, updated.SchemaDefinition, 1)
+			assert.Equal(t, interfaces.DataType_String, updated.SchemaDefinition[0].Type)
+			assert.Equal(t, "enum", updated.SchemaDefinition[0].OriginalType)
+			return nil
+		})
+
+	err := dh.enrichTableMetadata(context.Background(), &interfaces.DiscoverTask{}, connector, []tableDiscoverItem{{
+		resource:  resource,
+		tableMeta: &interfaces.TableMeta{Name: "orders", Schema: "public"},
+	}}, &interfaces.DiscoverResult{}, &discoverTaskReconcileProgress{lastProgress: 95})
+
+	require.NoError(t, err)
+}
+
 func TestEnrichTableMetadataSynchronizesSourceDescriptions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rs := vmock.NewMockResourceService(ctrl)


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Map MariaDB `ENUM` / `SET` column definitions to Vega `string`.
- [x] Normalize PostgreSQL catalog enum columns (`pg_type.typtype = e`) to a controlled `enum` native type and map it to `string`, while retaining the concrete type name in metadata.
- [x] Add focused mapping, discovery, and semantic-sample regression coverage.
- [x] Docs/doc 1: Not applicable; no API or user-facing documentation change.

---

## Why

- Related Issue: Closes #1382
- Related Feature: Vega enum/set semantic sample support
- Background: Enum and set values are textual, but previously discovered as `other`, which excluded them from semantic-understanding samples.

---

## How

- Key implementation points: MariaDB reuses existing parameter stripping before looking up `enum` and `set`; PostgreSQL uses the already selected `typtype` catalog value to distinguish enums from other user-defined types.
- Breaking changes (API, config, database, etc.): None. Existing resources require normal rediscovery to refresh persisted schema metadata.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; the change is fully covered with unit tests and SQL mocks.
- [ ] Verified in test environment — not run; no deployed environment was used.

Test notes:

- `go test ./logics/connector/local/table/mariadb ./logics/connector/local/table/postgresql ./logics/semantic_understanding_task`
- `make lint`
- `make test`
- `make ci`

---

## Risk & Rollback

- Potential risks: Rediscovery changes enum/set field classification from `other` to `string`, making their textual values eligible for existing semantic samples.
- Rollback plan: Revert commit `12df9ecc2`; rediscover affected resources to restore the prior persisted schema classification.

---

## Additional Notes

- PostgreSQL unknown user-defined types remain `other`; only catalog-confirmed enums are changed.