### PR TITLE
fix(sandbox): keep artifact paths relative to the workspace root

### DIFF
--- a/infra/sandbox/runtime/executor/application/commands/execute_code.py
+++ b/infra/sandbox/runtime/executor/application/commands/execute_code.py
@@ -210,6 +210,24 @@ class ExecuteCodeCommand:
             )
             return self._workspace_path
 
+    def _artifact_path_prefix(self, scan_root: Path) -> str:
+        """
+        Path segment that turns a scan-root-relative path into a workspace-relative one.
+
+        Args:
+            scan_root: Directory the artifacts were collected from
+
+        Returns:
+            Prefix ending in "/", or an empty string when the scan root is the
+            workspace root or lies outside it
+        """
+        try:
+            relative = scan_root.relative_to(self._workspace_path.resolve())
+        except ValueError:
+            return ""
+        text = relative.as_posix()
+        return "" if text in ("", ".") else text + "/"
+
     async def _execute_with_timeout(
         self,
         execution: Execution,
@@ -266,6 +284,11 @@ class ExecuteCodeCommand:
             include_temp=False,
         )
 
+        # Narrowing the scan must not move the path base: artifact paths stay
+        # relative to the workspace root, which is what the session file endpoints
+        # resolve against.
+        prefix = self._artifact_path_prefix(scan_root)
+
         # Only files that appeared during this execution are artifacts. Files that
         # were already present belong to earlier executions sharing the directory.
         artifacts = []
@@ -274,7 +297,7 @@ class ExecuteCodeCommand:
                 continue
             artifacts.append(
                 Artifact(
-                    path=artifact_data.path,
+                    path=prefix + artifact_data.path,
                     size=artifact_data.size,
                     mime_type=artifact_data.mime_type,
                     type=artifact_data.type,

--- a/infra/sandbox/runtime/executor/domain/value_objects.py
+++ b/infra/sandbox/runtime/executor/domain/value_objects.py
@@ -55,8 +55,7 @@ class Artifact:
     Also adds frozen=True for immutability (hexagonal architecture).
 
     Attributes:
-        path: Relative path from the execution's working directory, which is the
-            workspace root when the request did not name one
+        path: Relative path from workspace root
         size: File size in bytes
         mime_type: MIME type of the file
         type: Category of artifact

--- a/infra/sandbox/runtime/executor/tests/unit/commands/test_execute_code.py
+++ b/infra/sandbox/runtime/executor/tests/unit/commands/test_execute_code.py
@@ -200,6 +200,50 @@ class TestExecuteCodeCommand:
 
         result = await command.execute(request)
 
+        # Narrowing the scan must not move the path base: the session file endpoints
+        # resolve artifact paths against the workspace root.
+        assert [artifact.path for artifact in result.artifacts] == [
+            "conv-abc/fresh.json"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_keeps_workspace_relative_paths_without_working_directory(
+        self,
+        mock_isolation_port,
+        mock_artifact_scanner_port,
+        mock_callback_port,
+        mock_heartbeat_port,
+        tmp_path,
+    ):
+        """Without a working directory the scan root is the workspace root."""
+        fresh = Mock()
+        fresh.path = "fresh.json"
+        fresh.size = 20
+        fresh.mime_type = "application/json"
+        fresh.type = ArtifactType.ARTIFACT
+        fresh.created_at = datetime.now()
+        fresh.checksum = None
+        mock_artifact_scanner_port.collect_artifacts.return_value = [fresh]
+
+        command = ExecuteCodeCommand(
+            isolation_port=mock_isolation_port,
+            artifact_scanner_port=mock_artifact_scanner_port,
+            callback_port=mock_callback_port,
+            heartbeat_port=mock_heartbeat_port,
+            workspace_path=tmp_path,
+            control_plane_url="http://localhost:8000",
+        )
+        request = ExecutionRequest(
+            execution_id="exec_root",
+            session_id="session_root",
+            code="print('hello')",
+            language="python",
+            timeout=10,
+        )
+
+        result = await command.execute(request)
+
+        mock_artifact_scanner_port.snapshot.assert_called_once_with(tmp_path.resolve())
         assert [artifact.path for artifact in result.artifacts] == ["fresh.json"]
 
     @pytest.mark.asyncio

--- a/infra/sandbox/scripts/prune_empty_workspaces.py
+++ b/infra/sandbox/scripts/prune_empty_workspaces.py
@@ -10,8 +10,14 @@ root fills with directories that hold no files.
 
 Only empty directories are removed, via ``rmdir``, which fails on a non-empty
 directory. A directory modified more recently than ``--min-age-days`` is left
-alone so that a live conversation is never pulled out from under a running
-execution.
+alone, which keeps active conversations out of the way.
+
+That age check is not a lock. A directory older than the cutoff that is still
+empty can be removed while an execution is running in it, and that execution then
+writes into an unlinked directory and loses the file. The mtime of a directory
+does not change when a process merely chdirs into it, so an idle conversation that
+just started executing looks exactly like an abandoned one. Run this when the
+sandbox is quiet, or keep ``--min-age-days`` well above the longest execution.
 
 Usage:
     python3 prune_empty_workspaces.py /workspace --dry-run


### PR DESCRIPTION
Follow-up to #1394, which was merged before these two review findings were addressed. Both come from the automated review on that PR.

## Artifact path base moved, and the file endpoints did not

#1394 narrowed the artifact scan to the execution's working directory and reported the collected paths relative to that directory. `GET /api/v1/sessions/{id}/files/{file_path}` resolves a path against the workspace root, so an artifact path from an execution that named a working directory 404s on download. With context-loader now sending the working directory for every `run_code` and `run_shell`, that is every conversation.

The scan still narrows; only the reported base is restored. `_artifact_path_prefix` turns the scan-root-relative path back into a workspace-relative one, so the walk stays proportional to one execution while the contract stays where it was.

Verified on the test server:

```
no working_directory   workspace_path=/workspace                    artifacts: ['probe2.txt']
working_directory set  workspace_path=/workspace/conv-rebase_check  artifacts: ['conv-rebase_check/probe2.txt']
```

## prune_empty_workspaces.py promised something it cannot do

The docstring said the `--min-age-days` check keeps a running execution's directory safe. It does not. A directory's mtime does not change when a process chdirs into it, so a conversation that has been idle past the cutoff and has just started executing looks exactly like an abandoned one: the script can `rmdir` it while the execution is running, and the execution then writes into an unlinked directory and loses the file.

No behavior change — the guarantee was never real. The docstring now states the race and says to run the script when the sandbox is quiet, or to keep `--min-age-days` well above the longest execution.

Executor unit tests: 329 pass (1 new, covering the workspace-root case where no working directory is named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)