### PR TITLE
ci(build): build each architecture on a native runner instead of QEMU

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -218,7 +218,11 @@ jobs:
 
       # The manifest job pins the list to these digests (see header). One file
       # per leg, named by arch; the artifact name carries the image so several
-      # reusable-build calls in one workflow run don't collide.
+      # reusable-build calls in one workflow run don't collide. `__` is the
+      # delimiter because image names use `-` and can be prefixes of each other
+      # (vega-backend / vega-backend-python-base in one run): the manifest job
+      # matches `digest__<image>__*`, and `digest__vega-backend__*` cannot
+      # match `digest__vega-backend-python-base__amd64`.
       - name: Record image digest
         if: ${{ inputs.publish }}
         shell: bash
@@ -239,7 +243,7 @@ jobs:
         if: ${{ inputs.publish }}
         uses: actions/upload-artifact@v4
         with:
-          name: digest-${{ inputs.image-name }}-${{ matrix.arch }}
+          name: digest__${{ inputs.image-name }}__${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -254,12 +258,15 @@ jobs:
       contents: read
       packages: write
     steps:
+      # No merge-multiple: each artifact unpacks into its own directory named
+      # after the artifact, and the union step reads the exact
+      # `digest__<image>__<arch>/<arch>` path. Even if the pattern ever
+      # over-matched, another image's digest could not be read by mistake.
       - name: Download image digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digest-${{ inputs.image-name }}-*
+          pattern: digest__${{ inputs.image-name }}__*
           path: ${{ runner.temp }}/digests
-          merge-multiple: true
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -291,6 +298,21 @@ jobs:
           # can only ever contain this run's own images (see header). The same
           # manifest bytes went to both registries, so one digest per arch
           # serves GHCR and SWR alike.
+          digest_for() {
+            cat "${DIGEST_DIR}/digest__${IMAGE}__${1}/${1}"
+          }
+          for arch in "${archs[@]}"; do
+            file="${DIGEST_DIR}/digest__${IMAGE}__${arch}/${arch}"
+            if [ ! -f "${file}" ]; then
+              echo "::error::missing digest for ${IMAGE} ${arch} (expected ${file})"
+              exit 1
+            fi
+            if ! [[ "$(digest_for "${arch}")" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::malformed digest for ${IMAGE} ${arch}: $(digest_for "${arch}")"
+              exit 1
+            fi
+            echo "${arch}: $(digest_for "${arch}")"
+          done
           # `docker manifest` emits application/vnd.docker.distribution.manifest.list.v2+json,
           # the legacy list format SWR accepts. `buildx imagetools create` would
           # infer its media types from the sources instead, so the format SWR
@@ -301,7 +323,7 @@ jobs:
             local repo="$1"
             local children=()
             for arch in "${archs[@]}"; do
-              children+=("${repo}@$(cat "${DIGEST_DIR}/${arch}")")
+              children+=("${repo}@$(digest_for "${arch}")")
             done
             docker manifest create "${repo}:${VERSION}" "${children[@]}"
             docker manifest push "${repo}:${VERSION}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,5 +1,21 @@
 name: reusable-build
 
+# Each architecture builds on a runner of its own architecture, then the legs
+# are stitched into one multi-arch tag. The previous single-job build asked one
+# amd64 runner for `platforms: linux/amd64,linux/arm64`, which ran the arm64 leg
+# under QEMU. None of the Dockerfiles cross-compile (no `--platform=$BUILDPLATFORM`
+# builder stage), so `go build` with CGO and every `pip install` were interpreted
+# instruction by instruction: bkn-backend spent 16 minutes in the build step,
+# almost all of it in the arm64 leg.
+#
+# Registry shape after this change: every published version has the plain
+# `:<version>` manifest list (what charts and deploys reference) plus one
+# arch-suffixed tag per leg, `:<version>-amd64` / `:<version>-arm64`. The
+# suffixed tags are the list's children — a retention policy must keep them
+# alive as long as the list they back — and they double as a plain
+# `docker pull` handle for users who need a specific architecture without
+# skopeo or `--platform`.
+
 on:
   workflow_call:
     inputs:
@@ -17,7 +33,7 @@ on:
       platforms:
         type: string
         default: 'linux/amd64,linux/arm64'
-        description: 'Docker platforms'
+        description: 'Docker platforms (comma-separated; each gets a native runner)'
       image-name:
         type: string
         required: true
@@ -54,20 +70,76 @@ on:
         required: false
 
 jobs:
-  build:
+  # Turns the `platforms` input into the build matrix and settles the SWR
+  # decision once, so the legs and the manifest job agree on both.
+  setup:
     runs-on: ubuntu-latest
+    env:
+      # Surfaced so a step can test credential presence — secrets aren't
+      # allowed in `if:` directly. Empty when the SWR secrets aren't set.
+      SWR_USERNAME: ${{ secrets.HUAWEI_SWR_USERNAME }}
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      archs: ${{ steps.matrix.outputs.archs }}
+      swr: ${{ steps.swr.outputs.swr }}
+    steps:
+      - name: Resolve platforms to native runners
+        id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          # ubuntu-24.04-arm is GitHub-hosted and free for public repositories.
+          # Anything outside this table has no native runner here, so fail loud
+          # instead of silently falling back to emulation.
+          entries=()
+          archs=()
+          IFS=',' read -ra platforms <<< "${{ inputs.platforms }}"
+          for platform in "${platforms[@]}"; do
+            platform="$(echo "${platform}" | xargs)"
+            case "${platform}" in
+              linux/amd64) arch=amd64; runner=ubuntu-latest ;;
+              linux/arm64) arch=arm64; runner=ubuntu-24.04-arm ;;
+              *)
+                echo "::error::No native runner mapped for platform '${platform}' (supported: linux/amd64, linux/arm64)"
+                exit 1 ;;
+            esac
+            entries+=("{\"arch\":\"${arch}\",\"platform\":\"${platform}\",\"runner\":\"${runner}\"}")
+            archs+=("${arch}")
+          done
+          matrix="[$(IFS=,; echo "${entries[*]}")]"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "archs=${archs[*]}" >> "$GITHUB_OUTPUT"
+          echo "Build matrix: ${matrix}"
+
+      - name: Decide SWR mirror
+        id: swr
+        shell: bash
+        run: |
+          # SWR mirror only when publishing AND credentials present.
+          if [ "${{ inputs.publish }}" = "true" ] && [ -n "${SWR_USERNAME}" ]; then
+            echo "swr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "swr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # One leg per architecture, each on a runner that natively speaks it. Every
+  # leg publishes an arch-suffixed tag; the manifest job below unions them into
+  # the plain `:<version>` tag.
+  build:
+    name: build ${{ matrix.arch }}
+    needs: setup
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
-    env:
-      # Surfaced so step `if:` can test credential presence — secrets aren't
-      # allowed in `if:` directly. Empty when the SWR secrets aren't set.
-      SWR_USERNAME: ${{ secrets.HUAWEI_SWR_USERNAME }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
-
+      # No setup-qemu-action: each runner builds only its own architecture.
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
@@ -79,22 +151,25 @@ jobs:
           password: ${{ github.token }}
 
       - name: Login to Huawei SWR
-        if: ${{ inputs.publish && env.SWR_USERNAME != '' }}
+        if: ${{ needs.setup.outputs.swr == 'true' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ inputs.swr-registry }}
           username: ${{ secrets.HUAWEI_SWR_USERNAME }}
           password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
 
-      - name: Compute image tags
+      - name: Compute arch image tags
         id: tags
-        # GHCR always; SWR mirror only when publishing AND credentials present.
+        shell: bash
         run: |
+          # Arch-suffixed tags are the manifest list's children and are left in
+          # the registry on purpose: deleting them breaks the list that
+          # references their digests.
           {
             echo "tags<<EOF"
-            echo "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.version }}"
-            if [ "${{ inputs.publish }}" = "true" ] && [ -n "${SWR_USERNAME}" ]; then
-              echo "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}"
+            echo "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.version }}-${{ matrix.arch }}"
+            if [ "${{ needs.setup.outputs.swr }}" = "true" ]; then
+              echo "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}-${{ matrix.arch }}"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
@@ -104,10 +179,11 @@ jobs:
         with:
           context: ${{ inputs.service-path }}/${{ inputs.context }}
           file: ${{ inputs.service-path }}/${{ inputs.dockerfile }}
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ matrix.platform }}
           build-args: ${{ inputs.build-args }}
           target: ${{ inputs.target }}
-          push: ${{ inputs.publish }}
+          # Attestations would turn the result into an index even with
+          # oci-mediatypes off, which is the shape SWR refuses.
           provenance: false
           sbom: false
           tags: ${{ steps.tags.outputs.tags }}
@@ -116,4 +192,58 @@ jobs:
           # attestations/annotations were needed); Huawei SWR rejects the OCI
           # image index with "Invalid image, fail to parse 'manifest.json'".
           # GHCR accepts Docker media types fine, so one setting fixes both.
-          outputs: type=image,oci-mediatypes=false
+          # `outputs` replaces `push:` here: the two would each add an image
+          # exporter.
+          outputs: type=image,oci-mediatypes=false,push=${{ inputs.publish }}
+
+  # Unions the per-arch images under the plain `:<version>` tag. Skipped on
+  # verify-only runs, where nothing was pushed.
+  manifest:
+    needs: [setup, build]
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Huawei SWR
+        if: ${{ needs.setup.outputs.swr == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.swr-registry }}
+          username: ${{ secrets.HUAWEI_SWR_USERNAME }}
+          password: ${{ secrets.HUAWEI_SWR_PASSWORD }}
+
+      - name: Union arch images into the version tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          read -ra ARCHS <<< "${{ needs.setup.outputs.archs }}"
+          # `docker manifest` emits application/vnd.docker.distribution.manifest.list.v2+json,
+          # the legacy list format SWR accepts. `buildx imagetools create` would
+          # infer its media types from the sources instead, so the format SWR
+          # depends on would rest on inference rather than on the tool's
+          # contract. `--amend` keeps a re-run of this job idempotent.
+          union() {
+            local repo="$1"
+            local children=()
+            for arch in "${ARCHS[@]}"; do
+              children+=("${repo}:${VERSION}-${arch}")
+            done
+            docker manifest create --amend "${repo}:${VERSION}" "${children[@]}"
+            docker manifest push "${repo}:${VERSION}"
+            echo "Pushed multi-arch ${repo}:${VERSION}"
+            docker manifest inspect "${repo}:${VERSION}" | head -30
+          }
+          union "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}"
+          if [ "${{ needs.setup.outputs.swr }}" = "true" ]; then
+            union "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}"
+          fi

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -15,6 +15,19 @@ name: reusable-build
 # alive as long as the list they back — and they double as a plain
 # `docker pull` handle for users who need a specific architecture without
 # skopeo or `--platform`.
+#
+# The list is assembled from the digests each leg just pushed, not by
+# resolving the arch tags again: versions are not unique per run (release/*
+# branches build `X.Y.Z-release`, a `v*` tag can be rebuilt), and no caller
+# sets `concurrency`, so two runs of one version can interleave. Reading
+# tags back could pair an amd64 image from one commit with an arm64 image
+# from another; digests pin the list to this run's own builds. What remains
+# is that a leg can fail after the other already pushed its arch tag — then
+# `:<version>` keeps pointing at the previous list until the version builds
+# cleanly again, and the arch tag is ahead of it for that window.
+#
+# `ubuntu-24.04-arm` is GitHub-hosted and free for public repositories only;
+# a private fork of this workflow needs its own arm64 runner behind that label.
 
 on:
   workflow_call:
@@ -86,14 +99,15 @@ jobs:
       - name: Resolve platforms to native runners
         id: matrix
         shell: bash
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
         run: |
           set -euo pipefail
-          # ubuntu-24.04-arm is GitHub-hosted and free for public repositories.
           # Anything outside this table has no native runner here, so fail loud
           # instead of silently falling back to emulation.
           entries=()
           archs=()
-          IFS=',' read -ra platforms <<< "${{ inputs.platforms }}"
+          IFS=',' read -ra platforms <<< "${PLATFORMS}"
           for platform in "${platforms[@]}"; do
             platform="$(echo "${platform}" | xargs)"
             case "${platform}" in
@@ -161,20 +175,26 @@ jobs:
       - name: Compute arch image tags
         id: tags
         shell: bash
+        env:
+          IMAGE: ${{ inputs.image-name }}
+          VERSION: ${{ inputs.version }}
+          ARCH: ${{ matrix.arch }}
+          SWR_REPO: ${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}
         run: |
           # Arch-suffixed tags are the manifest list's children and are left in
           # the registry on purpose: deleting them breaks the list that
           # references their digests.
           {
             echo "tags<<EOF"
-            echo "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}:${{ inputs.version }}-${{ matrix.arch }}"
+            echo "ghcr.io/${{ github.repository_owner }}/${IMAGE}:${VERSION}-${ARCH}"
             if [ "${{ needs.setup.outputs.swr }}" = "true" ]; then
-              echo "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}:${{ inputs.version }}-${{ matrix.arch }}"
+              echo "${SWR_REPO}/${IMAGE}:${VERSION}-${ARCH}"
             fi
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ inputs.service-path }}/${{ inputs.context }}
@@ -196,6 +216,34 @@ jobs:
           # exporter.
           outputs: type=image,oci-mediatypes=false,push=${{ inputs.publish }}
 
+      # The manifest job pins the list to these digests (see header). One file
+      # per leg, named by arch; the artifact name carries the image so several
+      # reusable-build calls in one workflow run don't collide.
+      - name: Record image digest
+        if: ${{ inputs.publish }}
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::build-push-action reported no image digest for ${ARCH}"
+            exit 1
+          fi
+          mkdir -p "${RUNNER_TEMP}/digests"
+          printf '%s\n' "${DIGEST}" > "${RUNNER_TEMP}/digests/${ARCH}"
+          echo "${ARCH}: ${DIGEST}"
+
+      - name: Upload image digest
+        if: ${{ inputs.publish }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ inputs.image-name }}-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   # Unions the per-arch images under the plain `:<version>` tag. Skipped on
   # verify-only runs, where nothing was pushed.
   manifest:
@@ -206,6 +254,13 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ inputs.image-name }}-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -223,27 +278,37 @@ jobs:
 
       - name: Union arch images into the version tag
         shell: bash
+        env:
+          IMAGE: ${{ inputs.image-name }}
+          VERSION: ${{ inputs.version }}
+          ARCHS: ${{ needs.setup.outputs.archs }}
+          SWR_REPO: ${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}
+          DIGEST_DIR: ${{ runner.temp }}/digests
         run: |
           set -euo pipefail
-          VERSION="${{ inputs.version }}"
-          read -ra ARCHS <<< "${{ needs.setup.outputs.archs }}"
+          read -ra archs <<< "${ARCHS}"
+          # Children are addressed by the digests the legs recorded, so the list
+          # can only ever contain this run's own images (see header). The same
+          # manifest bytes went to both registries, so one digest per arch
+          # serves GHCR and SWR alike.
           # `docker manifest` emits application/vnd.docker.distribution.manifest.list.v2+json,
           # the legacy list format SWR accepts. `buildx imagetools create` would
           # infer its media types from the sources instead, so the format SWR
           # depends on would rest on inference rather than on the tool's
-          # contract. `--amend` keeps a re-run of this job idempotent.
+          # contract. The runner is fresh, so each run assembles the list from
+          # scratch; nothing local to amend.
           union() {
             local repo="$1"
             local children=()
-            for arch in "${ARCHS[@]}"; do
-              children+=("${repo}:${VERSION}-${arch}")
+            for arch in "${archs[@]}"; do
+              children+=("${repo}@$(cat "${DIGEST_DIR}/${arch}")")
             done
-            docker manifest create --amend "${repo}:${VERSION}" "${children[@]}"
+            docker manifest create "${repo}:${VERSION}" "${children[@]}"
             docker manifest push "${repo}:${VERSION}"
             echo "Pushed multi-arch ${repo}:${VERSION}"
             docker manifest inspect "${repo}:${VERSION}" | head -30
           }
-          union "ghcr.io/${{ github.repository_owner }}/${{ inputs.image-name }}"
+          union "ghcr.io/${{ github.repository_owner }}/${IMAGE}"
           if [ "${{ needs.setup.outputs.swr }}" = "true" ]; then
-            union "${{ inputs.swr-registry }}/${{ inputs.swr-namespace }}/${{ inputs.image-name }}"
+            union "${SWR_REPO}/${IMAGE}"
           fi

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -198,6 +198,12 @@ sudo bash ./deploy.sh openbkn install --latest --registry=swr
 sudo bash ./deploy.sh openbkn install --version_file=/tmp/m.yaml --registry=swr
 ```
 
+> Moving BKN images into an air-gapped cluster by hand: every published version
+> also carries single-architecture tags, `<image>:<version>-amd64` and
+> `<image>:<version>-arm64`. `docker pull` one of those on any machine (no
+> `--platform`, no skopeo), `docker save` it, and import it on the target node
+> under the plain `<image>:<version>` tag.
+
 > The committed migrations fix any DB-schema drift (e.g. `vega-backend` 0.9.x), but
 > only run when the **data-migrator pre-install job** runs — i.e. via `openbkn install`,
 > not a bare `kubectl set image`.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -198,11 +198,20 @@ sudo bash ./deploy.sh openbkn install --latest --registry=swr
 sudo bash ./deploy.sh openbkn install --version_file=/tmp/m.yaml --registry=swr
 ```
 
-> Moving BKN images into an air-gapped cluster by hand: every published version
-> also carries single-architecture tags, `<image>:<version>-amd64` and
-> `<image>:<version>-arm64`. `docker pull` one of those on any machine (no
-> `--platform`, no skopeo), `docker save` it, and import it on the target node
-> under the plain `<image>:<version>` tag.
+> Moving BKN images into an air-gapped cluster by hand: versions published from
+> 0.1.5 on also carry single-architecture tags, `<image>:<version>-amd64` and
+> `<image>:<version>-arm64` (earlier versions have only the multi-arch
+> `<image>:<version>`). Pull the one matching the target node on any machine —
+> no `--platform`, no skopeo — retag it to the plain version, and import it
+> into the node's containerd (`k3s ctr` on k3s):
+>
+> ```bash
+> docker pull ghcr.io/openbkn-ai/bkn-backend:0.1.5-arm64
+> docker tag  ghcr.io/openbkn-ai/bkn-backend:0.1.5-arm64 ghcr.io/openbkn-ai/bkn-backend:0.1.5
+> docker save ghcr.io/openbkn-ai/bkn-backend:0.1.5 -o bkn-backend.tar
+> # on the target node:
+> ctr -n k8s.io images import bkn-backend.tar
+> ```
 
 > The committed migrations fix any DB-schema drift (e.g. `vega-backend` 0.9.x), but
 > only run when the **data-migrator pre-install job** runs — i.e. via `openbkn install`,

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -193,6 +193,11 @@ sudo bash ./deploy.sh openbkn install --latest --registry=swr
 sudo bash ./deploy.sh openbkn install --version_file=/tmp/m.yaml --registry=swr
 ```
 
+> 手工把 BKN 镜像搬进离线集群：每个已发布版本都带单架构 tag
+> `<image>:<version>-amd64` 与 `<image>:<version>-arm64`。在任意机器上直接
+> `docker pull` 其一（不用 `--platform`，不用 skopeo），`docker save` 后导入目标节点，
+> 并打回 `<image>:<version>` 这个 tag。
+
 > 提交的迁移会修复 DB schema 漂移（如 `vega-backend` 0.9.x），但只在 **data-migrator
 > pre-install job 运行时**生效——即走 `openbkn install`，不是裸 `kubectl set image`。
 

--- a/deploy/README.zh.md
+++ b/deploy/README.zh.md
@@ -193,10 +193,18 @@ sudo bash ./deploy.sh openbkn install --latest --registry=swr
 sudo bash ./deploy.sh openbkn install --version_file=/tmp/m.yaml --registry=swr
 ```
 
-> 手工把 BKN 镜像搬进离线集群：每个已发布版本都带单架构 tag
-> `<image>:<version>-amd64` 与 `<image>:<version>-arm64`。在任意机器上直接
-> `docker pull` 其一（不用 `--platform`，不用 skopeo），`docker save` 后导入目标节点，
-> 并打回 `<image>:<version>` 这个 tag。
+> 手工把 BKN 镜像搬进离线集群：0.1.5 起发布的版本都带单架构 tag
+> `<image>:<version>-amd64` 与 `<image>:<version>-arm64`（更早的版本只有多架构的
+> `<image>:<version>`）。在任意机器上按目标节点架构 `docker pull` 其一（不用 `--platform`，
+> 不用 skopeo），打回不带后缀的版本 tag，再导入节点的 containerd（k3s 上用 `k3s ctr`）：
+>
+> ```bash
+> docker pull ghcr.io/openbkn-ai/bkn-backend:0.1.5-arm64
+> docker tag  ghcr.io/openbkn-ai/bkn-backend:0.1.5-arm64 ghcr.io/openbkn-ai/bkn-backend:0.1.5
+> docker save ghcr.io/openbkn-ai/bkn-backend:0.1.5 -o bkn-backend.tar
+> # 目标节点上：
+> ctr -n k8s.io images import bkn-backend.tar
+> ```
 
 > 提交的迁移会修复 DB schema 漂移（如 `vega-backend` 0.9.x），但只在 **data-migrator
 > pre-install job 运行时**生效——即走 `openbkn install`，不是裸 `kubectl set image`。


### PR DESCRIPTION
## Why

`reusable-build.yml` ran `platforms: linux/amd64,linux/arm64` in one buildx invocation on an amd64 runner, so the arm64 leg was emulated under QEMU. None of the Dockerfiles cross-compile (no `--platform=$BUILDPLATFORM` builder stage), which put `go build` with CGO and every `pip install` under emulation. Latest `release-adp-bkn-backend` on main: the `Build and push image` step took 16 minutes (15:19:49 → 15:35:49), almost all of it in the arm64 leg. Python-based images (model-factory-base, bkn-agent, sandbox) pay the same tax.

## What

Same shape bkn-studio already ships in `release-studio.yml`:

- `setup` job maps the existing `platforms` input to a matrix (`linux/amd64` → `ubuntu-latest`, `linux/arm64` → `ubuntu-24.04-arm`, GitHub-hosted, free for public repos). Unknown platforms fail loud instead of silently falling back to emulation.
- `build` matrix: one leg per architecture, no `setup-qemu-action`. Each leg pushes `:<version>-<arch>` to GHCR and (when credentials exist) SWR, and records the image digest as an artifact.
- `manifest` job unions the legs under the plain `:<version>` tag with `docker manifest create` + `push`, addressing children by the recorded digests (`repo@sha256:…`) rather than re-resolving the arch tags — versions are not unique per run (`X.Y.Z-release`, rebuilt `v*` tags) and no caller sets `concurrency`, so tag lookup could pair legs from two interleaved runs. `docker manifest` emits the legacy Docker manifest list media type, which Huawei SWR requires; `provenance: false` + `oci-mediatypes=false` on the legs keep the children in Docker schema2 as before.
- Verify-only runs (`publish: false`) build both legs and skip the manifest job.

Caller interface is unchanged; all 17 `release-*` workflows pick this up without edits.

## Registry shape

- `:<version>` stays a manifest list — pulls, charts, digest pinning, `skopeo copy --all` mirroring all behave as before.
- New per version: `:<version>-amd64` and `:<version>-arm64`. They are the list's children and must stay as long as the list does. They also let air-gapped users `docker pull` one architecture without `--platform` or skopeo — documented in `deploy/README*.md` with the pull/tag/save/import sequence.
- Known residual: if one leg fails after the other already pushed its arch tag, `:<version>` keeps pointing at the previous list and that arch tag is ahead of it until the version builds cleanly again. Noted in the workflow header.
- `automation-ghcr-cleanup.yml` is not touched. It has failed on every scheduled run since at least 2026-06-21 (`Unable to resolve action snok/container-retention-policy@v3` — only `v3.1.0` exists), so no retention runs today. Once repaired to v3.1.x, its multi-arch protection is digest-based and covers tagged children too (`filter_out_multi_arch_children.rs` filters both `tagged` and `untagged` candidates), so the arch tags of protected versions need no extra rule. Repairing the workflow itself (action ref, and its `image-tags` patterns are globs, not the regexes they are written as) is a separate issue.

## Verification

Every branch push triggers all `release-*` workflows with `publish: true` (they watch `reusable-*.yml`), so the branch builds exercise the new path end to end against GHCR and SWR.

- First wave (tag-addressed list): 17/17 release workflows green. `docker manifest inspect` on both GHCR and SWR: `application/vnd.docker.distribution.manifest.list.v2+json` with two `manifest.v2+json` children (linux/amd64, linux/arm64), identical list digest on both registries. GHCR registry API serves `:<version>` as the list and `:<version>-arm64` as a plain manifest.
- Verify-only path: `workflow_dispatch` with `publish=false` on release-deploy-redis (run 34306687678) and release-infra-oss-gateway (run 34306791501): both legs build, `manifest` skipped, downstream `chart / package` runs, run conclusion success.
- Timings vs main: bkn-backend 16 min → amd64 100s / arm64 83s + 23s manifest; model-factory-base ~10 min → ~2.6 min; bkn-agent ~7 min → ~1.4 min. arm64 runner queue wait across 17 concurrent jobs: median 5s, max 6s.
- Second wave (digest-addressed list) results are in the checks on the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
