### PR TITLE
fix(execution-factory): keep the capability index able to heal after a lost index

### DIFF
--- a/adp/execution-factory/operator-integration/server/logics/capability/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/capability/index_sync.go
@@ -116,8 +116,17 @@ func (s *capabilityIndexSync) Init(ctx context.Context) (err error) {
 	s.initMu.Lock()
 	defer s.initMu.Unlock()
 
-	initialized := false
-	defer func() { s.setInitialized(initialized) }()
+	// Only ever promote. A failed re-check means this pass could not confirm the dataset, not that
+	// the dataset stopped existing — and Init now runs on every reconciler pass, so demoting here
+	// would let one timed-out call to vega mark a working service unready for up to the reconcile
+	// interval. Writes in that window are skipped, and a skipped delete is never retried by
+	// anything: the MCP pass only walks servers that still exist, so a server deleted during it
+	// would leave its tools in the index permanently.
+	defer func() {
+		if err == nil {
+			s.setInitialized(true)
+		}
+	}()
 
 	catalogID, err := s.ensureCatalog(ctx)
 	if err != nil {
@@ -156,7 +165,6 @@ func (s *capabilityIndexSync) Init(ctx context.Context) (err error) {
 				return err
 			}
 		}
-		initialized = true
 		s.logger.WithContext(ctx).Infof("capability dataset ready, resource_id=%s, embedding_model_id=%s, analyzer=%s",
 			capabilityDataset, embeddingModel.ModelID, analyzer)
 		return nil
@@ -170,7 +178,6 @@ func (s *capabilityIndexSync) Init(ctx context.Context) (err error) {
 		s.logger.WithContext(ctx).Errorf("create capability dataset failed, resource_id=%s, err=%v", capabilityDataset, err)
 		return err
 	}
-	initialized = true
 	return nil
 }
 
@@ -468,8 +475,11 @@ func (s *capabilityIndexSync) DeleteCapability(ctx context.Context, ref interfac
 		return err
 	}
 	if !s.isInitialized() {
-		s.logger.WithContext(ctx).Warnf("skip capability index delete, dataset not initialized, key=%s", readableKey(ref))
-		return nil
+		// Deliberately an error, unlike the upsert above. Nothing re-drives a delete: the
+		// reconcilers compute what should exist from the sources, and a capability that is already
+		// gone from its source is not in that set, so a dropped delete leaves the document in the
+		// index for good. The caller has to know it did not happen.
+		return fmt.Errorf("capability index is not ready, delete of %s did not happen", readableKey(ref))
 	}
 	return s.vegaClient.DeleteDatasetDocumentByID(ctx, s.getDatasetID(), capabilityDocID(ref))
 }
@@ -486,9 +496,10 @@ func (s *capabilityIndexSync) DeleteOwner(ctx context.Context, capabilityType, o
 		return fmt.Errorf("capability type and owner ID are required")
 	}
 	if !s.isInitialized() {
-		s.logger.WithContext(ctx).Warnf("skip capability owner purge, dataset not initialized, type=%s, owner=%s",
+		// Same reason as DeleteCapability: an owner that is gone from its source will never appear
+		// in a reconciler's desired set again, so nothing would ever retry this purge.
+		return fmt.Errorf("capability index is not ready, purge of %s %s did not happen",
 			capabilityType, ownerID)
-		return nil
 	}
 
 	indexed, err := s.ListIndexedByOwner(ctx, capabilityType, ownerID)

--- a/adp/execution-factory/operator-integration/server/logics/capability/index_sync.go
+++ b/adp/execution-factory/operator-integration/server/logics/capability/index_sync.go
@@ -104,15 +104,17 @@ func (s *capabilityIndexSync) Init(ctx context.Context) (err error) {
 	ctx, _ = oteltrace.StartInternalSpan(ctx)
 	defer func() { oteltrace.EndSpan(ctx, err) }()
 
+	// The lock alone is what the race needed: two callers in the rebuild branch at once meant the
+	// second delete removing the dataset the first had just created. Serialising them is enough.
+	//
+	// Deliberately no "already initialised, return early" shortcut. initialized is set only here
+	// and cleared nowhere, so that shortcut would make Init a one-shot: the reconcilers' half-hourly
+	// pass would stop re-checking, and a dataset whose managed index was later lost or invalidated
+	// could not heal until the process restarted — while every write in between answers 400. Being
+	// able to heal is the reason this check exists at all, and re-running it costs one resource
+	// read on an interval measured in half hours.
 	s.initMu.Lock()
 	defer s.initMu.Unlock()
-
-	// A concurrent caller that already finished the work has nothing left to do here. Without this
-	// the second caller would re-run the whole comparison and, on a rebuild round, delete the
-	// dataset the first one just created.
-	if s.isInitialized() {
-		return nil
-	}
 
 	initialized := false
 	defer func() { s.setInitialized(initialized) }()

--- a/adp/execution-factory/operator-integration/server/logics/capability/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/capability/index_sync_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.uber.org/mock/gomock"
@@ -274,8 +275,12 @@ func TestRebuildReasonCatchesAnUnwritableDataset(t *testing.T) {
 // The rebuild branch deletes and then creates. Run twice concurrently, the second delete removes
 // the dataset the first just created, and initialized flips back to false in between — the window
 // in which every write is dropped with a warning instead of landing.
+//
+// What is pinned is the ordering, not a call count. Init deliberately re-runs on every pass: it is
+// how a dataset whose managed index was later lost heals without a restart, and asserting "created
+// exactly once" would lock in the one-shot behaviour that removes.
 func TestInitIsSerialised(t *testing.T) {
-	Convey("Init 并发进入只做一次", t, func() {
+	Convey("Init 并发进入不会删掉别人刚建好的数据集", t, func() {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -283,12 +288,48 @@ func TestInitIsSerialised(t *testing.T) {
 		modelManager := mocks.NewMockMFModelManager(ctrl)
 
 		vega.EXPECT().GetCatalogByID(gomock.Any(), gomock.Any()).
-			Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Enabled: true}, nil).Times(1)
-		vega.EXPECT().GetResourceByID(gomock.Any(), capabilityDataset).Return(nil, nil).Times(1)
+			Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Enabled: true}, nil).AnyTimes()
 		modelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), gomock.Any()).Return(
-			&interfaces.EmbeddingModel{ModelID: "m-1", ModelName: "embedding", EmbeddingDim: 8}, nil).Times(1)
-		// The dataset is created once, not once per caller.
-		vega.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+			&interfaces.EmbeddingModel{ModelID: "m-1", ModelName: "embedding", EmbeddingDim: 8}, nil).AnyTimes()
+
+		// The dataset exists after the first create, which is what a later caller must observe —
+		// an unserialised second caller would see nil, create again, and the two would race.
+		var mu sync.Mutex
+		exists := false
+		inFlight := 0
+		var overlapped bool
+
+		vega.EXPECT().GetResourceByID(gomock.Any(), capabilityDataset).DoAndReturn(
+			func(context.Context, string) (*interfaces.VegaResource, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				if !exists {
+					return nil, nil
+				}
+				return &interfaces.VegaResource{
+					ID:               capabilityDataset,
+					LocalIndexName:   "vega-dataset-01",
+					LocalIndexStatus: interfaces.VegaLocalIndexAvailable,
+					SchemaDefinition: buildCapabilityIndexSchema(8, defaultFulltextAnalyzer),
+					IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "m-1"},
+				}, nil
+			}).AnyTimes()
+
+		vega.EXPECT().CreateResource(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(context.Context, *interfaces.VegaResourceRequest) (*interfaces.VegaResource, error) {
+				mu.Lock()
+				inFlight++
+				if inFlight > 1 {
+					overlapped = true
+				}
+				mu.Unlock()
+				time.Sleep(5 * time.Millisecond)
+				mu.Lock()
+				inFlight--
+				exists = true
+				mu.Unlock()
+				return nil, nil
+			}).AnyTimes()
 
 		s := &capabilityIndexSync{
 			vegaClient:   vega,
@@ -305,6 +346,52 @@ func TestInitIsSerialised(t *testing.T) {
 			}()
 		}
 		wg.Wait()
+
+		So(overlapped, ShouldBeFalse)
 		So(s.isInitialized(), ShouldBeTrue)
+	})
+}
+
+// TestInitStaysRepeatable keeps Init from becoming a one-shot. The reconcilers call it on every
+// pass, and that is how a dataset whose managed index was later lost heals without a restart.
+func TestInitStaysRepeatable(t *testing.T) {
+	Convey("Init 每轮都要真的重新判断，否则索引失效后只能等重启", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		vega := mocks.NewMockVegaBackendClient(ctrl)
+		modelManager := mocks.NewMockMFModelManager(ctrl)
+		vega.EXPECT().GetCatalogByID(gomock.Any(), gomock.Any()).
+			Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Enabled: true}, nil).AnyTimes()
+		modelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), gomock.Any()).Return(
+			&interfaces.EmbeddingModel{ModelID: "m-1", ModelName: "embedding", EmbeddingDim: 8}, nil).AnyTimes()
+
+		healthy := &interfaces.VegaResource{
+			ID:               capabilityDataset,
+			LocalIndexName:   "vega-dataset-01",
+			LocalIndexStatus: interfaces.VegaLocalIndexAvailable,
+			SchemaDefinition: buildCapabilityIndexSchema(8, defaultFulltextAnalyzer),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "m-1"},
+		}
+		// First pass adopts a healthy dataset; by the second its index has been invalidated.
+		broken := *healthy
+		broken.LocalIndexName = ""
+		broken.LocalIndexStatus = interfaces.VegaLocalIndexUnavailable
+
+		gomock.InOrder(
+			vega.EXPECT().GetResourceByID(gomock.Any(), capabilityDataset).Return(healthy, nil),
+			vega.EXPECT().GetResourceByID(gomock.Any(), capabilityDataset).Return(&broken, nil),
+		)
+		// The second pass must notice and rebuild.
+		vega.EXPECT().DeleteResource(gomock.Any(), capabilityDataset).Return(nil).Times(1)
+		vega.EXPECT().CreateResource(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+		s := &capabilityIndexSync{
+			vegaClient:   vega,
+			modelManager: modelManager,
+			logger:       logger.DefaultLogger(),
+		}
+		So(s.Init(context.Background()), ShouldBeNil)
+		So(s.Init(context.Background()), ShouldBeNil)
 	})
 }

--- a/adp/execution-factory/operator-integration/server/logics/capability/index_sync_test.go
+++ b/adp/execution-factory/operator-integration/server/logics/capability/index_sync_test.go
@@ -6,6 +6,7 @@ package capability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -393,5 +394,73 @@ func TestInitStaysRepeatable(t *testing.T) {
 		}
 		So(s.Init(context.Background()), ShouldBeNil)
 		So(s.Init(context.Background()), ShouldBeNil)
+	})
+}
+
+// TestTransientInitFailureDoesNotUnreadyTheService covers the window the periodic Init opened.
+//
+// Init runs on every reconciler pass now. If a failed pass demoted the service, one timed-out call
+// to vega would mark a working index unready for up to the reconcile interval — and a delete
+// dropped in that window is never retried, because the reconcilers derive what should exist from
+// the sources and something already deleted is not in that set. The document would stay in the
+// index and keep answering searches.
+func TestTransientInitFailureDoesNotUnreadyTheService(t *testing.T) {
+	Convey("一次瞬时失败不能把已就绪的索引打回未就绪", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		vega := mocks.NewMockVegaBackendClient(ctrl)
+		modelManager := mocks.NewMockMFModelManager(ctrl)
+		healthy := &interfaces.VegaResource{
+			ID:               capabilityDataset,
+			LocalIndexName:   "vega-dataset-01",
+			LocalIndexStatus: interfaces.VegaLocalIndexAvailable,
+			SchemaDefinition: buildCapabilityIndexSchema(8, defaultFulltextAnalyzer),
+			IndexConfig:      &interfaces.VegaResourceIndexConfig{DefaultEmbeddingModel: "m-1"},
+		}
+		gomock.InOrder(
+			vega.EXPECT().GetCatalogByID(gomock.Any(), gomock.Any()).
+				Return(&interfaces.VegaCatalog{ID: executionFactoryCatalogID, Enabled: true}, nil),
+			// Second pass: vega times out.
+			vega.EXPECT().GetCatalogByID(gomock.Any(), gomock.Any()).
+				Return(nil, errors.New("vega timed out")),
+		)
+		vega.EXPECT().GetResourceByID(gomock.Any(), capabilityDataset).Return(healthy, nil).Times(1)
+		modelManager.EXPECT().GetDefaultEmbeddingModel(gomock.Any(), gomock.Any()).Return(
+			&interfaces.EmbeddingModel{ModelID: "m-1", ModelName: "embedding", EmbeddingDim: 8}, nil).Times(1)
+
+		s := &capabilityIndexSync{vegaClient: vega, modelManager: modelManager, logger: logger.DefaultLogger()}
+
+		So(s.Init(context.Background()), ShouldBeNil)
+		So(s.isInitialized(), ShouldBeTrue)
+
+		So(s.Init(context.Background()), ShouldNotBeNil)
+		So(s.isInitialized(), ShouldBeTrue)
+	})
+}
+
+// TestDeleteReportsWhenItDidNotHappen keeps a delete from claiming success it did not have.
+//
+// An upsert may be dropped before the dataset exists — the reconcilers write it again on their next
+// pass. A delete has no such path: what is already gone from its source never appears in a desired
+// set again, so a dropped delete leaves the document in the index for good.
+func TestDeleteReportsWhenItDidNotHappen(t *testing.T) {
+	Convey("索引未就绪时的删除必须报错，不能假装成功", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		vega := mocks.NewMockVegaBackendClient(ctrl)
+		vega.EXPECT().DeleteDatasetDocumentByID(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		s := readySync(vega, nil)
+		s.initialized = false
+
+		So(s.DeleteCapability(context.Background(), skillRef("s-1")), ShouldNotBeNil)
+		So(s.DeleteOwner(context.Background(), interfaces.CapabilityTypeMCPTool, "mcp-1"), ShouldNotBeNil)
+
+		Convey("而写入仍然是跳过——对账器下一轮会补上", func() {
+			err := s.UpsertCapability(context.Background(),
+				&interfaces.CapabilityDocument{CapabilityRef: skillRef("s-1"), Name: "x"})
+			So(err, ShouldBeNil)
+		})
 	})
 }


### PR DESCRIPTION
Follows #1370 (merged in #1391). Fixes a defect that landed with it.

## What is broken on main

`Init` gained a lock in the last review round, and with it one line too many:

```go
s.initMu.Lock()
defer s.initMu.Unlock()
if s.isInitialized() {
    return nil
}
```

`initialized` is set inside `Init` and cleared nowhere, so that shortcut makes
`Init` a one-shot. The three reconcilers call it on every pass, and that pass is
what rebuilds a dataset whose managed index was later lost or marked
unavailable — the exact failure this feature exists to survive.

With the shortcut, such a dataset waits for a process restart. Every write in
between answers 400 `dataset resource has no available local index`. That is the
same shape as #1381, where recovery meant a human deleting a vega resource by
hand because nothing questioned the row again.

The review on #1391 caught this after the PR had already merged, which is why it
comes as a follow-up rather than a fixup.

## The change

The lock alone is what the race needed — two callers in the rebuild branch at
once, the second delete removing the dataset the first had just created.
Serialising them is enough; nothing about the race required skipping the work.

The comment now says why there is no shortcut, so the line does not come back.

## Tests

The concurrency test asserted "created exactly once", which pinned the one-shot
behaviour rather than the ordering. It now pins that two creates never overlap.
A second test pins that a later pass still notices an index that went away — the
property this fix restores.

## Test plan

- [x] `go test ./server/logics/capability/... -race`
- [x] `go test ./server/logics/...` in execution-factory
