### PR TITLE
feat(bkn-safe): mount property grant management route

### DIFF
--- a/bkn-safe/server/extension/permdata/management.go
+++ b/bkn-safe/server/extension/permdata/management.go
@@ -1,0 +1,142 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permdata
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/propertyaccess"
+)
+
+// UserGrantAuthority distinguishes unrestricted platform authorization
+// administrators from callers delegated through authorize on one object type.
+type UserGrantAuthority struct {
+	Allowed      bool
+	Unrestricted bool
+}
+
+// ManagementServices is the core-owned authorization surface used by the
+// Enterprise property-grant manager. Implementations must return effective,
+// base-clamped property levels; returning sparse extension levels directly
+// would let a delegated caller grant more than they hold.
+type ManagementServices interface {
+	AuthorizeUserGrants(ctx context.Context, operatorID, objectTypeRef string) (UserGrantAuthority, error)
+	AuthorizePlatformRoleGrants(ctx context.Context, operatorID string) (bool, error)
+	EffectivePropertyLevels(ctx context.Context, operatorID, objectTypeRef string, propertyNames []string) (map[string]propertyaccess.Level, error)
+}
+
+// OperatorIDResolver reads the authenticated operator attached by MountManagement.
+// The identity is never accepted from query or request-body data.
+type OperatorIDResolver func(*http.Request) (string, bool)
+
+// ManagementHandlerFactory builds the private Enterprise business handler.
+// Core owns the public path, methods, entitlement gate, authentication and
+// account-state middleware; the factory owns only management behavior.
+type ManagementHandlerFactory func(services ManagementServices, operatorID OperatorIDResolver) http.Handler
+
+var (
+	managementFactory    ManagementHandlerFactory
+	managementMinEdition licverify.Edition
+	managementFrozen     bool
+)
+
+// RegisterManagementHandler installs the Enterprise management handler. The
+// property resolver must be registered first and both surfaces must declare the
+// same minimum edition so one capability cannot be only partially available.
+func RegisterManagementHandler(min licverify.Edition, factory ManagementHandlerFactory) {
+	if factory == nil {
+		panic("permdata: RegisterManagementHandler(nil)")
+	}
+	if managementFrozen {
+		panic("permdata: RegisterManagementHandler after management routes were mounted")
+	}
+	if managementFactory != nil {
+		panic("permdata: management handler already registered")
+	}
+	if load() == nil || minEdition == "" {
+		panic("permdata: property resolver must be registered before the management handler")
+	}
+	if min != minEdition {
+		panic("permdata: management handler and resolver must use the same minimum edition")
+	}
+	entitlement.MustBeAssembling("permdata management")
+	managementFactory = factory
+	managementMinEdition = min
+}
+
+// ManagementGate hides the registered management path when the live licence
+// is below Enterprise. Its response intentionally matches gin's unmounted
+// route byte for byte so an unauthenticated probe cannot distinguish an
+// unlicensed Enterprise binary from Community.
+func ManagementGate() gin.HandlerFunc {
+	min := managementMinEdition
+	if min == "" {
+		return func(c *gin.Context) { c.Next() }
+	}
+	return func(c *gin.Context) {
+		if entitlement.AtLeast(min) {
+			c.Next()
+			return
+		}
+		slog.Info("permdata: management route hidden, licence below the required tier",
+			"capability", Capability,
+			"min_edition", string(min),
+			"edition", string(entitlement.Current()),
+			"method", c.Request.Method,
+			"path", c.Request.URL.Path)
+		c.Abort()
+		c.Data(http.StatusNotFound, gin.MIMEPlain, []byte("404 page not found"))
+	}
+}
+
+type operatorContextKey struct{}
+
+func operatorIDFromRequest(request *http.Request) (string, bool) {
+	operatorID, ok := request.Context().Value(operatorContextKey{}).(string)
+	return operatorID, ok && operatorID != ""
+}
+
+// MountManagement mounts the core-owned management path when an Enterprise
+// handler was registered. resolveOperator bridges the authenticated gin
+// identity into the standard-library request received by the EE handler.
+func MountManagement(
+	group *gin.RouterGroup,
+	services ManagementServices,
+	resolveOperator func(*gin.Context) (string, bool),
+) bool {
+	managementFrozen = true
+	if managementFactory == nil {
+		return false
+	}
+	if group == nil || services == nil || resolveOperator == nil {
+		panic("permdata: incomplete management route dependencies")
+	}
+	handler := managementFactory(services, operatorIDFromRequest)
+	if handler == nil {
+		panic("permdata: management handler factory returned nil")
+	}
+	serve := func(c *gin.Context) {
+		request := c.Request
+		if operatorID, ok := resolveOperator(c); ok {
+			request = request.WithContext(context.WithValue(request.Context(), operatorContextKey{}, operatorID))
+		}
+		handler.ServeHTTP(c.Writer, request)
+	}
+	group.GET("/property-grants", serve)
+	group.PATCH("/property-grants", serve)
+	return true
+}
+
+func resetManagement() {
+	managementFactory = nil
+	managementMinEdition = ""
+	managementFrozen = false
+}

--- a/bkn-safe/server/extension/permdata/management_test.go
+++ b/bkn-safe/server/extension/permdata/management_test.go
@@ -1,0 +1,165 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permdata
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/propertyaccess"
+)
+
+type managementServicesStub struct{}
+
+func (managementServicesStub) AuthorizeUserGrants(context.Context, string, string) (UserGrantAuthority, error) {
+	return UserGrantAuthority{Allowed: true, Unrestricted: true}, nil
+}
+
+func (managementServicesStub) AuthorizePlatformRoleGrants(context.Context, string) (bool, error) {
+	return true, nil
+}
+
+func (managementServicesStub) EffectivePropertyLevels(context.Context, string, string, []string) (map[string]propertyaccess.Level, error) {
+	return map[string]propertyaccess.Level{}, nil
+}
+
+func registerManagementTestHandler(t *testing.T) {
+	t.Helper()
+	Register(licverify.EditionEnterprise, &fakeResolver{})
+	RegisterManagementHandler(licverify.EditionEnterprise, func(_ ManagementServices, operatorID OperatorIDResolver) http.Handler {
+		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			operator, ok := operatorID(request)
+			if !ok {
+				http.Error(response, "missing operator", http.StatusUnauthorized)
+				return
+			}
+			response.Header().Set("X-Operator-ID", operator)
+			response.WriteHeader(http.StatusNoContent)
+		})
+	})
+}
+
+func managementRouter(t *testing.T, withEnterpriseHandler bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	ResetForTest()
+	if withEnterpriseHandler {
+		registerManagementTestHandler(t)
+	}
+	router := gin.New()
+	group := router.Group("/api/safe/v1/admin", ManagementGate())
+	MountManagement(group, managementServicesStub{}, func(*gin.Context) (string, bool) {
+		return "operator-1", true
+	})
+	return router
+}
+
+type managementWireResponse struct {
+	status int
+	header http.Header
+	body   string
+}
+
+func serveManagement(t *testing.T, router *gin.Engine) managementWireResponse {
+	t.Helper()
+	server := httptest.NewServer(router)
+	defer server.Close()
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/api/safe/v1/admin/property-grants", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := server.Client().Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := response.Header.Clone()
+	header.Del("Date")
+	return managementWireResponse{status: response.StatusCode, header: header, body: string(body)}
+}
+
+func TestUnlicensedManagementResponseMatchesCommunity(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+	t.Cleanup(func() {
+		ResetForTest()
+		entitlement.ResetForTest()
+	})
+	community := serveManagement(t, managementRouter(t, false))
+	enterprise := serveManagement(t, managementRouter(t, true))
+
+	if community.status != http.StatusNotFound {
+		t.Fatalf("community status = %d, want 404", community.status)
+	}
+	if enterprise.status != community.status || enterprise.body != community.body {
+		t.Fatalf("enterprise response = %d %q, community = %d %q",
+			enterprise.status, enterprise.body, community.status, community.body)
+	}
+	for key, values := range community.header {
+		if strings.Join(enterprise.header.Values(key), ",") != strings.Join(values, ",") {
+			t.Fatalf("header %s = %v, community = %v", key, enterprise.header.Values(key), values)
+		}
+	}
+	for key, values := range enterprise.header {
+		if _, exists := community.header[key]; !exists {
+			t.Fatalf("enterprise response has extra header %s=%v", key, values)
+		}
+	}
+}
+
+func TestLicensedManagementRouteReceivesAuthenticatedOperator(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	t.Cleanup(func() {
+		ResetForTest()
+		entitlement.ResetForTest()
+	})
+	router := managementRouter(t, true)
+	request := httptest.NewRequest(http.MethodGet, "/api/safe/v1/admin/property-grants", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", response.Code, response.Body.String())
+	}
+	if operator := response.Header().Get("X-Operator-ID"); operator != "operator-1" {
+		t.Fatalf("operator = %q, want operator-1", operator)
+	}
+}
+
+func TestManagementRegistrationRequiresMatchingResolver(t *testing.T) {
+	setEdition(t, licverify.EditionEnterprise)
+	assertPanics := func(name string, call func()) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("expected panic")
+				}
+			}()
+			call()
+		})
+	}
+	assertPanics("resolver missing", func() {
+		RegisterManagementHandler(licverify.EditionEnterprise, func(ManagementServices, OperatorIDResolver) http.Handler {
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		})
+	})
+	Register(licverify.EditionEnterprise, &fakeResolver{})
+	assertPanics("edition mismatch", func() {
+		RegisterManagementHandler(licverify.EditionProfessional, func(ManagementServices, OperatorIDResolver) http.Handler {
+			return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+		})
+	})
+}

--- a/bkn-safe/server/extension/permdata/permdata.go
+++ b/bkn-safe/server/extension/permdata/permdata.go
@@ -254,4 +254,5 @@ func load() Resolver {
 func reset() {
 	implementation = atomic.Value{}
 	minEdition = ""
+	resetManagement()
 }

--- a/bkn-safe/server/internal/httpapi/propertygrant_route_test.go
+++ b/bkn-safe/server/internal/httpapi/propertygrant_route_test.go
@@ -1,0 +1,133 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permdata"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+)
+
+type routePropertyResolver struct{}
+
+func (routePropertyResolver) Resolve(context.Context, permdata.Request) (permdata.Resolution, error) {
+	return permdata.Resolution{}, nil
+}
+
+func propertyGrantRouter(t *testing.T, register bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	enforcer, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	permdata.ResetForTest()
+	if register {
+		permdata.Register(licverify.EditionEnterprise, routePropertyResolver{})
+		permdata.RegisterManagementHandler(licverify.EditionEnterprise, func(
+			_ permdata.ManagementServices,
+			operatorID permdata.OperatorIDResolver,
+		) http.Handler {
+			return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+				operator, ok := operatorID(request)
+				if !ok {
+					response.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				response.Header().Set("X-Operator-ID", operator)
+				response.WriteHeader(http.StatusNoContent)
+			})
+		})
+	}
+	if err := db.Create(&model.User{ID: "operator-1", Account: "operator-1", Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	return New(Deps{
+		Enforcer: enforcer, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
+		TokenVerifier: stubVerifier{},
+	})
+}
+
+func TestPropertyGrantGateRunsBeforeAuthentication(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+	t.Cleanup(func() {
+		permdata.ResetForTest()
+		entitlement.ResetForTest()
+	})
+	type wireResponse struct {
+		status int
+		header http.Header
+		body   string
+	}
+	probe := func(router *gin.Engine) wireResponse {
+		server := httptest.NewServer(router)
+		defer server.Close()
+		response, err := server.Client().Get(server.URL + "/api/safe/v1/admin/property-grants")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer response.Body.Close()
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		header := response.Header.Clone()
+		header.Del("Date")
+		return wireResponse{status: response.StatusCode, header: header, body: string(body)}
+	}
+	community := probe(propertyGrantRouter(t, false))
+	enterprise := probe(propertyGrantRouter(t, true))
+	if enterprise.status != community.status || enterprise.body != community.body ||
+		!reflect.DeepEqual(enterprise.header, community.header) {
+		t.Fatalf("unauthenticated probe distinguishes unavailable Enterprise route:\nenterprise=%d %q headers=%v\ncommunity=%d %q headers=%v",
+			enterprise.status, enterprise.body, enterprise.header,
+			community.status, community.body, community.header)
+	}
+	if enterprise.status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", enterprise.status)
+	}
+}
+
+func TestLicensedPropertyGrantRouteAuthenticatesAndBridgesOperator(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	t.Cleanup(func() {
+		permdata.ResetForTest()
+		entitlement.ResetForTest()
+	})
+	router := propertyGrantRouter(t, true)
+	request := httptest.NewRequest(http.MethodGet, "/api/safe/v1/admin/property-grants", nil)
+	request.Header.Set("Authorization", "Bearer operator-1")
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", response.Code, response.Body.String())
+	}
+	if operator := response.Header().Get("X-Operator-ID"); operator != "operator-1" {
+		t.Fatalf("operator = %q, want operator-1", operator)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/propertygrant_svc.go
+++ b/bkn-safe/server/internal/httpapi/propertygrant_svc.go
@@ -76,7 +76,7 @@ func (services *propertyGrantManagementServices) EffectivePropertyLevels(
 		AccessorID: operatorID,
 		Items: []permdata.RequestItem{{
 			ObjectTypeRef: objectTypeRef,
-			Properties:    append([]string(nil), propertyNames...),
+			Properties:    uniqueStrings(propertyNames),
 			BaseLevel:     basePropertyLevel(operations),
 		}},
 	})

--- a/bkn-safe/server/internal/httpapi/propertygrant_svc.go
+++ b/bkn-safe/server/internal/httpapi/propertygrant_svc.go
@@ -1,0 +1,91 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permdata"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/propertyaccess"
+)
+
+type propertyGrantManagementServices struct {
+	enforcer *authz.Enforcer
+}
+
+func newPropertyGrantManagementServices(enforcer *authz.Enforcer) permdata.ManagementServices {
+	return &propertyGrantManagementServices{enforcer: enforcer}
+}
+
+// AuthorizeUserGrants gives platform authorization administrators an
+// unrestricted path and object-type authorizers a delegated, ceiling-limited
+// path. The EE manager applies that ceiling before changing any row.
+func (services *propertyGrantManagementServices) AuthorizeUserGrants(
+	ctx context.Context,
+	operatorID, objectTypeRef string,
+) (permdata.UserGrantAuthority, error) {
+	canGrant, err := services.enforcer.Check(operatorID, "admin-authz", "*", "grant")
+	if err != nil {
+		return permdata.UserGrantAuthority{}, err
+	}
+	canRevoke, err := services.enforcer.Check(operatorID, "admin-authz", "*", "revoke")
+	if err != nil {
+		return permdata.UserGrantAuthority{}, err
+	}
+	if canGrant && canRevoke {
+		return permdata.UserGrantAuthority{Allowed: true, Unrestricted: true}, nil
+	}
+	allowed, err := services.enforcer.Check(operatorID, "object_type", objectTypeRef, opAuthorize)
+	if err != nil {
+		return permdata.UserGrantAuthority{}, err
+	}
+	return permdata.UserGrantAuthority{Allowed: allowed}, nil
+}
+
+// AuthorizePlatformRoleGrants requires the platform role-permission point.
+// Object-level authorize is intentionally insufficient because changing a role
+// can affect users outside the current object owner's delegation scope.
+func (services *propertyGrantManagementServices) AuthorizePlatformRoleGrants(
+	ctx context.Context,
+	operatorID string,
+) (bool, error) {
+	return services.enforcer.Check(operatorID, "admin-role", "*", "permissions")
+}
+
+// EffectivePropertyLevels resolves the operator through the same base-level
+// clamp and Enterprise property resolver used by runtime data exits.
+func (services *propertyGrantManagementServices) EffectivePropertyLevels(
+	ctx context.Context,
+	operatorID, objectTypeRef string,
+	propertyNames []string,
+) (map[string]propertyaccess.Level, error) {
+	allowed, err := services.enforcer.FilterResourceOps(operatorID,
+		[]authz.ResourceRef{{Type: "object_type", ID: objectTypeRef}}, nil,
+		[]string{"view_detail", "query_data"})
+	if err != nil {
+		return nil, err
+	}
+	var operations []string
+	if len(allowed) == 1 {
+		operations = allowed[0].Operations
+	}
+	response, err := permdata.Resolve(ctx, permdata.Request{
+		AccessorID: operatorID,
+		Items: []permdata.RequestItem{{
+			ObjectTypeRef: objectTypeRef,
+			Properties:    append([]string(nil), propertyNames...),
+			BaseLevel:     basePropertyLevel(operations),
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	levels := make(map[string]propertyaccess.Level, len(propertyNames))
+	for _, property := range response.Entries[0].Properties {
+		levels[property.Name] = property.Level
+	}
+	return levels, nil
+}

--- a/bkn-safe/server/internal/httpapi/propertygrant_svc_test.go
+++ b/bkn-safe/server/internal/httpapi/propertygrant_svc_test.go
@@ -1,0 +1,117 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permdata"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/propertyaccess"
+)
+
+func newPropertyGrantServicesForTest(t *testing.T) (*propertyGrantManagementServices, *authz.Enforcer) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	enforcer, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &propertyGrantManagementServices{enforcer: enforcer}, enforcer
+}
+
+func TestPropertyGrantManagementAuthoritySeparatesPlatformAndObjectScopes(t *testing.T) {
+	services, enforcer := newPropertyGrantServicesForTest(t)
+	if err := enforcer.GrantObjectPermission("security-admin", "admin-authz", "*", "grant"); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("security-admin", "admin-authz", "*", "revoke"); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("grant-only", "admin-authz", "*", "grant"); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("owner", "object_type", "kn-1/customer", opAuthorize); err != nil {
+		t.Fatal(err)
+	}
+	if err := enforcer.GrantObjectPermission("role-admin", "admin-role", "*", "permissions"); err != nil {
+		t.Fatal(err)
+	}
+
+	platform, err := services.AuthorizeUserGrants(t.Context(), "security-admin", "kn-1/customer")
+	if err != nil || !platform.Allowed || !platform.Unrestricted {
+		t.Fatalf("platform authority = %+v, err=%v", platform, err)
+	}
+	grantOnly, err := services.AuthorizeUserGrants(t.Context(), "grant-only", "kn-1/customer")
+	if err != nil || grantOnly.Allowed {
+		t.Fatalf("grant-only authority = %+v, err=%v", grantOnly, err)
+	}
+	owner, err := services.AuthorizeUserGrants(t.Context(), "owner", "kn-1/customer")
+	if err != nil || !owner.Allowed || owner.Unrestricted {
+		t.Fatalf("owner authority = %+v, err=%v", owner, err)
+	}
+	other, err := services.AuthorizeUserGrants(t.Context(), "owner", "kn-1/order")
+	if err != nil || other.Allowed {
+		t.Fatalf("other-object authority = %+v, err=%v", other, err)
+	}
+	roleAllowed, err := services.AuthorizePlatformRoleGrants(t.Context(), "role-admin")
+	if err != nil || !roleAllowed {
+		t.Fatalf("role admin allowed = %v, err=%v", roleAllowed, err)
+	}
+	ownerRoleAllowed, err := services.AuthorizePlatformRoleGrants(t.Context(), "owner")
+	if err != nil || ownerRoleAllowed {
+		t.Fatalf("object owner role authority = %v, err=%v", ownerRoleAllowed, err)
+	}
+}
+
+type effectiveLevelResolver struct{}
+
+func (effectiveLevelResolver) Resolve(_ context.Context, request permdata.Request) (permdata.Resolution, error) {
+	return permdata.Resolution{Entries: []permdata.ResolutionEntry{{
+		ObjectTypeRef: request.Items[0].ObjectTypeRef,
+		Properties: []permdata.ResolvedProperty{
+			{Name: request.Items[0].Properties[0], Level: propertyaccess.Full, Explicit: true},
+			{Name: request.Items[0].Properties[1], Level: propertyaccess.Masked, Explicit: true},
+		},
+	}}}, nil
+}
+
+func TestEffectivePropertyLevelsUsesRuntimeBaseClamp(t *testing.T) {
+	services, enforcer := newPropertyGrantServicesForTest(t)
+	if err := enforcer.GrantObjectPermission("owner", "object_type", "kn-1/customer", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	permdata.ResetForTest()
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	t.Cleanup(func() {
+		permdata.ResetForTest()
+		entitlement.ResetForTest()
+	})
+	permdata.Register(licverify.EditionEnterprise, effectiveLevelResolver{})
+
+	levels, err := services.EffectivePropertyLevels(t.Context(), "owner", "kn-1/customer", []string{"name", "mobile"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if levels["name"] != propertyaccess.Schema {
+		t.Fatalf("name level = %s, want schema (full extension level clamped by base)", levels["name"])
+	}
+	if levels["mobile"] != propertyaccess.Schema {
+		t.Fatalf("mobile level = %s, want schema (masked extension level clamped by base)", levels["mobile"])
+	}
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -17,6 +17,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permdata"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
@@ -169,6 +170,22 @@ func New(deps Deps) *gin.Engine {
 		}
 		if adminwrite.Mount(gatedAdmin, newAdminWriteServices(deps.Enforcer, deps.DB)) {
 			slog.Info("rbac_basic admin write routes mounted (enterprise build)")
+		}
+		// Property-grant management deliberately does not reuse gatedAdmin:
+		// callers holding authorize on this concrete object type may manage user
+		// restrictions without being platform administrators. The Enterprise
+		// gate still runs first, before authentication, so an unavailable paid
+		// surface is indistinguishable from Community's unmounted route.
+		propertyGrantAdmin := r.Group("/api/safe/v1/admin", permdata.ManagementGate(),
+			sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier), RequireActiveAccount(deps.DB))
+		if deps.Audit != nil {
+			propertyGrantAdmin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
+		}
+		if permdata.MountManagement(propertyGrantAdmin, newPropertyGrantManagementServices(deps.Enforcer), func(c *gin.Context) (string, bool) {
+			operatorID := c.GetString(ctxAccessorID)
+			return operatorID, operatorID != ""
+		}) {
+			slog.Info("property-grant management routes mounted (enterprise build)")
 		}
 		// Global AppKey oversight: list/revoke any user's keys.
 		if apiKeys != nil {

--- a/docs/api/bkn-safe/property-grants.yaml
+++ b/docs/api/bkn-safe/property-grants.yaml
@@ -1,0 +1,237 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+info:
+  title: BKN Safe Enterprise Property Grant Management API
+  version: 0.1.0
+  description: |
+    Manages sparse property-level restrictions for one user or role on one
+    object type. This surface is mounted only when the Enterprise
+    `perm_object_level` capability is assembled and licensed.
+
+    A platform authorization administrator may manage user grants without a
+    property ceiling. A caller holding `authorize` on the concrete object type
+    may manage user grants only up to their own effective, base-clamped level.
+    Role targets require the platform `admin-role:permissions` permission.
+servers:
+  - url: /api/safe/v1/admin
+security:
+  - BearerAuth: []
+paths:
+  /property-grants:
+    get:
+      tags: [Property grants]
+      operationId: listPropertyGrants
+      summary: List explicit property grants for one subject and object type
+      parameters:
+        - $ref: '#/components/parameters/AccessorType'
+        - $ref: '#/components/parameters/AccessorID'
+        - $ref: '#/components/parameters/ObjectTypeRef'
+      responses:
+        '200':
+          description: Explicit sparse grants, including expired entries
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GrantSnapshot'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '401':
+          description: Missing or invalid bearer token
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Capability is not assembled or the live licence is below Enterprise
+        '500':
+          $ref: '#/components/responses/InternalError'
+    patch:
+      tags: [Property grants]
+      operationId: patchPropertyGrants
+      summary: Apply an atomic batch of sparse property-grant changes
+      description: |
+        Every change describes the complete desired explicit row for one
+        property. `inherit` deletes that row. Omitted expiry and source metadata
+        are cleared. The batch and its audit records commit in one transaction.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchRequest'
+      responses:
+        '200':
+          description: Updated explicit grant snapshot and number of changed rows
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/GrantSnapshot'
+                  - type: object
+                    required: [changed]
+                    properties:
+                      changed:
+                        type: integer
+                        minimum: 0
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '401':
+          description: Missing or invalid bearer token
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: Capability is not assembled or the live licence is below Enterprise
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  parameters:
+    AccessorType:
+      name: accessor_type
+      in: query
+      required: true
+      schema:
+        type: string
+        enum: [user, role]
+    AccessorID:
+      name: accessor_id
+      in: query
+      required: true
+      schema:
+        type: string
+        minLength: 1
+        maxLength: 128
+    ObjectTypeRef:
+      name: object_type_ref
+      in: query
+      required: true
+      description: Canonical `<knowledge-network-id>/<object-type-id>` reference
+      schema:
+        type: string
+        pattern: '^[a-z0-9][a-z0-9_-]{0,39}/[a-z0-9][a-z0-9_-]{0,39}$'
+  schemas:
+    Subject:
+      type: object
+      required: [type, id]
+      additionalProperties: false
+      properties:
+        type:
+          type: string
+          enum: [user, role]
+        id:
+          type: string
+          minLength: 1
+          maxLength: 128
+    StoredLevel:
+      type: string
+      enum: [none, schema, masked, full]
+    ChangeLevel:
+      type: string
+      enum: [inherit, none, schema, masked, full]
+    GrantEntry:
+      type: object
+      required: [property_name, level, created_at, updated_at]
+      properties:
+        property_name:
+          type: string
+        level:
+          $ref: '#/components/schemas/StoredLevel'
+        expires_at:
+          type: string
+          format: date-time
+        source:
+          type: string
+        source_ref:
+          type: string
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    GrantSnapshot:
+      type: object
+      required: [accessor, object_type_ref, entries]
+      properties:
+        accessor:
+          $ref: '#/components/schemas/Subject'
+        object_type_ref:
+          type: string
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/GrantEntry'
+    GrantChange:
+      type: object
+      required: [property_name, level]
+      additionalProperties: false
+      properties:
+        property_name:
+          type: string
+        level:
+          $ref: '#/components/schemas/ChangeLevel'
+        expires_at:
+          type: string
+          format: date-time
+        source:
+          type: string
+          maxLength: 64
+        source_ref:
+          type: string
+          maxLength: 256
+    PatchRequest:
+      type: object
+      required: [accessor, object_type_ref, reason, changes]
+      additionalProperties: false
+      properties:
+        accessor:
+          $ref: '#/components/schemas/Subject'
+        object_type_ref:
+          type: string
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 512
+        changes:
+          type: array
+          minItems: 1
+          maxItems: 200
+          items:
+            $ref: '#/components/schemas/GrantChange'
+    ManagementError:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+            message:
+              type: string
+  responses:
+    InvalidRequest:
+      description: Invalid target, JSON body, change, expiry, or batch shape
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ManagementError'
+    Forbidden:
+      description: Caller lacks platform authority or object-type delegation
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ManagementError'
+    InternalError:
+      description: Property-grant management failed without committing a partial batch
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ManagementError'
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/docs/api/bkn-safe/property-grants.yaml
+++ b/docs/api/bkn-safe/property-grants.yaml
@@ -187,7 +187,9 @@ components:
       additionalProperties: false
       properties:
         accessor:
-          $ref: '#/components/schemas/Subject'
+        object_type_ref:
+          type: string
+          pattern: '^[a-z0-9][a-z0-9_-]{0,39}/[a-z0-9][a-z0-9_-]{0,39}$'
         object_type_ref:
           type: string
         reason:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added the core-owned Enterprise route socket for `GET|PATCH /api/safe/v1/admin/property-grants`.
- [x] Added platform and delegated object-type authorization adapters with effective property-level ceilings.
- [x] Added route parity, authorization, clamping, and registration regression tests.
- [x] Added the OpenAPI contract for property-grant management.

---

## Why

- Related Issue: [openbkn-ai/bkn-foundry#1314](https://github.com/openbkn-ai/bkn-foundry/issues/1314)
- Related Feature: [openbkn-ai/bkn-studio#571](https://github.com/openbkn-ai/bkn-studio/issues/571)
- Background: The Enterprise property-grant manager and HTTP handler already exist in `openbkn-ee`, but the public route intentionally remained unavailable until core provided an authenticated, licence-gated route socket. Studio currently receives a native 404 when loading property grants.

---

## How

- Key implementation points:
  - Core owns the external path and GET/PATCH method registration.
  - The Enterprise gate runs before cache, authentication, active-account, and audit middleware and reproduces Community's unmounted-route response when unavailable.
  - User grants allow either a platform authorization administrator holding both `admin-authz:grant` and `admin-authz:revoke`, or a delegated caller holding `authorize` on the concrete object type.
  - Delegated changes are capped by the caller's effective property levels after the normal object-type base clamp.
  - Role targets require `admin-role:permissions`.
  - Community builds register no management handler, so the route remains absent.
- Breaking changes (API, config, database, etc.): None. This adds a new gated endpoint and does not change existing request or response contracts.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `GOWORK=/tmp/codex-property-grants-work/go.work go test ./extension/permdata ./internal/httpapi`
- `GOWORK=/tmp/codex-property-grants-work/go.work go vet ./extension/permdata ./internal/httpapi`
- `redocly lint docs/api/bkn-safe/property-grants.yaml`
- Full repository tests were not run; verification was intentionally scoped to the affected bkn-safe packages.

---

## Risk & Rollback

- Potential risks: Incorrect middleware order could expose a distinguishable paid route, and incorrect delegated authorization could allow grants above the caller's effective property level. Regression tests cover both boundaries.
- Rollback plan: Revert this commit. Community behavior and all existing authorization routes are otherwise unchanged.

---

## Additional Notes

- The corresponding `openbkn-ee` PR will register the existing Enterprise management handler through this socket and update its core dependency.
- This PR references the authorization epic rather than closing it because the epic contains additional work beyond this route.
