### PR TITLE
feat(authz): require knowledge network action execution

### DIFF
--- a/adp/bkn/ontology-query/README.md
+++ b/adp/bkn/ontology-query/README.md
@@ -189,6 +189,7 @@ infrastructure failures return HTTP 503.
 When authentication is enabled, both submission and the real external invocation
 require all of the following for the authenticated execution subject:
 
+- `execute` on `knowledge_network:{kn_id}`;
 - `execute` on `action_type:{kn_id}/{action_type_id}`; this operation never
   inherits from the knowledge network;
 - `execute` on the referenced `tool_box` or `mcp` resource;

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization.go
@@ -69,11 +69,18 @@ func (s *actionSchedulerService) resolveActionPermissionRequirements(ctx context
 		return nil, actionPermissionInvalid(ctx, err.Error())
 	}
 
-	requirements := []interfaces.PermissionRequirement{{
-		ResourceType: interfaces.PermissionResourceTypeActionType,
-		ResourceID:   knID + "/" + actionType.ATID,
-		Operation:    interfaces.PermissionOperationExecute,
-	}}
+	requirements := []interfaces.PermissionRequirement{
+		{
+			ResourceType: interfaces.PermissionResourceTypeKnowledgeNetwork,
+			ResourceID:   knID,
+			Operation:    interfaces.PermissionOperationExecute,
+		},
+		{
+			ResourceType: interfaces.PermissionResourceTypeActionType,
+			ResourceID:   knID + "/" + actionType.ATID,
+			Operation:    interfaces.PermissionOperationExecute,
+		},
+	}
 	objectTypeIDs := []string{actionType.ObjectTypeID}
 	if actionType.Affect != nil {
 		objectTypeIDs = append(objectTypeIDs, actionType.Affect.ObjectTypeID)

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization_test.go
@@ -96,6 +96,7 @@ func TestAuthorizeActionTypeResolvesTrustedRequirements(t *testing.T) {
 	}
 	want := []interfaces.PermissionRequirement{
 		{ResourceType: "action_type", ResourceID: "kn-1/at-1", Operation: "execute"},
+		{ResourceType: "knowledge_network", ResourceID: "kn-1", Operation: "execute"},
 		{ResourceType: "object_type", ResourceID: "kn-1/ot-input", Operation: "query_data"},
 		{ResourceType: "object_type", ResourceID: "kn-1/ot-output", Operation: "query_data"},
 	}
@@ -124,8 +125,12 @@ func TestExecuteActionChecksPermissionsBeforeInstanceData(t *testing.T) {
 	if !errors.Is(err, permissionErr) || resp != nil {
 		t.Fatalf("ExecuteAction() = %#v, %v; want permission error before data access", resp, err)
 	}
-	if len(permissions.requirements) != 1 {
-		t.Fatalf("checked requirements = %#v", permissions.requirements)
+	want := []interfaces.PermissionRequirement{
+		{ResourceType: "action_type", ResourceID: "kn-1/at-1", Operation: "execute"},
+		{ResourceType: "knowledge_network", ResourceID: "kn-1", Operation: "execute"},
+	}
+	if !reflect.DeepEqual(permissions.requirements, want) {
+		t.Fatalf("checked requirements = %#v, want %#v", permissions.requirements, want)
 	}
 }
 

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -92,7 +92,8 @@
         {"id": "delete", "name": "删除"},
         {"id": "query_data", "name": "数据查询"},
         {"id": "authorize", "name": "授权"},
-        {"id": "task_manage", "name": "任务管理"}
+        {"id": "task_manage", "name": "任务管理"},
+        {"id": "execute", "name": "执行"}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -488,6 +488,27 @@ func TestCatalogResourceOperationSplit(t *testing.T) {
 	}
 }
 
+func TestKnowledgeNetworkDeclaresExecuteOperation(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	var count int64
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "knowledge_network", "execute").
+		Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("knowledge_network execute operation count = %d, want 1", count)
+	}
+}
+
 // network_builder has type-wide create only. Every operation on an existing KN
 // comes from a concrete instance grant written by the owning service.
 func TestNetworkBuilderOnlyCreatesKnowledgeNetworksTypeWide(t *testing.T) {

--- a/docs/api/knowledge-network-authorization.md
+++ b/docs/api/knowledge-network-authorization.md
@@ -69,7 +69,7 @@ concrete `action_type:{kn_id}/{action_type_id}` resource.
 | Modify child | `modify` on the canonical child |
 | Delete child | `delete` on every target; a batch is all-or-nothing |
 | Query object, relation, metric, or action data | `query_data` on every dependency resolved from the published model |
-| Submit or invoke an action | action-type `execute` AND execution-resource `execute` AND all data dependencies `query_data` |
+| Submit or invoke an action | knowledge-network `execute` AND action-type `execute` AND execution-resource `execute` AND all data dependencies `query_data` |
 | Manage action schedules or tasks | `task_manage` on the applicable action type or knowledge network |
 
 An action execution stores the authenticated execution subject. The worker


### PR DESCRIPTION
# Knowledge Network Execute Permission

## What Changed

- [x] bkn-safe permission catalog
  - Added `execute` to the `knowledge_network` resource type.
  - Added a seed regression test for `knowledge_network:execute`.
- [x] ontology-query action execution authorization
  - Requires `knowledge_network:{kn_id}:execute` when submitting an action execution.
  - Rechecks the same permission before the asynchronous external invocation.
  - Preserves existing action-type, execution-resource, and data-dependency checks.
- [x] Documentation
  - Updated the shared authorization contract and ontology-query README.

---

## Why

- Related Issue: N/A
- Related Feature: Knowledge network action execution authorization
- Background:
  - Action execution needs a knowledge-network-level permission switch in addition to the existing action-type-level permission.
  - Administrators must be able to grant or revoke execution access for an entire knowledge network.

---

## How

- Key implementation points:
  - Registered `knowledge_network:execute` in the bkn-safe resource catalog.
  - Added the knowledge-network requirement to the immutable action-execution permission snapshot.
  - The snapshot is checked both at submission time and immediately before external invocation.
  - No built-in role receives this permission by default.
- Breaking changes:
  - When authentication is enabled, existing users who execute actions must be granted `knowledge_network:{kn_id}:execute` in addition to their existing permissions.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not run
- [ ] Verified in test environment — not performed

Test notes:

- Passed:
  - `go test ./internal/seed -run TestKnowledgeNetworkDeclaresExecuteOperation -count=1`
  - `I18N_MODE_UT=true go test ./logics/action_scheduler -run 'TestAuthorizeActionTypeResolvesTrustedRequirements|TestExecuteActionChecksPermissionsBeforeInstanceData' -count=1`

---

## Risk & Rollback

- Potential risks:
  - Existing action execution requests will be denied until the caller has the new knowledge-network `execute` grant.
- Rollback plan:
  - Revert commit `184f0de46`.

---

## Additional Notes

- Existing `action_type:execute`, tool/MCP `execute`, and object-type `query_data` checks remain required.
- This PR intentionally does not add the new permission to built-in roles.