### PR TITLE
fix(bkn-backend): rebuild the concept dataset when its managed index is gone

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend.go
@@ -8,6 +8,10 @@ package interfaces
 
 const (
 	ResourceLocalIndexStatusAvailable = "available"
+	// ResourceLocalIndexStatusUnavailable means the managed index behind the resource cannot serve
+	// anything. Vega sets it when a schema update is classified as build-related, which also clears
+	// the index name: the row survives, the index behind it does not.
+	ResourceLocalIndexStatusUnavailable = "unavailable"
 
 	FieldFeatureType_Keyword  = "keyword"
 	FieldFeatureType_Fulltext = "fulltext"
@@ -68,6 +72,9 @@ type VegaResource struct {
 	Category         string                   `json:"category"`
 	SchemaDefinition []*Property              `json:"schema_definition,omitempty"`
 	IndexConfig      *VegaResourceIndexConfig `json:"index_config,omitempty"`
+	// LocalIndexName names the managed index behind the resource. An empty value means there is
+	// none: the dataset row exists but accepts no writes.
+	LocalIndexName string `json:"index_name,omitempty"`
 	// LocalIndexStatus is the source of truth for whether the managed local index can serve index capabilities.
 	LocalIndexStatus string `json:"local_status"`
 }

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -277,6 +277,14 @@ func datasetRebuildReason(dataset *interfaces.VegaResource, expectedSchema []*in
 	if dataset.LocalIndexStatus == interfaces.ResourceLocalIndexStatusUnavailable {
 		return "managed index is unavailable"
 	}
+	// "stale" is deliberately not a reason. It means the index exists and no longer matches a
+	// build-relevant change — vega keeps the index name, and the write path only requires a name,
+	// so documents still land. Rebuilding would delete every concept document to fix an index that
+	// is merely behind, which is the opposite of what this function is for. It does cost retrieval:
+	// VegaResourceIndexCaps reports no capabilities while a resource is stale, so the ranking
+	// degrades until the index is rebuilt through vega's own path. That is a narrower loss than
+	// deleting the data, and it is vega's maintenance concern rather than something to repair by
+	// dropping the resource here.
 	if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) {
 		return "schema changed"
 	}

--- a/adp/bkn/bkn-backend/server/logics/ontology_init.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/openbkn-ai/bkn-foundry/comm-go/logger"
 
@@ -85,12 +86,8 @@ func Init(ctx context.Context, appSetting *common.AppSetting, vbs interfaces.Veg
 		logger.Infof("Dataset %s created successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 	} else {
 		logger.Infof("Dataset %s found, ID: %s", interfaces.BKN_DATASET_NAME, dataset.ID)
-		// Compare the schema and the resource-level embedding model reference.
-		// Vega interprets DefaultEmbeddingModel as a model ID, so a historical
-		// model name must trigger recreation even when the schema is unchanged.
-		if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) ||
-			!sameDefaultEmbeddingModel(dataset.IndexConfig, defaultEmbeddingModel) {
-			logger.Infof("Dataset definition mismatch detected, deleting and recreating dataset...")
+		if reason := datasetRebuildReason(dataset, expectedSchema, defaultEmbeddingModel); reason != "" {
+			logger.Infof("Dataset needs rebuilding (%s), deleting and recreating dataset...", reason)
 			// Delete dataset
 			err = vbs.DeleteResource(ctx, dataset.ID)
 			if err != nil {
@@ -107,7 +104,7 @@ func Init(ctx context.Context, appSetting *common.AppSetting, vbs interfaces.Veg
 			}
 			logger.Infof("Dataset %s recreated successfully, ID: %s", interfaces.BKN_DATASET_NAME, interfaces.BKN_DATASET_ID)
 		} else {
-			logger.Infof("Dataset definition matches, no need to recreate dataset")
+			logger.Infof("Dataset definition matches and its index is usable, no need to recreate dataset")
 		}
 	}
 
@@ -254,4 +251,37 @@ func comparePropertyFeature(f1, f2 *interfaces.PropertyFeature) bool {
 	}
 
 	return true
+}
+
+// datasetRebuildReason says why an adopted concept dataset cannot be used as it stands, or "" when
+// it can.
+//
+// The schema and embedding model comparisons are the historical ones: vega interprets
+// DefaultEmbeddingModel as a model ID, so a stored model name has to force a rebuild even when the
+// schema is unchanged.
+//
+// The two index checks are the ones that were missing. A dataset row can outlive the index behind
+// it: vega clears the managed index name and marks it unavailable whenever a schema update is
+// classified as build-related. The row then still matches on schema and model, so adoption used to
+// accept it and every concept write afterwards failed with 400 "dataset resource has no available
+// local index" — permanently, because nothing here questioned the row again. Recovery meant a human
+// deleting the resource by hand, which first meant knowing this mechanism exists.
+func datasetRebuildReason(dataset *interfaces.VegaResource, expectedSchema []*interfaces.Property,
+	defaultEmbeddingModel string) string {
+	if dataset == nil {
+		return "resource is missing"
+	}
+	if strings.TrimSpace(dataset.LocalIndexName) == "" {
+		return "dataset has no managed index"
+	}
+	if dataset.LocalIndexStatus == interfaces.ResourceLocalIndexStatusUnavailable {
+		return "managed index is unavailable"
+	}
+	if !deepCompareSchemas(expectedSchema, dataset.SchemaDefinition) {
+		return "schema changed"
+	}
+	if !sameDefaultEmbeddingModel(dataset.IndexConfig, defaultEmbeddingModel) {
+		return "embedding model changed"
+	}
+	return ""
 }

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -179,6 +179,10 @@ func TestInitKeepsDatasetWhenSchemaAndEmbeddingModelIDMatch(t *testing.T) {
 			ID:               interfaces.BKN_DATASET_ID,
 			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
 			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelID},
+			// A dataset is only keepable when the index behind it can still be written. A row that
+			// matches on schema and model but has no managed index accepts nothing.
+			LocalIndexName:   "vega-dataset-01",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
 		}, nil)
 
 		err := Init(ctx, &common.AppSetting{ServerSetting: common.ServerSetting{DefaultSmallModelEnabled: true}}, vbs)
@@ -416,6 +420,60 @@ func Test_deepCompareSchemas(t *testing.T) {
 			s1 := []*interfaces.Property{{Name: "id", Type: "long"}}
 			s2 := []*interfaces.Property{{Name: "id", Type: "keyword"}}
 			So(deepCompareSchemas(s1, s2), ShouldBeFalse)
+		})
+	})
+}
+
+// ── datasetRebuildReason ──────────────────────────────────────────────────────
+
+// A concept dataset row can outlive the index behind it. Vega clears the managed index name and
+// marks it unavailable whenever a schema update is classified as build-related, and the row that
+// remains still matches on schema and embedding model. Adoption used to accept such a row, and
+// every concept write afterwards failed with 400 "dataset resource has no available local index" —
+// permanently, because startup never questioned the row again. Observed on a real environment:
+// creating a knowledge network answered InsertOpenSearchDataFailed / WriteDatasetDocument returned
+// HTTP 400, and the only way out was a human deleting the resource by hand.
+func Test_datasetRebuildReason(t *testing.T) {
+	Convey("接手存量概念数据集前要先问它还能不能写\n", t, func() {
+		schema := []*interfaces.Property{{Name: "name", Type: "text"}}
+		healthy := &interfaces.VegaResource{
+			ID:               interfaces.BKN_DATASET_ID,
+			SchemaDefinition: schema,
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "model-1"},
+			LocalIndexName:   "vega-dataset-01",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
+		}
+
+		Convey("健康的数据集不重建", func() {
+			So(datasetRebuildReason(healthy, schema, "model-1"), ShouldEqual, "")
+		})
+
+		Convey("托管索引名为空要重建", func() {
+			broken := *healthy
+			broken.LocalIndexName = ""
+			So(datasetRebuildReason(&broken, schema, "model-1"), ShouldNotEqual, "")
+		})
+
+		Convey("托管索引不可用要重建", func() {
+			broken := *healthy
+			broken.LocalIndexStatus = interfaces.ResourceLocalIndexStatusUnavailable
+			So(datasetRebuildReason(&broken, schema, "model-1"), ShouldNotEqual, "")
+		})
+
+		Convey("schema 变了要重建", func() {
+			changed := *healthy
+			So(datasetRebuildReason(&changed, []*interfaces.Property{{Name: "other", Type: "text"}}, "model-1"),
+				ShouldNotEqual, "")
+		})
+
+		Convey("embedding 模型变了要重建", func() {
+			changed := *healthy
+			changed.IndexConfig = &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "model-2"}
+			So(datasetRebuildReason(&changed, schema, "model-1"), ShouldNotEqual, "")
+		})
+
+		Convey("资源不存在要重建", func() {
+			So(datasetRebuildReason(nil, schema, "model-1"), ShouldNotEqual, "")
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
+++ b/adp/bkn/bkn-backend/server/logics/ontology_init_test.go
@@ -144,6 +144,10 @@ func TestInitRecreatesDatasetWhenEmbeddingModelIDDiffers(t *testing.T) {
 		vbs.EXPECT().GetResourceByID(ctx, interfaces.BKN_DATASET_ID).Return(&interfaces.VegaResource{
 			ID:               interfaces.BKN_DATASET_ID,
 			SchemaDefinition: interfaces.GetBKNConceptSchemaDefinition(model.EmbeddingDim, true),
+			// Healthy index: without it the managed-index check short-circuits and this case
+			// never reaches the comparison it exists to exercise.
+			LocalIndexName:   "vega-dataset-01",
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
 			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: model.ModelName},
 		}, nil)
 		vbs.EXPECT().DeleteResource(ctx, interfaces.BKN_DATASET_ID).Return(nil)
@@ -452,6 +456,16 @@ func Test_datasetRebuildReason(t *testing.T) {
 			broken := *healthy
 			broken.LocalIndexName = ""
 			So(datasetRebuildReason(&broken, schema, "model-1"), ShouldNotEqual, "")
+		})
+
+		Convey("stale 不重建——索引还在，写入照常，重建会白白删光概念文档", func() {
+			// vega marks a dataset stale when a build-relevant change lands, and keeps the index
+			// name. The write path only requires a name, so documents still land; what degrades is
+			// retrieval, until vega rebuilds the index through its own path. Deleting the resource
+			// here would trade a degraded ranking for lost data.
+			behind := *healthy
+			behind.LocalIndexStatus = "stale"
+			So(datasetRebuildReason(&behind, schema, "model-1"), ShouldEqual, "")
 		})
 
 		Convey("托管索引不可用要重建", func() {


### PR DESCRIPTION
Closes #1381

## What went wrong

A colleague could not create a knowledge network on the test server:

```json
{
  "description": "业务知识网络概念索引插入失败",
  "error_code": "BknBackend.KnowledgeNetwork.InternalError.InsertOpenSearchDataFailed",
  "error_details": "WriteDatasetDocument returned HTTP 400"
}
```

The concept index held zero documents, every object-type and action-type change
was failing to reach it, and `search_schema` was reading an empty index.

## Why

A dataset row can outlive the index behind it. Vega clears the managed index
name and marks it unavailable whenever a schema update is classified as
build-related — that is deliberate on its side, and the row that remains still
matches on schema and on embedding model.

Adoption only compared those two. So the row was accepted, one INFO line said
the definition matched, and every write afterwards failed with 400 `dataset
resource has no available local index`. Permanently: restarting changed nothing,
because startup never questioned the row again. Recovery meant a human deleting
the vega resource by hand, which first meant knowing that `f_local_index_name`
exists.

This is not an upgrade defect. The backfill migration ran on that server and
worked — the Skill dataset carries the value it wrote. Something invalidated the
concept dataset afterwards, and nothing noticed.

## The change

Adoption now asks whether the dataset can still be written before asking whether
its definition still matches, and rebuilds when it cannot. This is the same
question the execution factory asks of the capability index in #1370.

`interfaces.VegaResource` gains `index_name`; `local_status` was already parsed
and used by `VegaResourceIndexCaps`.

## Verified on the test server

Same broken state, only the image differs:

| | after restart |
|---|---|
| current build | index name empty, `unavailable`; listing knowledge networks 500s |
| this build | `vega-dataset-01a08000-…`, `available` |

```
Dataset needs rebuilding (dataset has no managed index), deleting and recreating dataset...
Dataset adp_bkn_concept_dataset recreated successfully
```

Creating a knowledge network then answered 201 and deleting it 204.

## Note

The rebuild restores the dataset, not its documents. Concept documents re-enter
the index as their object types and action types are next written. Nothing was
lost here because the index was already empty, but there is no full rebuild
entry point for the concept index — worth its own issue.

## Test plan

- [x] `go test ./logics/` in bkn-backend
- [x] Broken state reproduced and healed on the test server, current build shown not to heal
- [x] Knowledge network create (201) and delete (204) after the fix
