### PR TITLE
fix(context-loader): attach only the receipt fields a caller reads to MCP results

### DIFF
--- a/adp/context-loader/agent-retrieval/TRACE.md
+++ b/adp/context-loader/agent-retrieval/TRACE.md
@@ -51,7 +51,7 @@ Different transports preserve the native shape of the business response, so Rece
 | --- | --- | --- |
 | REST is executed normally for the first time | Response headers `bkn-receipt-id`, `bkn-operation-id` | The business response body remains unchanged; the caller uses the ID to query the complete Receipt |
 | REST terminal replay or pending | JSON response body field `receipt` | The downstream will no longer be executed and the persistent state will be returned |
-| MCP executes normally | `structuredContent.bkn_receipt` | Returned together with tool structured results |
+| MCP executes normally | `structuredContent.bkn_receipt` | Returned together with tool structured results as a projection: `receipt_status`, `evidence_durability`, `observed_evidence_refs`, `business_refs`, plus `partial_reasons` when set. The complete Receipt stays in Core |
 | MCP terminal replay or pending | `receipt` field of text content JSON | The downstream is no longer executed and the persistent state is returned; the error result does not carry `structuredContent` |
 
 `receipt_status` indicates whether the business Attempt has been completed, and `evidence_durability` indicates whether the evidence has received Core durable ACK. The two cannot be mixed:

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/lifecycle_adapter_test.go
@@ -576,8 +576,8 @@ func TestLifecycleMiddlewareFinalizesRealAdapterFailures(t *testing.T) {
 				t.Fatalf("downstream failure was not preserved: %#v", result)
 			}
 			structured := result.StructuredContent.(map[string]any)
-			receipt, ok := structured["bkn_receipt"].(bkntrace.Receipt)
-			if !ok || receipt.ReceiptStatus != "failed" {
+			receipt, ok := structured["bkn_receipt"].(map[string]any)
+			if !ok || receipt["receipt_status"] != "failed" {
 				t.Fatalf("real adapter did not return failed receipt: %#v", structured)
 			}
 		})

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard.go
@@ -187,10 +187,42 @@ func guardBusinessToolCallWithCompletion(
 			return result, nil
 		}
 		if completed != nil {
-			attachReceipt(result, completed.Receipt)
+			attachReceipt(result, agentReceiptView(completed.Receipt))
 		}
 		return result, nil
 	}
+}
+
+// agentReceiptFields are the receipt fields a caller reads off a managed tool result.
+//
+// The registered lifecycle tools take no receipt or operation id, so the only consumer is the
+// agent-side evidence recorder, which keys on status, durability and the evidence references.
+var agentReceiptFields = []string{
+	"receipt_status", "evidence_durability", "observed_evidence_refs", "business_refs",
+}
+
+// agentReceiptView trims the durable receipt to what a caller reads off a tool result.
+//
+// Core's receipt carries the whole lifecycle record -- owner, request and trace ids, row version,
+// timestamps -- and every managed call echoed all of it into the agent's context, several hundred
+// bytes per call that nothing read. partial_reasons is the one field the agent itself must see, so
+// it survives whenever Core set it. A receipt that cannot be read as a JSON object is passed
+// through untouched rather than lost.
+func agentReceiptView(receipt any) any {
+	payload, ok := structuredContentAsMap(receipt)
+	if !ok {
+		return receipt
+	}
+	view := make(map[string]any, len(agentReceiptFields)+1)
+	for _, field := range agentReceiptFields {
+		if value, present := payload[field]; present {
+			view[field] = value
+		}
+	}
+	if reasons, ok := payload["partial_reasons"].([]any); ok && len(reasons) > 0 {
+		view["partial_reasons"] = reasons
+	}
+	return view
 }
 
 func managedOperationKey(

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/session_guard_test.go
@@ -561,6 +561,122 @@ func TestSessionGuardKeepsDeclaredToolShapeWhenAttachingReceipt(t *testing.T) {
 	}
 }
 
+// TestSessionGuardAttachesOnlyTheReceiptFieldsACallerReads pins the projection of the receipt.
+//
+// Core's receipt carries the whole lifecycle record, and every managed call used to echo all of it
+// into the agent's context. Nothing on the caller side reads the owner, request and trace ids,
+// row version or timestamps: the registered lifecycle tools take no receipt id, and the agent-side
+// evidence recorder keys on status, durability and the evidence references alone.
+func TestSessionGuardAttachesOnlyTheReceiptFieldsACallerReads(t *testing.T) {
+	durable := bkntrace.Receipt{
+		ReceiptID:            "rcpt_1",
+		SchemaVersion:        "3.0.0",
+		Owner:                bkntrace.Owner{ApplicationPrincipalID: "app-1", EffectiveSubjectID: "user-1"},
+		ConversationID:       "conv-1",
+		InteractionID:        "int-1",
+		OperationID:          "op-1",
+		Attempt:              1,
+		OperationKey:         "mcp:abc",
+		ToolName:             "run_sql",
+		ReceiptStatus:        "completed",
+		EvidenceDurability:   "durable",
+		Required:             true,
+		RequestID:            "req-1",
+		TraceID:              strings.Repeat("a", 32),
+		CausationEventIDs:    []string{},
+		ObservedEvidenceRefs: []string{"evt_1"},
+		BusinessRefs: []bkntrace.BusinessRef{{
+			RefType: "data_resource", RefID: "resource:r1", Version: "unversioned",
+		}},
+		ArtifactRefs:   []string{},
+		PartialReasons: []string{},
+	}
+	guarded := guardBusinessToolCallWithCompletion(
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			return &operationResult{
+				Created: true, Execute: true,
+				Operation: map[string]any{"operation_id": "op-1", "attempt": float64(1)},
+				Receipt:   map[string]any{"receipt_id": "rcpt_1", "receipt_status": "pending"},
+			}, nil, nil
+		},
+		func(_ context.Context, ensured *operationResult, _ *mcpsdk.CallToolResult) (*operationResult, *lifecycleError, error) {
+			return &operationResult{Operation: ensured.Operation, Receipt: durable}, nil, nil
+		},
+		nil,
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"answer": "ok"}, `{"answer":"ok"}`), nil
+		},
+	)
+
+	result, err := guarded(context.Background(), validBusinessToolRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	structured := result.StructuredContent.(map[string]any)
+	receipt, ok := structured["bkn_receipt"].(map[string]any)
+	if !ok {
+		t.Fatalf("receipt is not a JSON object: %#v", structured["bkn_receipt"])
+	}
+	if len(receipt) != 4 {
+		t.Fatalf("projection leaked fields no caller reads: %#v", receipt)
+	}
+	if receipt["receipt_status"] != "completed" || receipt["evidence_durability"] != "durable" {
+		t.Fatalf("status or durability dropped by the projection: %#v", receipt)
+	}
+	if refs, ok := receipt["observed_evidence_refs"].([]any); !ok || len(refs) != 1 || refs[0] != "evt_1" {
+		t.Fatalf("observed_evidence_refs dropped by the projection: %#v", receipt)
+	}
+	// The agent-side recorder reads ref_type, ref_id and version off each business reference.
+	businessRefs, ok := receipt["business_refs"].([]any)
+	if !ok || len(businessRefs) != 1 {
+		t.Fatalf("business_refs dropped by the projection: %#v", receipt)
+	}
+	ref := businessRefs[0].(map[string]any)
+	if ref["ref_type"] != "data_resource" || ref["ref_id"] != "resource:r1" || ref["version"] != "unversioned" {
+		t.Fatalf("business reference reshaped by the projection: %#v", ref)
+	}
+}
+
+// TestSessionGuardKeepsPartialReasonsOnTheReceipt: a partial result is the one piece of the
+// receipt the agent itself must read, so it survives the projection whenever Core sets it.
+func TestSessionGuardKeepsPartialReasonsOnTheReceipt(t *testing.T) {
+	guarded := guardBusinessToolCallWithCompletion(
+		func(context.Context, operationIntent) (*operationResult, *lifecycleError, error) {
+			return &operationResult{
+				Created: true, Execute: true,
+				Operation: map[string]any{"operation_id": "op-1", "attempt": float64(1)},
+				Receipt:   map[string]any{"receipt_id": "rcpt_1", "receipt_status": "pending"},
+			}, nil, nil
+		},
+		func(_ context.Context, ensured *operationResult, _ *mcpsdk.CallToolResult) (*operationResult, *lifecycleError, error) {
+			return &operationResult{
+				Operation: ensured.Operation,
+				Receipt: bkntrace.Receipt{
+					ReceiptID: "rcpt_1", ReceiptStatus: "completed", EvidenceDurability: "pending",
+					PartialReasons: []string{"evidence_ack_pending"},
+				},
+			}, nil, nil
+		},
+		nil,
+		func(context.Context, mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, error) {
+			return mcpsdk.NewToolResultStructured(map[string]any{"answer": "ok"}, `{"answer":"ok"}`), nil
+		},
+	)
+
+	result, err := guarded(context.Background(), validBusinessToolRequest())
+	if err != nil {
+		t.Fatalf("guard returned protocol error: %v", err)
+	}
+	receipt := result.StructuredContent.(map[string]any)["bkn_receipt"].(map[string]any)
+	reasons, ok := receipt["partial_reasons"].([]any)
+	if !ok || len(reasons) != 1 || reasons[0] != "evidence_ack_pending" {
+		t.Fatalf("partial_reasons dropped by the projection: %#v", receipt)
+	}
+	if _, leaked := receipt["receipt_id"]; leaked {
+		t.Fatalf("projection leaked a field no caller reads: %#v", receipt)
+	}
+}
+
 func TestSessionGuardPreservesBusinessResultWhenTerminalTraceWriteFails(t *testing.T) {
 	businessResult := mcpsdk.NewToolResultStructured(
 		map[string]any{"answer": "ok", "rows": []any{map[string]any{"material_code": "101-000015"}}},


### PR DESCRIPTION
Target: `release/0.1.4-yf`. Not yet on `main`; the same commit cherry-picks onto `main` cleanly.

## Problem

Every managed MCP call echoed Core's complete durable receipt into the tool result under `bkn_receipt`: owner, request and trace ids, operation key, row version, timestamps — 22 fields, roughly 900 bytes per call, that nothing on the caller side reads.

- The registered lifecycle tools are `bkn_start_interaction` and `bkn_finish_interaction` only (`lifecycleToolNames`); neither takes a receipt or operation id, so the agent has no tool that consumes `receipt_id` / `operation_id`.
- The agent-side evidence recorder (`infra/bkn-agent/app/evidence.py`, MCP receipt branch) keys on `receipt_status`, `evidence_durability`, `observed_evidence_refs` and `business_refs` alone.

## Fix

- `agentReceiptView` projects the receipt to those four fields, plus `partial_reasons` whenever Core set it. `attachReceipt` attaches the projection; the tool's own payload shape is untouched (#1387 behaviour preserved).
- A receipt that cannot be read as a JSON object passes through untouched rather than being lost.
- The terminal replay (`receipt_terminal`) and pending (`receipt_pending`) error paths are unchanged: they still carry the full receipt.
- `TRACE.md` §4 documents the projection.

## Testing

- `go test ./...` in `adp/context-loader/agent-retrieval` — 27 packages, pass.
- New tests: `TestSessionGuardAttachesOnlyTheReceiptFieldsACallerReads` (real `bkntrace.Receipt` struct in, exactly four fields out, `business_refs` entries keep `ref_type`/`ref_id`/`version`), `TestSessionGuardKeepsPartialReasonsOnTheReceipt` (non-empty `partial_reasons` survives, `receipt_id` does not). Both red before the fix.
- `lifecycle_adapter_test.go` real-adapter failure case updated: the receipt is now a JSON object, asserted on `receipt_status`.
- Live on test server 14.103.77.23 (binary hot-swapped, then rolled back to the previous image): `list_knowledge_networks` with a declared `data_resource` ref returned
  `{"business_refs":[{"ref_id":"resource:…","ref_type":"data_resource","version":"unversioned"}],"evidence_durability":"durable","observed_evidence_refs":[],"receipt_status":"completed"}`
  where the same call before the swap returned the 22-field receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
