### PR TITLE
feat(bkn-safe): remove normal user built-in role

### DIFF
--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
@@ -203,7 +203,7 @@ func getBknSafe(ctx context.Context, client *http.Client, url, authorization str
 }
 
 func builtInRoles(values []string) []string {
-	allowed := map[string]struct{}{"super_admin": {}, "admin": {}, "security": {}, "audit": {}, "network_builder": {}, "normal_user": {}}
+	allowed := map[string]struct{}{"super_admin": {}, "admin": {}, "security": {}, "audit": {}, "network_builder": {}}
 	roles := make([]string, 0, len(values))
 	seen := map[string]struct{}{}
 	for _, value := range values {

--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
@@ -39,7 +39,7 @@ func TestResolveAccessProfile(t *testing.T) {
 	if !profile.IsOutboxAdmin() {
 		t.Fatal("IsOutboxAdmin() = false, want true")
 	}
-	if len(profile.Roles) != 2 || profile.Roles[0] != "admin" || profile.Roles[1] != "normal_user" {
+	if len(profile.Roles) != 1 || profile.Roles[0] != "admin" {
 		t.Fatalf("Roles = %#v, want sorted built-in roles", profile.Roles)
 	}
 }

--- a/adp/bkn/ontology-query/server/common/bkntrace/access_profile.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/access_profile.go
@@ -95,7 +95,7 @@ func getBknSafe(ctx context.Context, client *http.Client, url, authorization str
 }
 
 func builtInRoles(values []string) []string {
-	allowed := map[string]struct{}{"super_admin": {}, "admin": {}, "security": {}, "audit": {}, "network_builder": {}, "normal_user": {}}
+	allowed := map[string]struct{}{"super_admin": {}, "admin": {}, "security": {}, "audit": {}, "network_builder": {}}
 	roles := make([]string, 0, len(values))
 	seen := map[string]struct{}{}
 	for _, value := range values {

--- a/adp/bkn/ontology-query/server/common/bkntrace/access_profile_test.go
+++ b/adp/bkn/ontology-query/server/common/bkntrace/access_profile_test.go
@@ -38,7 +38,7 @@ func TestResolveAccessProfile(t *testing.T) {
 	if !profile.IsOutboxAdmin() {
 		t.Fatal("IsOutboxAdmin() = false, want true")
 	}
-	if len(profile.Roles) != 2 || profile.Roles[0] != "admin" || profile.Roles[1] != "normal_user" {
+	if len(profile.Roles) != 1 || profile.Roles[0] != "admin" {
 		t.Fatalf("Roles = %#v, want sorted built-in roles", profile.Roles)
 	}
 }

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -92,6 +92,12 @@ func Boot(opts Options) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init authz: %w", err)
 	}
+	// Run withdrawn-role cleanup independently of seed_on_start. This is an
+	// upgrade migration for bkn-safe-owned data, whereas seed_on_start only
+	// controls whether the current catalog and role matrix are reconciled.
+	if err := seed.ReconcileDeprecatedRoles(db, enforcer); err != nil {
+		return nil, fmt.Errorf("reconcile deprecated roles: %w", err)
+	}
 
 	if cfg.SeedOnStart {
 		if err := seed.Apply(db, enforcer); err != nil {

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -92,11 +92,11 @@ func Boot(opts Options) (*App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init authz: %w", err)
 	}
-	// Run withdrawn-role cleanup independently of seed_on_start. This is an
+	// Run the normal_user withdrawal independently of seed_on_start. This is an
 	// upgrade migration for bkn-safe-owned data, whereas seed_on_start only
 	// controls whether the current catalog and role matrix are reconciled.
-	if err := seed.ReconcileDeprecatedRoles(db, enforcer); err != nil {
-		return nil, fmt.Errorf("reconcile deprecated roles: %w", err)
+	if err := seed.ReconcileWithdrawnNormalUserRole(db, enforcer); err != nil {
+		return nil, fmt.Errorf("reconcile withdrawn normal user role: %w", err)
 	}
 
 	if cfg.SeedOnStart {

--- a/bkn-safe/server/internal/authz/effectiveperms_test.go
+++ b/bkn-safe/server/internal/authz/effectiveperms_test.go
@@ -287,8 +287,8 @@ func TestEffectivePermissionsTypeWideOnly(t *testing.T) {
 func TestEffectivePermissionsTypeWideOnlyInstanceOnlyType(t *testing.T) {
 	e := newTestEnforcer(t)
 	const user = "u-obj"
-	// Mirrors the shipped normal_user role: capability types type-wide, no data
-	// grants at all — data types are reachable only through object grants.
+	// Models a capability-only role: data types are reachable only through object
+	// grants.
 	mustNoErr(t, e.GrantRolePermission("role-normal", "tool_box", "*", "view"))
 	mustNoErr(t, e.AssignRole(user, "role-normal"))
 	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "view_detail"))

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -263,11 +263,10 @@ func (en *Enforcer) inheritedResources(accessorID, resourceType, op string, visi
 	// probe the type-wide case FIRST (vega's resolveOps and the operator
 	// integration both check obj="<type>:*" and skip enumeration when it holds),
 	// so this branch is only reached by an accessor holding the wildcard on the
-	// PARENT type but not on the type itself — which no seeded role is. #513
-	// creates exactly that state if it revokes normal_user's resource:* while
-	// leaving catalog:*, and the size question has to be answered there rather
-	// than by quietly truncating here: a short list would read as "these are the
-	// tables you may see".
+	// PARENT type but not on the type itself. A custom role can create that state,
+	// and the size question has to be answered there rather than by quietly
+	// truncating it: a short list would read as "these are the tables you may
+	// see".
 	wide, err := en.e.Enforce(accessorID, obj(parentType, "*"), parentOp)
 	if err != nil {
 		return nil, err

--- a/bkn-safe/server/internal/httpapi/audit_semantics_test.go
+++ b/bkn-safe/server/internal/httpapi/audit_semantics_test.go
@@ -46,7 +46,7 @@ func TestAuditDetailTargetPromotesBusinessObjectIdentifiers(t *testing.T) {
 		wantID   string
 	}{
 		{"object-grants", `{"accessor_id":"user-a","resource":{"type":"knowledge_network","id":"supplychain_hd0202"}}`, "supplychain_hd0202"},
-		{"role-bindings", `{"accessor_id":"user-a","role_id":"normal_user"}`, "user-a"},
+		{"role-bindings", `{"accessor_id":"user-a","role_id":"role-a"}`, "user-a"},
 	}
 	for _, test := range tests {
 		if got := auditDetailTargetID(test.resource, test.detail); got != test.wantID {

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Studio 0.1.0 role -> permission grants. super_admin gets wildcard. admin/security/audit are three-admin roles. network_builder has business build permissions. normal_user holds NO data grants at all (#513): catalogs, data resources and knowledge networks are visible only when granted explicitly, because a type-wide allow cannot be narrowed by an object grant in an allow-only engine. What it does keep is the capability surface — tools, models, agents — where a type-wide grant leaks no data and revoking it would only make the platform unusable.",
+  "_comment": "Studio 0.1.0 role -> permission grants. super_admin gets wildcard. admin/security/audit are three-admin roles. network_builder has business build permissions.",
   "grants": [
     {
       "role_id": "7dcfcc9c-ad02-11e8-aa06-000c29358ad6",
@@ -222,56 +222,6 @@
       "resource_type": "agent_tpl",
       "id_pattern": "*",
       "operations": ["publish", "unpublish", "unpublish_other_user_agent_tpl"]
-    },
-
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "small_model",
-      "id_pattern": "*",
-      "operations": ["display", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "large_model",
-      "id_pattern": "*",
-      "operations": ["display", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "operator",
-      "id_pattern": "*",
-      "operations": ["view", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "skill",
-      "id_pattern": "*",
-      "operations": ["view", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "mcp",
-      "id_pattern": "*",
-      "operations": ["view", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "tool_box",
-      "id_pattern": "*",
-      "operations": ["view", "execute"]
-    },
-    {
-      "role_id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e",
-      "role_name": "normal_user",
-      "resource_type": "agent",
-      "id_pattern": "*",
-      "operations": ["use"]
     }
   ]
 }

--- a/bkn-safe/server/internal/seed/data/roles.json
+++ b/bkn-safe/server/internal/seed/data/roles.json
@@ -3,6 +3,5 @@
   {"id": "d2bd2082-ad03-11e8-aa06-000c29358ad6", "name": "admin", "description": "系统管理员：系统运行维护、用户 / 部门基础管理", "source": "system"},
   {"id": "d8998f72-ad03-11e8-aa06-000c29358ad6", "name": "security", "description": "安全管理员：角色管理、授权管理、账号安全管理", "source": "system"},
   {"id": "def246f2-ad03-11e8-aa06-000c29358ad6", "name": "audit", "description": "审计管理员：审计日志、权限配置审查、管理行为监督", "source": "system"},
-  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "network_builder", "description": "业务网络构建者：数据连接、数据目录、知识网络、模型资源、执行工厂的业务建设", "source": "business"},
-  {"id": "b5f9ac3e-992c-4bbd-8126-95e87e51c46e", "name": "normal_user", "description": "普通用户：各模块查看、查询、执行与调用，不含创建、编辑、删除、发布、授权", "source": "business"}
+  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "network_builder", "description": "业务网络构建者：数据连接、数据目录、知识网络、模型资源、执行工厂的业务建设", "source": "business"}
 ]

--- a/bkn-safe/server/internal/seed/inheritance_test.go
+++ b/bkn-safe/server/internal/seed/inheritance_test.go
@@ -17,12 +17,9 @@ import (
 // asserted against the real seed rather than argued: turning inheritance on must
 // not widen what any SEEDED role can do to a data table.
 //
-// It holds today because of how the two roles are already granted —
-// network_builder holds every inheritable operation on resource:* directly, and
-// normal_user's catalog grant (view_detail) is one it already holds on
-// resource:* too. Neither fact is obvious from reading grants.json, and either
-// could be broken by a future edit that looks harmless, which is why this is a
-// test and not a comment.
+// It holds today because network_builder holds every inheritable operation on
+// resource:* directly. That fact is not obvious from reading grants.json, and a
+// future edit could break it, which is why this is a test and not a comment.
 //
 // The residual widening lives in per-object catalog grants made through the
 // admin console, which no seed file can predict.

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -26,7 +26,6 @@ func TestRoleResourceMatrix(t *testing.T) {
 
 	const (
 		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
-		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 		superAdmin     = "7dcfcc9c-ad02-11e8-aa06-000c29358ad6"
 	)
 
@@ -52,17 +51,6 @@ func TestRoleResourceMatrix(t *testing.T) {
 	}
 	roleAllowed := map[string]map[string]string{
 		networkBuilder: networkBuilderAllowed,
-		// The data types (catalog / resource / knowledge_network) are absent on
-		// purpose: the ordinary role holds no data grant, and visibility comes
-		// only from an explicit grant (#513).
-		normalUser: {
-			"agent":       "use",
-			"tool_box":    "execute",
-			"mcp":         "execute",
-			"operator":    "execute",
-			"skill":       "execute",
-			"small_model": "execute",
-		},
 	}
 	allTypes := make([]string, 0, len(repOp))
 	for tpe := range repOp {
@@ -70,7 +58,7 @@ func TestRoleResourceMatrix(t *testing.T) {
 	}
 
 	// Each role's user; plus super-admin and an unroled user.
-	roles := []string{networkBuilder, normalUser}
+	roles := []string{networkBuilder}
 	for _, role := range roles {
 		user := "u-" + role
 		if err := e.AssignRole(user, role); err != nil {

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -52,8 +52,9 @@ var deprecatedSeedRoleIDs = []string{
 	"f06ac18e-ad03-11e8-aa06-000c29358ad6", // Organization auditor
 	"00990824-4bf7-11f0-8fa7-865d5643e61f", // Data administrator
 	"3fb94948-5169-11f0-b662-3a7bdba2913f", // AI administrator
-	"b5f9ac3e-992c-4bbd-8126-95e87e51c46e", // normal_user
 }
+
+const normalUserRoleID = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 
 // AdminUserID is the built-in admin user's id, exported so callers can protect
 // it — the user-admin API refuses to delete or disable it (deleting the only
@@ -129,8 +130,11 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedCatalog(db); err != nil {
 		return fmt.Errorf("seed catalog: %w", err)
 	}
-	if err := ReconcileDeprecatedRoles(db, enforcer); err != nil {
+	if err := reconcileDeprecatedSeedRoles(db, enforcer); err != nil {
 		return fmt.Errorf("reconcile deprecated seed roles: %w", err)
+	}
+	if err := ReconcileWithdrawnNormalUserRole(db, enforcer); err != nil {
+		return fmt.Errorf("reconcile withdrawn normal user role: %w", err)
 	}
 	if err := reconcileSeedRoles(db, enforcer); err != nil {
 		return fmt.Errorf("reconcile seed roles: %w", err)
@@ -156,10 +160,7 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	return nil
 }
 
-// ReconcileDeprecatedRoles removes withdrawn built-in roles and every Casbin
-// policy or membership bound to them. It is idempotent so it is safe both on
-// startup and during the ordinary seed reconciliation.
-func ReconcileDeprecatedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
+func reconcileDeprecatedSeedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
 	for _, roleID := range deprecatedSeedRoleIDs {
 		if err := enforcer.RemoveRoleCompletely(roleID); err != nil {
 			return err
@@ -167,6 +168,38 @@ func ReconcileDeprecatedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
 		if err := db.Delete(&model.Role{}, "id = ?", roleID).Error; err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// ReconcileWithdrawnNormalUserRole removes the withdrawn normal_user role and
+// every Casbin policy or membership bound to it. It is idempotent and logs only
+// when a persisted role, binding, or policy is actually removed.
+func ReconcileWithdrawnNormalUserRole(db *gorm.DB, enforcer *authz.Enforcer) error {
+	var roleCount, bindingCount, policyCount int64
+	if err := db.Model(&model.Role{}).Where("id = ?", normalUserRoleID).Count(&roleCount).Error; err != nil {
+		return err
+	}
+	if err := db.Table("casbin_rule").Where("ptype = ? AND v1 = ?", "g", normalUserRoleID).Count(&bindingCount).Error; err != nil {
+		return err
+	}
+	if err := db.Table("casbin_rule").Where("ptype = ? AND v0 = ?", "p", normalUserRoleID).Count(&policyCount).Error; err != nil {
+		return err
+	}
+
+	if err := enforcer.RemoveRoleCompletely(normalUserRoleID); err != nil {
+		return err
+	}
+	if err := db.Delete(&model.Role{}, "id = ?", normalUserRoleID).Error; err != nil {
+		return err
+	}
+	if roleCount+bindingCount+policyCount > 0 {
+		slog.Info("removed withdrawn built-in role",
+			"role_id", normalUserRoleID,
+			"roles", roleCount,
+			"bindings", bindingCount,
+			"policies", policyCount,
+		)
 	}
 	return nil
 }

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -52,6 +52,7 @@ var deprecatedSeedRoleIDs = []string{
 	"f06ac18e-ad03-11e8-aa06-000c29358ad6", // Organization auditor
 	"00990824-4bf7-11f0-8fa7-865d5643e61f", // Data administrator
 	"3fb94948-5169-11f0-b662-3a7bdba2913f", // AI administrator
+	"b5f9ac3e-992c-4bbd-8126-95e87e51c46e", // normal_user
 }
 
 // AdminUserID is the built-in admin user's id, exported so callers can protect
@@ -128,6 +129,9 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedCatalog(db); err != nil {
 		return fmt.Errorf("seed catalog: %w", err)
 	}
+	if err := ReconcileDeprecatedRoles(db, enforcer); err != nil {
+		return fmt.Errorf("reconcile deprecated seed roles: %w", err)
+	}
 	if err := reconcileSeedRoles(db, enforcer); err != nil {
 		return fmt.Errorf("reconcile seed roles: %w", err)
 	}
@@ -148,6 +152,21 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	}
 	if err := seedBusinessProvenanceOwner(db); err != nil {
 		return fmt.Errorf("seed business provenance owner: %w", err)
+	}
+	return nil
+}
+
+// ReconcileDeprecatedRoles removes withdrawn built-in roles and every Casbin
+// policy or membership bound to them. It is idempotent so it is safe both on
+// startup and during the ordinary seed reconciliation.
+func ReconcileDeprecatedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
+	for _, roleID := range deprecatedSeedRoleIDs {
+		if err := enforcer.RemoveRoleCompletely(roleID); err != nil {
+			return err
+		}
+		if err := db.Delete(&model.Role{}, "id = ?", roleID).Error; err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -253,14 +272,6 @@ func reconcileSeedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
 		}
 	}
 
-	for _, roleID := range deprecatedSeedRoleIDs {
-		if err := enforcer.RemoveRoleCompletely(roleID); err != nil {
-			return err
-		}
-		if err := db.Delete(&model.Role{}, "id = ?", roleID).Error; err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -40,11 +40,11 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		t.Fatalf("apply seed: %v", err)
 	}
 
-	// 6 Studio roles, with the preserved three-admin UUIDs present.
+	// 5 Studio roles, with the preserved three-admin UUIDs present.
 	var roleCount int64
 	db.Model(&model.Role{}).Count(&roleCount)
-	if roleCount != 6 {
-		t.Errorf("role count = %d, want 6", roleCount)
+	if roleCount != 5 {
+		t.Errorf("role count = %d, want 5", roleCount)
 	}
 	for id, name := range map[string]string{
 		"7dcfcc9c-ad02-11e8-aa06-000c29358ad6": "super_admin",
@@ -52,7 +52,6 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		"d8998f72-ad03-11e8-aa06-000c29358ad6": "security",
 		"def246f2-ad03-11e8-aa06-000c29358ad6": "audit",
 		"1572fb82-526f-11f0-bde6-e674ec8dde71": "network_builder",
-		"b5f9ac3e-992c-4bbd-8126-95e87e51c46e": "normal_user",
 	} {
 		var r model.Role
 		if err := db.First(&r, "id = ?", id).Error; err != nil {
@@ -106,7 +105,6 @@ func TestSeededRoleGrants(t *testing.T) {
 		security       = "d8998f72-ad03-11e8-aa06-000c29358ad6"
 		audit          = "def246f2-ad03-11e8-aa06-000c29358ad6"
 		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
-		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 	)
 	cases := []struct {
 		name, role, typ, id, op string
@@ -128,14 +126,6 @@ func TestSeededRoleGrants(t *testing.T) {
 		{"network-builder manages catalog", networkBuilder, "catalog", "x", "create", true},
 		{"network-builder manages skill", networkBuilder, "skill", "s1", "publish", true},
 		{"network-builder not system users", networkBuilder, "admin-user", "x", "create", false},
-		// The data surface defaults to nothing (#513); capabilities are unchanged.
-		{"normal-user cannot query knowledge by default", normalUser, "knowledge_network", "kn1", "query_data", false},
-		{"normal-user cannot view a catalog by default", normalUser, "catalog", "c1", "view_detail", false},
-		{"normal-user cannot view a data resource by default", normalUser, "resource", "r1", "view_detail", false},
-		{"normal-user can execute skill", normalUser, "skill", "s1", "execute", true},
-		{"normal-user can use agent", normalUser, "agent", "a1", "use", true},
-		{"normal-user cannot create catalog", normalUser, "catalog", "x", "create", false},
-		{"normal-user cannot publish skill", normalUser, "skill", "s1", "publish", false},
 		{"super-admin does anything (agent)", superAdmin, "agent", "x", "use", true},
 		{"super-admin does anything (any type/op)", superAdmin, "whatever", "z", "some_random_op", true},
 	}
@@ -172,7 +162,6 @@ func TestAdminRoleCombinationGrantsRoleCatalogRead(t *testing.T) {
 	for _, roleID := range []string{
 		"d2bd2082-ad03-11e8-aa06-000c29358ad6", // admin
 		"1572fb82-526f-11f0-bde6-e674ec8dde71", // network_builder
-		"b5f9ac3e-992c-4bbd-8126-95e87e51c46e", // normal_user
 	} {
 		if err := e.AssignRole(owner, roleID); err != nil {
 			t.Fatal(err)
@@ -185,7 +174,6 @@ func TestAdminRoleCombinationGrantsRoleCatalogRead(t *testing.T) {
 	}{
 		{"role catalog read", "admin-role", "view", true},
 		{"user list read", "admin-user", "view", true},
-		{"large model display", "large_model", "display", true},
 		{"role creation remains restricted", "admin-role", "create", false},
 		{"role permission changes remain restricted", "admin-role", "permissions", false},
 	}
@@ -352,8 +340,8 @@ func TestApplyIdempotent(t *testing.T) {
 	}
 	var roleCount int64
 	db.Model(&model.Role{}).Count(&roleCount)
-	if roleCount != 6 {
-		t.Errorf("role count after re-seed = %d, want 6", roleCount)
+	if roleCount != 5 {
+		t.Errorf("role count after re-seed = %d, want 5", roleCount)
 	}
 }
 
@@ -401,7 +389,7 @@ func TestApplyReconcilesDeprecatedSeedRoles(t *testing.T) {
 	}
 }
 
-func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
+func TestReconcileDeprecatedRolesRemovesWithdrawnNormalUserRole(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -410,7 +398,7 @@ func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
 
 	const (
 		normalUserRole = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
-		user           = "u-stale-grant"
+		user           = "u-withdrawn-role"
 	)
 	if err := e.AssignRole(user, normalUserRole); err != nil {
 		t.Fatal(err)
@@ -421,25 +409,24 @@ func TestApplyReconcilesCurrentSeedRoleGrants(t *testing.T) {
 	if ok, err := e.Check(user, "admin-user", "u1", "create"); err != nil {
 		t.Fatal(err)
 	} else if !ok {
-		t.Fatal("test setup failed: stale grant did not take effect")
+		t.Fatal("test setup failed: withdrawn role grant did not take effect")
 	}
 
-	if err := Apply(db, e); err != nil {
-		t.Fatalf("apply: %v", err)
+	if err := ReconcileDeprecatedRoles(db, e); err != nil {
+		t.Fatalf("reconcile deprecated roles: %v", err)
 	}
 
 	if ok, err := e.Check(user, "admin-user", "u1", "create"); err != nil {
 		t.Fatal(err)
 	} else if ok {
-		t.Fatal("stale current-role grant still allows admin-user create")
+		t.Fatal("withdrawn role policy or binding still allows admin-user create")
 	}
-	// Assert the rebuild half with a grant the role actually holds: the data
-	// surface is gone (#513), so using catalog here would test the revocation
-	// instead, which is another test's job.
-	if ok, err := e.Check(user, "skill", "s1", "execute"); err != nil {
+	var count int64
+	if err := db.Model(&model.Role{}).Where("id = ?", normalUserRole).Count(&count).Error; err != nil {
 		t.Fatal(err)
-	} else if !ok {
-		t.Fatal("normal_user desired grant was not restored after reconcile")
+	}
+	if count != 0 {
+		t.Fatal("withdrawn normal_user role still exists after reconcile")
 	}
 }
 
@@ -498,100 +485,6 @@ func TestCatalogResourceOperationSplit(t *testing.T) {
 	}
 	if len(resourceOps) != 2 {
 		t.Errorf("resource declares %d operations, want exactly view_detail and query_data", len(resourceOps))
-	}
-}
-
-// TestSeedRevokesNormalUserDataGrants pins #513: the ordinary role holds no
-// data grant at all, so an object grant is finally the thing that decides.
-//
-// The point is not tidiness. In an allow-only engine a type-wide allow cannot be
-// narrowed by an object grant, so as long as normal_user held resource:* every
-// per-object configuration an administrator made was dead on arrival.
-//
-// The capability surface stays: tools, models and agents leak no data through a
-// type-wide grant, and revoking those would only leave a platform where a signed-in
-// user cannot invoke a model.
-func TestSeedRevokesNormalUserDataGrants(t *testing.T) {
-	db := newDB(t)
-	e, err := authz.New(db)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := Apply(db, e); err != nil {
-		t.Fatal(err)
-	}
-
-	const (
-		normalUser     = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
-		networkBuilder = "1572fb82-526f-11f0-bde6-e674ec8dde71"
-	)
-	user := "u-normal"
-	if err := e.AssignRole(user, normalUser); err != nil {
-		t.Fatal(err)
-	}
-
-	// The data surface: not one grant should be left.
-	for _, tc := range []struct{ rtype, op string }{
-		{"catalog", "view_detail"},
-		{"resource", "view_detail"},
-		{"resource", "query_data"},
-		{"knowledge_network", "view_detail"},
-		{"knowledge_network", "query_data"},
-	} {
-		allowed, err := e.Check(user, tc.rtype, "x-1", tc.op)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if allowed {
-			t.Errorf("normal_user still holds %s/%s by default — object grants stay overridden by it", tc.rtype, tc.op)
-		}
-	}
-
-	// Granted explicitly, it must be visible — otherwise revoking the wildcard
-	// leaves no working path to see anything at all.
-	if err := e.GrantObjectPermission(user, "catalog", "c-1", "view_detail"); err != nil {
-		t.Fatal(err)
-	}
-	allowed, err := e.Check(user, "catalog", "c-1", "view_detail")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !allowed {
-		t.Error("an explicit catalog grant still does not grant access — the convergence would leave no usable path")
-	}
-
-	// The capability surface is untouched: revoking it buys no safety and leaves a
-	// signed-in user unable to invoke a model.
-	for _, tc := range []struct{ rtype, op string }{
-		{"skill", "execute"},
-		{"tool_box", "execute"},
-		{"large_model", "execute"},
-		{"small_model", "execute"},
-		{"agent", "use"},
-	} {
-		allowed, err := e.Check(user, tc.rtype, "x-1", tc.op)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !allowed {
-			t.Errorf("normal_user lost the capability %s/%s — that is not convergence, it is an unusable platform", tc.rtype, tc.op)
-		}
-	}
-
-	// The builder is unaffected. Creating a table is judged on the target catalog
-	// now (#801): a table has to be created inside one, so "may create a table"
-	// and "may act on this catalog" were always the same question — and the old
-	// resource:*/create could not answer which catalog it would land in.
-	builder := "u-builder"
-	if err := e.AssignRole(builder, networkBuilder); err != nil {
-		t.Fatal(err)
-	}
-	allowed, err = e.Check(builder, "catalog", "c-1", "resource_manage")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !allowed {
-		t.Error("network_builder lost catalog resource_manage — creating a data table would 403 after upgrade")
 	}
 }
 

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -389,7 +389,7 @@ func TestApplyReconcilesDeprecatedSeedRoles(t *testing.T) {
 	}
 }
 
-func TestReconcileDeprecatedRolesRemovesWithdrawnNormalUserRole(t *testing.T) {
+func TestReconcileWithdrawnNormalUserRole(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -397,7 +397,7 @@ func TestReconcileDeprecatedRolesRemovesWithdrawnNormalUserRole(t *testing.T) {
 	}
 
 	const (
-		normalUserRole = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
+		normalUserRole = normalUserRoleID
 		user           = "u-withdrawn-role"
 	)
 	if err := e.AssignRole(user, normalUserRole); err != nil {
@@ -412,8 +412,8 @@ func TestReconcileDeprecatedRolesRemovesWithdrawnNormalUserRole(t *testing.T) {
 		t.Fatal("test setup failed: withdrawn role grant did not take effect")
 	}
 
-	if err := ReconcileDeprecatedRoles(db, e); err != nil {
-		t.Fatalf("reconcile deprecated roles: %v", err)
+	if err := ReconcileWithdrawnNormalUserRole(db, e); err != nil {
+		t.Fatalf("reconcile withdrawn normal user role: %v", err)
 	}
 
 	if ok, err := e.Check(user, "admin-user", "u1", "create"); err != nil {

--- a/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
+++ b/bkn-trace/agent-observability/src/drivenadapter/httpaccess/bknsafeaccess/client.go
@@ -25,7 +25,7 @@ const maxSafeResponseBytes = 4 << 20
 
 var builtInRoles = map[string]struct{}{
 	"super_admin": {}, "admin": {}, "security": {}, "audit": {},
-	"network_builder": {}, "normal_user": {},
+	"network_builder": {},
 }
 
 var networkManagementOperations = map[string]struct{}{

--- a/help/en/install.md
+++ b/help/en/install.md
@@ -423,7 +423,7 @@ openbkn admin role add-member <roleId> -u alice
 openbkn admin role remove-member <roleId> -u alice
 ```
 
-Always run **`role list` first** and use the **roleId** values from the output (role name strings such as `super_admin` / `normal_user`). For **quick start or POC**, to avoid 403s from missing roles, often assign **every** role in `role list` to a new user with one `openbkn admin user assign-role <userId> <roleId>` per entry. In **production**, grant least privilege; verify with `openbkn admin user roles <userId>`.
+Always run **`role list` first** and use the **roleId** values from the output (role name strings such as `super_admin` / `network_builder`). For **quick start or POC**, to avoid 403s from missing roles, often assign **every** role in `role list` to a new user with one `openbkn admin user assign-role <userId> <roleId>` per entry. In **production**, grant least privilege; verify with `openbkn admin user roles <userId>`.
 
 #### Models (LLM / Embedding)
 

--- a/help/en/quick-start.md
+++ b/help/en/quick-start.md
@@ -39,7 +39,7 @@ Use this when you want a custom username, custom role set, or simply prefer not 
 npm install -g @openbkn/bkn-sdk
 # admin initial password: generated at install, recorded as bknSafe.initialPassword in ~/.openbkn-ai/config.yaml
 openbkn auth login <platform-url> -u admin -p '<initial-password>' -k
-openbkn admin role list                                           # all roles and roleIds (e.g. super_admin, normal_user)
+openbkn admin role list                                           # all roles and roleIds (e.g. super_admin, network_builder)
 openbkn admin user create --login <new-username>                  # initial password is generated and returned ONCE (initial_password); first sign-in forces a change
 # Quick start / PoC: assign every roleId from role list to avoid API 403s due to missing roles
 openbkn admin user assign-role <userId> <roleId>

--- a/help/zh/install.md
+++ b/help/zh/install.md
@@ -425,7 +425,7 @@ openbkn admin role add-member <roleId> -u alice
 openbkn admin role remove-member <roleId> -u alice
 ```
 
-**赋权前务必先看 `role list`**，记下每条角色的 **roleId**（与名称如 `super_admin`、`normal_user` 等对应关系以你环境输出为准）。**快速开始/POC** 为减少「缺角色导致接口 403」，常对新用户**依次**执行 `openbkn admin user assign-role <userId> <roleId>`，把 `role list` 中的角色**全部**挂到该用户上；**生产**请按最小权限只赋业务所需角色，并用 `openbkn admin user roles <userId>` 复查。
+**赋权前务必先看 `role list`**，记下每条角色的 **roleId**（与名称如 `super_admin`、`network_builder` 等对应关系以你环境输出为准）。**快速开始/POC** 为减少「缺角色导致接口 403」，常对新用户**依次**执行 `openbkn admin user assign-role <userId> <roleId>`，把 `role list` 中的角色**全部**挂到该用户上；**生产**请按最小权限只赋业务所需角色，并用 `openbkn admin user roles <userId>` 复查。
 
 #### 模型（LLM / Embedding）
 

--- a/help/zh/quick-start.md
+++ b/help/zh/quick-start.md
@@ -45,7 +45,7 @@ sudo bash ./onboard.sh -y     # 非交互（按默认）
 npm install -g @openbkn/bkn-sdk
 # admin 初始密码：安装时生成，记录在 ~/.openbkn-ai/config.yaml 的 bknSafe.initialPassword
 openbkn auth login <平台地址> -u admin -p '<初始密码>' -k
-openbkn admin role list                                       # 列出全部角色及 roleId（如 super_admin、normal_user）
+openbkn admin role list                                       # 列出全部角色及 roleId（如 super_admin、network_builder）
 openbkn admin user create --login <新用户名>                  # 初始密码随机生成，仅在创建响应中返回一次（initial_password），首次登录强制改密
 # 快速开始/POC：把 role list 中每个 roleId 都挂上，避免后续 API 因缺角色被拒
 openbkn admin user assign-role <userId> <roleId>


### PR DESCRIPTION
Remove the withdrawn normal_user seed role and its default grants. Clean up historical role bindings and Casbin policies during startup, including when regular seeding is disabled.

# Pull Request

## What Changed

Brief description of changes:

- [x] Remove the built-in `normal_user` role from bkn-safe seed data.
- [x] Remove its default Casbin permission grants.
- [x] Reconcile historical `normal_user` role records, member bindings, and role policies during bkn-safe startup, including when `seed_on_start=false`.
- [x] Update seed authorization matrix and regression tests.

---

## Why

- Related Issue: N/A
- Related Feature: Built-in role cleanup
- Background: `normal_user` is no longer part of the intended authorization model. Existing deployments may still contain its role record and Casbin policies, so removing seed data alone would not revoke its historical permissions.

---

## How

- Key implementation points:
  - Add `normal_user` to the withdrawn seed-role list.
  - Run idempotent withdrawn-role reconciliation after database migration and Casbin initialization.
  - Delete the role record, its `g` member bindings, and its `p` permission policies.
  - Keep the cleanup independent from normal seed reconciliation.

- Breaking changes (API, config, database, etc.):
  - No API or configuration changes.
  - This is an authorization behavior change: users previously assigned `normal_user` lose the permissions provided exclusively by that role.
  - User accounts, other role bindings, and direct object grants are not removed.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable
- [ ] Verified in test environment

Test notes:

```bash
cd bkn-safe/server
go test ./...