### PR TITLE
feat(bkn-backend): safeguard knowledge network data migration

### DIFF
--- a/adp/bkn/bkn-backend/.gitignore
+++ b/adp/bkn/bkn-backend/.gitignore
@@ -25,3 +25,6 @@ go.work
 go.work.sum
 # Test result output (per TESTING spec)
 test-result/
+
+# Local logical dumps created by the knowledge-network migration command
+script/migrate_kn_data/backups/

--- a/adp/bkn/bkn-backend/script/migrate_kn_data/README.md
+++ b/adp/bkn/bkn-backend/script/migrate_kn_data/README.md
@@ -17,6 +17,8 @@ required BKN or bkn-safe tables are unavailable.
 
 One execution performs all required data work:
 
+- creates and verifies logical backups of the BKN and bkn-safe databases before
+  the first migration write;
 - normalizes blank BKN branches to `main`;
 - rebuilds the seven knowledge-network authorization resource types in
   bkn-safe;
@@ -36,15 +38,18 @@ role, and public policies. After migration, that authorization baseline contains
 - one `execute` creator policy for each action type;
 - one parent edge from every child resource to its knowledge network.
 
-The command only reads and writes database data. It does not install or upgrade
-OpenBKN, control workloads, create a backup, write a report file, or call a
-running service or HTTP API.
+The command reads and writes database data and creates a local backup manifest.
+It does not install or upgrade OpenBKN, control workloads, or call a running
+service or HTTP API.
 
 ## Requirements
 
 - Python 3.9+
 - PyMySQL 1.1.0
+- `mariadb-dump` or `mysqldump` in `PATH`
 - MariaDB or MySQL access to the BKN and bkn-safe databases
+- enough writable disk space for full compressed logical backups of both
+  databases
 
 ```bash
 python3 -m pip install pymysql==1.1.0
@@ -52,8 +57,24 @@ python3 -m pip install pymysql==1.1.0
 
 ## Configuration
 
-The default database names are `openbkn` and `safe`. The command reads database
-connections from the existing runtime environment:
+Run the script on the database server or inside its database container. It
+automatically reads standard MariaDB container variables and defaults to a
+local database server at `127.0.0.1:3306`.
+
+Configuration is resolved in this order:
+
+1. explicit `BKN_DB_*` or `SAFE_DB_*` variables;
+2. `MARIADB_*` variables provided by the database server/container;
+3. local defaults (`127.0.0.1:3306`, user `root`, databases `openbkn` and
+   `safe`).
+
+Direct password values and password files are both supported. The relevant
+standard variables are `MARIADB_PASSWORD`, `MARIADB_PASSWORD_FILE`,
+`MARIADB_ROOT_PASSWORD`, and `MARIADB_ROOT_PASSWORD_FILE`. Explicit overrides
+can use `BKN_DB_PASSWORD_FILE` and `SAFE_DB_PASSWORD_FILE` as well as the direct
+password variables shown below.
+
+The explicit overrides are:
 
 ```bash
 export BKN_DB_HOST=localhost
@@ -71,8 +92,12 @@ export SAFE_DB_NAME=safe
 
 The two databases normally use the same MariaDB instance and credentials. When
 `SAFE_DB_HOST`, `SAFE_DB_PORT`, `SAFE_DB_USER`, or `SAFE_DB_PASSWORD` is not
-set, the command automatically reuses its corresponding `BKN_DB_*` value. Only
+set, the command automatically reuses the resolved BKN connection. Only
 `SAFE_DB_NAME` defaults independently to `safe`.
+
+The script does not query Kubernetes Secrets. If it is run outside the database
+server/container, provide the explicit overrides above. An unreadable password
+file or invalid port stops the command before any database connection or write.
 
 ## Usage
 
@@ -93,6 +118,44 @@ The migration command validates all source data, applies the caller-authorizatio
 managed-proxy migrations, verifies the result, and then exits. It uses the
 fixed bkn-safe built-in `admin` identity as the migration grantor; users do not
 need to find or pass an account ID.
+
+## Backup and restore
+
+After validation and immediately before the first write, the script creates:
+
+```text
+backups/YYYYMMDD_HHMMSS/
+├── bkn.sql.gz
+├── safe.sql.gz
+└── manifest.json
+```
+
+`backups` is located beside `script.py`. Set
+`OPENBKN_MIGRATION_BACKUP_DIR` only when that directory is not writable or a
+different backup volume is required. Existing backup directories and files are
+never overwritten; a same-second rerun receives a numeric suffix.
+
+Each archive is a full logical dump created with transaction-consistent dump
+options and includes routines, events, triggers, and binary data. The manifest
+records file sizes, SHA-256 checksums, and password-free restore commands. The
+resolved database password is passed to the dump process through its environment;
+it is never included in command arguments, terminal output, or the manifest.
+
+The script prints the backup directory and restore commands before migration
+writes begin. To restore, keep the services stopped, set `MYSQL_PWD` from the
+same environment or password file, and run the applicable printed command. For
+example:
+
+```bash
+export MYSQL_PWD="$(cat /path/to/database-password-file)"
+gzip -dc backups/YYYYMMDD_HHMMSS/bkn.sql.gz \
+  | mariadb --host=127.0.0.1 --port=3306 --user=root
+```
+
+Restore both archives before retrying when a failed run may have committed one
+database but not the other. A missing dump utility, unwritable backup directory,
+failed dump, empty archive, or checksum-verification failure stops execution
+before the first migration write. Previously completed backups remain untouched.
 
 The migration is idempotent: it reuses existing managed accounts and mappings,
 reactivates matching source rows, and reconciles owned policies. A successful

--- a/adp/bkn/bkn-backend/script/migrate_kn_data/script.py
+++ b/adp/bkn/bkn-backend/script/migrate_kn_data/script.py
@@ -16,6 +16,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import tempfile
 import traceback
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
@@ -1660,19 +1661,30 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def validate_backup_archive(path: Path, role: str, database: str) -> None:
-    """Read the complete gzip stream so truncation and empty dumps fail closed."""
+def validate_backup_archive(
+    path: Path,
+    role: str,
+    database: str,
+    expected_content_sha256: str,
+) -> None:
+    """Verify the complete gzip stream against its independently captured digest."""
     has_content = False
+    content_digest = hashlib.sha256()
     try:
         with gzip.open(path, "rb") as backup_content:
             for block in iter(lambda: backup_content.read(1024 * 1024), b""):
                 has_content = has_content or bool(block)
+                content_digest.update(block)
     except (EOFError, OSError) as error:
         raise MigrationError(
             f"database backup is invalid for {role}/{database}"
         ) from error
     if not has_content:
         raise MigrationError(f"database backup is empty for {role}/{database}")
+    if content_digest.hexdigest() != expected_content_sha256:
+        raise MigrationError(
+            f"database backup checksum verification failed for {role}/{database}"
+        )
 
 
 def backup_directory(root: Path, timestamp: str) -> Path:
@@ -1755,29 +1767,56 @@ def create_pre_migration_backup(
                 os.O_WRONLY | os.O_CREAT | os.O_EXCL,
                 0o600,
             )
+            content_digest = hashlib.sha256()
             with os.fdopen(descriptor, "wb") as raw_output:
-                with gzip.GzipFile(fileobj=raw_output, mode="wb") as output:
-                    result = subprocess.run(
+                with tempfile.TemporaryFile() as error_output:
+                    process = subprocess.Popen(
                         command,
-                        stdout=output,
-                        stderr=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=error_output,
                         env=child_environment,
-                        check=False,
                     )
-            if result.returncode != 0:
-                detail = result.stderr.decode("utf-8", errors="replace").strip()
+                    if process.stdout is None:
+                        process.kill()
+                        process.wait()
+                        raise MigrationError(
+                            f"database backup output is unavailable for "
+                            f"{role}/{config.database}"
+                        )
+                    try:
+                        with process.stdout:
+                            with gzip.GzipFile(
+                                fileobj=raw_output, mode="wb"
+                            ) as output:
+                                for block in iter(
+                                    lambda: process.stdout.read(1024 * 1024), b""
+                                ):
+                                    content_digest.update(block)
+                                    output.write(block)
+                        return_code = process.wait()
+                    except Exception:
+                        try:
+                            process.kill()
+                        except OSError:
+                            pass
+                        process.wait()
+                        raise
+                    error_output.seek(0)
+                    error_detail = error_output.read()
+            if return_code != 0:
+                detail = error_detail.decode("utf-8", errors="replace").strip()
                 detail = redact_secrets(detail, configs.values())
                 raise MigrationError(
                     f"database backup failed for {role}/{config.database}: "
                     f"{detail or 'dump command returned a non-zero exit code'}"
                 )
-            validate_backup_archive(archive, role, config.database)
+            validate_backup_archive(
+                archive,
+                role,
+                config.database,
+                content_digest.hexdigest(),
+            )
             checksum = sha256_file(archive)
-            if sha256_file(archive) != checksum:
-                raise MigrationError(
-                    f"database backup checksum verification failed for "
-                    f"{role}/{config.database}"
-                )
             command_text = restore_command(config, archive)
             restore_commands.append(command_text)
             entries.append(

--- a/adp/bkn/bkn-backend/script/migrate_kn_data/script.py
+++ b/adp/bkn/bkn-backend/script/migrate_kn_data/script.py
@@ -7,15 +7,20 @@
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import json
 import os
 import secrets
+import shlex
+import shutil
+import subprocess
 import sys
 import traceback
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Iterable, Optional
 
 
@@ -25,6 +30,7 @@ NETWORK_BUILDER_ROLE_ID = "1572fb82-526f-11f0-bde6-e674ec8dde71"
 MIGRATION_GRANTOR_ID = "266c6a42-6131-4d62-8f39-853e7093701c"
 PUBLIC_ACCESSOR_ID = "00000000-0000-0000-0000-000000000000"
 PROXY_SOURCE_TYPE = "kn_proxy_binding"
+BACKUP_ROOT_ENV = "OPENBKN_MIGRATION_BACKUP_DIR"
 KN_CREATOR_OPERATIONS = (
     "view_detail",
     "modify",
@@ -80,6 +86,12 @@ class DBConfig:
     user: str
     password: str
     database: str
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    path: Path
+    restore_commands: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -1500,23 +1512,320 @@ def verify_proxy_plan(
                 raise MigrationError(f"proxy mapping verification failed for {network.kn_id}")
 
 
-def database_config(prefix: str, default_name: str) -> DBConfig:
-    """Build one database configuration from environment variables."""
-    fallback_prefix = "BKN_DB" if prefix == "SAFE_DB" else prefix
+def first_environment_value(names: Iterable[str], default: str) -> str:
+    """Return the first explicitly defined environment value."""
+    for name in names:
+        if name in os.environ:
+            return os.environ[name]
+    return default
 
-    def setting(name: str, default: str) -> str:
-        return os.getenv(
-            f"{prefix}_{name}",
-            os.getenv(f"{fallback_prefix}_{name}", default),
+
+def password_from_environment(names: Iterable[str], default: str = "") -> str:
+    """Resolve a password without putting its value in command-line arguments."""
+    for name in names:
+        if name not in os.environ:
+            continue
+        if not name.endswith("_FILE"):
+            return os.environ[name]
+        password_path = Path(os.environ[name])
+        try:
+            return password_path.read_text(encoding="utf-8").rstrip("\r\n")
+        except OSError as error:
+            raise MigrationError(
+                f"cannot read database password file configured by {name}: "
+                f"{password_path}"
+            ) from error
+    return default
+
+
+def database_config(
+    prefix: str, default_name: str, fallback: Optional[DBConfig] = None
+) -> DBConfig:
+    """Build one database configuration from explicit or server environment values."""
+    if prefix == "SAFE_DB" and fallback is None:
+        fallback = database_config("BKN_DB", "openbkn")
+
+    if fallback is not None:
+        host = first_environment_value((f"{prefix}_HOST",), fallback.host)
+        port_text = first_environment_value((f"{prefix}_PORT",), str(fallback.port))
+        user = first_environment_value((f"{prefix}_USER",), fallback.user)
+        password = password_from_environment(
+            (f"{prefix}_PASSWORD", f"{prefix}_PASSWORD_FILE"),
+            fallback.password,
+        )
+    else:
+        host = first_environment_value(
+            (f"{prefix}_HOST", "MARIADB_HOST", "MARIADB_HOSTNAME"),
+            "127.0.0.1",
+        )
+        port_text = first_environment_value(
+            (f"{prefix}_PORT", "MARIADB_PORT_NUMBER", "MARIADB_PORT"),
+            "3306",
+        )
+        explicit_user = os.environ.get(f"{prefix}_USER")
+        mariadb_user = os.environ.get("MARIADB_USER")
+        mariadb_password_defined = any(
+            name in os.environ
+            for name in ("MARIADB_PASSWORD", "MARIADB_PASSWORD_FILE")
+        )
+        root_password_defined = any(
+            name in os.environ
+            for name in ("MARIADB_ROOT_PASSWORD", "MARIADB_ROOT_PASSWORD_FILE")
+        )
+        if explicit_user is not None:
+            user = explicit_user
+        elif root_password_defined:
+            user = "root"
+        elif mariadb_user is not None and mariadb_password_defined:
+            user = mariadb_user
+        else:
+            user = "root"
+
+        if user == mariadb_user and mariadb_password_defined:
+            standard_password_sources = (
+                "MARIADB_PASSWORD",
+                "MARIADB_PASSWORD_FILE",
+            )
+        elif user == "root":
+            standard_password_sources = (
+                "MARIADB_ROOT_PASSWORD",
+                "MARIADB_ROOT_PASSWORD_FILE",
+                "MARIADB_PASSWORD",
+                "MARIADB_PASSWORD_FILE",
+            )
+        else:
+            standard_password_sources = ()
+        password = password_from_environment(
+            (
+                f"{prefix}_PASSWORD",
+                f"{prefix}_PASSWORD_FILE",
+                *standard_password_sources,
+            )
         )
 
+    try:
+        port = int(port_text)
+    except ValueError as error:
+        raise MigrationError(
+            f"invalid database port for {prefix}: {port_text!r}"
+        ) from error
+    if port < 1 or port > 65535:
+        raise MigrationError(f"invalid database port for {prefix}: {port}")
+
+    database_names = (f"{prefix}_NAME",)
+    if fallback is None:
+        database_names += ("MARIADB_DATABASE",)
     return DBConfig(
-        host=setting("HOST", "localhost"),
-        port=int(setting("PORT", "3306")),
-        user=setting("USER", "root"),
-        password=setting("PASSWORD", ""),
-        database=os.getenv(f"{prefix}_NAME", default_name),
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=first_environment_value(database_names, default_name),
     )
+
+
+def database_configs() -> tuple[DBConfig, DBConfig]:
+    """Resolve BKN and bkn-safe connections from one server environment."""
+    bkn_config = database_config("BKN_DB", "openbkn")
+    safe_config = database_config("SAFE_DB", "safe", fallback=bkn_config)
+    return bkn_config, safe_config
+
+
+def find_dump_executable() -> str:
+    """Find a compatible logical-backup client."""
+    for name in ("mariadb-dump", "mysqldump"):
+        executable = shutil.which(name)
+        if executable:
+            return executable
+    raise MigrationError(
+        "database backup requires mariadb-dump or mysqldump in PATH"
+    )
+
+
+def redact_secrets(message: str, configs: Iterable[DBConfig]) -> str:
+    """Remove resolved passwords from an external command error."""
+    redacted = message
+    for config in configs:
+        if config.password:
+            redacted = redacted.replace(config.password, "<redacted>")
+    return redacted
+
+
+def sha256_file(path: Path) -> str:
+    """Calculate the SHA-256 checksum of a backup archive."""
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def validate_backup_archive(path: Path, role: str, database: str) -> None:
+    """Read the complete gzip stream so truncation and empty dumps fail closed."""
+    has_content = False
+    try:
+        with gzip.open(path, "rb") as backup_content:
+            for block in iter(lambda: backup_content.read(1024 * 1024), b""):
+                has_content = has_content or bool(block)
+    except (EOFError, OSError) as error:
+        raise MigrationError(
+            f"database backup is invalid for {role}/{database}"
+        ) from error
+    if not has_content:
+        raise MigrationError(f"database backup is empty for {role}/{database}")
+
+
+def backup_directory(root: Path, timestamp: str) -> Path:
+    """Create a new timestamped directory without overwriting an older backup."""
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        raise MigrationError(f"cannot create backup root: {root}") from error
+    for suffix in range(1000):
+        name = timestamp if suffix == 0 else f"{timestamp}-{suffix:02d}"
+        candidate = root / name
+        try:
+            candidate.mkdir(mode=0o700)
+            return candidate
+        except FileExistsError:
+            continue
+        except OSError as error:
+            raise MigrationError(
+                f"cannot create backup directory: {candidate}"
+            ) from error
+    raise MigrationError(f"cannot allocate a unique backup directory under {root}")
+
+
+def restore_command(config: DBConfig, archive: Path) -> str:
+    """Build a password-free restore command for operator guidance."""
+    return " ".join(
+        (
+            "gzip -dc",
+            shlex.quote(str(archive)),
+            "| mariadb",
+            f"--host={shlex.quote(config.host)}",
+            f"--port={config.port}",
+            f"--user={shlex.quote(config.user)}",
+        )
+    )
+
+
+def create_pre_migration_backup(
+    configs: dict[str, DBConfig],
+    backup_root: Optional[Path] = None,
+    now: Optional[datetime] = None,
+    dump_executable: Optional[str] = None,
+) -> BackupResult:
+    """Create verified logical backups before any migration write is attempted."""
+    if not configs:
+        raise MigrationError("no databases were configured for backup")
+    root = backup_root or Path(
+        os.getenv(BACKUP_ROOT_ENV, str(Path(__file__).resolve().parent / "backups"))
+    )
+    instant = now or datetime.now(timezone.utc)
+    timestamp = instant.astimezone(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    executable = dump_executable or find_dump_executable()
+    target = backup_directory(root, timestamp)
+    entries = []
+    restore_commands = []
+    created_files = []
+    try:
+        for role, config in configs.items():
+            archive = target / f"{role}.sql.gz"
+            created_files.append(archive)
+            command = [
+                executable,
+                f"--host={config.host}",
+                f"--port={config.port}",
+                f"--user={config.user}",
+                "--single-transaction",
+                "--routines",
+                "--events",
+                "--triggers",
+                "--hex-blob",
+                "--databases",
+                config.database,
+            ]
+            child_environment = os.environ.copy()
+            child_environment.pop("MYSQL_PWD", None)
+            if config.password:
+                child_environment["MYSQL_PWD"] = config.password
+            descriptor = os.open(
+                archive,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            with os.fdopen(descriptor, "wb") as raw_output:
+                with gzip.GzipFile(fileobj=raw_output, mode="wb") as output:
+                    result = subprocess.run(
+                        command,
+                        stdout=output,
+                        stderr=subprocess.PIPE,
+                        env=child_environment,
+                        check=False,
+                    )
+            if result.returncode != 0:
+                detail = result.stderr.decode("utf-8", errors="replace").strip()
+                detail = redact_secrets(detail, configs.values())
+                raise MigrationError(
+                    f"database backup failed for {role}/{config.database}: "
+                    f"{detail or 'dump command returned a non-zero exit code'}"
+                )
+            validate_backup_archive(archive, role, config.database)
+            checksum = sha256_file(archive)
+            if sha256_file(archive) != checksum:
+                raise MigrationError(
+                    f"database backup checksum verification failed for "
+                    f"{role}/{config.database}"
+                )
+            command_text = restore_command(config, archive)
+            restore_commands.append(command_text)
+            entries.append(
+                {
+                    "role": role,
+                    "database": config.database,
+                    "host": config.host,
+                    "port": config.port,
+                    "user": config.user,
+                    "archive": archive.name,
+                    "size_bytes": archive.stat().st_size,
+                    "sha256": checksum,
+                    "restore_command": command_text,
+                }
+            )
+
+        manifest = target / "manifest.json"
+        manifest_content = json.dumps(
+            {
+                "format_version": 1,
+                "created_at": instant.astimezone(timezone.utc).isoformat(),
+                "dump_utility": Path(executable).name,
+                "databases": entries,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        manifest_content += "\n"
+        descriptor = os.open(
+            manifest,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write(manifest_content)
+        return BackupResult(target, tuple(restore_commands))
+    except Exception:
+        for path in reversed(created_files):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+        try:
+            (target / "manifest.json").unlink(missing_ok=True)
+            target.rmdir()
+        except OSError:
+            pass
+        raise
 
 
 def format_failures(failures: Iterable[Failure]) -> str:
@@ -1533,8 +1842,9 @@ def run() -> int:
     bkn_connection = None
     safe_connection = None
     try:
-        bkn_connection = connect_database(database_config("BKN_DB", "openbkn"))
-        safe_connection = connect_database(database_config("SAFE_DB", "safe"))
+        bkn_config, safe_config = database_configs()
+        bkn_connection = connect_database(bkn_config)
+        safe_connection = connect_database(safe_config)
         rows = load_resources(bkn_connection)
         creator_ids = [
             row.creator_id.strip()
@@ -1561,6 +1871,14 @@ def run() -> int:
             raise MigrationError(
                 "migration validation failed:\n" + format_failures(failures)
             )
+
+        backup = create_pre_migration_backup(
+            {"bkn": bkn_config, "safe": safe_config}
+        )
+        print(f"Pre-migration backup created: {backup.path}")
+        print("Set MYSQL_PWD from the same environment, then restore if needed:")
+        for command in backup.restore_commands:
+            print(f"  {command}")
 
         try:
             normalize_branches(bkn_connection, commit=False)

--- a/adp/bkn/bkn-backend/script/migrate_kn_data/test_script.py
+++ b/adp/bkn/bkn-backend/script/migrate_kn_data/test_script.py
@@ -3,6 +3,7 @@
 # Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
 import gzip
+import hashlib
 import io
 import json
 import os
@@ -475,19 +476,41 @@ class PreMigrationBackupTest(unittest.TestCase):
             "safe": DBConfig("127.0.0.1", 3306, "root", "safe-secret", "safe"),
         }
 
+    def test_streams_a_real_dump_process_into_a_valid_gzip_archive(self):
+        content = b"-- dump from a real child process\n"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            executable = root / "fake-mariadb-dump"
+            executable.write_text(
+                "#!/bin/sh\nprintf '%s\\n' '-- dump from a real child process'\n",
+                encoding="utf-8",
+            )
+            executable.chmod(0o700)
+
+            backup = migration.create_pre_migration_backup(
+                {"bkn": self.configs["bkn"]},
+                backup_root=root / "backups",
+                dump_executable=str(executable),
+            )
+
+            with gzip.open(backup.path / "bkn.sql.gz", "rb") as source:
+                self.assertEqual(content, source.read())
+
     def test_creates_verified_secret_free_backups_without_overwriting(self):
         calls = []
 
-        def dump(command, stdout, stderr, env, check):
-            del stderr, check
+        def dump(command, stdout, stderr, env):
             calls.append((command, env))
-            stdout.write(b"-- complete logical dump\n")
-            return SimpleNamespace(returncode=0, stderr=b"")
+            self.assertIs(migration.subprocess.PIPE, stdout)
+            return SimpleNamespace(
+                stdout=io.BytesIO(b"-- complete logical dump\n"),
+                wait=lambda: 0,
+            )
 
         instant = datetime(2026, 9, 8, 12, 30, tzinfo=timezone.utc)
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            with patch.object(migration.subprocess, "run", side_effect=dump):
+            with patch.object(migration.subprocess, "Popen", side_effect=dump):
                 first = migration.create_pre_migration_backup(
                     self.configs,
                     backup_root=root,
@@ -531,16 +554,17 @@ class PreMigrationBackupTest(unittest.TestCase):
             self.assertIn(environment["MYSQL_PWD"], {"bkn-secret", "safe-secret"})
 
     def test_removes_an_incomplete_backup_and_redacts_dump_errors(self):
-        def failed_dump(command, stdout, stderr, env, check):
-            del command, stdout, stderr, env, check
+        def failed_dump(command, stdout, stderr, env):
+            del command, stdout, env
+            stderr.write(b"authentication rejected for bkn-secret")
             return SimpleNamespace(
-                returncode=1,
-                stderr=b"authentication rejected for bkn-secret",
+                stdout=io.BytesIO(),
+                wait=lambda: 1,
             )
 
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            with patch.object(migration.subprocess, "run", side_effect=failed_dump):
+            with patch.object(migration.subprocess, "Popen", side_effect=failed_dump):
                 with self.assertRaises(migration.MigrationError) as context:
                     migration.create_pre_migration_backup(
                         self.configs,
@@ -552,35 +576,28 @@ class PreMigrationBackupTest(unittest.TestCase):
             self.assertIn("<redacted>", str(context.exception))
             self.assertEqual([], list(root.iterdir()))
 
-    def test_checksum_verification_failure_stops_and_removes_backup(self):
-        def dump(command, stdout, stderr, env, check):
-            del command, stderr, env, check
-            stdout.write(b"-- complete logical dump\n")
-            return SimpleNamespace(returncode=0, stderr=b"")
-
+    def test_validates_archive_against_the_independent_source_checksum(self):
+        content = b"-- complete logical dump\n"
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            with ExitStack() as stack:
-                stack.enter_context(
-                    patch.object(migration.subprocess, "run", side_effect=dump)
-                )
-                stack.enter_context(
-                    patch.object(
-                        migration,
-                        "sha256_file",
-                        side_effect=["first", "second"],
-                    )
-                )
-                with self.assertRaisesRegex(
-                    migration.MigrationError, "checksum verification failed"
-                ):
-                    migration.create_pre_migration_backup(
-                        self.configs,
-                        backup_root=root,
-                        dump_executable="/usr/bin/mariadb-dump",
-                    )
+            archive = Path(directory) / "backup.sql.gz"
+            with gzip.open(archive, "wb") as output:
+                output.write(content)
 
-            self.assertEqual([], list(root.iterdir()))
+            migration.validate_backup_archive(
+                archive,
+                "bkn",
+                "openbkn",
+                hashlib.sha256(content).hexdigest(),
+            )
+            with self.assertRaisesRegex(
+                migration.MigrationError, "checksum verification failed"
+            ):
+                migration.validate_backup_archive(
+                    archive,
+                    "bkn",
+                    "openbkn",
+                    hashlib.sha256(b"different source").hexdigest(),
+                )
 
 
 class OneShotMigrationTest(unittest.TestCase):

--- a/adp/bkn/bkn-backend/script/migrate_kn_data/test_script.py
+++ b/adp/bkn/bkn-backend/script/migrate_kn_data/test_script.py
@@ -2,16 +2,24 @@
 #
 # Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
 
+import gzip
 import io
+import json
+import os
+import tempfile
 import unittest
-from contextlib import redirect_stderr
-from datetime import datetime
+from contextlib import ExitStack, redirect_stderr
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import script as migration
 
 from script import (
+    BackupResult,
+    DBConfig,
     GrantIndex,
     KN_CREATOR_OPERATIONS,
     NETWORK_BUILDER_ROLE_ID,
@@ -377,7 +385,206 @@ class ProxyPlanTest(unittest.TestCase):
         )
 
 
+class DatabaseConfigurationTest(unittest.TestCase):
+    def test_explicit_settings_take_precedence_over_server_environment(self):
+        environment = {
+            "BKN_DB_HOST": "explicit-host",
+            "BKN_DB_PORT": "4406",
+            "BKN_DB_USER": "explicit-user",
+            "BKN_DB_PASSWORD": "explicit-secret",
+            "BKN_DB_NAME": "explicit-bkn",
+            "MARIADB_HOST": "server-host",
+            "MARIADB_PORT_NUMBER": "3307",
+            "MARIADB_USER": "server-user",
+            "MARIADB_PASSWORD": "server-secret",
+            "MARIADB_DATABASE": "server-bkn",
+        }
+
+        with patch.dict(os.environ, environment, clear=True):
+            bkn_config, safe_config = migration.database_configs()
+
+        self.assertEqual(
+            DBConfig(
+                "explicit-host",
+                4406,
+                "explicit-user",
+                "explicit-secret",
+                "explicit-bkn",
+            ),
+            bkn_config,
+        )
+        self.assertEqual(
+            DBConfig(
+                "explicit-host", 4406, "explicit-user", "explicit-secret", "safe"
+            ),
+            safe_config,
+        )
+
+    def test_reads_server_password_file_and_reuses_connection_for_safe(self):
+        with tempfile.TemporaryDirectory() as directory:
+            password_file = Path(directory) / "mariadb-password"
+            password_file.write_text("file-secret\n", encoding="utf-8")
+            environment = {
+                "MARIADB_HOST": "127.0.0.9",
+                "MARIADB_PORT_NUMBER": "3308",
+                "MARIADB_USER": "server-user",
+                "MARIADB_PASSWORD_FILE": str(password_file),
+                "MARIADB_DATABASE": "server-bkn",
+            }
+
+            with patch.dict(os.environ, environment, clear=True):
+                bkn_config, safe_config = migration.database_configs()
+
+        self.assertEqual("file-secret", bkn_config.password)
+        self.assertEqual("server-bkn", bkn_config.database)
+        self.assertEqual("safe", safe_config.database)
+        self.assertEqual(bkn_config.host, safe_config.host)
+        self.assertEqual(bkn_config.port, safe_config.port)
+        self.assertEqual(bkn_config.user, safe_config.user)
+        self.assertEqual(bkn_config.password, safe_config.password)
+
+    def test_prefers_server_root_credentials_when_both_accounts_are_available(self):
+        environment = {
+            "MARIADB_USER": "application-user",
+            "MARIADB_PASSWORD": "application-secret",
+            "MARIADB_ROOT_PASSWORD": "root-secret",
+        }
+
+        with patch.dict(os.environ, environment, clear=True):
+            bkn_config, safe_config = migration.database_configs()
+
+        self.assertEqual("root", bkn_config.user)
+        self.assertEqual("root-secret", bkn_config.password)
+        self.assertEqual("root", safe_config.user)
+        self.assertEqual("root-secret", safe_config.password)
+
+    def test_reports_an_unreadable_password_file_without_exposing_a_secret(self):
+        environment = {"BKN_DB_PASSWORD_FILE": "/missing/password-file"}
+
+        with patch.dict(os.environ, environment, clear=True):
+            with self.assertRaisesRegex(
+                migration.MigrationError, "BKN_DB_PASSWORD_FILE"
+            ):
+                migration.database_configs()
+
+
+class PreMigrationBackupTest(unittest.TestCase):
+    def setUp(self):
+        self.configs = {
+            "bkn": DBConfig("127.0.0.1", 3306, "root", "bkn-secret", "openbkn"),
+            "safe": DBConfig("127.0.0.1", 3306, "root", "safe-secret", "safe"),
+        }
+
+    def test_creates_verified_secret_free_backups_without_overwriting(self):
+        calls = []
+
+        def dump(command, stdout, stderr, env, check):
+            del stderr, check
+            calls.append((command, env))
+            stdout.write(b"-- complete logical dump\n")
+            return SimpleNamespace(returncode=0, stderr=b"")
+
+        instant = datetime(2026, 9, 8, 12, 30, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with patch.object(migration.subprocess, "run", side_effect=dump):
+                first = migration.create_pre_migration_backup(
+                    self.configs,
+                    backup_root=root,
+                    now=instant,
+                    dump_executable="/usr/bin/mariadb-dump",
+                )
+                second = migration.create_pre_migration_backup(
+                    self.configs,
+                    backup_root=root,
+                    now=instant,
+                    dump_executable="/usr/bin/mariadb-dump",
+                )
+
+            self.assertEqual("20260908_123000", first.path.name)
+            self.assertEqual("20260908_123000-01", second.path.name)
+            self.assertEqual(0o700, first.path.stat().st_mode & 0o777)
+            manifest_path = first.path / "manifest.json"
+            self.assertEqual(0o600, manifest_path.stat().st_mode & 0o777)
+            manifest = json.loads(manifest_path.read_text())
+            serialized_manifest = json.dumps(manifest)
+            self.assertNotIn("bkn-secret", serialized_manifest)
+            self.assertNotIn("safe-secret", serialized_manifest)
+            self.assertEqual(2, len(manifest["databases"]))
+            for entry in manifest["databases"]:
+                archive = first.path / entry["archive"]
+                self.assertEqual(0o600, archive.stat().st_mode & 0o777)
+                self.assertEqual(entry["sha256"], migration.sha256_file(archive))
+                with gzip.open(archive, "rb") as source:
+                    self.assertEqual(b"-- complete logical dump\n", source.read())
+            for command in first.restore_commands:
+                self.assertIn("gzip -dc", command)
+                self.assertIn("| mariadb", command)
+                self.assertNotIn("bkn-secret", command)
+                self.assertNotIn("safe-secret", command)
+
+        self.assertEqual(4, len(calls))
+        for command, environment in calls:
+            command_text = " ".join(command)
+            self.assertNotIn("bkn-secret", command_text)
+            self.assertNotIn("safe-secret", command_text)
+            self.assertIn(environment["MYSQL_PWD"], {"bkn-secret", "safe-secret"})
+
+    def test_removes_an_incomplete_backup_and_redacts_dump_errors(self):
+        def failed_dump(command, stdout, stderr, env, check):
+            del command, stdout, stderr, env, check
+            return SimpleNamespace(
+                returncode=1,
+                stderr=b"authentication rejected for bkn-secret",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with patch.object(migration.subprocess, "run", side_effect=failed_dump):
+                with self.assertRaises(migration.MigrationError) as context:
+                    migration.create_pre_migration_backup(
+                        self.configs,
+                        backup_root=root,
+                        dump_executable="/usr/bin/mariadb-dump",
+                    )
+
+            self.assertNotIn("bkn-secret", str(context.exception))
+            self.assertIn("<redacted>", str(context.exception))
+            self.assertEqual([], list(root.iterdir()))
+
+    def test_checksum_verification_failure_stops_and_removes_backup(self):
+        def dump(command, stdout, stderr, env, check):
+            del command, stderr, env, check
+            stdout.write(b"-- complete logical dump\n")
+            return SimpleNamespace(returncode=0, stderr=b"")
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with ExitStack() as stack:
+                stack.enter_context(
+                    patch.object(migration.subprocess, "run", side_effect=dump)
+                )
+                stack.enter_context(
+                    patch.object(
+                        migration,
+                        "sha256_file",
+                        side_effect=["first", "second"],
+                    )
+                )
+                with self.assertRaisesRegex(
+                    migration.MigrationError, "checksum verification failed"
+                ):
+                    migration.create_pre_migration_backup(
+                        self.configs,
+                        backup_root=root,
+                        dump_executable="/usr/bin/mariadb-dump",
+                    )
+
+            self.assertEqual([], list(root.iterdir()))
+
+
 class OneShotMigrationTest(unittest.TestCase):
+    @patch.object(migration, "create_pre_migration_backup")
     @patch.object(migration, "verify_proxy_plan")
     @patch.object(migration, "apply_proxy_plan", return_value={"mappings_ready": 0})
     @patch.object(migration, "apply_safe_plan", return_value=(0, 0))
@@ -402,13 +609,24 @@ class OneShotMigrationTest(unittest.TestCase):
         apply_safe_plan_mock,
         apply_proxy_plan_mock,
         verify_proxy_plan,
+        create_pre_migration_backup,
     ):
         bkn_connection = MagicMock()
         safe_connection = MagicMock()
         connect_database.side_effect = [bkn_connection, safe_connection]
+        events = []
+        create_pre_migration_backup.side_effect = lambda configs: (
+            events.append("backup")
+            or BackupResult(Path("/backup/20260908_120000"), ())
+        )
+        normalize_branches.side_effect = lambda *args, **kwargs: (
+            events.append("first-write") or 0
+        )
 
         self.assertEqual(0, migration.run())
 
+        self.assertEqual(["backup", "first-write"], events)
+        create_pre_migration_backup.assert_called_once()
         apply_safe_plan_mock.assert_called_once()
         apply_proxy_plan_mock.assert_called_once()
         self.assertEqual(
@@ -418,6 +636,75 @@ class OneShotMigrationTest(unittest.TestCase):
         verify_proxy_plan.assert_called_once()
         safe_connection.commit.assert_called_once_with()
         bkn_connection.commit.assert_called_once_with()
+
+    def test_backup_failure_prevents_all_migration_writes(self):
+        bkn_connection = MagicMock()
+        safe_connection = MagicMock()
+        configs = (
+            DBConfig("127.0.0.1", 3306, "root", "", "openbkn"),
+            DBConfig("127.0.0.1", 3306, "root", "", "safe"),
+        )
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(migration, "database_configs", return_value=configs)
+            )
+            stack.enter_context(
+                patch.object(
+                    migration,
+                    "connect_database",
+                    side_effect=[bkn_connection, safe_connection],
+                )
+            )
+            stack.enter_context(
+                patch.object(migration, "load_resources", return_value=[])
+            )
+            stack.enter_context(
+                patch.object(migration, "load_accounts", return_value={})
+            )
+            stack.enter_context(
+                patch.object(migration, "count_branch_updates", return_value=0)
+            )
+            stack.enter_context(
+                patch.object(
+                    migration, "load_existing_safe_counts", return_value=(0, 0)
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    migration, "build_plan", return_value=MigrationPlan({}, 0)
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    migration,
+                    "load_proxy_plan",
+                    return_value=ProxyMigrationPlan(),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    migration,
+                    "create_pre_migration_backup",
+                    side_effect=migration.MigrationError("backup failed"),
+                )
+            )
+            normalize_branches = stack.enter_context(
+                patch.object(migration, "normalize_branches")
+            )
+            apply_safe_plan_mock = stack.enter_context(
+                patch.object(migration, "apply_safe_plan")
+            )
+            apply_proxy_plan_mock = stack.enter_context(
+                patch.object(migration, "apply_proxy_plan")
+            )
+            with self.assertRaisesRegex(migration.MigrationError, "backup failed"):
+                migration.run()
+
+        normalize_branches.assert_not_called()
+        apply_safe_plan_mock.assert_not_called()
+        apply_proxy_plan_mock.assert_not_called()
+        bkn_connection.close.assert_called_once_with()
+        safe_connection.close.assert_called_once_with()
 
     @patch.object(migration, "run", side_effect=RuntimeError("database write failed"))
     def test_command_prints_the_complete_traceback_on_failure(self, run):


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Create verified, timestamped logical backups of the BKN and bkn-safe databases before the first migration write
- [x] Discover database connection settings from explicit migration overrides or the database server's standard MariaDB environment
- [x] Document backup contents, configuration precedence, failure behavior, and restoration

---

## Why

- Related Issue: Closes #1311
- Related Feature: Knowledge-network data migration safety
- Background: The one-shot 0.1.4-to-0.1.5 migration previously required manually supplied connection variables and could begin changing data without first preserving a recoverable database snapshot.

---

## How

- Key implementation points:
  - Resolve `BKN_DB_*` and `SAFE_DB_*` first, then standard `MARIADB_*` values, password files, and local-server defaults.
  - Prefer available server root credentials for complete logical dumps and let Safe reuse the resolved BKN connection unless explicitly overridden.
  - Run `mariadb-dump` or `mysqldump` for both databases after read-only validation and before any write function.
  - Stream dump stdout through gzip while computing a source-content digest, then decompress and hash the stored archive independently before accepting it.
  - Store gzip archives in a non-overwriting timestamped directory with restrictive permissions, a secret-free manifest, SHA-256 checksums, and password-free restore commands.
  - Abort before writes on missing tooling, dump errors, empty or invalid archives, checksum mismatches, or filesystem failures.
- Breaking changes (API, config, database, etc.): No API or schema changes. The migration now requires `mariadb-dump` or `mysqldump` and writable backup storage; this is an intentional fail-closed operator-safety gate.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `python3 -m unittest -v test_script.py` — 21 tests passed
- `./test_service_control.sh` — passed
- Coverage includes environment precedence, server root and password-file discovery, secret redaction, secure backup artifacts, an actual child-process-to-gzip stream, independent checksum verification, restore guidance, non-overwrite behavior, write ordering, and backup-failure gating.
- Integration tests are not applicable locally because they would require a disposable MariaDB instance with representative 0.1.4 data; test-environment validation remains pending.
- No migration was executed against a shared or production database.

---

## Risk & Rollback

- Potential risks: Full logical dumps require sufficient local disk space and database privileges. Backup duration depends on database size. Sequential dumps are consistent per database while application services remain stopped.
- Rollback plan: Revert the two commits in this PR to restore the previous script behavior. If an operator needs to undo a migration run, keep services stopped and restore both generated archives using the commands recorded in `manifest.json` before retrying.

---

## Additional Notes

- Backup output defaults to `script/migrate_kn_data/backups/` and is excluded from Git. `OPENBKN_MIGRATION_BACKUP_DIR` can select a dedicated writable volume.
- CI and code-owner review remain required before merge.
