### PR TITLE
fix(context-loader): keep the tool's own shape when attaching a trace receipt

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -141,10 +141,7 @@ func guardBusinessToolCallWithCompletion(
 			status = receiptStatus(ensured.Receipt)
 		}
 		if status == "completed" || status == "failed" {
-			replay := map[string]any{"operation": ensured.Operation, "receipt": ensured.Receipt}
-			result := mcpsdk.NewToolResultStructured(replay, "operation is terminal; durable receipt reused")
-			result.IsError = status == "failed"
-			return result, nil
+			return receiptTerminalToolError(status, ensured.Operation, ensured.Receipt), nil
 		}
 		if ensured != nil && !ensured.Execute && status == "pending" {
 			return receiptPendingToolError(ensured.Receipt), nil
@@ -190,13 +187,7 @@ func guardBusinessToolCallWithCompletion(
 			return result, nil
 		}
 		if completed != nil {
-			if structured, ok := result.StructuredContent.(map[string]any); ok {
-				structured["bkn_receipt"] = completed.Receipt
-			} else {
-				result.StructuredContent = map[string]any{
-					"result": result.StructuredContent, "bkn_receipt": completed.Receipt,
-				}
-			}
+			attachReceipt(result, completed.Receipt)
 		}
 		return result, nil
 	}
@@ -335,6 +326,70 @@ func receiptPendingToolError(receipt any) *mcpsdk.CallToolResult {
 		Retryable: true, RequiredAction: "poll_receipt",
 	}
 	return lifecycleToolErrorWithDetails(errorValue, map[string]any{"receipt": receipt})
+}
+
+// receiptTerminalToolError replays a terminal operation without re-executing the tool.
+//
+// A lost response leaves nothing but the durable receipt: the tool did not run again, so there is no
+// payload in the shape its output schema declares. Returning that receipt as a successful structured
+// result made every schema-validating host reject the call, and handed an agent a receipt where it
+// had asked for rows. It travels as a lifecycle error instead -- hosts skip output validation on
+// error results, and the caller is told plainly that this operation is already terminal.
+func receiptTerminalToolError(status string, operation any, receipt any) *mcpsdk.CallToolResult {
+	errorValue := lifecycleError{
+		Code:           "receipt_terminal",
+		Message:        "operation is terminal; durable receipt reused, the tool was not re-executed",
+		CurrentStatus:  status,
+		RequiredAction: "read_receipt",
+	}
+	return lifecycleToolErrorWithDetails(errorValue, map[string]any{
+		"operation": operation, "receipt": receipt,
+	})
+}
+
+// attachReceipt hangs the durable receipt on a tool result without reshaping the tool's own payload.
+//
+// Business handlers hand back their response struct as structured content, so the map assertion used
+// to miss and the whole payload got nested under "result". That silently broke the contract every
+// tool publishes in its output schema, and search_instance -- the only schema with a required field
+// -- failed validation outright on hosts that check it. Marshalling the struct into a map keeps the
+// tool's own fields at the top level, which is where both the schema and the agent look for them.
+//
+// Payloads that are not JSON objects (text-only or errored results) have no shape worth preserving,
+// so they keep the nested envelope rather than losing the receipt.
+func attachReceipt(result *mcpsdk.CallToolResult, receipt any) {
+	if structured, ok := result.StructuredContent.(map[string]any); ok {
+		structured["bkn_receipt"] = receipt
+		return
+	}
+	if payload, ok := structuredContentAsMap(result.StructuredContent); ok {
+		payload["bkn_receipt"] = receipt
+		result.StructuredContent = payload
+		return
+	}
+	result.StructuredContent = map[string]any{
+		"result": result.StructuredContent, "bkn_receipt": receipt,
+	}
+}
+
+// structuredContentAsMap re-reads a structured payload as a JSON object.
+//
+// The decode keeps wide integers as json.Number rather than rounding them through float64: this
+// round-trip sits on the way out to the client, and is the last place the precision the driven
+// adapters preserved could still be lost.
+func structuredContentAsMap(value any) (map[string]any, bool) {
+	if value == nil {
+		return nil, false
+	}
+	raw, err := sonic.ConfigStd.Marshal(value)
+	if err != nil {
+		return nil, false
+	}
+	var payload map[string]any
+	if err := common.UnmarshalPreciseJSON(raw, &payload); err != nil || payload == nil {
+		return nil, false
+	}
+	return payload, true
 }
 
 func receiptStatus(receipt any) string {

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -8,6 +8,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/bkntrace"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/common"
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/infra/rest"
 	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
 )
 
@@ -251,10 +253,18 @@ func TestSessionGuardLostResponseReplayReturnsExistingReceiptWithoutDownstream(t
 	if downstreamCalls != 0 {
 		t.Fatalf("completed operation replay must not call downstream, got %d", downstreamCalls)
 	}
-	structured := result.StructuredContent.(map[string]any)
-	receipt := structured["receipt"].(map[string]any)
+	envelope := errorEnvelopeFromResult(t, result)
+	receipt := envelope["receipt"].(map[string]any)
 	if receipt["receipt_id"] != "receipt-1" {
-		t.Fatalf("replay did not return durable receipt: %#v", structured)
+		t.Fatalf("replay did not return durable receipt: %#v", envelope)
+	}
+	// A replay carries no tool payload, so it must not pose as a successful structured result:
+	// hosts validate structured content against the tool's output schema and would reject it.
+	if result.StructuredContent != nil {
+		t.Fatalf("replay published structured content that no output schema describes: %#v", result.StructuredContent)
+	}
+	if errorValue := lifecycleErrorFromResult(t, result); errorValue["code"] != "receipt_terminal" {
+		t.Fatalf("unexpected replay error: %#v", errorValue)
 	}
 }
 
@@ -282,9 +292,13 @@ func TestSessionGuardFailedResponseReplayReturnsExistingReceiptWithoutDownstream
 	if downstreamCalls != 0 {
 		t.Fatalf("failed operation replay must not call downstream, got %d", downstreamCalls)
 	}
-	receipt := result.StructuredContent.(map[string]any)["receipt"].(map[string]any)
+	envelope := errorEnvelopeFromResult(t, result)
+	receipt := envelope["receipt"].(map[string]any)
 	if receipt["receipt_status"] != "failed" {
-		t.Fatalf("replay did not return failed durable receipt: %#v", result.StructuredContent)
+		t.Fatalf("replay did not return failed durable receipt: %#v", envelope)
+	}
+	if !result.IsError {
+		t.Fatalf("failed replay must stay an error result: %#v", result)
 	}
 }
 
@@ -489,6 +503,60 @@ func TestSessionGuardCompletesAttemptAndReturnsDurableReceipt(t *testing.T) {
 	structured := result.StructuredContent.(map[string]any)
 	receipt := structured["bkn_receipt"].(map[string]any)
 	if receipt["receipt_status"] != "completed" {
+		t.Fatalf("durable receipt missing from result: %#v", structured)
+	}
+}
+
+// TestSessionGuardKeepsDeclaredToolShapeWhenAttachingReceipt pins the shape of a struct payload.
+//
+// Business handlers return a response struct, not a map, so the receipt used to be attached by
+// nesting the whole payload under "result". search_instance is the one tool whose output schema
+// marks a field required, and a validating host rejected every managed call with
+// "data must have required property 'nodes'".
+func TestSessionGuardKeepsDeclaredToolShapeWhenAttachingReceipt(t *testing.T) {
+	guarded := guardBusinessToolCallWithCompletion(
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			return &operationResult{
+				Created: true, Execute: true,
+				Operation: map[string]any{"operation_id": "op-1", "attempt": float64(1)},
+				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "pending"},
+			}, nil, nil
+		},
+		func(_ context.Context, ensured *operationResult, _ *mcpsdk.CallToolResult) (*operationResult, *lifecycleError, error) {
+			return &operationResult{
+				Operation: ensured.Operation,
+				Receipt:   map[string]any{"receipt_id": "receipt-1", "receipt_status": "completed"},
+			}, nil, nil
+		},
+		nil,
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return BuildMCPToolResult(&interfaces.SearchInstanceResp{
+				Nodes: []any{map[string]any{
+					"object_type_id": "customer",
+					"order_no":       json.Number("9223372036854775807"),
+				}},
+			}, rest.FormatJSON)
+		},
+	)
+
+	result, err := guarded(context.Background(), validBusinessToolRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	structured, ok := result.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content is not a JSON object: %#v", result.StructuredContent)
+	}
+	nodes, ok := structured["nodes"].([]any)
+	if !ok || len(nodes) != 1 {
+		t.Fatalf("receipt attachment moved the tool payload off the top level: %#v", structured)
+	}
+	// The round-trip through a map is the last place a wide integer could be rounded through float64.
+	if orderNo := nodes[0].(map[string]any)["order_no"]; orderNo != json.Number("9223372036854775807") {
+		t.Fatalf("receipt attachment rounded a wide integer: %#v", orderNo)
+	}
+	receipt, ok := structured["bkn_receipt"].(map[string]any)
+	if !ok || receipt["receipt_status"] != "completed" {
 		t.Fatalf("durable receipt missing from result: %#v", structured)
 	}
 }


### PR DESCRIPTION
Backport of #1171 (commit 434dc5b3c) to `release/0.1.4-yf`.

## Problem

Managed MCP calls attached the durable receipt by type-asserting structured content to `map[string]any`, which never held: business handlers hand back their response struct. Every managed call therefore nested the tool's payload under `"result"`, breaking the contract each tool publishes in its output schema.

`search_instance` is the only schema with a required field, so it was the one that failed outright — schema-validating hosts rejected the call with JSON-RPC `-32602 data must have required property 'nodes'`. Other tools were silently reshaped: no error, but the agent could not read the declared fields.

## Fix

Cherry-picked unchanged from main:

- `attachReceipt` marshals the payload into a map and injects the receipt in place, keeping the tool's fields at the top level. The decode preserves wide integers as `json.Number`.
- A replayed terminal operation now travels as a lifecycle error instead of posing as a successful result carrying fields no schema describes — hosts skip output validation on error results.

## Testing

- `go build ./...` — pass
- `go test ./...` (adp/context-loader/agent-retrieval, go1.25.6) — all green, including the `session_guard` regression tests carried by the cherry-pick