### PR TITLE
fix(bkn): expose knowledge network navigation for authorized children

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"sync"
 
 	sq "github.com/Masterminds/squirrel"
@@ -31,6 +32,18 @@ import (
 const (
 	KN_TABLE_NAME = "t_knowledge_network"
 )
+
+var knChildResourceTables = []struct {
+	resourceType string
+	tableName    string
+}{
+	{interfaces.RESOURCE_TYPE_CONCEPT_GROUP, "t_concept_group"},
+	{interfaces.RESOURCE_TYPE_OBJECT_TYPE, "t_object_type"},
+	{interfaces.RESOURCE_TYPE_RELATION_TYPE, "t_relation_type"},
+	{interfaces.RESOURCE_TYPE_ACTION_TYPE, "t_action_type"},
+	{interfaces.RESOURCE_TYPE_METRIC, "t_metric_definition"},
+	{interfaces.RESOURCE_TYPE_RISK_TYPE, "t_risk_type"},
+}
 
 var (
 	knAccessOnce sync.Once
@@ -1060,6 +1073,68 @@ func (kna *knowledgeNetworkAccess) ListKnSrcs(ctx context.Context,
 
 	span.SetStatus(codes.Ok, "")
 	return srcs, nil
+}
+
+// ListKNChildResourceCandidates returns the authorization identities of all
+// model children under the requested knowledge networks. The six child tables
+// are read in one round trip so list visibility does not degrade into N+1
+// queries as the number of networks grows.
+func (kna *knowledgeNetworkAccess) ListKNChildResourceCandidates(ctx context.Context,
+	knIDs []string, branch string) ([]interfaces.KNChildResourceCandidate, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "Select knowledge network child resources")
+	defer span.End()
+
+	if len(knIDs) == 0 {
+		return []interfaces.KNChildResourceCandidate{}, nil
+	}
+	if branch == "" {
+		branch = interfaces.MAIN_BRANCH
+	}
+
+	queries := make([]string, 0, len(knChildResourceTables))
+	args := make([]any, 0)
+	for _, childTable := range knChildResourceTables {
+		builder := sq.Select().
+			Column(sq.Expr("? AS f_resource_type", childTable.resourceType)).
+			Column("f_kn_id").
+			Column("f_id").
+			From(childTable.tableName).
+			Where(sq.Eq{"f_kn_id": knIDs}).
+			Where(sq.Eq{"f_branch": branch})
+		query, values, err := builder.ToSql()
+		if err != nil {
+			common.LogSafeError(ctx, "Failed to build child resource query", err)
+			return nil, err
+		}
+		queries = append(queries, query)
+		args = append(args, values...)
+	}
+
+	query := strings.Join(queries, " UNION ALL ")
+	otellog.LogInfo(ctx, common.SafeQuerySummary(query, len(args)))
+	rows, err := kna.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		common.LogSafeError(ctx, "Failed to list knowledge network child resources", err)
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	candidates := make([]interfaces.KNChildResourceCandidate, 0)
+	for rows.Next() {
+		candidate := interfaces.KNChildResourceCandidate{}
+		if err := rows.Scan(&candidate.Type, &candidate.KNID, &candidate.ResourceID); err != nil {
+			common.LogSafeError(ctx, "Failed to scan knowledge network child resource", err)
+			return nil, err
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		common.LogSafeError(ctx, "Failed to iterate knowledge network child resources", err)
+		return nil, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return candidates, nil
 }
 
 func processConceptGroupRelationsQueryCondition(query interfaces.ConceptGroupRelationsQueryParams, subBuilder sq.SelectBuilder, fieldPrefix string) sq.SelectBuilder {

--- a/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/knowledge_network/knowledge_network_access_test.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -849,6 +850,58 @@ func Test_knowledgeNetworkAccess_ListKnSrcs(t *testing.T) {
 				t.Errorf("there were unfulfilled expectations: %s", err)
 			}
 		})
+	})
+}
+
+func Test_knowledgeNetworkAccess_ListKNChildResourceCandidates(t *testing.T) {
+	Convey("List child authorization identities for multiple knowledge networks", t, func() {
+		appSetting := &common.AppSetting{}
+		kna, smock := MockNewKNAccess(appSetting)
+		knIDs := []string{"kn1", "kn2"}
+
+		queries := make([]string, 0, len(knChildResourceTables))
+		for _, childTable := range knChildResourceTables {
+			query, _, err := sq.Select().
+				Column(sq.Expr("? AS f_resource_type", childTable.resourceType)).
+				Column("f_kn_id").
+				Column("f_id").
+				From(childTable.tableName).
+				Where(sq.Eq{"f_kn_id": knIDs}).
+				Where(sq.Eq{"f_branch": interfaces.MAIN_BRANCH}).
+				ToSql()
+			So(err, ShouldBeNil)
+			queries = append(queries, query)
+		}
+		expectedSQL := strings.Join(queries, " UNION ALL ")
+		rows := sqlmock.NewRows([]string{"f_resource_type", "f_kn_id", "f_id"}).
+			AddRow(interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn1", "ot1").
+			AddRow(interfaces.RESOURCE_TYPE_RELATION_TYPE, "kn2", "rt1")
+		smock.ExpectQuery(expectedSQL).WithArgs(
+			interfaces.RESOURCE_TYPE_CONCEPT_GROUP, "kn1", "kn2", interfaces.MAIN_BRANCH,
+			interfaces.RESOURCE_TYPE_OBJECT_TYPE, "kn1", "kn2", interfaces.MAIN_BRANCH,
+			interfaces.RESOURCE_TYPE_RELATION_TYPE, "kn1", "kn2", interfaces.MAIN_BRANCH,
+			interfaces.RESOURCE_TYPE_ACTION_TYPE, "kn1", "kn2", interfaces.MAIN_BRANCH,
+			interfaces.RESOURCE_TYPE_METRIC, "kn1", "kn2", interfaces.MAIN_BRANCH,
+			interfaces.RESOURCE_TYPE_RISK_TYPE, "kn1", "kn2", interfaces.MAIN_BRANCH,
+		).WillReturnRows(rows)
+
+		candidates, err := kna.ListKNChildResourceCandidates(testCtx, knIDs, interfaces.MAIN_BRANCH)
+		So(err, ShouldBeNil)
+		So(candidates, ShouldResemble, []interfaces.KNChildResourceCandidate{
+			{Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE, KNID: "kn1", ResourceID: "ot1"},
+			{Type: interfaces.RESOURCE_TYPE_RELATION_TYPE, KNID: "kn2", ResourceID: "rt1"},
+		})
+		So(smock.ExpectationsWereMet(), ShouldBeNil)
+	})
+
+	Convey("Empty knowledge network input avoids a database query", t, func() {
+		appSetting := &common.AppSetting{}
+		kna, smock := MockNewKNAccess(appSetting)
+
+		candidates, err := kna.ListKNChildResourceCandidates(testCtx, nil, interfaces.MAIN_BRANCH)
+		So(err, ShouldBeNil)
+		So(candidates, ShouldResemble, []interfaces.KNChildResourceCandidate{})
+		So(smock.ExpectationsWereMet(), ShouldBeNil)
 	})
 }
 

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -133,6 +133,10 @@ type KN struct {
 	// NavigationOnly marks a shell exposed through a visible child resource.
 	// It is internal state used to calculate permission-filtered statistics.
 	NavigationOnly bool `json:"-" mapstructure:"-"`
+	// NavigationStatistics caches the child visibility result calculated while
+	// loading a navigation-only detail so include_statistics does not repeat the
+	// database and Safe queries in the same request.
+	NavigationStatistics *Statistics `json:"-" mapstructure:"-"`
 
 	// Vector.
 	Vector []float32 `json:"_vector,omitempty"`

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -130,6 +130,9 @@ type KN struct {
 	Statistics *Statistics `json:"statistics,omitempty"`
 	// Operation permissions.
 	Operations []string `json:"operations,omitempty"`
+	// NavigationOnly marks a shell exposed through a visible child resource.
+	// It is internal state used to calculate permission-filtered statistics.
+	NavigationOnly bool `json:"-" mapstructure:"-"`
 
 	// Vector.
 	Vector []float32 `json:"_vector,omitempty"`

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_access.go
@@ -32,6 +32,7 @@ type KNAccess interface {
 	// filtering and is only used to display names on object-level authorization pages. Missing IDs are skipped and
 	// empty IDs return empty entries.
 	GetKNNamesByIDs(ctx context.Context, ids []string, branch string) ([]*KNNameEntry, error)
+	ListKNChildResourceCandidates(ctx context.Context, knIDs []string, branch string) ([]KNChildResourceCandidate, error)
 
 	ListKnSrcs(ctx context.Context, query KNsQueryParams) ([]PermissionResource, error)
 }

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_access.go
@@ -208,6 +208,21 @@ func (mr *MockKNAccessMockRecorder) ListKNs(ctx, query any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKNs", reflect.TypeOf((*MockKNAccess)(nil).ListKNs), ctx, query)
 }
 
+// ListKNChildResourceCandidates mocks base method.
+func (m *MockKNAccess) ListKNChildResourceCandidates(ctx context.Context, knIDs []string, branch string) ([]interfaces.KNChildResourceCandidate, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListKNChildResourceCandidates", ctx, knIDs, branch)
+	ret0, _ := ret[0].([]interfaces.KNChildResourceCandidate)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListKNChildResourceCandidates indicates an expected call of ListKNChildResourceCandidates.
+func (mr *MockKNAccessMockRecorder) ListKNChildResourceCandidates(ctx, knIDs, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListKNChildResourceCandidates", reflect.TypeOf((*MockKNAccess)(nil).ListKNChildResourceCandidates), ctx, knIDs, branch)
+}
+
 // ListKnSrcs mocks base method.
 func (m *MockKNAccess) ListKnSrcs(ctx context.Context, query interfaces.KNsQueryParams) ([]interfaces.PermissionResource, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/interfaces/permission_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_access.go
@@ -93,6 +93,14 @@ type PermissionResourceParent struct {
 	ParentID   string `json:"parent_id"`
 }
 
+// KNChildResourceCandidate ties one persisted child resource to its owning
+// knowledge network for restricted navigation visibility checks.
+type KNChildResourceCandidate struct {
+	KNID       string
+	ResourceID string
+	Type       string
+}
+
 // KNChildResourceID returns the canonical Safe ID for a child resource.
 func KNChildResourceID(knID, childID string) string {
 	return knID + "/" + childID

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -543,6 +543,90 @@ func (kns *knowledgeNetworkService) ValidateKN(ctx context.Context, kn *interfac
 	return nil
 }
 
+type knNavigationVisibility struct {
+	operations       map[string]interfaces.PermissionResourceOps
+	childVisibleKNs  map[string]struct{}
+	visibleChildRows map[string]map[string]interfaces.PermissionResourceOps
+}
+
+func (kns *knowledgeNetworkService) resolveKNNavigationVisibility(ctx context.Context,
+	knIDs []string, branch string) (*knNavigationVisibility, error) {
+	visibility := &knNavigationVisibility{
+		operations:       map[string]interfaces.PermissionResourceOps{},
+		childVisibleKNs:  map[string]struct{}{},
+		visibleChildRows: map[string]map[string]interfaces.PermissionResourceOps{},
+	}
+	if len(knIDs) == 0 {
+		return visibility, nil
+	}
+
+	operations, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, knIDs,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+	if err != nil {
+		return nil, err
+	}
+	visibility.operations = operations
+
+	restrictedKNIDs := make([]string, 0, len(knIDs))
+	for _, knID := range knIDs {
+		if _, ok := operations[knID]; !ok {
+			restrictedKNIDs = append(restrictedKNIDs, knID)
+		}
+	}
+	if len(restrictedKNIDs) == 0 {
+		return visibility, nil
+	}
+
+	candidates, err := kns.kna.ListKNChildResourceCandidates(ctx, restrictedKNIDs, branch)
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+	}
+	resourceIDsByType := make(map[string][]string)
+	for _, candidate := range candidates {
+		if !interfaces.IsValidAuthorizationID(candidate.KNID) ||
+			!interfaces.IsValidAuthorizationID(candidate.ResourceID) {
+			continue
+		}
+		canonicalID := interfaces.KNChildResourceID(candidate.KNID, candidate.ResourceID)
+		resourceIDsByType[candidate.Type] = append(resourceIDsByType[candidate.Type], canonicalID)
+	}
+
+	for resourceType, resourceIDs := range resourceIDsByType {
+		matched, err := permission.FilterKNChildResourceIDs(ctx, kns.ps, resourceType,
+			common.DuplicateSlice(resourceIDs), interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			permission.KNChildOperationCandidates(resourceType))
+		if err != nil {
+			return nil, err
+		}
+		visibility.visibleChildRows[resourceType] = matched
+	}
+	for _, candidate := range candidates {
+		canonicalID := interfaces.KNChildResourceID(candidate.KNID, candidate.ResourceID)
+		if _, ok := visibility.visibleChildRows[candidate.Type][canonicalID]; ok {
+			visibility.childVisibleKNs[candidate.KNID] = struct{}{}
+		}
+	}
+	return visibility, nil
+}
+
+func restrictKNToNavigation(kn *interfaces.KN) {
+	kn.SkillContent = ""
+	kn.ConceptGroups = nil
+	kn.ObjectTypes = nil
+	kn.RelationTypes = nil
+	kn.ActionTypes = nil
+	kn.RiskTypes = nil
+	kn.Metrics = nil
+	kn.Statistics = nil
+	kn.Operations = nil
+	kn.NavigationOnly = true
+	kn.Creator = interfaces.AccountInfo{}
+	kn.Updater = interfaces.AccountInfo{}
+	kn.Vector = nil
+	kn.Score = nil
+}
+
 func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter interfaces.KNsQueryParams) ([]*interfaces.KN, int, error) {
 
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "查询业务知识网络列表")
@@ -571,9 +655,7 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 		KNIDs = append(KNIDs, m.KNID)
 	}
 
-	// Filter objects by view permission. The filtered length is the total, so no separate total query is needed.
-	matchResoucesMap, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, KNIDs,
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+	visibility, err := kns.resolveKNNavigationVisibility(ctx, KNIDs, parameter.Branch)
 	if err != nil {
 		span.SetStatus(codes.Error, "Filter resources error")
 		return []*interfaces.KN{}, 0, err
@@ -581,7 +663,9 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 
 	visibleKNIDs := make([]string, 0, len(KNArr))
 	for _, kn := range KNArr {
-		if _, exist := matchResoucesMap[kn.KNID]; exist {
+		_, directlyVisible := visibility.operations[kn.KNID]
+		_, childVisible := visibility.childVisibleKNs[kn.KNID]
+		if directlyVisible || childVisible {
 			visibleKNIDs = append(visibleKNIDs, kn.KNID)
 		}
 	}
@@ -623,20 +707,28 @@ func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter inter
 			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
 	}
 	for _, kn := range KNs {
-		kn.Operations = matchResoucesMap[kn.KNID].Operations
+		if resource, directlyVisible := visibility.operations[kn.KNID]; directlyVisible {
+			kn.Operations = resource.Operations
+		} else {
+			restrictKNToNavigation(kn)
+		}
 	}
 
 	accountInfos := make([]*interfaces.AccountInfo, 0, len(KNs)*2)
 	for _, kn := range KNs {
-		accountInfos = append(accountInfos, &kn.Creator, &kn.Updater)
+		if _, directlyVisible := visibility.operations[kn.KNID]; directlyVisible {
+			accountInfos = append(accountInfos, &kn.Creator, &kn.Updater)
+		}
 	}
 
-	err = kns.ums.GetAccountNames(ctx, accountInfos)
-	if err != nil {
-		span.SetStatus(codes.Error, "GetAccountNames error")
+	if len(accountInfos) > 0 {
+		err = kns.ums.GetAccountNames(ctx, accountInfos)
+		if err != nil {
+			span.SetStatus(codes.Error, "GetAccountNames error")
 
-		return []*interfaces.KN{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-			berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+			return []*interfaces.KN{}, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+				berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+		}
 	}
 
 	span.SetStatus(codes.Ok, "")
@@ -754,27 +846,24 @@ func (kns *knowledgeNetworkService) getKNByID(ctx context.Context, knID string, 
 	}
 
 	if enforceUserPermission {
-		// Filter objects by view permission. The filtered length is the total, so no separate total query is needed.
-		matchResoucesMap, err := kns.ps.FilterResources(ctx, interfaces.RESOURCE_TYPE_KN, []string{kn.KNID},
-			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		visibility, err := kns.resolveKNNavigationVisibility(ctx, []string{kn.KNID}, branch)
 		if err != nil {
 			span.SetStatus(codes.Error, "Filter resources error")
 			return nil, err
 		}
 
-		if resrc, exist := matchResoucesMap[kn.KNID]; exist {
-			kn.Operations = resrc.Operations // Operations currently allowed for the user
+		if resource, directlyVisible := visibility.operations[kn.KNID]; directlyVisible {
+			kn.Operations = resource.Operations
+			accountInfos := []*interfaces.AccountInfo{&kn.Creator, &kn.Updater}
+			if err = kns.ums.GetAccountNames(ctx, accountInfos); err != nil {
+				span.SetStatus(codes.Error, "GetAccountNames error")
+				return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+					berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
+			}
+		} else if _, childVisible := visibility.childVisibleKNs[kn.KNID]; childVisible && mode == "" {
+			restrictKNToNavigation(kn)
 		} else {
 			return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
-		}
-
-		accountInfos := []*interfaces.AccountInfo{&kn.Creator, &kn.Updater}
-		err = kns.ums.GetAccountNames(ctx, accountInfos)
-		if err != nil {
-			span.SetStatus(codes.Error, "GetAccountNames error")
-
-			return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-				berrors.BknBackend_KnowledgeNetwork_InternalError).WithErrorDetails(err.Error())
 		}
 	}
 
@@ -856,6 +945,27 @@ func (kns *knowledgeNetworkService) GetStatByKN(ctx context.Context, kn *interfa
 	// Get business knowledge networks.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, fmt.Sprintf("查询业务知识网络[%s]信息", kn.KNID))
 	defer span.End()
+
+	// A navigation-only network has no network-level view_detail operation.
+	// Return only counts of child resources that are actually visible to the
+	// caller; capability bindings have no child authorization resource and must
+	// not be disclosed through the restricted shell.
+	if kn.NavigationOnly {
+		visibility, err := kns.resolveKNNavigationVisibility(ctx, []string{kn.KNID}, kn.Branch)
+		if err != nil {
+			return nil, err
+		}
+		statistics := &interfaces.Statistics{
+			CgTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_CONCEPT_GROUP]),
+			OtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_OBJECT_TYPE]),
+			RtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RELATION_TYPE]),
+			AtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_ACTION_TYPE]),
+			RiskTypeTotal: len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RISK_TYPE]),
+			MetricsTotal:  len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_METRIC]),
+		}
+		span.SetStatus(codes.Ok, "")
+		return statistics, nil
+	}
 
 	// Get counts of object, relation, and action types in the business knowledge network.
 	otCnt, err := kns.ota.GetObjectTypesTotal(ctx, interfaces.ObjectTypesQueryParams{

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -621,10 +621,22 @@ func restrictKNToNavigation(kn *interfaces.KN) {
 	kn.Statistics = nil
 	kn.Operations = nil
 	kn.NavigationOnly = true
+	kn.NavigationStatistics = nil
 	kn.Creator = interfaces.AccountInfo{}
 	kn.Updater = interfaces.AccountInfo{}
 	kn.Vector = nil
 	kn.Score = nil
+}
+
+func navigationStatistics(visibility *knNavigationVisibility) *interfaces.Statistics {
+	return &interfaces.Statistics{
+		CgTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_CONCEPT_GROUP]),
+		OtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_OBJECT_TYPE]),
+		RtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RELATION_TYPE]),
+		AtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_ACTION_TYPE]),
+		RiskTypeTotal: len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RISK_TYPE]),
+		MetricsTotal:  len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_METRIC]),
+	}
 }
 
 func (kns *knowledgeNetworkService) ListKNs(ctx context.Context, parameter interfaces.KNsQueryParams) ([]*interfaces.KN, int, error) {
@@ -862,6 +874,9 @@ func (kns *knowledgeNetworkService) getKNByID(ctx context.Context, knID string, 
 			}
 		} else if _, childVisible := visibility.childVisibleKNs[kn.KNID]; childVisible && mode == "" {
 			restrictKNToNavigation(kn)
+			// Detail visibility is resolved for this knowledge network only, so the
+			// same result can safely serve include_statistics in the handler.
+			kn.NavigationStatistics = navigationStatistics(visibility)
 		} else {
 			return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
 		}
@@ -951,20 +966,16 @@ func (kns *knowledgeNetworkService) GetStatByKN(ctx context.Context, kn *interfa
 	// caller; capability bindings have no child authorization resource and must
 	// not be disclosed through the restricted shell.
 	if kn.NavigationOnly {
+		if kn.NavigationStatistics != nil {
+			span.SetStatus(codes.Ok, "")
+			return kn.NavigationStatistics, nil
+		}
 		visibility, err := kns.resolveKNNavigationVisibility(ctx, []string{kn.KNID}, kn.Branch)
 		if err != nil {
 			return nil, err
 		}
-		statistics := &interfaces.Statistics{
-			CgTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_CONCEPT_GROUP]),
-			OtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_OBJECT_TYPE]),
-			RtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RELATION_TYPE]),
-			AtTotal:       len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_ACTION_TYPE]),
-			RiskTypeTotal: len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_RISK_TYPE]),
-			MetricsTotal:  len(visibility.visibleChildRows[interfaces.RESOURCE_TYPE_METRIC]),
-		}
 		span.SetStatus(codes.Ok, "")
-		return statistics, nil
+		return navigationStatistics(visibility), nil
 	}
 
 	// Get counts of object, relation, and action types in the business knowledge network.
@@ -1542,6 +1553,16 @@ func (kns *knowledgeNetworkService) GetRelationTypePaths(ctx context.Context,
 	query interfaces.RelationTypePathsBaseOnSource) ([]interfaces.RelationTypePath, error) {
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "GetRelationTypePaths")
 	defer span.End()
+
+	// This endpoint returns the complete object/relation topology reachable from
+	// the source object type. A visible child is sufficient for navigation, but
+	// must not grant access to the full knowledge-network graph.
+	if err := kns.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   query.KNID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
+	}
 
 	// 1. Get the source object type.
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -929,6 +929,9 @@ func Test_knowledgeNetworkService_ChildPermissionNavigation(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(result.NavigationOnly, ShouldBeTrue)
 		So(result.SkillContent, ShouldBeEmpty)
+		stats, err := service.GetStatByKN(ctx, result)
+		So(err, ShouldBeNil)
+		So(stats.RtTotal, ShouldEqual, 1)
 
 		exportKN := &interfaces.KN{KNID: "kn1", KNName: "Network 1", Branch: interfaces.MAIN_BRANCH}
 		kna.EXPECT().GetKNByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH).Return(exportKN, nil)
@@ -1765,11 +1768,19 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 		appSetting := &common.AppSetting{}
 		kna := bmock.NewMockKNAccess(mockCtrl)
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
 
 		service := &knowledgeNetworkService{
 			appSetting: appSetting,
 			kna:        kna,
 			ots:        ots,
+			ps:         ps,
+		}
+		allowKNView := func() {
+			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   "kn1",
+			}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).Return(nil)
 		}
 
 		Convey("Success getting relation type paths\n", func() {
@@ -1801,6 +1812,7 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 				},
 			}
 
+			allowKNView()
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&objectType, nil).AnyTimes()
 			kna.EXPECT().GetNeighborPathsBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(neighborPathsMap, nil)
 
@@ -1824,6 +1836,7 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 				},
 			}
 
+			allowKNView()
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&objectType, nil).AnyTimes()
 
 			paths, err := service.GetRelationTypePaths(ctx, query)
@@ -1840,6 +1853,7 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 				PathLength:        1,
 			}
 
+			allowKNView()
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
 
@@ -1863,6 +1877,7 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 				},
 			}
 
+			allowKNView()
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&objectType, nil).AnyTimes()
 			kna.EXPECT().GetNeighborPathsBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
 
@@ -1889,12 +1904,33 @@ func Test_knowledgeNetworkService_GetRelationTypePaths(t *testing.T) {
 				"ot1": {},
 			}
 
+			allowKNView()
 			ots.EXPECT().GetObjectTypeByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&objectType, nil).AnyTimes()
 			kna.EXPECT().GetNeighborPathsBatch(gomock.Any(), gomock.Any(), gomock.Any()).Return(neighborPathsMap, nil)
 
 			paths, err := service.GetRelationTypePaths(ctx, query)
 			So(err, ShouldBeNil)
 			So(len(paths), ShouldEqual, 1)
+		})
+
+		Convey("Child-only visibility cannot read the complete relation graph\n", func() {
+			query := interfaces.RelationTypePathsBaseOnSource{
+				KNID:              "kn1",
+				Branch:            interfaces.MAIN_BRANCH,
+				SourceObjecTypeId: "ot1",
+				Direction:         "out",
+				PathLength:        1,
+			}
+			ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+				Type: interfaces.RESOURCE_TYPE_KN,
+				ID:   "kn1",
+			}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}).
+				Return(rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden))
+
+			paths, err := service.GetRelationTypePaths(ctx, query)
+			So(err, ShouldNotBeNil)
+			So(paths, ShouldBeNil)
+			So(err.(*rest.HTTPError).BaseError.ErrorCode, ShouldEqual, rest.PublicError_Forbidden)
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -365,6 +365,8 @@ func Test_knowledgeNetworkService_ListKNs(t *testing.T) {
 			ps:         ps,
 			ums:        ums,
 		}
+		kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]interfaces.KNChildResourceCandidate{}, nil).AnyTimes()
 
 		Convey("Success listing KNs\n", func() {
 			parameter := interfaces.KNsQueryParams{
@@ -624,6 +626,8 @@ func Test_knowledgeNetworkService_GetKNByID(t *testing.T) {
 			ps:         ps,
 			ums:        ums,
 		}
+		kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]interfaces.KNChildResourceCandidate{}, nil).AnyTimes()
 
 		Convey("Success getting KN by ID\n", func() {
 			knID := "kn1"
@@ -787,6 +791,194 @@ func Test_knowledgeNetworkService_GetKNByID(t *testing.T) {
 			So(result, ShouldNotBeNil)
 			So(result.KNID, ShouldEqual, knID)
 		})
+	})
+}
+
+func Test_knowledgeNetworkService_ChildPermissionNavigation(t *testing.T) {
+	Convey("A visible child exposes only a restricted knowledge network shell", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &knowledgeNetworkService{kna: kna, ps: ps}
+		parameter := interfaces.KNsQueryParams{
+			PaginationQueryParameters: interfaces.PaginationQueryParameters{Limit: 10},
+			Branch:                    interfaces.MAIN_BRANCH,
+		}
+		candidateQuery := parameter
+		candidateQuery.OnlyIDs = true
+		candidateQuery.Limit = -1
+		detailQuery := parameter
+		detailQuery.CandidateIDs = []string{"kn1"}
+		detailQuery.Offset = 0
+		detailQuery.Limit = 1
+
+		candidateKNs := []*interfaces.KN{{KNID: "kn1"}}
+		detailKNs := []*interfaces.KN{{
+			KNID: "kn1", KNName: "Network 1", Branch: interfaces.MAIN_BRANCH,
+			SkillContent: "private instructions",
+			Creator:      interfaces.AccountInfo{ID: "creator-1"},
+		}}
+		childCandidates := []interfaces.KNChildResourceCandidate{
+			{KNID: "kn1", ResourceID: "ot1", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE},
+			{KNID: "kn1", ResourceID: "ot2", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE},
+		}
+		canonicalObjectIDs := []string{
+			interfaces.KNChildResourceID("kn1", "ot1"),
+			interfaces.KNChildResourceID("kn1", "ot2"),
+		}
+
+		gomock.InOrder(
+			kna.EXPECT().ListKNs(gomock.Any(), candidateQuery).Return(candidateKNs, nil),
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil),
+			kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{"kn1"}, interfaces.MAIN_BRANCH).
+				Return(childCandidates, nil),
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE, canonicalObjectIDs,
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				permission.KNChildOperationCandidates(interfaces.RESOURCE_TYPE_OBJECT_TYPE)).
+				Return(map[string]interfaces.PermissionResourceOps{
+					canonicalObjectIDs[0]: {ResourceID: canonicalObjectIDs[0], Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+					canonicalObjectIDs[1]: {ResourceID: canonicalObjectIDs[1], Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+				}, nil),
+			kna.EXPECT().ListKNs(gomock.Any(), detailQuery).Return(detailKNs, nil),
+		)
+
+		kns, total, err := service.ListKNs(ctx, parameter)
+		So(err, ShouldBeNil)
+		So(total, ShouldEqual, 1)
+		So(kns, ShouldHaveLength, 1)
+		So(kns[0].KNName, ShouldEqual, "Network 1")
+		So(kns[0].NavigationOnly, ShouldBeTrue)
+		So(kns[0].Operations, ShouldBeEmpty)
+		So(kns[0].SkillContent, ShouldBeEmpty)
+		So(kns[0].Creator, ShouldResemble, interfaces.AccountInfo{})
+	})
+
+	Convey("Revoking the last visible child removes the knowledge network shell", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &knowledgeNetworkService{kna: kna, ps: ps}
+		parameter := interfaces.KNsQueryParams{
+			PaginationQueryParameters: interfaces.PaginationQueryParameters{Limit: 10},
+			Branch:                    interfaces.MAIN_BRANCH,
+		}
+		candidateQuery := parameter
+		candidateQuery.OnlyIDs = true
+		candidateQuery.Limit = -1
+		canonicalObjectID := interfaces.KNChildResourceID("kn1", "ot1")
+
+		gomock.InOrder(
+			kna.EXPECT().ListKNs(gomock.Any(), candidateQuery).Return([]*interfaces.KN{{KNID: "kn1"}}, nil),
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil),
+			kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{"kn1"}, interfaces.MAIN_BRANCH).
+				Return([]interfaces.KNChildResourceCandidate{{
+					KNID: "kn1", ResourceID: "ot1", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+				}}, nil),
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE, []string{canonicalObjectID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				permission.KNChildOperationCandidates(interfaces.RESOURCE_TYPE_OBJECT_TYPE)).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil),
+		)
+
+		kns, total, err := service.ListKNs(ctx, parameter)
+		So(err, ShouldBeNil)
+		So(total, ShouldEqual, 0)
+		So(kns, ShouldBeEmpty)
+	})
+
+	Convey("A child-visible network detail is reachable but cannot be exported", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &knowledgeNetworkService{kna: kna, ps: ps}
+		childCandidates := []interfaces.KNChildResourceCandidate{{
+			KNID: "kn1", ResourceID: "rt1", Type: interfaces.RESOURCE_TYPE_RELATION_TYPE,
+		}}
+		canonicalRelationID := interfaces.KNChildResourceID("kn1", "rt1")
+		expectVisibility := func() {
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil)
+			kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{"kn1"}, interfaces.MAIN_BRANCH).
+				Return(childCandidates, nil)
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_RELATION_TYPE, []string{canonicalRelationID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				permission.KNChildOperationCandidates(interfaces.RESOURCE_TYPE_RELATION_TYPE)).
+				Return(map[string]interfaces.PermissionResourceOps{
+					canonicalRelationID: {ResourceID: canonicalRelationID, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+				}, nil)
+		}
+
+		kn := &interfaces.KN{KNID: "kn1", KNName: "Network 1", Branch: interfaces.MAIN_BRANCH, SkillContent: "private"}
+		kna.EXPECT().GetKNByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH).Return(kn, nil)
+		expectVisibility()
+		result, err := service.GetKNByID(ctx, "kn1", interfaces.MAIN_BRANCH, "")
+		So(err, ShouldBeNil)
+		So(result.NavigationOnly, ShouldBeTrue)
+		So(result.SkillContent, ShouldBeEmpty)
+
+		exportKN := &interfaces.KN{KNID: "kn1", KNName: "Network 1", Branch: interfaces.MAIN_BRANCH}
+		kna.EXPECT().GetKNByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH).Return(exportKN, nil)
+		expectVisibility()
+		result, err = service.GetKNByID(ctx, "kn1", interfaces.MAIN_BRANCH, interfaces.Mode_Export)
+		So(result, ShouldBeNil)
+		So(err, ShouldNotBeNil)
+		So(err.(*rest.HTTPError).BaseError.ErrorCode, ShouldEqual, rest.PublicError_Forbidden)
+	})
+
+	Convey("Restricted statistics count only visible child resources", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &knowledgeNetworkService{kna: kna, ps: ps}
+		kn := &interfaces.KN{KNID: "kn1", Branch: interfaces.MAIN_BRANCH, NavigationOnly: true}
+		candidates := []interfaces.KNChildResourceCandidate{
+			{KNID: "kn1", ResourceID: "ot1", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE},
+			{KNID: "kn1", ResourceID: "ot2", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE},
+			{KNID: "kn1", ResourceID: "metric1", Type: interfaces.RESOURCE_TYPE_METRIC},
+		}
+
+		ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{"kn1"},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+			Return(map[string]interfaces.PermissionResourceOps{}, nil)
+		kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{"kn1"}, interfaces.MAIN_BRANCH).
+			Return(candidates, nil)
+		ps.EXPECT().FilterResources(gomock.Any(), gomock.Any(), gomock.Any(),
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, gomock.Any()).
+			DoAndReturn(func(_ context.Context, resourceType string, ids, _ []string, _ bool, _ []string) (map[string]interfaces.PermissionResourceOps, error) {
+				matched := map[string]interfaces.PermissionResourceOps{}
+				switch resourceType {
+				case interfaces.RESOURCE_TYPE_OBJECT_TYPE:
+					id := interfaces.KNChildResourceID("kn1", "ot1")
+					matched[id] = interfaces.PermissionResourceOps{ResourceID: id}
+				case interfaces.RESOURCE_TYPE_METRIC:
+					matched[ids[0]] = interfaces.PermissionResourceOps{ResourceID: ids[0]}
+				}
+				return matched, nil
+			}).Times(2)
+
+		stats, err := service.GetStatByKN(ctx, kn)
+		So(err, ShouldBeNil)
+		So(stats.OtTotal, ShouldEqual, 1)
+		So(stats.MetricsTotal, ShouldEqual, 1)
+		So(stats.RtTotal, ShouldEqual, 0)
+		So(stats.SkillsTotal, ShouldEqual, 0)
 	})
 }
 

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1225,21 +1225,15 @@ func (ots *objectTypeService) handleObjectTypeImportMode(ctx context.Context, mo
 	return creates, updates, nil
 }
 
-// Internal use without permission checks.
+// GetObjectTypesMapByIDs resolves object metadata for an already-authorized
+// relation or action response. It deliberately performs no independent object
+// permission check: callers expose only the simple object reference and mapped
+// property display names required to render the authorized parent resource.
 func (ots *objectTypeService) GetObjectTypesMapByIDs(ctx context.Context, knID string,
 	branch string, otIDs []string, needPropMap bool) (map[string]*interfaces.ObjectType, error) {
 	// Get object types.
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, fmt.Sprintf("查询对象类[%v]信息", otIDs))
 	defer span.End()
-
-	// Check whether the user ID can modify the business knowledge network.
-	err := ots.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   knID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
-	if err != nil {
-		return map[string]*interfaces.ObjectType{}, err
-	}
 
 	// De-duplicate IDs before querying.
 	otIDs = common.DuplicateSlice(otIDs)

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -1805,12 +1805,10 @@ func Test_objectTypeService_GetObjectTypesMapByIDs(t *testing.T) {
 
 		appSetting := &common.AppSetting{}
 		ota := bmock.NewMockObjectTypeAccess(mockCtrl)
-		ps := bmock.NewMockPermissionService(mockCtrl)
 
 		service := &objectTypeService{
 			appSetting: appSetting,
 			ota:        ota,
-			ps:         ps,
 		}
 
 		Convey("Success getting object types map\n", func() {
@@ -1838,7 +1836,6 @@ func Test_objectTypeService_GetObjectTypesMapByIDs(t *testing.T) {
 				},
 			}
 
-			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			ota.EXPECT().GetObjectTypesByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(otArr, nil)
 
 			result, err := service.GetObjectTypesMapByIDs(ctx, knID, branch, otIDs, true)
@@ -1849,12 +1846,13 @@ func Test_objectTypeService_GetObjectTypesMapByIDs(t *testing.T) {
 			So(result["ot1"].PropertyMap["prop1"], ShouldEqual, "Property1")
 		})
 
-		Convey("Failed when permission check fails\n", func() {
+		Convey("Failed when object type lookup fails\n", func() {
 			knID := "kn1"
 			branch := interfaces.MAIN_BRANCH
 			otIDs := []string{"ot1"}
 
-			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(rest.NewHTTPError(ctx, 403, berrors.BknBackend_InternalError_CheckPermissionFailed))
+			ota.EXPECT().GetObjectTypesByIDs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ObjectType_InternalError))
 
 			result, err := service.GetObjectTypesMapByIDs(ctx, knID, branch, otIDs, false)
 			So(err, ShouldNotBeNil)

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization.go
@@ -69,7 +69,7 @@ func CheckKNChildBatchPermission(ctx context.Context, ps interfaces.PermissionSe
 	}
 
 	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
-	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, childOperation)
+	matched, err := FilterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, childOperation)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func FilterKNChildIDs(ctx context.Context, ps interfaces.PermissionService,
 	}
 
 	resourceIDs := interfaces.KNChildResourceIDs(knID, validChildIDs)
-	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, operation)
+	matched, err := FilterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs, operation)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func FilterAndPaginateKNChildren[T any](ctx context.Context, ps interfaces.Permi
 	}
 
 	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
-	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType,
+	matched, err := FilterKNChildResourceIDs(ctx, ps, resourceType,
 		resourceIDs, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 	if err != nil {
 		return nil, 0, err
@@ -211,7 +211,7 @@ func FilterAndPaginateKNChildrenWithOperations[T any](ctx context.Context, ps in
 	}
 
 	resourceIDs := interfaces.KNChildResourceIDs(knID, childIDs)
-	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs,
+	matched, err := FilterKNChildResourceIDs(ctx, ps, resourceType, resourceIDs,
 		interfaces.OPERATION_TYPE_VIEW_DETAIL, candidateOperations)
 	if err != nil {
 		return nil, 0, nil, err
@@ -235,7 +235,7 @@ func GetKNChildOperations(ctx context.Context, ps interfaces.PermissionService,
 		return nil, err
 	}
 	canonicalID := interfaces.KNChildResourceID(knID, childID)
-	matched, err := filterKNChildResourceIDs(ctx, ps, resourceType, []string{canonicalID},
+	matched, err := FilterKNChildResourceIDs(ctx, ps, resourceType, []string{canonicalID},
 		interfaces.OPERATION_TYPE_VIEW_DETAIL, KNChildOperationCandidates(resourceType))
 	if err != nil {
 		return nil, err
@@ -247,7 +247,10 @@ func GetKNChildOperations(ctx context.Context, ps interfaces.PermissionService,
 	return resourceOps.Operations, nil
 }
 
-func filterKNChildResourceIDs(ctx context.Context, ps interfaces.PermissionService,
+// FilterKNChildResourceIDs filters canonical child resource IDs in bounded
+// batches. It is shared by child list endpoints and parent navigation
+// visibility so both paths evaluate the same Safe contract.
+func FilterKNChildResourceIDs(ctx context.Context, ps interfaces.PermissionService,
 	resourceType string, resourceIDs []string, operation string, candidateOperations ...[]string) (map[string]interfaces.PermissionResourceOps, error) {
 
 	fullOperations := []string{operation}


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Expose a restricted knowledge network navigation shell when the caller can view at least one child resource.
- [x] Filter restricted statistics to child resources visible to the caller.
- [x] Allow authorized relation and action responses to resolve minimal referenced object metadata without requiring parent knowledge network permission.
- [x] Add focused regression coverage for duplicate parent visibility, last-child revocation, restricted detail/export, statistics, and child discovery.

---

## Why

- Related Issue: [Issue #1383](https://github.com/openbkn-ai/bkn-foundry/issues/1383)
- Related Feature: Knowledge network child-level authorization
- Background: Users with child-level view_detail permission could not see or enter the owning knowledge network because parent navigation was filtered only by knowledge-network-level permission. Relation and action enrichment could also fail with 403 when the referenced object type was not independently authorized.

---

## How

- Key implementation points:
  - Discover persisted concept group, object type, relation type, action type, metric, and risk type authorization identities for candidate knowledge networks in one database round trip.
  - Reuse the bounded Safe resource-filter contract to derive parent navigation visibility from visible children.
  - Return only navigation metadata and permission-filtered child counts for child-only knowledge networks.
  - Keep export and mutation behavior protected by direct knowledge-network operations.
  - Resolve only the minimal object metadata required to render an already-authorized relation or action response.
- Breaking changes (API, config, database, etc.): None. No schema, configuration, or public response-field changes are introduced.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run; focused backend package tests cover the changed paths.
- [ ] Verified in test environment — not performed in this local change.

Test notes:

- I18N_MODE_UT=true go test ./logics/knowledge_network ./logics/object_type ./logics/relation_type ./logics/action_type ./logics/permission ./drivenadapters/knowledge_network -count=1
- I18N_MODE_UT=true go vet ./logics/knowledge_network ./logics/object_type ./logics/relation_type ./logics/action_type ./logics/permission ./drivenadapters/knowledge_network

---

## Risk & Rollback

- Potential risks: Child-only navigation adds a constant-size child discovery query and Safe filtering for knowledge networks that are not directly visible. Restricted shells intentionally omit full knowledge network content and capability counts.
- Rollback plan: Revert commit c7c5b8bbb to restore parent-only navigation filtering and the previous enrichment permission check.

---

## Additional Notes

- The current bkn-studio navigation is already always visible and requires no frontend change for this behavior.
- Closes #1383