### PR TITLE
feat(vega): support safe binary resource previews

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler.go
@@ -186,7 +186,8 @@ func (r *restHandler) executeResourceDataQuery(c *gin.Context, ctx context.Conte
 	}
 
 	resultData := map[string]any{
-		"entries": result.Entries,
+		"query_source": result.QuerySource,
+		"entries":      result.Entries,
 	}
 	if params.NeedTotal || result.NeedTotal {
 		resultData["total_count"] = result.TotalCount

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -106,9 +106,10 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 				assert.Equal(t, 0, params.Offset)
 				assert.Equal(t, 2, params.Limit)
 				return &interfaces.ResourceDataQueryResult{
-					Entries:    []map[string]any{{"id": "doc-1"}},
-					TotalCount: 1,
-					Paging:     &interfaces.PagingResponse{},
+					Entries:     []map[string]any{{"id": "doc-1"}},
+					TotalCount:  1,
+					Paging:      &interfaces.PagingResponse{},
+					QuerySource: interfaces.ResourceQuerySourceLocalIndex,
 				}, nil
 			})
 
@@ -121,6 +122,7 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), `"entries"`)
+		assert.Contains(t, w.Body.String(), `"query_source":"local_index"`)
 		assert.Contains(t, w.Body.String(), `"total_count":1`)
 	})
 
@@ -211,6 +213,84 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 
 		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
 		assert.Contains(t, w.Body.String(), "VegaBackend.InvalidParameter.GroupBy")
+	})
+
+	t.Run("rejects binary group by fields", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{{Name: "payload", Type: interfaces.DataType_Binary}}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"payload"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "binary field \\\"payload\\\" cannot be used in group_by")
+	})
+
+	t.Run("rejects other group by fields", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{{Name: "metadata", Type: interfaces.DataType_Other}}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"metadata"}]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "other field \\\"metadata\\\" cannot be used in group_by")
+	})
+
+	t.Run("rejects binary output fields in aggregation queries", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{
+			{Name: "score", Type: interfaces.DataType_Integer},
+			{Name: "payload", Type: interfaces.DataType_Binary},
+		}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"aggregation":{"property":"score","aggr":"sum"},"output_fields":["payload"]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "Binary field \\\"payload\\\" cannot be requested by an aggregation query")
+	})
+
+	t.Run("rejects other output fields in aggregation queries", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{
+			{Name: "score", Type: interfaces.DataType_Integer},
+			{Name: "metadata", Type: interfaces.DataType_Other},
+		}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"aggregation":{"property":"score","aggr":"sum"},"output_fields":["metadata"]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "Other field \\\"metadata\\\" cannot be requested by an aggregation query")
 	})
 
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource.go
@@ -51,7 +51,10 @@ func validateResourceRequestSchema(ctx context.Context, req *interfaces.Resource
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_SchemaDefinition).
 				WithErrorDetails("schema_definition is required and must contain at least one field")
 		}
-		return validateSchemaProperties(ctx, req.SchemaDefinition, false)
+		if err := validateSchemaProperties(ctx, req.SchemaDefinition, false); err != nil {
+			return err
+		}
+		return validateDatasetSchemaTypes(ctx, req.SchemaDefinition)
 	default:
 		// Only raw resources support ref_property, and only their legacy data can contain
 		// self-references. Normalize this branch alone: dataset ref_property already returned
@@ -61,6 +64,16 @@ func validateResourceRequestSchema(ctx context.Context, req *interfaces.Resource
 		resourcelogic.NormalizeSelfReferencingFeatures(req.SchemaDefinition)
 		return validateSchemaProperties(ctx, req.SchemaDefinition, true)
 	}
+}
+
+func validateDatasetSchemaTypes(ctx context.Context, props []*interfaces.Property) error {
+	for _, prop := range props {
+		if prop.Type == interfaces.DataType_Binary || prop.Type == interfaces.DataType_Other {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Dataset_InvalidParameter_FieldType).
+				WithErrorDetails(fmt.Sprintf("Dataset field %q type %q is not supported", prop.Name, prop.Type))
+		}
+	}
+	return nil
 }
 
 // validateSchemaProperties verifies the name, type and Feature of the schema field.

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -37,6 +37,10 @@ func ValidateResourceDataQueryParams(ctx context.Context, params *interfaces.Res
 	if err := validateBinaryMode(ctx, params.BinaryMode); err != nil {
 		return err
 	}
+	if params.BinaryMode == nil {
+		defaultBinaryMode := interfaces.BinaryModeMetadata
+		params.BinaryMode = &defaultBinaryMode
+	}
 
 	err := validateResourceDataPaging(ctx, params)
 	if err != nil {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -34,6 +34,9 @@ func ValidateResourceDataQueryParams(ctx context.Context, params *interfaces.Res
 			return err
 		}
 	}
+	if err := validateBinaryMode(ctx, params.BinaryMode); err != nil {
+		return err
+	}
 
 	err := validateResourceDataPaging(ctx, params)
 	if err != nil {
@@ -70,6 +73,14 @@ func ValidateResourceDataQueryParams(ctx context.Context, params *interfaces.Res
 	}
 
 	return nil
+}
+
+func validateBinaryMode(ctx context.Context, mode *string) error {
+	if mode == nil || *mode == interfaces.BinaryModeMetadata || *mode == interfaces.BinaryModeContent {
+		return nil
+	}
+	return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
+		WithErrorDetails("binary_mode must be either metadata or content")
 }
 
 func validateResourceDataPaging(ctx context.Context, params *interfaces.ResourceDataQueryParams) error {
@@ -117,14 +128,14 @@ func validateResourceDataCursorContinuation(ctx context.Context, params *interfa
 	paging := params.Paging
 	if paging.Mode != "" || paging.Offset != 0 || paging.Limit != 0 || paging.KeepAliveSec != 0 ||
 		params.FilterCondition != nil || len(params.Sort) != 0 || len(params.OutputFields) != 0 ||
-		params.Aggregation != nil || len(params.GroupBy) != 0 || params.Having != nil {
+		params.Aggregation != nil || len(params.GroupBy) != 0 || params.Having != nil ||
+		params.BinaryMode != nil || params.IgnoreLocalIndex != nil {
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails("cursor continuation must contain only paging.cursor")
 	}
 	params.Offset = 0
 	params.Limit = 0
-	// The initial request freezes this value in the cursor session. A value on
-	// continuation is accepted for request-shape consistency but cannot change it.
+	// The initial request freezes this value in the cursor session.
 	params.NeedTotal = false
 	return nil
 }
@@ -351,21 +362,53 @@ func validateAggregateParams(ctx context.Context, params *interfaces.ResourceDat
 	return nil
 }
 
-// validateResourceDataQueryGroupByFields verifies that group-by fields are declared by the resource.
+// validateResourceDataQueryGroupByFields verifies fields whose validity depends on the resource schema.
 // It runs after the resource is loaded so request-level validation can remain resource independent.
 func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfaces.ResourceDataQueryParams,
 	schemaDefinition []*interfaces.Property) error {
-	fields := make(map[string]struct{}, len(schemaDefinition))
+	fields := make(map[string]string, len(schemaDefinition))
 	for _, property := range schemaDefinition {
 		if property != nil && property.Name != "" {
-			fields[property.Name] = struct{}{}
+			fields[property.Name] = property.Type
 		}
 	}
 
 	for _, groupByItem := range params.GroupBy {
-		if _, ok := fields[groupByItem.Property]; !ok {
+		fieldType, ok := fields[groupByItem.Property]
+		if !ok {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_GroupBy).
 				WithErrorDetails(fmt.Sprintf("GroupBy property %q is not defined by the resource", groupByItem.Property))
+		}
+		if fieldType == interfaces.DataType_Binary || fieldType == interfaces.DataType_Other {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_GroupBy).
+				WithErrorDetails(fmt.Sprintf("%s field %q cannot be used in group_by", fieldType, groupByItem.Property))
+		}
+	}
+
+	if !isAggregateQuery(params) {
+		return nil
+	}
+	if params.Aggregation != nil && fields[params.Aggregation.Property] == interfaces.DataType_Binary {
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Aggregation).
+			WithErrorDetails(fmt.Sprintf("Binary field %q cannot be used in aggregation", params.Aggregation.Property))
+	}
+	groupByFields := make(map[string]struct{}, len(params.GroupBy))
+	for _, groupByItem := range params.GroupBy {
+		groupByFields[groupByItem.Property] = struct{}{}
+	}
+	for _, outputField := range params.OutputFields {
+		fieldType := fields[outputField]
+		if fieldType == interfaces.DataType_Binary {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("Binary field %q cannot be requested by an aggregation query", outputField))
+		}
+		if fieldType == interfaces.DataType_Other {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("Other field %q cannot be requested by an aggregation query", outputField))
+		}
+		if _, grouped := groupByFields[outputField]; !grouped {
+			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
+				WithErrorDetails(fmt.Sprintf("Output field %q must be included in group_by for an aggregation query", outputField))
 		}
 	}
 

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
@@ -137,6 +137,14 @@ func TestValidateResourceDataQueryParams(t *testing.T) {
 				Paging:      interfaces.PagingRequest{Cursor: "opaque-cursor"},
 				Aggregation: &interfaces.Aggregation{Property: "score", Aggr: "sum"},
 			},
+			"binary mode": {
+				Paging:     interfaces.PagingRequest{Cursor: "opaque-cursor"},
+				BinaryMode: stringPtr(interfaces.BinaryModeContent),
+			},
+			"ignore local index": {
+				Paging:           interfaces.PagingRequest{Cursor: "opaque-cursor"},
+				IgnoreLocalIndex: boolPtr(false),
+			},
 		} {
 			t.Run(name, func(t *testing.T) {
 				require.Error(t, ValidateResourceDataQueryParams(ctx, params))
@@ -171,6 +179,26 @@ func TestValidateResourceDataQueryParams(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestValidateBinaryMode(t *testing.T) {
+	ctx := context.Background()
+	require.NoError(t, validateBinaryMode(ctx, nil))
+	for _, mode := range []string{interfaces.BinaryModeMetadata, interfaces.BinaryModeContent} {
+		require.NoError(t, validateBinaryMode(ctx, &mode))
+	}
+	mode := "raw"
+	err := validateBinaryMode(ctx, &mode)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "binary_mode must be either metadata or content")
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }
 
 func TestValidateFormat(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data_test.go
@@ -29,6 +29,8 @@ func TestValidateResourceDataQueryParams(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, interfaces.Format_Original, params.Format)
 		assert.Equal(t, interfaces.DefaultPageLimit, params.Limit)
+		require.NotNil(t, params.BinaryMode)
+		assert.Equal(t, interfaces.BinaryModeMetadata, *params.BinaryMode)
 	})
 
 	t.Run("maps legacy top-level limit into paging", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/driveradapters/validate_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_test.go
@@ -248,6 +248,18 @@ func TestValidateResourceRequestDatasetSchema(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	for _, dataType := range []string{interfaces.DataType_Binary, interfaces.DataType_Other} {
+		t.Run("ValidateResourceRequest rejects unsupported dataset type "+dataType, func(t *testing.T) {
+			err := ValidateResourceRequest(ctx, baseReq([]*interfaces.Property{
+				{Name: "unsupported", Type: dataType},
+			}))
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "unsupported")
+			assert.ErrorContains(t, err, dataType)
+			assert.ErrorContains(t, err, "not supported")
+		})
+	}
+
 	t.Run("ValidateResourceRequest rejects dataset feature ref_property", func(t *testing.T) {
 		err := ValidateResourceRequest(ctx, baseReq([]*interfaces.Property{
 			{Name: "content_keyword", Type: interfaces.DataType_String},

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -25,6 +25,17 @@ const (
 	CALENDAR_UNIT_MONTH   = "month"
 	CALENDAR_UNIT_QUARTER = "quarter"
 	CALENDAR_UNIT_YEAR    = "year"
+
+	BinaryModeMetadata = "metadata"
+	BinaryModeContent  = "content"
+
+	ResourceQuerySourceLocalIndex = "local_index"
+	ResourceQuerySourceSource     = "source"
+
+	ResourceValueModeUnavailable  = "unavailable"
+	ResourceValueModeNotRequested = "not_requested"
+	ResourceValueModeMetadata     = "metadata"
+	ResourceValueModeContent      = "content"
 )
 
 // SortField represents a field to sort by.
@@ -70,7 +81,9 @@ type ResourceDataQueryParams struct {
 
 	FilterCondition any `json:"filter_condition,omitempty"`
 
-	OutputFields []string `json:"output_fields"` // Specify the list of fields for output
+	OutputFields     []string `json:"output_fields"` // Specify the list of fields for output
+	BinaryMode       *string  `json:"binary_mode,omitempty"`
+	IgnoreLocalIndex *bool    `json:"ignore_local_index,omitempty"`
 
 	NeedTotal   bool          `json:"need_total,omitempty"`
 	Format      string        `json:"-"`
@@ -95,8 +108,18 @@ type ResourceDataQueryParams struct {
 // logic-view queries. Paging follows the same single/cursor contract as raw
 // queries.
 type ResourceDataQueryResult struct {
-	Entries    []map[string]any
-	TotalCount int64
-	Paging     *PagingResponse
-	NeedTotal  bool
+	Entries     []map[string]any
+	TotalCount  int64
+	Paging      *PagingResponse
+	NeedTotal   bool
+	QuerySource string
+}
+
+// ResourceValue is the JSON representation of a resource field that needs
+// special handling. Binary content uses Base64 data; byte_length applies only
+// to Binary fields.
+type ResourceValue struct {
+	Mode       string `json:"mode"`
+	ByteLength *int64 `json:"byte_length,omitempty"`
+	Data       any    `json:"data,omitempty"`
 }

--- a/adp/vega/vega-backend/server/interfaces/resource_data.go
+++ b/adp/vega/vega-backend/server/interfaces/resource_data.go
@@ -32,10 +32,9 @@ const (
 	ResourceQuerySourceLocalIndex = "local_index"
 	ResourceQuerySourceSource     = "source"
 
-	ResourceValueModeUnavailable  = "unavailable"
-	ResourceValueModeNotRequested = "not_requested"
-	ResourceValueModeMetadata     = "metadata"
-	ResourceValueModeContent      = "content"
+	ResourceValueModeUnavailable = "unavailable"
+	ResourceValueModeMetadata    = "metadata"
+	ResourceValueModeContent     = "content"
 )
 
 // SortField represents a field to sort by.

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -21,8 +21,11 @@ import (
 )
 
 // convertValue converts []byte to string for MariaDB driver compatibility
-func convertValue(v any) any {
+func convertValue(v any, preserveBinary bool) any {
 	if b, ok := v.([]byte); ok {
+		if preserveBinary {
+			return b
+		}
 		return string(b)
 	}
 	return v
@@ -87,7 +90,7 @@ func (c *MariaDBConnector) ExecuteRawSQL(ctx context.Context, sql string) (*inte
 
 		row := make(map[string]any)
 		for i, col := range columns {
-			row[col] = convertValue(values[i])
+			row[col] = convertValue(values[i], false)
 		}
 		response.Entries = append(response.Entries, row)
 	}
@@ -136,7 +139,8 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 			selectFields = append(selectFields, dateFmt+" AS "+quoteColumnName(groupByItem.Property))
 			selected[groupByItem.Property] = struct{}{}
 		} else {
-			selectFields = append(selectFields, quoteColumnName(column))
+			selectFields = append(selectFields,
+				quoteColumnName(column)+" AS "+quoteColumnName(groupByItem.Property))
 			selected[groupByItem.Property] = struct{}{}
 		}
 	}
@@ -172,17 +176,34 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 	}
 
 	// Select every field when the query is neither aggregated nor grouped
+	selectField := func(name string) string {
+		column := quoteColumnName(originalName(name))
+		if prop := fieldMap[name]; prop != nil && prop.Type == interfaces.DataType_Binary {
+			if params.BinaryMode == nil {
+				return "NULL AS " + quoteColumnName(name)
+			}
+			switch *params.BinaryMode {
+			case interfaces.BinaryModeMetadata:
+				return "OCTET_LENGTH(" + column + ") AS " + quoteColumnName(name)
+			case interfaces.BinaryModeContent:
+				return column + " AS " + quoteColumnName(name)
+			default:
+				return "NULL AS " + quoteColumnName(name)
+			}
+		}
+		return column + " AS " + quoteColumnName(name)
+	}
 	if len(params.GroupBy) == 0 && params.Aggregation == nil {
 		if len(params.OutputFields) > 0 {
 			for _, outName := range params.OutputFields {
-				selectFields = append(selectFields, quoteColumnName(originalName(outName)))
+				selectFields = append(selectFields, selectField(outName))
 			}
 		} else if len(selectFields) == 0 {
 			// No output fields specified, so query them all. This branch needs the
 			// originalName fallback too, or a property with an empty original_name
 			// renders as an empty identifier and breaks the statement.
 			for _, prop := range resource.SchemaDefinition {
-				selectFields = append(selectFields, quoteColumnName(originalName(prop.Name)))
+				selectFields = append(selectFields, selectField(prop.Name))
 			}
 		}
 	} else if len(params.OutputFields) > 0 {
@@ -191,7 +212,7 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 			if _, found := selected[outName]; found {
 				continue
 			}
-			selectFields = append(selectFields, quoteColumnName(originalName(outName)))
+			selectFields = append(selectFields, selectField(outName))
 			selected[outName] = struct{}{}
 		}
 	}
@@ -322,6 +343,14 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 	}
 	result.Columns = columns
 
+	binaryContentColumns := map[string]bool{}
+	if params.BinaryMode != nil && *params.BinaryMode == interfaces.BinaryModeContent {
+		for _, prop := range resource.SchemaDefinition {
+			if prop != nil && prop.Type == interfaces.DataType_Binary {
+				binaryContentColumns[prop.Name] = true
+			}
+		}
+	}
 	for rows.Next() {
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
@@ -335,7 +364,7 @@ func (c *MariaDBConnector) ExecuteQuery(ctx context.Context, resource *interface
 
 		row := make(map[string]any)
 		for i, col := range columns {
-			row[col] = convertValue(values[i])
+			row[col] = convertValue(values[i], binaryContentColumns[col])
 		}
 		result.Entries = append(result.Entries, row)
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -152,7 +152,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `id`, `key`, `created_at` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
+			"SELECT `id` AS `id`, `key` AS `key`, `created_at` AS `created` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
 			sql)
 	})
 
@@ -163,7 +163,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
-		assert.Equal(t, "SELECT `key`, `created_at` FROM `yanfeng_kb`.`fact` LIMIT 5 OFFSET 0", sql)
+		assert.Equal(t, "SELECT `key` AS `key`, `created_at` AS `created` FROM `yanfeng_kb`.`fact` LIMIT 5 OFFSET 0", sql)
 	})
 
 	t.Run("sort quotes the column and maps to its original name", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `id` FROM `yanfeng_kb`.`fact` ORDER BY `created_at` DESC LIMIT 5 OFFSET 0",
+			"SELECT `id` AS `id` FROM `yanfeng_kb`.`fact` ORDER BY `created_at` DESC LIMIT 5 OFFSET 0",
 			sql)
 	})
 
@@ -206,7 +206,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `content_vector` FROM `yanfeng_kb`.`fact` ORDER BY `content_vector` DESC LIMIT 5 OFFSET 0",
+			"SELECT `content_vector` AS `content_vector` FROM `yanfeng_kb`.`fact` ORDER BY `content_vector` DESC LIMIT 5 OFFSET 0",
 			sql)
 	})
 
@@ -231,7 +231,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `id`, `content_vector` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
+			"SELECT `id` AS `id`, `content_vector` AS `content_vector` FROM `yanfeng_kb`.`fact` LIMIT 10 OFFSET 0",
 			sql)
 	})
 
@@ -246,7 +246,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
+			"SELECT `key` AS `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
 			sql)
 	})
 
@@ -263,7 +263,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `key`, COUNT(`id`) AS `created` FROM `yanfeng_kb`.`fact` GROUP BY `key` "+
+			"SELECT `key` AS `key`, COUNT(`id`) AS `created` FROM `yanfeng_kb`.`fact` GROUP BY `key` "+
 				"ORDER BY `created` DESC LIMIT 20 OFFSET 0",
 			sql)
 	})
@@ -280,7 +280,7 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		sql, _, err := builder.ToSql()
 		require.NoError(t, err)
 		assert.Equal(t,
-			"SELECT `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
+			"SELECT `key` AS `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
 			sql)
 	})
 
@@ -302,8 +302,9 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 
 func TestMariaDBConvertValue(t *testing.T) {
 	t.Run("maria dbconvert value", func(t *testing.T) {
-		assert.Equal(t, "hello", convertValue([]byte("hello")))
-		assert.Equal(t, int64(1), convertValue(int64(1)))
-		assert.Nil(t, convertValue(nil))
+		assert.Equal(t, "hello", convertValue([]byte("hello"), false))
+		assert.Equal(t, []byte("hello"), convertValue([]byte("hello"), true))
+		assert.Equal(t, int64(1), convertValue(int64(1), false))
+		assert.Nil(t, convertValue(nil, false))
 	})
 }

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -122,7 +122,7 @@ func (c *PostgresqlConnector) ExecuteRawSQL(ctx context.Context, sql string) (*i
 
 		row := make(map[string]any)
 		for i, col := range columns {
-			row[col] = convertValue(values[i], col, nil, false)
+			row[col] = convertRawValue(values[i], false)
 		}
 		response.Entries = append(response.Entries, row)
 	}
@@ -155,19 +155,12 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 		return property
 	}
 
-	// Build the origTypeMap in advance to only store the correspondence between column names and primitive types
-	origTypeMap := map[string]string{}
-	if resource.SourceMetadata != nil {
-		if columnsAny, ok := resource.SourceMetadata["columns"].([]any); ok {
-			for _, colAny := range columnsAny {
-				if col, ok := colAny.(map[string]any); ok {
-					if name, ok := col["name"].(string); ok {
-						if origType, ok := col["original_type"].(string); ok {
-							origTypeMap[name] = origType
-						}
-					}
-				}
-			}
+	// Results are always aliased to property names, so retain original types by
+	// the same logical names instead of re-reading source metadata.
+	origTypeMap := make(map[string]string, len(resource.SchemaDefinition))
+	for _, prop := range resource.SchemaDefinition {
+		if prop.OriginalType != "" {
+			origTypeMap[prop.Name] = prop.OriginalType
 		}
 	}
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query.go
@@ -19,15 +19,18 @@ import (
 	"vega-backend/logics/connector/local/table"
 )
 
-func convertRawValue(v any) any {
+func convertRawValue(v any, preserveBinary bool) any {
 	if b, ok := v.([]byte); ok {
+		if preserveBinary {
+			return b
+		}
 		return string(b)
 	}
 	return v
 }
 
 // convertValue converts time values with time zones to the current time zone and handles other types
-func convertValue(v any, colName string, origTypeMap map[string]string) any {
+func convertValue(v any, colName string, origTypeMap map[string]string, preserveBinary bool) any {
 	if v == nil {
 		return nil
 	}
@@ -35,7 +38,7 @@ func convertValue(v any, colName string, origTypeMap map[string]string) any {
 	// Obtain the original type information from origTypeMap
 	origType, ok := origTypeMap[colName]
 	if !ok {
-		return convertRawValue(v)
+		return convertRawValue(v, preserveBinary)
 	}
 
 	// Only time types with time zones need to be converted
@@ -47,7 +50,7 @@ func convertValue(v any, colName string, origTypeMap map[string]string) any {
 	}
 
 	if !needsConversion {
-		return convertRawValue(v)
+		return convertRawValue(v, preserveBinary)
 	}
 
 	// Processing time type
@@ -56,7 +59,7 @@ func convertValue(v any, colName string, origTypeMap map[string]string) any {
 		// Convert to the local time zone
 		return t.Local()
 	default:
-		return convertRawValue(v)
+		return convertRawValue(v, preserveBinary)
 	}
 }
 
@@ -119,7 +122,7 @@ func (c *PostgresqlConnector) ExecuteRawSQL(ctx context.Context, sql string) (*i
 
 		row := make(map[string]any)
 		for i, col := range columns {
-			row[col] = convertValue(values[i], col, nil)
+			row[col] = convertValue(values[i], col, nil, false)
 		}
 		response.Entries = append(response.Entries, row)
 	}
@@ -193,7 +196,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 			selectFields = append(selectFields,
 				c.buildDateFormat(column, groupByItem.CalendarInterval)+" AS "+quoteColumnName(groupByItem.Property))
 		} else {
-			selectFields = append(selectFields, column)
+			selectFields = append(selectFields, column+" AS "+quoteColumnName(groupByItem.Property))
 		}
 	}
 
@@ -222,19 +225,32 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	}
 
 	// If it is not an aggregated query and GROUP BY is not specified, add all fields
+	selectField := func(name string) string {
+		column := quoteColumnName(originalName(name))
+		if prop := fieldMap[name]; prop != nil && prop.Type == interfaces.DataType_Binary {
+			if params.BinaryMode == nil {
+				return "NULL AS " + quoteColumnName(name)
+			}
+			switch *params.BinaryMode {
+			case interfaces.BinaryModeMetadata:
+				return "octet_length(" + column + ") AS " + quoteColumnName(name)
+			case interfaces.BinaryModeContent:
+				return column + " AS " + quoteColumnName(name)
+			default:
+				return "NULL AS " + quoteColumnName(name)
+			}
+		}
+		return column + " AS " + quoteColumnName(name)
+	}
 	if len(params.GroupBy) == 0 && params.Aggregation == nil {
 		if len(params.OutputFields) > 0 {
 			for _, field := range params.OutputFields {
-				if prop, ok := fieldMap[field]; ok {
-					selectFields = append(selectFields, prop.OriginalName)
-				} else {
-					selectFields = append(selectFields, field)
-				}
+				selectFields = append(selectFields, selectField(field))
 			}
 		} else if len(selectFields) == 0 {
 			// If no output field is specified, all fields will be queried
 			for _, prop := range resource.SchemaDefinition {
-				selectFields = append(selectFields, prop.OriginalName)
+				selectFields = append(selectFields, selectField(prop.Name))
 			}
 		}
 	}
@@ -324,6 +340,14 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 	}
 	result.Columns = columns
 
+	binaryContentColumns := map[string]bool{}
+	if params.BinaryMode != nil && *params.BinaryMode == interfaces.BinaryModeContent {
+		for _, prop := range resource.SchemaDefinition {
+			if prop != nil && prop.Type == interfaces.DataType_Binary {
+				binaryContentColumns[prop.Name] = true
+			}
+		}
+	}
 	for rows.Next() {
 		values := make([]any, len(columns))
 		valuePtrs := make([]any, len(columns))
@@ -337,7 +361,7 @@ func (c *PostgresqlConnector) ExecuteQuery(ctx context.Context, resource *interf
 
 		row := make(map[string]any)
 		for i, col := range columns {
-			row[col] = convertValue(values[i], col, origTypeMap)
+			row[col] = convertValue(values[i], col, origTypeMap, binaryContentColumns[col])
 		}
 		result.Entries = append(result.Entries, row)
 	}

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
@@ -103,6 +103,30 @@ func TestPostgresqlConnectorExecuteQueryAliasesGroupByFields(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestPostgresqlConnectorExecuteQueryConvertsAliasedTimezoneField(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	connector := &PostgresqlConnector{db: db, connected: true}
+	resource := &interfaces.Resource{
+		SourceIdentifier: "public.events",
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "createdAt", OriginalName: "created_at", OriginalType: "timestamptz"},
+		},
+	}
+	params := &interfaces.ResourceDataQueryParams{Limit: 1}
+	utc := time.Date(2026, 9, 9, 8, 0, 0, 0, time.UTC)
+	mock.ExpectQuery("SELECT \"created_at\" AS \"createdAt\" FROM \"public\".\"events\" LIMIT 1 OFFSET 0").
+		WillReturnRows(sqlmock.NewRows([]string{"createdAt"}).AddRow(utc))
+
+	result, err := connector.ExecuteQuery(context.Background(), resource, params)
+	require.NoError(t, err)
+	require.Len(t, result.Entries, 1)
+	assert.Equal(t, utc.Local(), result.Entries[0]["createdAt"])
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPostgresqlBuildHavingCondition(t *testing.T) {
 	connector := &PostgresqlConnector{}
 	tests := []struct {

--- a/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/postgresql/postgresql_query_test.go
@@ -74,6 +74,35 @@ func TestPostgresqlConnectorExecuteQueryQuotesCalendarIntervalIdentifiers(t *tes
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestPostgresqlConnectorExecuteQueryAliasesGroupByFields(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	connector := &PostgresqlConnector{db: db, connected: true}
+	resource := &interfaces.Resource{
+		SourceIdentifier: "public.events",
+		SchemaDefinition: []*interfaces.Property{
+			{Name: "groupKey", OriginalName: "group_key"},
+			{Name: "id", OriginalName: "id"},
+		},
+	}
+	params := &interfaces.ResourceDataQueryParams{
+		GroupBy:     []*interfaces.GroupByItem{{Property: "groupKey"}},
+		Aggregation: &interfaces.Aggregation{Property: "id", Aggr: "count"},
+		Limit:       20,
+	}
+	expectedQuery := "SELECT \"group_key\" AS \"groupKey\", COUNT(\"id\") AS \"__value\" " +
+		"FROM \"public\".\"events\" GROUP BY \"group_key\" LIMIT 20 OFFSET 0"
+	mock.ExpectQuery(expectedQuery).
+		WillReturnRows(sqlmock.NewRows([]string{"groupKey", "__value"}).AddRow("priority", 1))
+
+	result, err := connector.ExecuteQuery(context.Background(), resource, params)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"groupKey", "__value"}, result.Columns)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPostgresqlBuildHavingCondition(t *testing.T) {
 	connector := &PostgresqlConnector{}
 	tests := []struct {
@@ -144,14 +173,14 @@ func TestPostgresqlConvertValue(t *testing.T) {
 		utc := time.Date(2026, 7, 9, 8, 0, 0, 0, time.UTC)
 		converted := convertValue(utc, "created_at", map[string]string{
 			"created_at": "timestamptz",
-		})
+		}, false)
 
 		require.IsType(t, time.Time{}, converted)
 		assert.Equal(t, utc.Local(), converted)
-		assert.Equal(t, "hello", convertValue([]byte("hello"), "name", map[string]string{"name": "varchar"}))
-		assert.Equal(t, "hello", convertValue([]byte("hello"), "unknown", map[string]string{}))
-		assert.Equal(t, int64(1), convertValue(int64(1), "count", map[string]string{"count": "int8"}))
-		assert.Nil(t, convertValue(nil, "name", map[string]string{"name": "varchar"}))
+		assert.Equal(t, "hello", convertValue([]byte("hello"), "name", map[string]string{"name": "varchar"}, false))
+		assert.Equal(t, []byte("hello"), convertValue([]byte("hello"), "name", map[string]string{"name": "bytea"}, true))
+		assert.Equal(t, int64(1), convertValue(int64(1), "count", map[string]string{"count": "int8"}, false))
+		assert.Nil(t, convertValue(nil, "name", map[string]string{"name": "varchar"}, false))
 	})
 }
 

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
@@ -3,6 +3,7 @@ package resource_data
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -187,7 +188,7 @@ func (rds *resourceDataService) query(ctx context.Context, resource *interfaces.
 	case interfaces.ResourceCategoryTable:
 		// Only an available managed index may be queried. Stale index names are
 		// retained for diagnostics and must fall back to the source.
-		if interfaces.HasAvailableLocalIndex(resource) {
+		if interfaces.HasAvailableLocalIndex(resource) && !shouldIgnoreLocalIndex(params) {
 			// Call the local index manager to list the build product documentation
 			documents, total, err := rds.lim.ListDocuments(ctx, resource.LocalIndexName, resource, params)
 			if err != nil {
@@ -197,7 +198,7 @@ func (rds *resourceDataService) query(ctx context.Context, resource *interfaces.
 			}
 
 			span.SetStatus(codes.Ok, "")
-			return documents, total, nil
+			return normalizeIndexedUnavailableQueryValues(documents, resource, params), total, nil
 		}
 
 		// Prepare the sort parameter
@@ -218,8 +219,13 @@ func (rds *resourceDataService) query(ctx context.Context, resource *interfaces.
 				WithErrorDetails(err.Error())
 		}
 
+		normalized, normalizeErr := normalizeBinaryQueryValues(data, resource, params)
+		if normalizeErr != nil {
+			return nil, 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, verrors.VegaBackend_Resource_InternalError).
+				WithErrorDetails("binary query result normalization failed")
+		}
 		span.SetStatus(codes.Ok, "")
-		return data, total, nil
+		return normalized, total, nil
 
 	case interfaces.ResourceCategoryIndex:
 		data, total, err := rds.QueryData(ctx, catalog, resource, params)
@@ -278,6 +284,96 @@ func (rds *resourceDataService) query(ctx context.Context, resource *interfaces.
 	}
 }
 
+func normalizeBinaryQueryValues(entries []map[string]any, resource *interfaces.Resource, params *interfaces.ResourceDataQueryParams) ([]map[string]any, error) {
+	if resource == nil {
+		return entries, nil
+	}
+	binaryFields := make([]*interfaces.Property, 0)
+	for _, prop := range resource.SchemaDefinition {
+		if prop.Type == interfaces.DataType_Binary && shouldIncludeOutputField(params, prop.Name) {
+			binaryFields = append(binaryFields, prop)
+		}
+	}
+	binaryMode := ""
+	if params.BinaryMode != nil {
+		binaryMode = *params.BinaryMode
+	}
+	for _, entry := range entries {
+		for _, prop := range binaryFields {
+			value, exists := entry[prop.Name]
+			if binaryMode == "" {
+				entry[prop.Name] = interfaces.ResourceValue{
+					Mode: interfaces.ResourceValueModeNotRequested,
+				}
+				continue
+			}
+			if !exists || value == nil {
+				continue
+			}
+			if binaryMode == interfaces.BinaryModeMetadata {
+				length, ok := value.(int64)
+				if !ok {
+					return nil, fmt.Errorf("binary field %q returned %T byte length", prop.Name, value)
+				}
+				entry[prop.Name] = interfaces.ResourceValue{
+					Mode:       interfaces.ResourceValueModeMetadata,
+					ByteLength: &length,
+				}
+				continue
+			}
+			bytes, ok := value.([]byte)
+			if !ok {
+				return nil, fmt.Errorf("binary field %q returned %T instead of []byte", prop.Name, value)
+			}
+			length := int64(len(bytes))
+			data := base64.StdEncoding.EncodeToString(bytes)
+			entry[prop.Name] = interfaces.ResourceValue{
+				Mode:       interfaces.ResourceValueModeContent,
+				ByteLength: &length,
+				Data:       &data,
+			}
+		}
+	}
+	return entries, nil
+}
+
+func normalizeIndexedUnavailableQueryValues(entries []map[string]any, resource *interfaces.Resource,
+	params *interfaces.ResourceDataQueryParams) []map[string]any {
+	if resource == nil {
+		return entries
+	}
+	unavailableFields := make([]*interfaces.Property, 0)
+	for _, prop := range resource.SchemaDefinition {
+		if (prop.Type == interfaces.DataType_Binary || prop.Type == interfaces.DataType_Other) &&
+			shouldIncludeOutputField(params, prop.Name) {
+			unavailableFields = append(unavailableFields, prop)
+		}
+	}
+	for _, entry := range entries {
+		for _, prop := range unavailableFields {
+			entry[prop.Name] = interfaces.ResourceValue{
+				Mode: interfaces.ResourceValueModeUnavailable,
+			}
+		}
+	}
+	return entries
+}
+
+func shouldIncludeOutputField(params *interfaces.ResourceDataQueryParams, field string) bool {
+	if params == nil {
+		return true
+	}
+	if len(params.OutputFields) == 0 {
+		return !isIndexAggregateQuery(params)
+	}
+	for _, outputField := range params.OutputFields {
+		if outputField == field {
+			return true
+		}
+	}
+	return false
+}
+
 // QueryWithPaging is the sole public resource-data query entrypoint.
 func (rds *resourceDataService) QueryWithPaging(ctx context.Context, resource *interfaces.Resource,
 	params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
@@ -292,18 +388,28 @@ func (rds *resourceDataService) QueryWithPaging(ctx context.Context, resource *i
 		return nil, err
 	}
 	if resource.Category == interfaces.ResourceCategoryLogicView {
-		return rds.lvs.QueryWithPaging(ctx, resource, params)
+		result, err := rds.lvs.QueryWithPaging(ctx, resource, params)
+		if result != nil {
+			result.QuerySource = resourceQuerySource(resource, params)
+		}
+		return result, err
 	}
-	paginationCategory := resourceDataPaginationCategory(resource)
+	paginationCategory := resourceDataPaginationCategory(resource, params)
 	if params.Paging.Cursor != "" {
 		if !resourceDataCursorSupported(resource.Category) {
 			return nil, rest.NewHTTPError(ctx, http.StatusNotImplemented, verrors.VegaBackend_Query_InvalidParameter).
 				WithErrorDetails("cursor paging is not implemented for this resource category")
 		}
-		return querylogic.ExecuteResourceDataCursorContinuation(ctx, accountIDFromContext(ctx), resource, params.Paging.Cursor,
+		querySource := ""
+		result, err := querylogic.ExecuteResourceDataCursorContinuation(ctx, accountIDFromContext(ctx), resource, params.Paging.Cursor,
 			func(pageCtx context.Context, pageParams *interfaces.ResourceDataQueryParams) ([]map[string]any, int64, error) {
+				querySource = resourceQuerySource(resource, pageParams)
 				return rds.query(pageCtx, resource, pageParams)
 			})
+		if result != nil {
+			result.QuerySource = querySource
+		}
+		return result, err
 	}
 	if paginationCategory == interfaces.ResourceCategoryIndex && !isIndexAggregateQuery(params) {
 		limit := params.Paging.EffectiveLimit()
@@ -322,10 +428,16 @@ func (rds *resourceDataService) QueryWithPaging(ctx context.Context, resource *i
 				return nil, rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 					WithErrorDetails("cursor paging does not support index aggregation queries")
 			}
-			return querylogic.ExecuteInitialResourceDataCursorWithCategory(ctx, accountIDFromContext(ctx), resource, paginationCategory, params,
+			querySource := ""
+			result, err := querylogic.ExecuteInitialResourceDataCursorWithCategory(ctx, accountIDFromContext(ctx), resource, paginationCategory, params,
 				func(pageCtx context.Context, pageParams *interfaces.ResourceDataQueryParams) ([]map[string]any, int64, error) {
+					querySource = resourceQuerySource(resource, pageParams)
 					return rds.query(pageCtx, resource, pageParams)
 				})
+			if result != nil {
+				result.QuerySource = querySource
+			}
+			return result, err
 		}
 		return nil, rest.NewHTTPError(ctx, http.StatusNotImplemented, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails("cursor paging is not implemented for this resource category")
@@ -335,23 +447,43 @@ func (rds *resourceDataService) QueryWithPaging(ctx context.Context, resource *i
 	if err != nil {
 		return nil, err
 	}
-	return &interfaces.ResourceDataQueryResult{Entries: entries, TotalCount: total, Paging: &interfaces.PagingResponse{}}, nil
+	return &interfaces.ResourceDataQueryResult{
+		Entries:     entries,
+		TotalCount:  total,
+		Paging:      &interfaces.PagingResponse{},
+		QuerySource: resourceQuerySource(resource, params),
+	}, nil
 }
 
 func isIndexAggregateQuery(params *interfaces.ResourceDataQueryParams) bool {
 	return params.Aggregation != nil || len(params.GroupBy) > 0 || params.Having != nil
 }
 
-func resourceDataPaginationCategory(resource *interfaces.Resource) string {
+func resourceDataPaginationCategory(resource *interfaces.Resource, params *interfaces.ResourceDataQueryParams) string {
 	if resource == nil {
 		return ""
 	}
+	ignoreLocalIndex := shouldIgnoreLocalIndex(params)
 	if resource.Category == interfaces.ResourceCategoryDataset ||
 		resource.Category == interfaces.ResourceCategoryIndex ||
-		(resource.Category == interfaces.ResourceCategoryTable && interfaces.HasAvailableLocalIndex(resource)) {
+		(resource.Category == interfaces.ResourceCategoryTable &&
+			interfaces.HasAvailableLocalIndex(resource) && !ignoreLocalIndex) {
 		return interfaces.ResourceCategoryIndex
 	}
 	return resource.Category
+}
+
+func resourceQuerySource(resource *interfaces.Resource, params *interfaces.ResourceDataQueryParams) string {
+	ignoreLocalIndex := shouldIgnoreLocalIndex(params)
+	if resource != nil && resource.Category == interfaces.ResourceCategoryTable &&
+		interfaces.HasAvailableLocalIndex(resource) && !ignoreLocalIndex {
+		return interfaces.ResourceQuerySourceLocalIndex
+	}
+	return interfaces.ResourceQuerySourceSource
+}
+
+func shouldIgnoreLocalIndex(params *interfaces.ResourceDataQueryParams) bool {
+	return params != nil && params.IgnoreLocalIndex != nil && *params.IgnoreLocalIndex
 }
 
 func resourceDataCursorSupported(category string) bool {

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service.go
@@ -294,19 +294,13 @@ func normalizeBinaryQueryValues(entries []map[string]any, resource *interfaces.R
 			binaryFields = append(binaryFields, prop)
 		}
 	}
-	binaryMode := ""
+	binaryMode := interfaces.BinaryModeMetadata
 	if params.BinaryMode != nil {
 		binaryMode = *params.BinaryMode
 	}
 	for _, entry := range entries {
 		for _, prop := range binaryFields {
 			value, exists := entry[prop.Name]
-			if binaryMode == "" {
-				entry[prop.Name] = interfaces.ResourceValue{
-					Mode: interfaces.ResourceValueModeNotRequested,
-				}
-				continue
-			}
 			if !exists || value == nil {
 				continue
 			}

--- a/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
+++ b/adp/vega/vega-backend/server/logics/resource_data/resource_data_service_test.go
@@ -229,6 +229,8 @@ func TestResourceDataServiceQuery(t *testing.T) {
 			LocalIndexName:   "vega-build-resource-1-task-1",
 			SchemaDefinition: []*interfaces.Property{
 				{Name: "name"},
+				{Name: "blob", Type: interfaces.DataType_Binary},
+				{Name: "native_value", Type: interfaces.DataType_Other},
 			},
 		}
 		params := &interfaces.ResourceDataQueryParams{}
@@ -242,7 +244,43 @@ func TestResourceDataServiceQuery(t *testing.T) {
 		rows, total, err := rds.query(context.Background(), resource, params)
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), total)
-		assert.Equal(t, wantRows, rows)
+		assert.Equal(t, "openbkn", rows[0]["name"])
+		assert.Equal(t, interfaces.ResourceValue{Mode: interfaces.ResourceValueModeUnavailable}, rows[0]["blob"])
+		assert.Equal(t, interfaces.ResourceValue{Mode: interfaces.ResourceValueModeUnavailable}, rows[0]["native_value"])
+	})
+
+	t.Run("force source bypasses local index and returns binary metadata", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockCS := mock_interfaces.NewMockCatalogService(ctrl)
+		mockCF := mock_interfaces.NewMockConnectorFactory(ctrl)
+		mockConn := mock_interfaces.NewMockTableConnector(ctrl)
+		rds := &resourceDataService{cs: mockCS, cf: mockCF}
+		resource := &interfaces.Resource{
+			ID:               "resource-1",
+			Enabled:          true,
+			CatalogID:        "catalog-1",
+			Category:         interfaces.ResourceCategoryTable,
+			LocalIndexStatus: interfaces.ResourceLocalIndexStatusAvailable,
+			LocalIndexName:   "vega-build-resource-1-task-1",
+			SchemaDefinition: []*interfaces.Property{{Name: "blob", Type: interfaces.DataType_Binary}},
+		}
+		ignoreLocalIndex := true
+		binaryMode := interfaces.BinaryModeMetadata
+		params := &interfaces.ResourceDataQueryParams{IgnoreLocalIndex: &ignoreLocalIndex, BinaryMode: &binaryMode}
+
+		mockCS.EXPECT().GetByID(gomock.Any(), "catalog-1", true).
+			Return(&interfaces.Catalog{ID: "catalog-1", Enabled: true}, nil)
+		mockCF.EXPECT().CreateConnectorInstance(gomock.Any(), gomock.Any(), gomock.Any()).Return(mockConn, nil)
+		mockConn.EXPECT().Connect(gomock.Any()).Return(nil)
+		mockConn.EXPECT().Close(gomock.Any()).Return(nil)
+		mockConn.EXPECT().ExecuteQuery(gomock.Any(), resource, params).
+			Return(&interfaces.QueryResult{Entries: []map[string]any{{"blob": int64(12)}}, Total: 1}, nil)
+
+		rows, total, err := rds.query(context.Background(), resource, params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), total)
+		length := int64(12)
+		assert.Equal(t, interfaces.ResourceValue{Mode: interfaces.ResourceValueModeMetadata, ByteLength: &length}, rows[0]["blob"])
 	})
 
 	t.Run("query dataset builds actual filter condition and delegates", func(t *testing.T) {
@@ -330,6 +368,41 @@ func TestResourceDataServiceQuery(t *testing.T) {
 	})
 }
 
+func TestNormalizeResourceValuesRespectOutputFields(t *testing.T) {
+	resource := &interfaces.Resource{SchemaDefinition: []*interfaces.Property{
+		{Name: "id", Type: interfaces.DataType_Integer},
+		{Name: "blob", Type: interfaces.DataType_Binary},
+		{Name: "native_value", Type: interfaces.DataType_Other},
+	}}
+	params := &interfaces.ResourceDataQueryParams{OutputFields: []string{"id"}}
+
+	sourceRows := []map[string]any{{"id": int64(1)}}
+	normalizedSourceRows, err := normalizeBinaryQueryValues(sourceRows, resource, params)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"id": int64(1)}, normalizedSourceRows[0])
+
+	indexedRows := normalizeIndexedUnavailableQueryValues([]map[string]any{{"id": int64(1)}}, resource, params)
+	assert.Equal(t, map[string]any{"id": int64(1)}, indexedRows[0])
+}
+
+func TestNormalizeResourceValuesDoesNotAddFieldsToAggregateResults(t *testing.T) {
+	resource := &interfaces.Resource{SchemaDefinition: []*interfaces.Property{
+		{Name: "blob", Type: interfaces.DataType_Binary},
+		{Name: "native_value", Type: interfaces.DataType_Other},
+	}}
+	params := &interfaces.ResourceDataQueryParams{
+		Aggregation: &interfaces.Aggregation{Property: "id", Aggr: "count"},
+	}
+
+	sourceRows := []map[string]any{{"__value": int64(1)}}
+	normalizedSourceRows, err := normalizeBinaryQueryValues(sourceRows, resource, params)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]any{"__value": int64(1)}, normalizedSourceRows[0])
+
+	indexedRows := normalizeIndexedUnavailableQueryValues([]map[string]any{{"__value": int64(1)}}, resource, params)
+	assert.Equal(t, map[string]any{"__value": int64(1)}, indexedRows[0])
+}
+
 func TestResourceDataServiceRejectsIndexAggregationCursor(t *testing.T) {
 	rds := &resourceDataService{}
 	_, err := rds.QueryWithPaging(interfaces.WithTrustedProxyRead(context.Background()), &interfaces.Resource{
@@ -364,7 +437,7 @@ func TestResourceDataPaginationCategoryUsesPhysicalEngine(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, resourceDataPaginationCategory(tt.resource))
+			assert.Equal(t, tt.want, resourceDataPaginationCategory(tt.resource, &interfaces.ResourceDataQueryParams{}))
 		})
 	}
 }

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -394,8 +394,7 @@ components:
         entries:
           description: |
             文档条目。Binary 或无法索引的字段可返回 `ResourceValue`：`unavailable` 表示该字段
-            不在本地索引中；`not_requested` 表示未请求 Binary 值；`metadata` / `content` 分别表示
-            Binary 长度或 Base64 内容。
+            不在本地索引中；`metadata` / `content` 分别表示 Binary 长度或 Base64 内容。
           type: array
           items:
             $ref: "#/components/schemas/Document"
@@ -417,7 +416,7 @@ components:
       properties:
         mode:
           type: string
-          enum: [unavailable, not_requested, metadata, content]
+          enum: [unavailable, metadata, content]
         byte_length:
           description: Binary 字段的字节长度。
           type: integer

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -315,6 +315,19 @@ components:
           type: array
           items:
             type: string
+        binary_mode:
+          description: |
+            Binary 字段的返回形式。省略时不读取 Binary 值，字段值返回
+            `{ "mode": "not_requested" }`；`metadata` 返回字节长度；`content` 返回
+            Base64 编码内容与字节长度。cursor 续页不得重复传递。
+          type: string
+          enum: [metadata, content]
+        ignore_local_index:
+          description: |
+            是否跳过可用的本地索引并查询表的原始数据源；默认 `false`。仅对 table resource
+            生效。cursor 续页不得重复传递。
+          type: boolean
+          default: false
         need_total:
           description: 是否在响应里携带 total_count。cursor 首次请求的值会被冻结；续页携带的值被忽略。
           type: boolean
@@ -374,8 +387,15 @@ components:
       required:
         - entries
       properties:
+        query_source:
+          description: 本次查询实际使用的数据路径。`local_index` 表示 table 的本地索引；`source` 表示未使用该本地索引。
+          type: string
+          enum: [local_index, source]
         entries:
-          description: 文档条目
+          description: |
+            文档条目。Binary 或无法索引的字段可返回 `ResourceValue`：`unavailable` 表示该字段
+            不在本地索引中；`not_requested` 表示未请求 Binary 值；`metadata` / `content` 分别表示
+            Binary 长度或 Base64 内容。
           type: array
           items:
             $ref: "#/components/schemas/Document"
@@ -390,6 +410,20 @@ components:
           type: array
           items:
             type: string
+    ResourceValue:
+      description: Binary 或无法索引字段的特殊值表示。
+      type: object
+      required: [mode]
+      properties:
+        mode:
+          type: string
+          enum: [unavailable, not_requested, metadata, content]
+        byte_length:
+          description: Binary 字段的字节长度。
+          type: integer
+          format: int64
+        data:
+          description: 字段内容；Binary 内容为 Base64 编码字符串。
     PagingRequest:
       description: 首次请求使用 offset 和 limit；cursor 续页以 cursor 定位，need_total 可携带但不会覆盖首次请求冻结值，其余查询参数不得重传。
       type: object

--- a/docs/api/vega/resource-data.yaml
+++ b/docs/api/vega/resource-data.yaml
@@ -317,11 +317,11 @@ components:
             type: string
         binary_mode:
           description: |
-            Binary 字段的返回形式。省略时不读取 Binary 值，字段值返回
-            `{ "mode": "not_requested" }`；`metadata` 返回字节长度；`content` 返回
+            Binary 字段的返回形式。省略时按 `metadata` 处理并返回字节长度；`content` 返回
             Base64 编码内容与字节长度。cursor 续页不得重复传递。
           type: string
           enum: [metadata, content]
+          default: metadata
         ignore_local_index:
           description: |
             是否跳过可用的本地索引并查询表的原始数据源；默认 `false`。仅对 table resource


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Add safe Binary response modes and source/index provenance.
- [x] Prevent Binary/Other fields from unsafe local-index, grouping, and aggregation outputs.
- [x] Update the resource-data API contract and regression tests.

---

## Why

- Related Issue: [Issue #566](https://github.com/openbkn-ai/bkn-studio/issues/566)
- Related Feature: Safe Binary and Other field handling in resource preview.
- Background: Avoid implicit large Binary reads while keeping an explicit source-backed preview path.

Closes openbkn-ai/bkn-studio#566

---

## How

- Key implementation points: Add `binary_mode` and `ignore_local_index`; normalize unavailable, metadata, and content values consistently across MariaDB, PostgreSQL, and local-index results.
- Breaking changes (API, config, database, etc.): Additive query and response fields; Dataset schema validation rejects Binary and Other fields.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `make ci`
- `make api-docs-lint`

---

## Risk & Rollback

- Potential risks: Clients must explicitly request Binary content; default responses omit it.
- Rollback plan: Revert commit `7aa1344ef`.

---

## Additional Notes

- Paired with the bkn-studio preview UX PR.