### PR TITLE
fix(context-loader): let _display carry the display property's own type

### DIFF
--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/get_logic_properties_values.json
@@ -65,8 +65,8 @@
           "type": "object",
           "properties": {
             "_display": {
-              "type": "string",
-              "description": "给人看的展示名，由服务端按对象类的展示字段挑出。"
+              "type": ["string", "number", "boolean", "null"],
+              "description": "给人看的展示名，由服务端按对象类的展示字段挑出；类型随展示字段而变（数值、布尔或日期等字符串），该行展示字段为空时为 null。"
             },
             "_instance_id": {
               "type": "string",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/locales/en-US/schema_descriptions.json
@@ -63,7 +63,7 @@
     "input_schema.properties.additional_context.description": "Optional extra context for resolving ambiguous logic properties.",
     "input_schema.properties.llm_model.description": "Optional LLM model override for property resolution.",
     "output_schema.properties.datas.description": "Resolved logic property values.",
-    "output_schema.properties.datas.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type.",
+    "output_schema.properties.datas.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type. Its type follows that display property (a number, a boolean, or a string such as a date) and it is null when the row's display field is empty.",
     "output_schema.properties.datas.items.properties._instance_id.description": "Globally unique instance id, usable directly with query_instance_subgraph.",
     "output_schema.properties.datas.items.properties._instance_identity.description": "The field values that form the primary key of this instance",
     "output_schema.properties.datas.items.description": "Every other key is a property name of that object type and varies with it. Read data_properties from get_object_types or search_schema first; do not guess from the field semantics."
@@ -130,7 +130,7 @@
     "input_schema.properties.relation_type_paths.items.properties.relation_types.items.properties.target_object_type_id.description": "Target object type id for the relation.",
     "input_schema.properties.relation_type_paths.items.properties.limit.description": "Maximum subgraph results for this path.",
     "output_schema.properties.entries.description": "Subgraph query results.",
-    "output_schema.properties.entries.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type.",
+    "output_schema.properties.entries.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type. Its type follows that display property (a number, a boolean, or a string such as a date) and it is null when the row's display field is empty.",
     "output_schema.properties.entries.items.properties._instance_id.description": "Globally unique instance id, usable directly with query_instance_subgraph.",
     "output_schema.properties.entries.items.properties._instance_identity.description": "The field values that form the primary key of this instance",
     "output_schema.properties.entries.items.description": "Every other key is a property name of that object type and varies with it. Read data_properties from get_object_types or search_schema first; do not guess from the field semantics."
@@ -189,7 +189,7 @@
     "output_schema.properties.cursor.description": "Opaque authenticated cursor for the next page. Pass it back unchanged.",
     "input_schema.properties.condition.properties.limit_key.description": "knn only: the key naming the neighbour count, always k. It appears together with limit_value.",
     "input_schema.properties.condition.properties.limit_value.description": "knn only: how many nearest neighbours to take. The server applies a default when it is omitted.",
-    "output_schema.properties.datas.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type.",
+    "output_schema.properties.datas.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type. Its type follows that display property (a number, a boolean, or a string such as a date) and it is null when the row's display field is empty.",
     "output_schema.properties.datas.items.properties._instance_id.description": "Globally unique instance id, usable directly with query_instance_subgraph.",
     "output_schema.properties.datas.items.properties._instance_identity.description": "The field values that form the primary key of this instance",
     "output_schema.properties.datas.items.description": "Every other key is a property name of that object type and varies with it. Read data_properties from get_object_types or search_schema first; do not guess from the field semantics."
@@ -202,7 +202,7 @@
     "output_schema.properties.entries.description": "Result rows.",
     "output_schema.properties.total_count.description": "Number of returned rows.",
     "output_schema.properties.warnings.description": "Warnings produced while validating or executing SQL.",
-    "output_schema.properties.entries.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type.",
+    "output_schema.properties.entries.items.properties._display.description": "Human-readable display name, chosen by the server from the display fields of the object type. Its type follows that display property (a number, a boolean, or a string such as a date) and it is null when the row's display field is empty.",
     "output_schema.properties.entries.items.properties._instance_id.description": "Globally unique instance id, usable directly with query_instance_subgraph.",
     "output_schema.properties.entries.items.properties._instance_identity.description": "The field values that form the primary key of this instance",
     "output_schema.properties.entries.items.description": "Every other key is a property name of that object type and varies with it. Read data_properties from get_object_types or search_schema first; do not guess from the field semantics."

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_instance_subgraph.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_instance_subgraph.json
@@ -214,8 +214,8 @@
           "type": "object",
           "properties": {
             "_display": {
-              "type": "string",
-              "description": "给人看的展示名，由服务端按对象类的展示字段挑出。"
+              "type": ["string", "number", "boolean", "null"],
+              "description": "给人看的展示名，由服务端按对象类的展示字段挑出；类型随展示字段而变（数值、布尔或日期等字符串），该行展示字段为空时为 null。"
             },
             "_instance_id": {
               "type": "string",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/query_object_instance.json
@@ -248,8 +248,8 @@
           "type": "object",
           "properties": {
             "_display": {
-              "type": "string",
-              "description": "给人看的展示名，由服务端按对象类的展示字段挑出。"
+              "type": ["string", "number", "boolean", "null"],
+              "description": "给人看的展示名，由服务端按对象类的展示字段挑出；类型随展示字段而变（数值、布尔或日期等字符串），该行展示字段为空时为 null。"
             },
             "_instance_id": {
               "type": "string",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/run_sql.json
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/schemas/run_sql.json
@@ -50,8 +50,8 @@
           "type": "object",
           "properties": {
             "_display": {
-              "type": "string",
-              "description": "给人看的展示名，由服务端按对象类的展示字段挑出。"
+              "type": ["string", "number", "boolean", "null"],
+              "description": "给人看的展示名，由服务端按对象类的展示字段挑出；类型随展示字段而变（数值、布尔或日期等字符串），该行展示字段为空时为 null。"
             },
             "_instance_id": {
               "type": "string",

--- a/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_schema_test.go
+++ b/adp/context-loader/agent-retrieval/server/driveradapters/mcp/tools_display_schema_test.go
@@ -1,0 +1,104 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/context-loader/agent-retrieval/server/interfaces"
+)
+
+// _display carries the raw value of the object type's display property. bkn-backend accepts an
+// integer, float, decimal, boolean or date/time display key as well as a string one, and
+// ontology-query copies the value through untouched (null when the row's field is empty).
+// MCP SDK clients validate structuredContent against output_schema and drop the whole result on
+// the first mismatch, so pinning _display to string turned every numeric display key into a
+// failed tool call.
+var displayBearingTools = map[string]string{
+	"query_object_instance":       "datas",
+	"get_logic_properties_values": "datas",
+	"query_instance_subgraph":     "entries",
+	"run_sql":                     "entries",
+}
+
+func compileOutputSchema(t *testing.T, locale, tool string) *jsonschema.Schema {
+	t.Helper()
+	_, raw := loadMCPLocaleBundle(locale).ToolSchemas(tool)
+	var document any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", document); err != nil {
+		t.Fatal(err)
+	}
+	schema, err := compiler.Compile("schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func TestDisplayOutputSchemaAcceptsEveryDisplayKeyType(t *testing.T) {
+	accepted := map[string]any{
+		"integer": float64(7), "float": 3.5, "boolean": true, "string": "Block 7", "empty": nil,
+	}
+	rejected := map[string]any{
+		"object": map[string]any{"name": "x"}, "array": []any{"x"},
+	}
+	for tool, listKey := range displayBearingTools {
+		for _, locale := range []string{"zh-CN", "en-US"} {
+			schema := compileOutputSchema(t, locale, tool)
+			for name, value := range accepted {
+				t.Run(tool+"/"+locale+"/"+name, func(t *testing.T) {
+					wire := map[string]any{listKey: []any{map[string]any{"_display": value, "_instance_id": "ot:1"}}}
+					if err := schema.Validate(wire); err != nil {
+						t.Errorf("a %s display value fails the published schema: %v", name, err)
+					}
+				})
+			}
+			for name, value := range rejected {
+				t.Run(tool+"/"+locale+"/rejects-"+name, func(t *testing.T) {
+					wire := map[string]any{listKey: []any{map[string]any{"_display": value}}}
+					if err := schema.Validate(wire); err == nil {
+						t.Errorf("schema accepted a %s _display; the loosening must stop at scalars", name)
+					}
+				})
+			}
+		}
+	}
+}
+
+// The handler passes ontology-query's rows through untouched, so what the client validates is
+// exactly the display property's own type.
+func TestHandleQueryObjectInstanceNumericDisplayMatchesSchema(t *testing.T) {
+	stub := &stubOntologyQuery{resp: &interfaces.QueryObjectInstancesResp{
+		Data: []any{
+			map[string]any{"seq": 0, "_display": 0, "_instance_id": "block:0", "_instance_identity": map[string]any{"id": "b0"}},
+			map[string]any{"seq": 1, "_display": nil, "_instance_id": "block:1", "_instance_identity": map[string]any{"id": "b1"}},
+		},
+	}}
+	handler := handleQueryObjectInstance(stub)
+	result, err := handler(context.Background(), mcpReq(map[string]any{
+		"kn_id": "kn", "ot_id": "block", "response_format": "json",
+	}))
+	if err != nil || result.IsError {
+		t.Fatalf("unexpected result: err=%v result=%+v", err, result)
+	}
+	wire := resultToMap(t, result)
+	rows := wire["datas"].([]any)
+	if got := rows[0].(map[string]any)["_display"]; got != float64(0) {
+		t.Fatalf("numeric _display must reach the client unchanged, got %#v", got)
+	}
+	for _, locale := range []string{"zh-CN", "en-US"} {
+		if err := compileOutputSchema(t, locale, "query_object_instance").Validate(wire); err != nil {
+			t.Errorf("%s: structuredContent violates the published schema: %v", locale, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

OpenClaw, and any client built on the MCP SDKs (Claude Code, the Python SDK), rejected every `query_object_instance` result for an object type whose display key is numeric:

```
MCP error -32602: Structured content does not match the tool's output schema: data/datas/0/_display must be string, data/datas/1/_display must be string
```

The four instance-returning tools declare `_display` as `string` in their `output_schema`, but ontology-query copies the display property's raw value through untouched. bkn-backend accepts integer, float, decimal, boolean and date/time display keys (`validDisplayKeyTypes`), and the value is `null` when the row's display field is empty. The SDK validates `structuredContent` against the advertised schema on the client side and drops the whole result on the first mismatch, so the server's successful response never reaches the agent.

Affected tools: `query_object_instance`, `query_instance_subgraph`, `run_sql`, `get_logic_properties_values`. The declarations came in with #982, written from string-keyed samples.

## Fix

Declare `_display` as `string | number | boolean | null` in all four schemas and say in the zh/en descriptions that the type follows the display property. Response bodies do not change a byte; only `tools/list` does.

## Verification

- New `tools_display_schema_test.go`: numeric, float, boolean, string and null `_display` validate against every published schema in both locales, object/array values are still rejected, and `handleQueryObjectInstance` output carrying numeric and null `_display` passes the published schema end to end. The test fails on the previous schemas and passes now.
- `go test ./driveradapters/mcp/` and `make -C infra/sandbox bkn-tools-check` are green.
- MCP TypeScript SDK 1.29.0 client (the validator OpenClaw and Claude Code run) against an in-memory server: with the old schema the call fails with exactly the message above; with the new schema it succeeds and the client sees `[7, null]`.
- Live on the dev VM (0.1.4-yf release image + this fix, MCP TypeScript SDK 1.30.0 client, the version OpenClaw pins): with an object type whose display key is an integer property, `query_object_instance` returns `_display` values `[1, 2, 3]` and the call succeeds; the same data against the unpatched release image fails client-side with exactly `data/datas/0/_display must be string, data/datas/1/_display must be string, data/datas/2/_display must be string`. OpenClaw's own validator (`createMcpJsonSchemaValidator`) delegates to the SDK's Ajv provider for schemas without `$schema`, which is what these tools publish.

Same change for the 0.1.4-yf line: #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
