### PR TITLE
fix(authz): align network builder role permissions

### DIFF
--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -130,37 +130,14 @@
       "role_name": "network_builder",
       "resource_type": "catalog",
       "id_pattern": "*",
-      "_note": "无 authorize:同 knowledge_network 的理由。casbin keyMatch 下 catalog:* 匹配任意目录,构建者会在别人建的目录上也拿到转授权,而 authorize 只能由管理员收回。创建者不受影响 —— vega 建目录时把 COMMON_OPERATIONS(含 authorize)写成 catalog:<id> 的对象授权。",
-      "operations": ["view_detail", "create", "modify", "delete", "task_manage", "resource_manage", "query_data"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "resource",
-      "id_pattern": "*",
-      "operations": ["view_detail", "query_data"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "connector_type",
-      "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage"]
+      "operations": ["view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
       "role_name": "network_builder",
       "resource_type": "knowledge_network",
       "id_pattern": "*",
-      "_note": "network_builder only holds type-wide create; all operations on an existing KN come from concrete instance grants.",
-      "operations": ["create"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "stream_data_pipeline",
-      "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "authorize"]
+      "operations": ["view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
@@ -189,39 +166,6 @@
       "resource_type": "tool_box",
       "id_pattern": "*",
       "operations": ["create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "small_model",
-      "id_pattern": "*",
-      "operations": ["create", "display", "modify", "delete", "execute"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "large_model",
-      "id_pattern": "*",
-      "operations": ["create", "display", "modify", "delete", "execute"]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "agent",
-      "id_pattern": "*",
-      "operations": [
-        "use", "publish", "unpublish", "unpublish_other_user_agent",
-        "publish_to_be_skill_agent", "publish_to_be_web_sdk_agent",
-        "publish_to_be_api_agent", "publish_to_be_data_flow_agent",
-        "create_system_agent", "mgnt_built_in_agent", "see_trajectory_analysis"
-      ]
-    },
-    {
-      "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",
-      "role_name": "network_builder",
-      "resource_type": "agent_tpl",
-      "id_pattern": "*",
-      "operations": ["publish", "unpublish", "unpublish_other_user_agent_tpl"]
     }
   ]
 }

--- a/bkn-safe/server/internal/seed/data/roles.json
+++ b/bkn-safe/server/internal/seed/data/roles.json
@@ -3,5 +3,5 @@
   {"id": "d2bd2082-ad03-11e8-aa06-000c29358ad6", "name": "admin", "description": "系统管理员：系统运行维护、用户 / 部门基础管理", "source": "system"},
   {"id": "d8998f72-ad03-11e8-aa06-000c29358ad6", "name": "security", "description": "安全管理员：角色管理、授权管理、账号安全管理", "source": "system"},
   {"id": "def246f2-ad03-11e8-aa06-000c29358ad6", "name": "audit", "description": "审计管理员：审计日志、权限配置审查、管理行为监督", "source": "system"},
-  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "network_builder", "description": "业务网络构建者：数据连接、数据目录、知识网络、模型资源、执行工厂的业务建设", "source": "business"}
+  {"id": "1572fb82-526f-11f0-bde6-e674ec8dde71", "name": "network_builder", "description": "负责数据、知识和执行工厂资产的业务网络构建者。", "source": "business"}
 ]

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -32,25 +32,25 @@ func TestRoleResourceMatrix(t *testing.T) {
 	// a representative, granted op per resource type (positive case uses these).
 	repOp := map[string]string{
 		"agent": "use", "agent_tpl": "publish",
-		"stream_data_pipeline": "create", "catalog": "create",
+		"stream_data_pipeline": "create", "catalog": "authorize",
 		// 数据表上不再有 create/modify/delete：建表判目录的 resource_manage，
 		// 改删判这张表再回落到目录（#801）。
 		"resource":       "view_detail",
-		"connector_type": "create", "knowledge_network": "create",
+		"connector_type": "create", "data_flow": "view", "knowledge_network": "execute",
 		"concept_group": "view_detail", "object_type": "query_data", "relation_type": "query_data",
 		"action_type": "execute", "metric": "query_data", "risk_type": "view_detail",
 		"tool_box": "execute", "mcp": "execute", "operator": "execute", "skill": "execute",
-		"small_model": "execute",
-	}
-	networkBuilderAllowed := make(map[string]string, len(repOp))
-	for resourceType, operation := range repOp {
-		networkBuilderAllowed[resourceType] = operation
-	}
-	for _, childType := range []string{"concept_group", "object_type", "relation_type", "action_type", "metric", "risk_type"} {
-		delete(networkBuilderAllowed, childType)
+		"small_model": "execute", "large_model": "execute",
 	}
 	roleAllowed := map[string]map[string]string{
-		networkBuilder: networkBuilderAllowed,
+		networkBuilder: {
+			"catalog":           "authorize",
+			"knowledge_network": "execute",
+			"operator":          "execute",
+			"tool_box":          "execute",
+			"skill":             "execute",
+			"mcp":               "execute",
+		},
 	}
 	allTypes := make([]string, 0, len(repOp))
 	for tpe := range repOp {

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -5,6 +5,7 @@
 package seed
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -60,6 +61,13 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		if r.Name != name {
 			t.Errorf("role %s name = %q, want %q", id, r.Name, name)
 		}
+	}
+	var networkBuilder model.Role
+	if err := db.First(&networkBuilder, "id = ?", "1572fb82-526f-11f0-bde6-e674ec8dde71").Error; err != nil {
+		t.Fatal(err)
+	}
+	if networkBuilder.Description != "负责数据、知识和执行工厂资产的业务网络构建者。" {
+		t.Errorf("network_builder description = %q", networkBuilder.Description)
 	}
 
 	// agent and Studio admin resource types + their operations seeded.
@@ -509,9 +517,7 @@ func TestKnowledgeNetworkDeclaresExecuteOperation(t *testing.T) {
 	}
 }
 
-// network_builder has type-wide create only. Every operation on an existing KN
-// comes from a concrete instance grant written by the owning service.
-func TestNetworkBuilderOnlyCreatesKnowledgeNetworksTypeWide(t *testing.T) {
+func TestNetworkBuilderManagesKnowledgeNetworksTypeWide(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -528,47 +534,18 @@ func TestNetworkBuilderOnlyCreatesKnowledgeNetworksTypeWide(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ok, err := e.Check(builder, "knowledge_network", network, "create"); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Error("network_builder must retain type-wide knowledge_network/create")
-	}
-	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize", "task_manage"} {
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"} {
 		ok, err := e.Check(builder, "knowledge_network", network, op)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if ok {
-			t.Errorf("network_builder must not hold type-wide knowledge_network/%s", op)
-		}
-	}
-
-	// The creator's own grant is untouched: existing-network authority comes
-	// from this instance-level path.
-	const creator = "u-creator"
-	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize", "task_manage"} {
-		if err := e.GrantObjectPermission(creator, "knowledge_network", network, op); err != nil {
-			t.Fatal(err)
-		}
-		if ok, err := e.Check(creator, "knowledge_network", network, op); err != nil {
-			t.Fatal(err)
-		} else if !ok {
-			t.Errorf("creator's object-level knowledge_network/%s grant must be effective", op)
+		if !ok {
+			t.Errorf("network_builder lost type-wide knowledge_network/%s", op)
 		}
 	}
 }
 
-// The same rule as knowledge networks, arrived at the same way: a type-wide
-// `authorize` on catalog let every network_builder hand out a catalog somebody
-// else created, because casbin's keyMatch makes `catalog:*` match every id.
-// Observed on a live deployment — an account whose only role is network_builder
-// saw the share control on catalogs created by the administrator, and the write
-// behind it succeeded.
-//
-// The creator is unaffected: vega writes COMMON_OPERATIONS, `authorize`
-// included, as a `catalog:<id>` object grant at create time, and the owner
-// surface reads exactly that.
-func TestNetworkBuilderCannotShareCatalogsItDidNotCreate(t *testing.T) {
+func TestNetworkBuilderManagesCatalogsTypeWide(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -585,30 +562,44 @@ func TestNetworkBuilderCannotShareCatalogsItDidNotCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if ok, err := e.Check(builder, "catalog", catalog, "authorize"); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Error("network_builder must not hold type-wide authorize on catalogs")
-	}
-
-	// Everything else the role needs to run the business plane stays.
-	for _, op := range []string{"view_detail", "create", "modify", "delete", "task_manage", "resource_manage", "query_data"} {
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"} {
 		ok, err := e.Check(builder, "catalog", catalog, op)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !ok {
-			t.Errorf("network_builder lost %q on catalog", op)
+			t.Errorf("network_builder lost type-wide catalog/%s", op)
 		}
 	}
+}
 
-	// A catalog the builder created carries the grant on the instance instead.
-	if err := e.GrantObjectPermission(builder, "catalog", "cat-mine", "authorize"); err != nil {
+func TestNetworkBuilderPermissionMatrixMatchesBusinessBuilderRole(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if ok, err := e.Check(builder, "catalog", "cat-mine", "authorize"); err != nil {
+	if err := Apply(db, e); err != nil {
 		t.Fatal(err)
-	} else if !ok {
-		t.Error("the creator's own object grant must still authorize sharing")
+	}
+
+	grants, err := e.RolePermissions("1572fb82-526f-11f0-bde6-e674ec8dde71")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make(map[string][]string, len(grants))
+	for _, grant := range grants {
+		got[grant.Object] = grant.Operations
+	}
+	want := map[string][]string{
+		"catalog:*":           {"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"},
+		"knowledge_network:*": {"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"},
+		"operator:*":          {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
+		"tool_box:*":          {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
+		"skill:*":             {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
+		"mcp:*":               {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("network_builder grants = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 更新内置 `network_builder` 角色权限，使其与已确认的业务网络构建者权限集合一致：
  - `catalog:*`
  - `knowledge_network:*`
  - `operator:*`
  - `tool_box:*`
  - `skill:*`
  - `mcp:*`
- [x] 为 `catalog` 补充 `authorize`，为 `knowledge_network` 补充管理操作及 `execute`。
- [x] 移除 `resource`、`connector_type`、`stream_data_pipeline`、`data_flow`、`small_model`、`large_model`、`agent`、`agent_tpl` 等不属于该角色目标范围的类型级授权。
- [x] 更新 `network_builder` 描述为“负责数据、知识和执行工厂资产的业务网络构建者。”
- [x] 更新角色资源矩阵测试，并新增完整权限集合回归测试，防止后续误扩权或遗漏权限。
- [ ] Docs/doc 1（不涉及用户文档或 API 文档）

---

## Why

- Related Issue: N/A
- Related Feature: 内置业务网络构建者角色权限对齐
- Background:

  当前内置 `network_builder` 的权限集合与已确认的业务角色定义不一致：一方面缺少知识网络执行及目录授权等业务操作；另一方面仍包含连接器、流式管道、模型、Agent 等不应由该角色承担的资源类型。

  本次将内置角色 ID `1572fb82-526f-11f0-bde6-e674ec8dde71` 的权限调整为确认后的六类资产权限集合，保持角色 ID 与成员绑定不变。

---

## How

- Key implementation points:
  - 修改 `bkn-safe/server/internal/seed/data/grants.json` 中内置 `network_builder` 的种子授权。
  - 修改 `roles.json` 中该内置角色的描述。
  - 调整 `matrix_test.go`，仅允许该角色访问确认后的六类资源；其余资源类型维持拒绝断言。
  - 在 `seed_test.go` 中校验角色描述、目录与知识网络的类型级操作，并精确校验完整授权矩阵。
  - 此次将原分支中的两笔提交压缩为一个独立提交，避免旧分支提交历史导致的 GitHub 问题。

- Breaking changes (API, config, database, etc.):
  - 不涉及 API、数据库 schema 或配置项变更。
  - 当部署启用 `seed_on_start=true` 时，升级重启会重新协调内置角色的 Casbin policy：
    - 已绑定 `network_builder` 的成员关系保持不变；
    - 自定义角色和对象级授权不受此种子文件修改影响；
    - 该内置角色会新增对任意目录/知识网络的类型级管理与授权能力；
    - 同时失去上述已移除资源类型的类型级权限。
  - 若 `seed_on_start=false`，仅升级代码不会自动变更既有策略，需要按部署策略显式执行种子同步。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本次未执行）
- [ ] Verified in test environment（待验证）

Test notes:

```bash
cd bkn-safe/server
go test ./internal/seed -count=1