### PR TITLE
test(context-loader): pin the empty-result message to the caller's own filters

### DIFF
--- a/adp/context-loader/agent-retrieval/server/logics/kntools/capabilities.go
+++ b/adp/context-loader/agent-retrieval/server/logics/kntools/capabilities.go
@@ -139,9 +139,14 @@ func (s *knToolsService) SearchCapabilities(ctx context.Context,
 	switch {
 	case len(entries) == 0 && total > 0:
 		resp.Message = infraErr.LocalizedDetail(ctx, "ToolsMatchedButNotVisible")
-	case len(entries) == 0 && !req.kindsAreIntrinsic && len(req.Types) > 0,
-		len(entries) == 0 && len(req.MetadataTypes) > 0:
+	case len(entries) == 0 && !req.kindsAreIntrinsic && len(req.Types) > 0:
+		// Both filters are the caller's, so both can be named.
 		resp.Message = infraErr.LocalizedDetail(ctx, "NoCapabilitiesOfRequestedKind")
+	case len(entries) == 0 && len(req.MetadataTypes) > 0:
+		// Only the tool box kind was the caller's. Naming types here would repeat the original
+		// mistake one level down: search_tools sets types itself and exposes no input for it, so
+		// "drop these two parameters" is advice half of which cannot be followed.
+		resp.Message = infraErr.LocalizedDetail(ctx, "NoToolsOfRequestedKind")
 	case len(entries) == 0:
 		resp.Message = infraErr.LocalizedDetail(ctx, "NoPublishedToolsMatched")
 	case more:

--- a/adp/context-loader/agent-retrieval/server/logics/kntools/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/kntools/index_test.go
@@ -814,7 +814,10 @@ func TestEmptyAnswerNamesItsCause(t *testing.T) {
 		}
 	})
 
-	t.Run("调用方自己传了 metadata_types 才该点名它", func(t *testing.T) {
+	t.Run("只传了 metadata_types 时，提示不得连带点名 types", func(t *testing.T) {
+		// The branch fires correctly, but its text used to name both filters. search_tools sets
+		// types itself and exposes no input for it, so half of "drop these two parameters" is
+		// advice the caller cannot follow — the same defect one level down.
 		op := &fakeOperator{hits: nil}
 		svc := NewKnToolsServiceWith(op, &fakeBkn{refs: functionRefs("box-1/t1")}, &fakeKnAuthz{})
 		resp, err := svc.SearchTools(context.Background(), &SearchToolsReq{
@@ -825,6 +828,9 @@ func TestEmptyAnswerNamesItsCause(t *testing.T) {
 		}
 		if !strings.Contains(resp.Message, "metadata_types") {
 			t.Fatalf("这次确实是调用方筛空的，该点名: %q", resp.Message)
+		}
+		if strings.Contains(resp.Message, "types /") || strings.Contains(resp.Message, "/ metadata_types") {
+			t.Fatalf("不该连带让调用方去掉它设不了的 types: %q", resp.Message)
 		}
 	})
 }

--- a/adp/context-loader/agent-retrieval/server/logics/kntools/index_test.go
+++ b/adp/context-loader/agent-retrieval/server/logics/kntools/index_test.go
@@ -795,7 +795,11 @@ func TestEmptyAnswerNamesItsCause(t *testing.T) {
 		}
 	})
 
-	t.Run("确实没有匹配", func(t *testing.T) {
+	t.Run("确实没有匹配：不能怪到调用方没传过的参数上", func(t *testing.T) {
+		// search_tools pins the kinds when it delegates. If that counted as a caller's filter,
+		// this answer would tell the caller to drop a types parameter it never set and cannot set.
+		// Asserting only that a message exists is what let the wrong branch through review: every
+		// branch satisfies it.
 		op := &fakeOperator{hits: nil}
 		svc := NewKnToolsServiceWith(op, &fakeBkn{refs: functionRefs("box-1/t1")}, &fakeKnAuthz{})
 		resp, err := svc.SearchTools(context.Background(), &SearchToolsReq{KnID: "kn1", Query: "毫不相关"})
@@ -804,6 +808,23 @@ func TestEmptyAnswerNamesItsCause(t *testing.T) {
 		}
 		if resp.Message == "" {
 			t.Fatal("空结果总该给个说法")
+		}
+		if strings.Contains(resp.Message, "types") {
+			t.Fatalf("不该让调用方去改它传不了的参数: %q", resp.Message)
+		}
+	})
+
+	t.Run("调用方自己传了 metadata_types 才该点名它", func(t *testing.T) {
+		op := &fakeOperator{hits: nil}
+		svc := NewKnToolsServiceWith(op, &fakeBkn{refs: functionRefs("box-1/t1")}, &fakeKnAuthz{})
+		resp, err := svc.SearchTools(context.Background(), &SearchToolsReq{
+			KnID: "kn1", Query: "汇率", MetadataTypes: []string{"function"},
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !strings.Contains(resp.Message, "metadata_types") {
+			t.Fatalf("这次确实是调用方筛空的，该点名: %q", resp.Message)
 		}
 	})
 }


### PR DESCRIPTION
Follows #1388 (merged in #1397). Adds a regression test that a previous commit
claimed to add and did not.

## What happened

The round that fixed the empty-result message said it had replaced the "no match
at all" case with one asserting that the message does not name a parameter the
caller cannot pass. It had not. The edit matched on text differing by one
character, silently changed nothing, and the case it meant to replace — asserting
only `Message != ""` — passes under every branch. Nothing went red, and I
reported the work as done.

The review on #1397 caught the discrepancy and marked it as the one fix left
without a regression test. It was right.

## The test

`search_tools` pins the capability kinds when it delegates to
`search_capabilities`. If that counted as a caller's filter, an empty answer
would tell the caller to drop a `types` parameter it never set and has no input
for. The fix distinguishes intrinsic narrowing from requested narrowing; this
pins it.

Verified by removing the fix rather than by trusting a green run: with the
`kindsAreIntrinsic` branch reverted the case fails with the exact message a
caller would have received —

```
不该让调用方去改它传不了的参数: "该知识网络挂载了能力，但没有 types / metadata_types
指定类型的。去掉这两个参数可看到全部已挂载能力。"
```

— and passes again with the fix restored. The second case pins the other
direction: a caller who does pass `metadata_types` is told about it.

## Test plan

- [x] `go test ./server/logics/kntools/...`
- [x] Fix reverted locally to confirm the assertion fails, then restored
