### PR TITLE
feat(bkn-backend): conditions, parameters, aggregation and richer patterns for Cypher (0.1.4-yf)

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/cypher_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/cypher_handler.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -24,9 +25,14 @@ import (
 )
 
 // CypherQueryRequest is the request body of a Cypher query. Paging is written
-// in the query itself, with SKIP and LIMIT, so there is nothing else to carry.
+// in the query itself, with SKIP and LIMIT, so there is nothing else to carry
+// beyond the values the query refers to.
 type CypherQueryRequest struct {
 	Query string `json:"query"`
+	// Parameters supply what the query writes as $name. They are values only:
+	// a parameter changes which rows come back, never which resource or
+	// column is read.
+	Parameters map[string]any `json:"parameters"`
 }
 
 func (r *restHandler) RunCypherQueryByEx(c *gin.Context) {
@@ -54,7 +60,12 @@ func (r *restHandler) RunCypherQuery(c *gin.Context, vis hydra.Visitor) {
 	span.SetAttributes(attr.Key("kn_id").String(knID), attr.Key("branch").String(branch))
 
 	var body CypherQueryRequest
-	if err := c.ShouldBindJSON(&body); err != nil {
+	// Numbers are decoded as json.Number rather than float64: a parameter may
+	// carry an identifier that does not survive a float, and comparing it
+	// against the wrong value is worse than refusing it.
+	decoder := json.NewDecoder(c.Request.Body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&body); err != nil {
 		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_InvalidParameter_RequestBody)
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
 		rest.ReplyError(c, httpErr)
@@ -74,9 +85,10 @@ func (r *restHandler) RunCypherQuery(c *gin.Context, vis hydra.Visitor) {
 	}
 
 	result, err := r.cqs.Query(ctx, interfaces.CypherQuery{
-		KNID:   knID,
-		Branch: branch,
-		Query:  body.Query,
+		KNID:       knID,
+		Branch:     branch,
+		Query:      body.Query,
+		Parameters: body.Parameters,
 	})
 	if err != nil {
 		replyHandlerError(c, span, ctx, err)

--- a/adp/bkn/bkn-backend/server/interfaces/cypher_query_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/cypher_query_service.go
@@ -17,6 +17,10 @@ const (
 	CYPHER_MAX_LIMIT = 10000
 	// CYPHER_DEFAULT_TIMEOUT_SEC bounds one statement at the connector.
 	CYPHER_DEFAULT_TIMEOUT_SEC = 30
+	// CYPHER_MAX_PATH_LENGTH bounds how many relationships one pattern may
+	// hold. Each is a join, and the row limit bounds what comes back rather
+	// than what it costs to produce, so the number of joins is bounded here.
+	CYPHER_MAX_PATH_LENGTH = 8
 )
 
 // CypherQuery is one read-only query against a knowledge network.
@@ -24,6 +28,10 @@ type CypherQuery struct {
 	KNID   string
 	Branch string
 	Query  string
+	// Parameters supply the values the query refers to as $name. They are
+	// values only: a parameter can change which rows come back, never which
+	// resource or column is read.
+	Parameters map[string]any
 }
 
 // CypherQueryResult carries the rows a query produced. The generated SQL is

--- a/adp/bkn/bkn-backend/server/logics/cypher/aggregate_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/aggregate_test.go
@@ -1,0 +1,185 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"strings"
+	"testing"
+)
+
+// Cypher has no GROUP BY: aggregating anything groups by everything else that
+// is returned. These assert the whole statement, because the grouping is
+// derived rather than written and a change in it has to be deliberate.
+func TestCompileAggregates(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "count of rows",
+			query: "MATCH (o:Order) RETURN count(*) AS n",
+			want:  "SELECT COUNT(*) AS `n` FROM {{.res_order}} t0",
+		},
+		{
+			name:  "count of values",
+			query: "MATCH (o:Order) RETURN count(o.region) AS n",
+			want:  "SELECT COUNT(t0.`f_region`) AS `n` FROM {{.res_order}} t0",
+		},
+		{
+			name:  "count of distinct values",
+			query: "MATCH (o:Order) RETURN count(DISTINCT o.region) AS n",
+			want:  "SELECT COUNT(DISTINCT t0.`f_region`) AS `n` FROM {{.res_order}} t0",
+		},
+		{
+			name:  "grouping is derived from what is returned",
+			query: "MATCH (o:Order) RETURN o.region AS region, count(*) AS n",
+			want: "SELECT t0.`f_region` AS `region`, COUNT(*) AS `n` FROM {{.res_order}} t0 " +
+				"GROUP BY t0.`f_region`",
+		},
+		{
+			name:  "several groups and several aggregates",
+			query: "MATCH (o:Order) RETURN o.region AS r, o.customer_code AS c, sum(o.amount) AS total, max(o.amount) AS biggest",
+			want: "SELECT t0.`f_region` AS `r`, t0.`f_cust_code` AS `c`, SUM(t0.`f_total`) AS `total`, " +
+				"MAX(t0.`f_total`) AS `biggest` FROM {{.res_order}} t0 " +
+				"GROUP BY t0.`f_region`, t0.`f_cust_code`",
+		},
+		{
+			name:  "everything aggregated is one row and no grouping",
+			query: "MATCH (o:Order) RETURN min(o.amount) AS lowest, avg(o.amount) AS mean",
+			want:  "SELECT MIN(t0.`f_total`) AS `lowest`, AVG(t0.`f_total`) AS `mean` FROM {{.res_order}} t0",
+		},
+		{
+			name:  "aggregate over a join",
+			query: "MATCH (o:Order)-[:PLACED_BY]->(c:Customer) RETURN c.name AS customer, count(*) AS n",
+			want: "SELECT t1.`f_name` AS `customer`, COUNT(*) AS `n` " +
+				"FROM {{.res_order}} t0 JOIN {{.res_customer}} t1 " +
+				"ON t0.`f_cust_code` = t1.`f_code` AND t0.`f_region` = t1.`f_region` " +
+				"GROUP BY t1.`f_name`",
+		},
+		{
+			name:  "sorted by the name of the aggregate",
+			query: "MATCH (o:Order) RETURN o.region AS region, count(*) AS n ORDER BY n DESC LIMIT 5",
+			want: "SELECT t0.`f_region` AS `region`, COUNT(*) AS `n` FROM {{.res_order}} t0 " +
+				"GROUP BY t0.`f_region` ORDER BY `n` DESC LIMIT 5",
+		},
+		{
+			name:  "sorted by the aggregate written out again",
+			query: "MATCH (o:Order) RETURN o.region AS region, count(*) AS n ORDER BY count(*) DESC",
+			want: "SELECT t0.`f_region` AS `region`, COUNT(*) AS `n` FROM {{.res_order}} t0 " +
+				"GROUP BY t0.`f_region` ORDER BY COUNT(*) DESC",
+		},
+		{
+			name:  "unaliased aggregate is named after what was written",
+			query: "MATCH (o:Order) RETURN count(DISTINCT o.region)",
+			want:  "SELECT COUNT(DISTINCT t0.`f_region`) AS `count(DISTINCT o.region)` FROM {{.res_order}} t0",
+		},
+		{
+			name:  "filtered before grouping",
+			query: "MATCH (o:Order) WHERE o.amount > 100 RETURN o.region AS region, count(*) AS n",
+			want: "SELECT t0.`f_region` AS `region`, COUNT(*) AS `n` FROM {{.res_order}} t0 " +
+				"WHERE t0.`f_total` > 100 GROUP BY t0.`f_region`",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mustCompile(t, tc.query); got != tc.want {
+				t.Fatalf("got  %s\nwant %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileAggregateRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "sorting a grouped result by something it does not return",
+			query: "MATCH (o:Order) RETURN o.region AS r, count(*) AS n ORDER BY o.amount",
+			want:  "can only be sorted by a returned value",
+		},
+		{
+			name:  "sorting by a name the query does not return",
+			query: "MATCH (o:Order) RETURN o.region AS r, count(*) AS n ORDER BY total",
+			want:  `"total" is not returned by this query`,
+		},
+		{
+			name:  "an aggregate over something that is not a property",
+			query: "MATCH (o:Order) RETURN sum(1) AS n",
+			want:  "only variable.property references are supported",
+		},
+		{
+			name:  "an aggregate over an unknown property",
+			query: "MATCH (o:Order) RETURN sum(o.nope) AS n",
+			want:  `has no property "nope"`,
+		},
+		{
+			name:  "a function that is not an aggregate",
+			query: "MATCH (o:Order) RETURN collect(o.region) AS n",
+			want:  "function calls",
+		},
+		{
+			name:  "an aggregate over several arguments",
+			query: "MATCH (o:Order) RETURN max(o.amount, o.region) AS n",
+			want:  "an aggregate over 2 arguments",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compile(t, tc.query, GenerateOptions{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}
+
+// The duplicate-name check has to point at the item that repeats the name,
+// whichever kind it is.
+func TestCompileDuplicateAliasOnAggregatePointsAtIt(t *testing.T) {
+	_, err := compile(t, "MATCH (o:Order)\nRETURN o.id AS x,\ncount(*) AS x", GenerateOptions{})
+	planError, ok := err.(*PlanError)
+	if !ok {
+		t.Fatalf("error = %T (%v), want *PlanError", err, err)
+	}
+	if planError.Pos.Line != 3 {
+		t.Fatalf("line = %d, want 3", planError.Pos.Line)
+	}
+}
+
+// Aggregation collapses rows whether or not it derives a GROUP BY, so the
+// ordering rule has to test for aggregation rather than for grouping.
+func TestCompileOrderingUnderAggregation(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			// Every column aggregated derives no GROUP BY and collapses to one
+			// row, which used to slip past a check that looked at GROUP BY.
+			name:  "all aggregated, sorted by a column",
+			query: "MATCH (o:Order) RETURN count(*) AS n ORDER BY o.amount",
+			want:  "can only be sorted by a returned value",
+		},
+		{
+			// Sorting by an aggregate the projection does not have would group
+			// the whole result on the way to ordering it.
+			name:  "no aggregate returned, sorted by one",
+			query: "MATCH (o:Order) RETURN o.id AS id ORDER BY count(*)",
+			want:  "needs the query to return an aggregate too",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compile(t, tc.query, GenerateOptions{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf16"
 
 	"github.com/antlr4-go/antlr/v4"
 
+	"bkn-backend/interfaces"
 	"bkn-backend/logics/cypher/parsing"
 )
 
@@ -100,35 +102,42 @@ func Analyze(tree parsing.IOC_CypherContext) (*Query, error) {
 	}
 
 	query := &Query{}
-	pattern, err := analyzePattern(match.OC_Pattern())
+	pattern, inline, err := analyzePattern(match.OC_Pattern())
 	if err != nil {
 		return nil, err
 	}
 	query.Pattern = *pattern
 
 	if where := match.OC_Where(); where != nil {
-		query.Where, err = analyzePredicates(where.OC_Expression())
+		written, err := analyzePredicate(where.OC_Expression())
 		if err != nil {
 			return nil, err
 		}
+		inline = append(inline, written)
 	}
+	// Conditions from the pattern and from WHERE mean the same thing and are
+	// joined the way Cypher joins them.
+	query.Where = combine("AND", inline, positionOf(match))
 	if err := analyzeProjectionBody(query, returning.OC_ProjectionBody()); err != nil {
 		return nil, err
 	}
 	return query, nil
 }
 
-func analyzePattern(ctx parsing.IOC_PatternContext) (*Pattern, error) {
+// analyzePattern reads the path and the conditions written inside it. Inline
+// property maps come back as ordinary conditions, which is what Cypher defines
+// them to be.
+func analyzePattern(ctx parsing.IOC_PatternContext) (*Pattern, []Predicate, error) {
 	parts := ctx.AllOC_PatternPart()
 	if len(parts) != 1 {
 		// Several comma-separated parts is a cartesian product between them,
 		// which the planner has no shape for yet.
-		return nil, unsupportedf(ctx, "multiple pattern parts",
+		return nil, nil, unsupportedf(ctx, "multiple pattern parts",
 			"MATCH must contain a single path, got %d comma-separated patterns", len(parts))
 	}
 	part := parts[0]
 	if part.OC_Variable() != nil {
-		return nil, unsupported(part, "path variables")
+		return nil, nil, unsupported(part, "path variables")
 	}
 
 	element := part.OC_AnonymousPatternPart().OC_PatternElement()
@@ -138,56 +147,137 @@ func analyzePattern(ctx parsing.IOC_PatternContext) (*Pattern, error) {
 	}
 
 	pattern := &Pattern{}
-	node, err := analyzeNode(element.OC_NodePattern())
+	node, conditions, err := analyzeNode(element.OC_NodePattern(), 0)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pattern.Nodes = append(pattern.Nodes, *node)
+	inline := conditions
 
 	chains := element.AllOC_PatternElementChain()
-	if len(chains) > 1 {
-		// Multi-hop needs a join order decision the planner does not make yet.
-		return nil, unsupportedf(ctx, "multi-hop patterns",
-			"a path may contain at most one relationship, got %d", len(chains))
+	if len(chains) > interfaces.CYPHER_MAX_PATH_LENGTH {
+		// Every relationship is a join. The row limit bounds what comes back,
+		// not what the database does to produce it, so the length of the path
+		// is bounded here instead.
+		return nil, nil, unsupportedf(ctx, "a path this long",
+			"a path may hold at most %d relationships, got %d",
+			interfaces.CYPHER_MAX_PATH_LENGTH, len(chains))
 	}
-	for _, chain := range chains {
+	for i, chain := range chains {
 		edge, err := analyzeRelationship(chain.OC_RelationshipPattern())
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		node, err := analyzeNode(chain.OC_NodePattern())
+		node, conditions, err := analyzeNode(chain.OC_NodePattern(), i+1)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		pattern.Edges = append(pattern.Edges, *edge)
 		pattern.Nodes = append(pattern.Nodes, *node)
+		inline = append(inline, conditions...)
 	}
-	return pattern, nil
+	return pattern, inline, nil
 }
 
-func analyzeNode(ctx parsing.IOC_NodePatternContext) (*NodeRef, error) {
-	if ctx.OC_Properties() != nil {
-		return nil, unsupportedf(ctx, "inline property maps", "write the condition in WHERE instead")
-	}
+func analyzeNode(ctx parsing.IOC_NodePatternContext, index int) (*NodeRef, []Predicate, error) {
 	node := &NodeRef{Pos: positionOf(ctx)}
 	if variable := ctx.OC_Variable(); variable != nil {
-		node.Variable = identifier(variable.GetText())
+		name, err := namedIdentifier(variable, "variable name")
+		if err != nil {
+			return nil, nil, err
+		}
+		node.Variable = name
+	}
+
+	var conditions []Predicate
+	if properties := ctx.OC_Properties(); properties != nil {
+		if node.Variable == "" {
+			// An inline map on an anonymous node still has to name something
+			// the planner can resolve. The name is unwritable in Cypher, so it
+			// cannot collide with one the author chose.
+			node.Variable = anonymousVariable(index)
+			node.Anonymous = true
+		}
+		var err error
+		conditions, err = analyzeInlineProperties(properties, node.Variable)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	labels := ctx.OC_NodeLabels()
 	if labels == nil {
 		// Without a label there is no object type, and without an object type
 		// there is no table to read.
-		return nil, unsupportedf(ctx, "nodes without a label",
+		return nil, nil, unsupportedf(ctx, "nodes without a label",
 			"every node must name one object type, as in (n:ObjectType)")
 	}
 	all := labels.AllOC_NodeLabel()
 	if len(all) != 1 {
-		return nil, unsupportedf(ctx, "multiple labels on one node",
+		return nil, nil, unsupportedf(ctx, "multiple labels on one node",
 			"a node maps to exactly one object type, got %d labels", len(all))
 	}
-	node.Label = identifier(all[0].OC_LabelName().GetText())
-	return node, nil
+	label, err := namedIdentifier(all[0].OC_LabelName(), "label")
+	if err != nil {
+		return nil, nil, err
+	}
+	node.Label = label
+	return node, conditions, nil
+}
+
+// anonymousVariable names a node the query did not name. A backtick cannot
+// appear unescaped in a Cypher identifier, so the name is unreachable from a
+// query and cannot shadow one.
+func anonymousVariable(index int) string {
+	return "`anonymous-" + strconv.Itoa(index)
+}
+
+// analyzeInlineProperties reads (n:Label {a: 1, b: $b}) as the equalities it
+// stands for. Cypher defines it as exactly that, and turning it into
+// conditions here means the planner and the generator have one shape to
+// handle rather than two.
+func analyzeInlineProperties(ctx parsing.IOC_PropertiesContext, variable string) ([]Predicate, error) {
+	if ctx.OC_Parameter() != nil {
+		return nil, unsupportedf(ctx, "a parameter in place of a property map",
+			"write the properties out, as in {name: $name}")
+	}
+	literal := ctx.OC_MapLiteral()
+	if literal == nil {
+		return nil, unsupported(ctx, "this property map")
+	}
+
+	keys := literal.AllOC_PropertyKeyName()
+	values := literal.AllOC_Expression()
+	conditions := make([]Predicate, 0, len(keys))
+	for i, key := range keys {
+		value, err := analyzeOperand(values[i])
+		if err != nil {
+			return nil, err
+		}
+		if value.operand() == nil {
+			return nil, unsupportedf(values[i], "a property map holding something other than a value",
+				"inline properties take literals or parameters")
+		}
+		if value.literal != nil && value.literal.Kind == LiteralNull {
+			return nil, unsupportedf(values[i], "null in a property map",
+				"a null there matches nothing; write IS NULL in WHERE if that is the intent")
+		}
+		property, err := namedIdentifier(key, "property name")
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, Comparison{
+			Left: PropertyRef{
+				Variable: variable,
+				Property: property,
+				Pos:      positionOf(key),
+			},
+			Operator: "=",
+			Right:    *value.operand(),
+			Pos:      positionOf(key),
+		})
+	}
+	return conditions, nil
 }
 
 func analyzeRelationship(ctx parsing.IOC_RelationshipPatternContext) (*EdgeRef, error) {
@@ -202,10 +292,7 @@ func analyzeRelationship(ctx parsing.IOC_RelationshipPatternContext) (*EdgeRef, 
 	case left:
 		edge.Direction = Incoming
 	default:
-		// A relation type has a source and a target, so an undirected pattern
-		// would have to be compiled as a union of both readings.
-		return nil, unsupportedf(ctx, "undirected relationships",
-			"write either -[:TYPE]-> or <-[:TYPE]-")
+		edge.Direction = Undirected
 	}
 
 	detail := ctx.OC_RelationshipDetail()
@@ -234,7 +321,11 @@ func analyzeRelationship(ctx parsing.IOC_RelationshipPatternContext) (*EdgeRef, 
 		return nil, unsupportedf(detail, "alternative relationship types",
 			"a relationship maps to exactly one relation type, got %d", len(names))
 	}
-	edge.Type = identifier(names[0].GetText())
+	relationshipType, err := namedIdentifier(names[0], "relationship type")
+	if err != nil {
+		return nil, err
+	}
+	edge.Type = relationshipType
 	return edge, nil
 }
 
@@ -248,27 +339,28 @@ func analyzeProjectionBody(query *Query, ctx parsing.IOC_ProjectionBodyContext) 
 		return unsupportedf(items, "RETURN *", "list the properties to return")
 	}
 	for _, item := range items.AllOC_ProjectionItem() {
-		property, err := analyzePropertyRef(item.OC_Expression())
+		projection, err := analyzeProjection(item.OC_Expression())
 		if err != nil {
 			return err
 		}
-		projection := Projection{Property: *property, Alias: property.String()}
 		if variable := item.OC_Variable(); variable != nil {
-			projection.Alias = identifier(variable.GetText())
+			alias, err := namedIdentifier(variable, "column name")
+			if err != nil {
+				return err
+			}
+			projection.Alias = alias
 		}
-		query.Return = append(query.Return, projection)
+		query.Return = append(query.Return, *projection)
 	}
 
 	if order := ctx.OC_Order(); order != nil {
 		for _, item := range order.AllOC_SortItem() {
-			property, err := analyzePropertyRef(item.OC_Expression())
+			key, err := analyzeSortKey(item.OC_Expression())
 			if err != nil {
 				return err
 			}
-			query.OrderBy = append(query.OrderBy, SortKey{
-				Property:   *property,
-				Descending: item.DESCENDING() != nil || item.DESC() != nil,
-			})
+			key.Descending = item.DESCENDING() != nil || item.DESC() != nil
+			query.OrderBy = append(query.OrderBy, *key)
 		}
 	}
 	if skip := ctx.OC_Skip(); skip != nil {
@@ -305,88 +397,465 @@ func analyzeRowCount(ctx parsing.IOC_ExpressionContext, clause string) (int64, e
 	return value.literal.Integer, nil
 }
 
+// analyzeProjection reads one RETURN item: a property, or an aggregate over
+// one. The alias defaults to what was written, which is how Cypher names a
+// column nobody named.
+func analyzeProjection(ctx parsing.IOC_ExpressionContext) (*Projection, error) {
+	if aggregate, ok, err := analyzeAggregate(ctx); err != nil {
+		return nil, err
+	} else if ok {
+		return &Projection{Aggregate: aggregate, Alias: aggregate.String()}, nil
+	}
+
+	property, err := analyzePropertyRef(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &Projection{Property: property, Alias: property.String()}, nil
+}
+
+// analyzeSortKey reads one ORDER BY item. Besides a property it accepts the
+// name of a returned column and an aggregate written out again, because with
+// aggregates in RETURN those are the only ways to say what to sort by.
+func analyzeSortKey(ctx parsing.IOC_ExpressionContext) (*SortKey, error) {
+	if aggregate, ok, err := analyzeAggregate(ctx); err != nil {
+		return nil, err
+	} else if ok {
+		return &SortKey{Aggregate: aggregate, Pos: aggregate.Pos}, nil
+	}
+
+	if name, ok := bareVariable(ctx); ok {
+		return &SortKey{Alias: name, Pos: positionOf(ctx)}, nil
+	}
+
+	property, err := analyzePropertyRef(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &SortKey{Property: property, Pos: property.Pos}, nil
+}
+
+// bareVariable reports a term that is nothing but a name. In ORDER BY that is
+// a reference to a returned column; everywhere else it is a whole node, which
+// the analyzer refuses.
+func bareVariable(ctx parsing.IOC_ExpressionContext) (string, bool) {
+	atom, ok := singleExpressionAtom(ctx)
+	if !ok || len(atom.propertyLookups) > 0 {
+		return "", false
+	}
+	variable := atom.atom.OC_Variable()
+	if variable == nil {
+		return "", false
+	}
+	name := identifier(variable.GetText())
+	// The grammar allows a pair of backticks with nothing between them. An
+	// empty name refers to nothing, so it is left for the property path to
+	// refuse by name rather than taken as a reference.
+	return name, name != ""
+}
+
+// aggregateFunctions are the ones whose SQL spelling is the same and whose
+// meaning over a grouped result matches. Anything else stays a function call,
+// which is refused.
+var aggregateFunctions = map[string]string{
+	"count": "COUNT",
+	"sum":   "SUM",
+	"avg":   "AVG",
+	"min":   "MIN",
+	"max":   "MAX",
+}
+
+// analyzeAggregate reads count(*), count(x.p), sum(x.p) and their DISTINCT
+// forms. It reports whether the term was an aggregate at all, so a caller can
+// fall through to reading a plain property.
+func analyzeAggregate(ctx parsing.IOC_ExpressionContext) (*Aggregate, bool, error) {
+	term, ok := singleExpressionAtom(ctx)
+	if !ok {
+		return nil, false, nil
+	}
+	if len(term.propertyLookups) > 0 {
+		return nil, false, nil
+	}
+
+	// count(*) is its own shape in the grammar rather than a function call.
+	if count := term.atom.COUNT(); count != nil {
+		return &Aggregate{Function: "COUNT", Name: count.GetText(), Pos: positionOf(term.atom)}, true, nil
+	}
+
+	invocation := term.atom.OC_FunctionInvocation()
+	if invocation == nil {
+		return nil, false, nil
+	}
+	written := identifier(invocation.OC_FunctionName().GetText())
+	name := strings.ToLower(written)
+	function, isAggregate := aggregateFunctions[name]
+	if !isAggregate {
+		return nil, false, nil
+	}
+
+	arguments := invocation.AllOC_Expression()
+	if len(arguments) != 1 {
+		return nil, false, unsupportedf(invocation, "an aggregate over "+strconv.Itoa(len(arguments))+" arguments",
+			"%s takes one property", name)
+	}
+	property, err := analyzePropertyRef(arguments[0])
+	if err != nil {
+		return nil, false, err
+	}
+	return &Aggregate{
+		Function: function,
+		Name:     written,
+		Distinct: invocation.DISTINCT() != nil,
+		Property: property,
+		Pos:      positionOf(invocation),
+	}, true, nil
+}
+
+// expressionAtom is one term stripped of the precedence chain around it: the
+// atom itself and the property lookups applied to it.
+type expressionAtom struct {
+	atom            parsing.IOC_AtomContext
+	propertyLookups []parsing.IOC_PropertyLookupContext
+}
+
+// singleExpressionAtom descends an expression that is one term, reporting
+// false for anything with an operator in it.
+func singleExpressionAtom(ctx parsing.IOC_ExpressionContext) (expressionAtom, bool) {
+	xors := ctx.OC_OrExpression().AllOC_XorExpression()
+	if len(xors) != 1 {
+		return expressionAtom{}, false
+	}
+	ands := xors[0].AllOC_AndExpression()
+	if len(ands) != 1 {
+		return expressionAtom{}, false
+	}
+	nots := ands[0].AllOC_NotExpression()
+	if len(nots) != 1 || len(nots[0].AllNOT()) > 0 {
+		return expressionAtom{}, false
+	}
+	comparison := nots[0].OC_ComparisonExpression()
+	if len(comparison.AllOC_PartialComparisonExpression()) > 0 {
+		return expressionAtom{}, false
+	}
+	stringListNull := comparison.OC_StringListNullPredicateExpression()
+	if len(stringListNull.AllOC_StringPredicateExpression())+
+		len(stringListNull.AllOC_ListPredicateExpression())+
+		len(stringListNull.AllOC_NullPredicateExpression()) > 0 {
+		return expressionAtom{}, false
+	}
+	multiplications := stringListNull.OC_AddOrSubtractExpression().AllOC_MultiplyDivideModuloExpression()
+	if len(multiplications) != 1 {
+		return expressionAtom{}, false
+	}
+	powers := multiplications[0].AllOC_PowerOfExpression()
+	if len(powers) != 1 {
+		return expressionAtom{}, false
+	}
+	unaries := powers[0].AllOC_UnaryAddOrSubtractExpression()
+	if len(unaries) != 1 {
+		return expressionAtom{}, false
+	}
+	listOperator := unaries[0].OC_ListOperatorExpression()
+	if listOperator.GetChildCount() > 1 {
+		return expressionAtom{}, false
+	}
+	propertyOrLabels := listOperator.OC_PropertyOrLabelsExpression()
+	if propertyOrLabels.OC_NodeLabels() != nil {
+		return expressionAtom{}, false
+	}
+	return expressionAtom{atom: propertyOrLabels.OC_Atom(),
+		propertyLookups: propertyOrLabels.AllOC_PropertyLookup()}, true
+}
+
 func analyzePropertyRef(ctx parsing.IOC_ExpressionContext) (*PropertyRef, error) {
 	value, err := analyzeOperand(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if value.property == nil {
+		if value.literal == nil {
+			return nil, unsupportedf(ctx, "an expression here",
+				"only variable.property references are supported")
+		}
 		return nil, unsupportedf(ctx, "an expression here",
 			"only variable.property references are supported, got %s", value.literal.describe())
 	}
 	return value.property, nil
 }
 
-// analyzePredicates flattens the WHERE expression into the conjunction the
-// planner expects. Only AND is accepted for now: OR and NOT change which rows
-// a join produces, and getting that wrong returns wrong data rather than an
-// error, so they wait until the planner handles them deliberately.
-func analyzePredicates(ctx parsing.IOC_ExpressionContext) ([]Comparison, error) {
-	orExpression := ctx.OC_OrExpression()
-	xorExpressions := orExpression.AllOC_XorExpression()
-	if len(xorExpressions) != 1 {
-		return nil, unsupported(orExpression, "OR")
-	}
-	andExpressions := xorExpressions[0].AllOC_AndExpression()
-	if len(andExpressions) != 1 {
-		return nil, unsupported(xorExpressions[0], "XOR")
-	}
+// analyzePredicate reads the WHERE expression as a tree. The boolean grammar
+// is a chain of one rule per precedence level, so the descent below is the
+// grammar read downwards: OR over XOR over AND over NOT over comparison.
+func analyzePredicate(ctx parsing.IOC_ExpressionContext) (Predicate, error) {
+	return analyzeOrPredicate(ctx.OC_OrExpression())
+}
 
-	notExpressions := andExpressions[0].AllOC_NotExpression()
-	comparisons := make([]Comparison, 0, len(notExpressions))
-	for _, notExpression := range notExpressions {
-		comparison, err := analyzeComparison(notExpression)
+func analyzeOrPredicate(ctx parsing.IOC_OrExpressionContext) (Predicate, error) {
+	operands := make([]Predicate, 0, len(ctx.AllOC_XorExpression()))
+	for _, xor := range ctx.AllOC_XorExpression() {
+		operand, err := analyzeXorPredicate(xor)
 		if err != nil {
 			return nil, err
 		}
-		comparisons = append(comparisons, *comparison)
+		operands = append(operands, operand)
 	}
-	return comparisons, nil
+	return combine("OR", operands, positionOf(ctx)), nil
 }
 
-func analyzeComparison(ctx parsing.IOC_NotExpressionContext) (*Comparison, error) {
-	if len(ctx.AllNOT()) > 0 {
-		return nil, unsupported(ctx, "NOT")
+func analyzeXorPredicate(ctx parsing.IOC_XorExpressionContext) (Predicate, error) {
+	// XOR has no portable spelling: MySQL has the operator, PostgreSQL does
+	// not, and the rewrites differ in how they treat a null operand. It is
+	// rare enough to refuse rather than to guess at.
+	if len(ctx.AllOC_AndExpression()) > 1 {
+		return nil, unsupportedf(ctx, "XOR", "write it with AND, OR and NOT")
 	}
-	comparisonExpression := ctx.OC_ComparisonExpression()
-	// The left side is read first so that a predicate written with IN, IS
-	// NULL or STARTS WITH is named for what it is: those forms carry no
-	// comparison operator, and reporting the missing operator instead would
-	// point at the wrong thing.
-	left, err := analyzeStringListNullOperand(comparisonExpression.OC_StringListNullPredicateExpression())
+	operands := make([]Predicate, 0, len(ctx.AllOC_AndExpression()))
+	for _, and := range ctx.AllOC_AndExpression() {
+		operand, err := analyzeAndPredicate(and)
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, operand)
+	}
+	return combine("XOR", operands, positionOf(ctx)), nil
+}
+
+func analyzeAndPredicate(ctx parsing.IOC_AndExpressionContext) (Predicate, error) {
+	operands := make([]Predicate, 0, len(ctx.AllOC_NotExpression()))
+	for _, not := range ctx.AllOC_NotExpression() {
+		operand, err := analyzeNotPredicate(not)
+		if err != nil {
+			return nil, err
+		}
+		operands = append(operands, operand)
+	}
+	return combine("AND", operands, positionOf(ctx)), nil
+}
+
+// combine keeps a single operand as itself rather than wrapping it in an
+// operator with nothing to combine, so the tree carries only what was written.
+func combine(operator string, operands []Predicate, pos Position) Predicate {
+	switch len(operands) {
+	case 0:
+		// A query with neither a WHERE nor inline properties has no condition
+		// at all, which is not the same as one that is always true.
+		return nil
+	case 1:
+		return operands[0]
+	}
+	return LogicalOperator{Operator: operator, Operands: operands, Pos: pos}
+}
+
+func analyzeNotPredicate(ctx parsing.IOC_NotExpressionContext) (Predicate, error) {
+	inner, err := analyzeComparison(ctx.OC_ComparisonExpression())
+	if err != nil {
+		return nil, err
+	}
+	// Two NOTs cancel, which is worth doing here rather than emitting them:
+	// the generated SQL should read like the condition, not like its history.
+	if len(ctx.AllNOT())%2 == 1 {
+		return Negation{Operand: inner, Pos: positionOf(ctx)}, nil
+	}
+	return inner, nil
+}
+
+func analyzeComparison(ctx parsing.IOC_ComparisonExpressionContext) (Predicate, error) {
+	// The left side is read first so that a predicate written with IN or IS
+	// NULL is recognised as one: those forms carry no comparison operator, and
+	// reporting the missing operator instead would point at the wrong thing.
+	left, leftValue, err := analyzeStringListNullPredicate(ctx.OC_StringListNullPredicateExpression(), groupsConditions)
 	if err != nil {
 		return nil, err
 	}
 
-	partials := comparisonExpression.AllOC_PartialComparisonExpression()
+	partials := ctx.AllOC_PartialComparisonExpression()
 	switch {
 	case len(partials) == 0:
-		return nil, unsupportedf(comparisonExpression, "a non-comparison predicate",
-			"WHERE takes comparisons such as n.property = 'value'")
+		if left == nil {
+			return nil, unsupportedf(ctx, "a non-comparison predicate",
+				"WHERE takes comparisons such as n.property = 'value'")
+		}
+		return left, nil
 	case len(partials) > 1:
-		return nil, unsupportedf(comparisonExpression, "chained comparisons",
+		return nil, unsupportedf(ctx, "chained comparisons",
 			"write a < b AND b < c instead")
 	}
-	right, err := analyzeStringListNullOperand(partials[0].OC_StringListNullPredicateExpression())
+	if left != nil {
+		return nil, unsupportedf(ctx, "comparing a condition",
+			"a comparison must be variable.property against a value")
+	}
+
+	right, rightValue, err := analyzeStringListNullPredicate(partials[0].OC_StringListNullPredicateExpression(), groupsConditions)
 	if err != nil {
 		return nil, err
 	}
-	if left.property == nil || right.literal == nil {
-		// One side has to be a column and the other a constant; anything else
+	if right != nil {
+		return nil, unsupportedf(ctx, "comparing a condition",
+			"a comparison must be variable.property against a value")
+	}
+	if leftValue.property == nil || rightValue.property != nil || rightValue.operand() == nil {
+		// One side has to be a column and the other a value; anything else
 		// would need expression generation the subset does not have yet.
-		return nil, unsupportedf(comparisonExpression, "this comparison",
-			"a comparison must be variable.property against a literal")
+		return nil, unsupportedf(ctx, "this comparison",
+			"a comparison must be variable.property against a literal or a parameter")
 	}
-	if right.literal.Kind == LiteralNull {
-		return nil, unsupportedf(comparisonExpression, "comparing against null",
-			"use IS NULL semantics once they are supported")
+	if rightValue.literal != nil && rightValue.literal.Kind == LiteralNull {
+		return nil, unsupportedf(ctx, "comparing against null",
+			"write IS NULL or IS NOT NULL instead")
 	}
-	return &Comparison{
-		Left:     *left.property,
+	return Comparison{
+		Left:     *leftValue.property,
 		Operator: comparisonOperator(partials[0]),
-		Right:    *right.literal,
-		Pos:      positionOf(comparisonExpression),
+		Right:    *rightValue.operand(),
+		Pos:      positionOf(ctx),
 	}, nil
+}
+
+// analyzeStringListNullPredicate reads one side of a comparison. A side that
+// carries an IN or IS NULL suffix is a predicate in its own right and is
+// returned as one; otherwise it is a value.
+// grouping says whether parentheses at this position mean a grouped condition.
+// In a WHERE they do, and refusing them would leave OR and AND stuck in their
+// default precedence. In a projection they do not: there is nothing there to
+// group, so they are refused by name.
+type grouping bool
+
+const (
+	groupsConditions   grouping = true
+	refusesParentheses grouping = false
+)
+
+func analyzeStringListNullPredicate(ctx parsing.IOC_StringListNullPredicateExpressionContext,
+	parentheses grouping) (Predicate, operand, error) {
+
+	if len(ctx.AllOC_StringPredicateExpression()) > 0 {
+		return nil, operand{}, unsupported(ctx, "STARTS WITH, ENDS WITH and CONTAINS")
+	}
+
+	// Parentheses are how a reader groups OR against AND, so a parenthesised
+	// condition is read as one rather than refused: without it the operators
+	// below could only ever be written in their default precedence.
+	if parentheses == groupsConditions &&
+		len(ctx.AllOC_ListPredicateExpression())+len(ctx.AllOC_NullPredicateExpression()) == 0 {
+		if inner, ok := parenthesizedExpression(ctx.OC_AddOrSubtractExpression()); ok {
+			predicate, err := analyzePredicate(inner)
+			if err != nil {
+				return nil, operand{}, err
+			}
+			return predicate, operand{}, nil
+		}
+	}
+
+	subject, err := analyzeAddOrSubtractOperand(ctx.OC_AddOrSubtractExpression())
+	if err != nil {
+		return nil, operand{}, err
+	}
+
+	lists := ctx.AllOC_ListPredicateExpression()
+	nulls := ctx.AllOC_NullPredicateExpression()
+	if len(lists)+len(nulls) == 0 {
+		return nil, subject, nil
+	}
+	if len(lists)+len(nulls) > 1 {
+		return nil, operand{}, unsupportedf(ctx, "combining IN and IS NULL in one term",
+			"write them as separate terms joined by AND")
+	}
+	if subject.property == nil {
+		return nil, operand{}, unsupportedf(ctx, "this predicate",
+			"IN and IS NULL apply to variable.property")
+	}
+
+	if len(nulls) == 1 {
+		return NullCheck{
+			Property: *subject.property,
+			Negated:  nulls[0].NOT() != nil,
+			Pos:      positionOf(ctx),
+		}, operand{}, nil
+	}
+
+	values, err := analyzeListOperands(lists[0].OC_AddOrSubtractExpression())
+	if err != nil {
+		return nil, operand{}, err
+	}
+	return Membership{Property: *subject.property, Values: values, Pos: positionOf(ctx)}, operand{}, nil
+}
+
+// analyzeListOperands reads the right side of IN, which has to be a list
+// written in the query. A list computed at run time would need evaluation the
+// compiler does not do.
+func analyzeListOperands(ctx parsing.IOC_AddOrSubtractExpressionContext) ([]Operand, error) {
+	multiplications := ctx.AllOC_MultiplyDivideModuloExpression()
+	if len(multiplications) != 1 {
+		return nil, unsupported(ctx, "arithmetic")
+	}
+	atom, err := singleAtom(multiplications[0])
+	if err != nil {
+		return nil, unsupportedf(ctx, "IN over something other than a list",
+			"write the values as a list, as in n.property IN [1, 2]")
+	}
+	literal := atom.OC_Literal()
+	if literal == nil || literal.OC_ListLiteral() == nil {
+		return nil, unsupportedf(ctx, "IN over something other than a list",
+			"write the values as a list, as in n.property IN [1, 2]")
+	}
+
+	var values []Operand
+	for _, element := range literal.OC_ListLiteral().AllOC_Expression() {
+		value, err := analyzeOperand(element)
+		if err != nil {
+			return nil, err
+		}
+		if value.operand() == nil || value.property != nil {
+			return nil, unsupportedf(element, "a list holding something other than values",
+				"IN takes literals or parameters")
+		}
+		if value.literal != nil && value.literal.Kind == LiteralNull {
+			return nil, unsupportedf(element, "null in an IN list",
+				"a null there matches nothing and hides a mistake")
+		}
+		values = append(values, *value.operand())
+	}
+	return values, nil
+}
+
+// parenthesizedExpression reports the expression inside ( ), when the term is
+// nothing but a parenthesised one.
+func parenthesizedExpression(ctx parsing.IOC_AddOrSubtractExpressionContext) (parsing.IOC_ExpressionContext, bool) {
+	multiplications := ctx.AllOC_MultiplyDivideModuloExpression()
+	if len(multiplications) != 1 {
+		return nil, false
+	}
+	atom, err := singleAtom(multiplications[0])
+	if err != nil || atom == nil {
+		return nil, false
+	}
+	parenthesized := atom.OC_ParenthesizedExpression()
+	if parenthesized == nil {
+		return nil, false
+	}
+	return parenthesized.OC_Expression(), true
+}
+
+// singleAtom descends the arithmetic chain to the one atom under it, refusing
+// anything that is an operation rather than a value.
+func singleAtom(ctx parsing.IOC_MultiplyDivideModuloExpressionContext) (parsing.IOC_AtomContext, error) {
+	powers := ctx.AllOC_PowerOfExpression()
+	if len(powers) != 1 {
+		return nil, unsupported(ctx, "arithmetic")
+	}
+	unaries := powers[0].AllOC_UnaryAddOrSubtractExpression()
+	if len(unaries) != 1 {
+		return nil, unsupported(powers[0], "arithmetic")
+	}
+	listOperator := unaries[0].OC_ListOperatorExpression()
+	if listOperator.GetChildCount() > 1 {
+		return nil, unsupported(listOperator, "list indexing and slicing")
+	}
+	propertyOrLabels := listOperator.OC_PropertyOrLabelsExpression()
+	if len(propertyOrLabels.AllOC_PropertyLookup()) > 0 {
+		return nil, unsupportedf(propertyOrLabels, "a property here", "expected a value")
+	}
+	return propertyOrLabels.OC_Atom(), nil
 }
 
 // comparisonOperator reads the operator token of a partial comparison. The
@@ -404,10 +873,24 @@ func comparisonOperator(ctx parsing.IOC_PartialComparisonExpressionContext) stri
 	return ""
 }
 
-// operand is either a column reference or a constant. Exactly one field is set.
+// operand is what one side of a comparison reads as: a column reference, a
+// constant, or a parameter the request supplies. Exactly one field is set.
 type operand struct {
-	property *PropertyRef
-	literal  *Literal
+	property  *PropertyRef
+	literal   *Literal
+	parameter *ParameterRef
+}
+
+// operand returns the value this side carries, or nil when it is a column.
+func (o operand) operand() *Operand {
+	switch {
+	case o.literal != nil:
+		return &Operand{Literal: o.literal}
+	case o.parameter != nil:
+		return &Operand{Parameter: o.parameter}
+	default:
+		return nil
+	}
 }
 
 func analyzeOperand(ctx parsing.IOC_ExpressionContext) (operand, error) {
@@ -432,24 +915,22 @@ func analyzeOperand(ctx parsing.IOC_ExpressionContext) (operand, error) {
 		return operand{}, unsupportedf(comparisonExpression, "a comparison here",
 			"expected a value, not a condition")
 	}
-	return analyzeStringListNullOperand(comparisonExpression.OC_StringListNullPredicateExpression())
+	predicate, value, err := analyzeStringListNullPredicate(comparisonExpression.OC_StringListNullPredicateExpression(), refusesParentheses)
+	if err != nil {
+		return operand{}, err
+	}
+	if predicate != nil {
+		return operand{}, unsupportedf(comparisonExpression, "a condition here", "expected a value")
+	}
+	return value, nil
 }
 
-func analyzeStringListNullOperand(ctx parsing.IOC_StringListNullPredicateExpressionContext) (operand, error) {
-	if len(ctx.AllOC_StringPredicateExpression()) > 0 {
-		return operand{}, unsupported(ctx, "STARTS WITH, ENDS WITH and CONTAINS")
-	}
-	if len(ctx.AllOC_ListPredicateExpression()) > 0 {
-		return operand{}, unsupported(ctx, "IN")
-	}
-	if len(ctx.AllOC_NullPredicateExpression()) > 0 {
-		return operand{}, unsupported(ctx, "IS NULL and IS NOT NULL")
-	}
-
-	addOrSubtract := ctx.OC_AddOrSubtractExpression()
-	multiplications := addOrSubtract.AllOC_MultiplyDivideModuloExpression()
+// analyzeAddOrSubtractOperand reads a value, refusing the arithmetic the
+// grammar allows around it.
+func analyzeAddOrSubtractOperand(ctx parsing.IOC_AddOrSubtractExpressionContext) (operand, error) {
+	multiplications := ctx.AllOC_MultiplyDivideModuloExpression()
 	if len(multiplications) != 1 {
-		return operand{}, unsupported(addOrSubtract, "arithmetic")
+		return operand{}, unsupported(ctx, "arithmetic")
 	}
 	powers := multiplications[0].AllOC_PowerOfExpression()
 	if len(powers) != 1 {
@@ -490,6 +971,10 @@ func analyzeUnaryOperand(ctx parsing.IOC_UnaryAddOrSubtractExpressionContext) (o
 	if !negated {
 		return value, nil
 	}
+	if value.parameter != nil {
+		return operand{}, unsupportedf(ctx, "negating a parameter",
+			"pass the negative value instead")
+	}
 	// A leading minus only means anything on a number; on anything else it is
 	// arithmetic the subset does not generate.
 	if value.literal == nil {
@@ -513,11 +998,22 @@ func analyzeAtomOperand(ctx parsing.IOC_PropertyOrLabelsExpressionContext) (oper
 
 	switch len(lookups) {
 	case 0:
-		if atom.OC_Variable() != nil {
+		if parameter := atom.OC_Parameter(); parameter != nil {
+			name, err := parameterName(parameter)
+			if err != nil {
+				return operand{}, err
+			}
+			return operand{parameter: &ParameterRef{Name: name, Pos: positionOf(parameter)}}, nil
+		}
+		if variable := atom.OC_Variable(); variable != nil {
+			name, err := namedIdentifier(variable, "variable name")
+			if err != nil {
+				return operand{}, err
+			}
 			// A bare variable is a whole node, which cannot be projected or
 			// compared as a value.
 			return operand{}, unsupportedf(ctx, "referring to a node as a value",
-				"use %s.property", identifier(atom.OC_Variable().GetText()))
+				"use %s.property", name)
 		}
 		return analyzeAtomLiteral(atom)
 	case 1:
@@ -526,9 +1022,17 @@ func analyzeAtomOperand(ctx parsing.IOC_PropertyOrLabelsExpressionContext) (oper
 			return operand{}, unsupportedf(ctx, "property access on an expression",
 				"only variable.property references are supported")
 		}
+		name, err := namedIdentifier(variable, "variable name")
+		if err != nil {
+			return operand{}, err
+		}
+		property, err := namedIdentifier(lookups[0].OC_PropertyKeyName(), "property name")
+		if err != nil {
+			return operand{}, err
+		}
 		return operand{property: &PropertyRef{
-			Variable: identifier(variable.GetText()),
-			Property: identifier(lookups[0].OC_PropertyKeyName().GetText()),
+			Variable: name,
+			Property: property,
 			Pos:      positionOf(ctx),
 		}}, nil
 	default:
@@ -610,13 +1114,38 @@ func describeAtom(ctx parsing.IOC_AtomContext) string {
 	}
 }
 
+// parameterName reads $name. The numeric form ($0) is refused: it is a
+// positional parameter, and the request carries parameters by name.
+func parameterName(ctx parsing.IOC_ParameterContext) (string, error) {
+	if symbolic := ctx.OC_SymbolicName(); symbolic != nil {
+		return namedIdentifier(symbolic, "parameter name")
+	}
+	return "", unsupportedf(ctx, "positional parameters", "name the parameter, as in $value")
+}
+
 // identifier strips the backticks of an escaped symbolic name, where a literal
 // backtick is written doubled.
+//
+// The grammar allows a pair of backticks with nothing between them, so this can
+// produce an empty name. Callers reject that: an empty name matches nothing in
+// the model, and letting one through reaches SQL as an empty identifier, which
+// the database rejects with an error the caller cannot act on.
 func identifier(text string) string {
 	if len(text) >= 2 && strings.HasPrefix(text, "`") && strings.HasSuffix(text, "`") {
 		return strings.ReplaceAll(text[1:len(text)-1], "``", "`")
 	}
 	return text
+}
+
+// namedIdentifier is identifier for the places where an empty name is not a
+// name at all: a variable, a label, a property, an alias.
+func namedIdentifier(ctx antlr.ParserRuleContext, kind string) (string, error) {
+	name := identifier(ctx.GetText())
+	if name == "" {
+		return "", unsupportedf(ctx, "an empty "+kind,
+			"a pair of backticks with nothing between them names nothing")
+	}
+	return name, nil
 }
 
 // decodeStringLiteral turns the source form of a string literal into its
@@ -675,12 +1204,18 @@ func decodeStringLiteral(text string) (string, error) {
 }
 
 // decodeUnicodeEscape reads the four- or eight-digit form after \u. The
-// eight-digit form is tried first because a valid one starts with four digits
-// that would otherwise be read as the short form.
+// eight-digit form is tried first because the lexer matches greedily: eight
+// hex digits are one escape, not a four-digit escape followed by four literal
+// characters, and reading them the other way would silently produce a
+// different string.
 func decodeUnicodeEscape(rest string) (int, rune, error) {
 	if len(rest) >= 8 {
 		if value, err := strconv.ParseUint(rest[:8], 16, 32); err == nil {
-			return 8, rune(value), nil
+			decoded, err := codePoint(value, rest[:8])
+			if err != nil {
+				return 0, 0, err
+			}
+			return 8, decoded, nil
 		}
 	}
 	if len(rest) < 4 {
@@ -690,9 +1225,25 @@ func decodeUnicodeEscape(rest string) (int, rune, error) {
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid unicode escape sequence \\u%s", rest[:4])
 	}
-	decoded := rune(value)
-	if utf16.IsSurrogate(decoded) {
-		return 0, 0, fmt.Errorf("unpaired surrogate in unicode escape sequence \\u%s", rest[:4])
+	decoded, err := codePoint(value, rest[:4])
+	if err != nil {
+		return 0, 0, err
 	}
 	return 4, decoded, nil
+}
+
+// codePoint turns a parsed escape into a rune, refusing the values that are
+// not one. Eight hex digits reach well past the last code point, and a rune is
+// a signed 32-bit value, so converting without this check would wrap a large
+// escape into a negative rune that later encodes as a replacement character --
+// a query that silently means something else instead of an error.
+func codePoint(value uint64, digits string) (rune, error) {
+	if value > unicode.MaxRune {
+		return 0, fmt.Errorf("unicode escape sequence \\u%s is beyond the last code point", digits)
+	}
+	decoded := rune(value)
+	if utf16.IsSurrogate(decoded) {
+		return 0, fmt.Errorf("unpaired surrogate in unicode escape sequence \\u%s", digits)
+	}
+	return decoded, nil
 }

--- a/adp/bkn/bkn-backend/server/logics/cypher/analyze_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/analyze_test.go
@@ -65,13 +65,16 @@ func TestAnalyzeFullQuery(t *testing.T) {
 		t.Fatal("DISTINCT was dropped")
 	}
 
-	if len(query.Where) != 2 {
-		t.Fatalf("predicates = %d, want 2", len(query.Where))
+	conjunction, ok := query.Where.(LogicalOperator)
+	if !ok || conjunction.Operator != "AND" || len(conjunction.Operands) != 2 {
+		t.Fatalf("where = %+v, want an AND of two comparisons", query.Where)
 	}
-	if p := query.Where[0]; p.Left.String() != "a.amount" || p.Operator != ">" || p.Right.Integer != 100 {
+	if p := conjunction.Operands[0].(Comparison); p.Left.String() != "a.amount" ||
+		p.Operator != ">" || p.Right.Literal.Integer != 100 {
 		t.Fatalf("first predicate = %+v", p)
 	}
-	if p := query.Where[1]; p.Left.String() != "b.name" || p.Operator != "=" || p.Right.String != "Acme" {
+	if p := conjunction.Operands[1].(Comparison); p.Left.String() != "b.name" ||
+		p.Operator != "=" || p.Right.Literal.String != "Acme" {
 		t.Fatalf("second predicate = %+v", p)
 	}
 
@@ -171,6 +174,26 @@ func TestAnalyzeLiterals(t *testing.T) {
 			},
 		},
 		{
+			name:  "eight-digit unicode escape",
+			where: `a.name = '\U0001F600'`,
+			check: func(t *testing.T, l Literal) {
+				if l.String != "\U0001F600" {
+					t.Fatalf("got %q", l.String)
+				}
+			},
+		},
+		{
+			name:  "four-digit unicode escape",
+			where: `a.name = '\u0041b'`,
+			check: func(t *testing.T, l Literal) {
+				// Four hex digits then a non-hex character: the short form,
+				// with the character after it kept as itself.
+				if l.String != "Ab" {
+					t.Fatalf("got %q", l.String)
+				}
+			},
+		},
+		{
 			name:  "double quoted",
 			where: `a.name = "quoted"`,
 			check: func(t *testing.T, l Literal) {
@@ -182,7 +205,7 @@ func TestAnalyzeLiterals(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			query := mustAnalyze(t, "MATCH (a:Order) WHERE "+tc.where+" RETURN a.id")
-			tc.check(t, query.Where[0].Right)
+			tc.check(t, *query.Where.(Comparison).Right.Literal)
 		})
 	}
 }
@@ -190,7 +213,7 @@ func TestAnalyzeLiterals(t *testing.T) {
 func TestAnalyzeComparisonOperators(t *testing.T) {
 	for _, operator := range []string{"=", "<>", "<", ">", "<=", ">="} {
 		query := mustAnalyze(t, "MATCH (a:Order) WHERE a.amount "+operator+" 1 RETURN a.id")
-		if got := query.Where[0].Operator; got != operator {
+		if got := query.Where.(Comparison).Operator; got != operator {
 			t.Fatalf("operator = %q, want %q", got, operator)
 		}
 	}
@@ -216,38 +239,35 @@ func TestAnalyzeRejections(t *testing.T) {
 		{"MATCH p = (a:Order) RETURN a.id", "path variables"},
 		{"MATCH (a) RETURN a.id", "nodes without a label"},
 		{"MATCH (a:Order:Invoice) RETURN a.id", "multiple labels"},
-		{"MATCH (a:Order {id: 1}) RETURN a.id", "inline property maps"},
-		{"MATCH (a:Order)-[:R]-(b:Customer) RETURN a.id", "undirected relationships"},
 		{"MATCH (a:Order)<-[:R]->(b:Customer) RETURN a.id", "pointing both ways"},
 		{"MATCH (a:Order)-->(b:Customer) RETURN a.id", "relationships without a type"},
 		{"MATCH (a:Order)-[r:R]->(b:Customer) RETURN a.id", "relationship variables"},
 		{"MATCH (a:Order)-[:R*1..3]->(b:Customer) RETURN a.id", "variable-length"},
 		{"MATCH (a:Order)-[:R|:S]->(b:Customer) RETURN a.id", "alternative relationship types"},
 		{"MATCH (a:Order)-[:R {x: 1}]->(b:Customer) RETURN a.id", "inline property maps"},
-		{"MATCH (a:Order)-[:R]->(b:C)-[:S]->(c:D) RETURN a.id", "multi-hop"},
 		{"MATCH (a:Order) RETURN *", "RETURN *"},
 		{"MATCH (a:Order) RETURN a", "referring to a node as a value"},
-		{"MATCH (a:Order) RETURN count(a.id)", "function calls"},
-		{"MATCH (a:Order) RETURN count(*)", "count(*)"},
+		{"MATCH (a:Order) RETURN lower(a.id)", "function calls"},
 		{"MATCH (a:Order) RETURN a.id + 1", "arithmetic"},
-		{"MATCH (a:Order) RETURN $parameter", "query parameters"},
+		{"MATCH (a:Order) RETURN CASE a.x WHEN 1 THEN 2 ELSE 3 END", "CASE"},
+		{"MATCH (a:Order) RETURN [x IN [1, 2] | x]", "list comprehensions"},
+		{"MATCH (a:Order) RETURN [(a)-[:R]->(b:Customer) | b.id]", "pattern comprehensions"},
+		{"MATCH (a:Order) WHERE all(x IN [1] WHERE x = 1) RETURN a.id", "quantified expressions"},
+		{"MATCH (a:Order) RETURN a.x IS NULL", "a condition here"},
 		{"MATCH (a:Order) RETURN a.items[0]", "list indexing"},
 		{"MATCH (a:Order) RETURN a.x.y", "nested property access"},
 		{"MATCH (a:Order) RETURN 1", "only variable.property references"},
-		{"MATCH (a:Order) WHERE a.x = 1 OR a.y = 2 RETURN a.id", "OR"},
 		{"MATCH (a:Order) WHERE a.x = 1 XOR a.y = 2 RETURN a.id", "XOR"},
-		{"MATCH (a:Order) WHERE NOT a.x = 1 RETURN a.id", "NOT"},
-		{"MATCH (a:Order) WHERE a.x IN [1, 2] RETURN a.id", "IN"},
-		{"MATCH (a:Order) WHERE a.x IS NULL RETURN a.id", "IS NULL"},
 		{"MATCH (a:Order) WHERE a.x STARTS WITH 'A' RETURN a.id", "STARTS WITH"},
 		{"MATCH (a:Order) WHERE a.x = a.y RETURN a.id", "against a literal"},
 		{"MATCH (a:Order) WHERE a.x = null RETURN a.id", "comparing against null"},
+		{"MATCH (a:Order) WHERE a.x = 1 XOR a.y = 2 RETURN a.id", "XOR"},
 		{"MATCH (a:Order) WHERE a.x < a.y < a.z RETURN a.id", "chained comparisons"},
 		{"MATCH (a:Order) WHERE a.x RETURN a.id", "non-comparison predicate"},
 		{"MATCH (a:Order) WHERE a.x = [1] RETURN a.id", "list and map literals"},
 		{"MATCH (a:Order) WHERE (a)-[:R]->(:Customer) RETURN a.id", "pattern predicates"},
 		{"MATCH (a:Order) WHERE EXISTS { (a)-[:R]->(:Customer) } RETURN a.id", "EXISTS subqueries"},
-		{"MATCH (a:Order) WHERE (a.x = 1) RETURN a.id", "parenthesized expressions"},
+		{"MATCH (a:Order) RETURN (a.x)", "parenthesized expressions"},
 		{"MATCH (a:Order) RETURN a.id LIMIT 1 + 1", "arithmetic"},
 		{"MATCH (a:Order) RETURN a.id LIMIT 'ten'", "non-integer LIMIT"},
 		{"MATCH (a:Order) RETURN a.id SKIP -1", "negative SKIP"},
@@ -264,15 +284,119 @@ func TestAnalyzeRejections(t *testing.T) {
 	}
 }
 
+// An escape past the last code point used to wrap into a negative rune and
+// encode as a replacement character, which would have made the query mean
+// something other than what was written.
+func TestAnalyzeRejectsUnicodeEscapesThatAreNotCodePoints(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "beyond the last code point",
+			query: `MATCH (a:Order) WHERE a.name = '\uFFFFFFFF' RETURN a.id`,
+			want:  "beyond the last code point",
+		},
+		{
+			name:  "unpaired surrogate",
+			query: `MATCH (a:Order) WHERE a.name = '\uD800' RETURN a.id`,
+			want:  "unpaired surrogate",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := analyze(t, tc.query)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Analyze(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}
+
+// Every escape the grammar allows is decoded here, and the two malformed
+// forms are refused rather than passed through as text.
+func TestAnalyzeStringEscapes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		where string
+		want  string
+	}{
+		{name: "backspace", where: `a.name = '\b'`, want: "\b"},
+		{name: "form feed", where: `a.name = '\f'`, want: "\f"},
+		{name: "carriage return", where: `a.name = '\r'`, want: "\r"},
+		{name: "newline", where: `a.name = '\n'`, want: "\n"},
+		{name: "double quote", where: `a.name = '\"'`, want: `"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			query := mustAnalyze(t, "MATCH (a:Order) WHERE "+tc.where+" RETURN a.id")
+			if got := query.Where.(Comparison).Right.Literal.String; got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The lexer refuses a malformed escape before the decoder ever sees it, so
+// these branches are a second line rather than the first. They are exercised
+// directly: reaching them through a query is not possible, and a test that
+// pretended otherwise would be asserting the lexer instead.
+func TestDecodeStringLiteralRefusesMalformedEscapes(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		literal string
+		want    string
+	}{
+		{name: "unknown escape", literal: `'\q'`, want: "unknown escape sequence"},
+		{name: "trailing backslash", literal: "'a\\'", want: "trailing backslash"},
+		{name: "incomplete unicode escape", literal: `'\u41'`, want: "incomplete unicode escape"},
+		{name: "invalid unicode digits", literal: `'\uzzzz'`, want: "invalid unicode escape"},
+		{name: "not a literal at all", literal: `'`, want: "malformed string literal"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeStringLiteral(tc.literal)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("decodeStringLiteral(%s) = %v, want an error mentioning %q", tc.literal, err, tc.want)
+			}
+		})
+	}
+}
+
 // A rejection has to say where, because a long query has many places the same
 // construct could appear.
 func TestAnalyzeRejectionCarriesPosition(t *testing.T) {
-	_, err := analyze(t, "MATCH (a:Order)\nWHERE NOT a.paid = true\nRETURN a.id")
+	_, err := analyze(t, "MATCH (a:Order)\nWHERE a.name STARTS WITH 'A'\nRETURN a.id")
 	unsupported, ok := err.(*Unsupported)
 	if !ok {
 		t.Fatalf("error = %T (%v), want *Unsupported", err, err)
 	}
 	if unsupported.Pos.Line != 2 {
 		t.Fatalf("line = %d, want 2", unsupported.Pos.Line)
+	}
+}
+
+// The grammar allows a pair of backticks with nothing between them, so an
+// empty name can be written wherever a name can. It refers to nothing, and
+// letting one through reached SQL as an empty identifier -- a 500 the caller
+// could not act on -- or, in ORDER BY, a nil dereference.
+func TestAnalyzeRejectsEmptyNames(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{name: "variable", query: "MATCH (``:Order) RETURN o.id", want: "an empty variable name"},
+		{name: "label", query: "MATCH (o:``) RETURN o.id", want: "an empty label"},
+		{name: "property", query: "MATCH (o:Order) RETURN o.``", want: "an empty property name"},
+		{name: "column name", query: "MATCH (o:Order) RETURN o.id AS ``", want: "an empty column name"},
+		{name: "sort key", query: "MATCH (o:Order) RETURN o.id AS id ORDER BY ``", want: "an empty variable name"},
+		{name: "relationship type", query: "MATCH (o:Order)-[:``]->(c:Customer) RETURN o.id", want: "an empty relationship type"},
+		{name: "parameter", query: "MATCH (o:Order) WHERE o.id = $`` RETURN o.id", want: "an empty parameter name"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := analyze(t, tc.query)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Analyze(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/cypher/ast.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/ast.go
@@ -30,12 +30,15 @@ const (
 	Outgoing Direction = iota
 	// Incoming is (a)<-[:R]-(b): b is the relation's source.
 	Incoming
+	// Undirected is (a)-[:R]-(b): either node may be the source, and which
+	// readings are possible depends on what the relation type connects.
+	Undirected
 )
 
 // Query is one accepted read-only query.
 type Query struct {
 	Pattern  Pattern
-	Where    []Comparison // conjunctive: every entry must hold
+	Where    Predicate // nil when the query has no WHERE
 	Return   []Projection
 	Distinct bool
 	OrderBy  []SortKey
@@ -55,7 +58,11 @@ type Pattern struct {
 type NodeRef struct {
 	Variable string
 	Label    string
-	Pos      Position
+	// Anonymous marks a variable the compiler invented for a node the query
+	// did not name, so a message about it can say "the node" rather than
+	// quote a name the author never wrote.
+	Anonymous bool
+	Pos       Position
 }
 
 // EdgeRef is one relationship of the pattern.
@@ -74,13 +81,62 @@ type PropertyRef struct {
 
 func (p PropertyRef) String() string { return p.Variable + "." + p.Property }
 
-// Comparison is one predicate: a property against a literal.
+// Predicate is one node of a WHERE expression. The shapes below are the whole
+// set: anything else the grammar allows is refused while reading the query, so
+// later stages never meet a predicate they cannot generate.
+type Predicate interface {
+	predicatePosition() Position
+}
+
+// Comparison is a property against a value.
 type Comparison struct {
 	Left     PropertyRef
 	Operator string
-	Right    Literal
+	Right    Operand
 	Pos      Position
 }
+
+func (c Comparison) predicatePosition() Position { return c.Pos }
+
+// LogicalOperator is AND, OR or XOR over two or more predicates. It keeps the
+// operands of one operator flat rather than nesting them pairwise, which is
+// how the source reads and how the generated SQL is written.
+type LogicalOperator struct {
+	Operator string // AND, OR, XOR
+	Operands []Predicate
+	Pos      Position
+}
+
+func (l LogicalOperator) predicatePosition() Position { return l.Pos }
+
+// Negation is NOT applied to one predicate.
+type Negation struct {
+	Operand Predicate
+	Pos     Position
+}
+
+func (n Negation) predicatePosition() Position { return n.Pos }
+
+// NullCheck is IS NULL, or IS NOT NULL when negated.
+type NullCheck struct {
+	Property PropertyRef
+	Negated  bool
+	Pos      Position
+}
+
+func (n NullCheck) predicatePosition() Position { return n.Pos }
+
+// Membership is IN over a list written in the query. An empty list matches
+// nothing, which is what Cypher says and what the generator has to write
+// explicitly because SQL has no empty IN.
+type Membership struct {
+	Property PropertyRef
+	Values   []Operand
+	Negated  bool
+	Pos      Position
+}
+
+func (m Membership) predicatePosition() Position { return m.Pos }
 
 // LiteralKind tags which field of Literal carries the value.
 type LiteralKind int
@@ -120,15 +176,72 @@ func (l Literal) describe() string {
 	}
 }
 
-// Projection is one RETURN item. Alias is what the column is called in the
-// result; it defaults to the source text of the property reference.
-type Projection struct {
-	Property PropertyRef
-	Alias    string
+// Operand is a value written in the query: a literal, or a parameter that the
+// request supplies. Both are values and never identifiers -- a parameter can
+// change which rows come back, never which table or column is read.
+type Operand struct {
+	Literal   *Literal
+	Parameter *ParameterRef
 }
 
-// SortKey is one ORDER BY item.
+// ParameterRef is $name, resolved against the request's parameters before the
+// statement is generated.
+type ParameterRef struct {
+	Name string
+	Pos  Position
+}
+
+func (o Operand) describe() string {
+	if o.Parameter != nil {
+		return "parameter $" + o.Parameter.Name
+	}
+	if o.Literal != nil {
+		return o.Literal.describe()
+	}
+	return "an empty operand"
+}
+
+// Projection is one RETURN item: a property, or an aggregate over one. Alias
+// is what the column is called in the result; it defaults to the source text
+// of what was projected.
+type Projection struct {
+	Property  *PropertyRef
+	Aggregate *Aggregate
+	Alias     string
+}
+
+// Aggregate is count, sum, avg, min or max. Property is nil for count(*),
+// which counts rows rather than values.
+type Aggregate struct {
+	// Function is the SQL spelling, taken from a fixed set. Name is what the
+	// author wrote, which is what an unaliased column is called: a result read
+	// by key should carry the name the query used.
+	Function string
+	Name     string
+	Distinct bool
+	Property *PropertyRef
+	Pos      Position
+}
+
+// String renders the aggregate the way it was written, which is what an
+// unaliased column is named after.
+func (a Aggregate) String() string {
+	inner := "*"
+	if a.Property != nil {
+		inner = a.Property.String()
+	}
+	if a.Distinct {
+		inner = "DISTINCT " + inner
+	}
+	return a.Name + "(" + inner + ")"
+}
+
+// SortKey is one ORDER BY item. It is a property, an aggregate written out
+// again, or the name of something the query returns.
 type SortKey struct {
-	Property   PropertyRef
+	Property   *PropertyRef
+	Aggregate  *Aggregate
+	Alias      string
 	Descending bool
+	Pos        Position
 }

--- a/adp/bkn/bkn-backend/server/logics/cypher/binder.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/binder.go
@@ -170,12 +170,17 @@ func dataPropertyNames(ot *interfaces.ObjectType) []string {
 	return names
 }
 
+// suggestObjectTypes offers both ids and names, because a label may be written
+// either way and the near miss is as likely to be on one as on the other.
 func (s *Schema) suggestObjectTypes(label string) string {
-	names := make([]string, 0, len(s.objectTypesByID))
-	for id := range s.objectTypesByID {
-		names = append(names, id)
+	candidates := make([]string, 0, 2*len(s.objectTypesByID))
+	for id, ot := range s.objectTypesByID {
+		candidates = append(candidates, id)
+		if ot.OTName != "" && ot.OTName != id {
+			candidates = append(candidates, ot.OTName)
+		}
 	}
-	return suggest(label, names)
+	return suggest(label, candidates)
 }
 
 // suggest offers near matches so a typo does not read as a modelling gap. It

--- a/adp/bkn/bkn-backend/server/logics/cypher/binder_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/binder_test.go
@@ -51,9 +51,11 @@ func dataProperty(name, column string) *interfaces.DataProperty {
 func relationType(id, name string) *interfaces.RelationType {
 	return &interfaces.RelationType{
 		RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
-			RTID:   id,
-			RTName: name,
-			Type:   interfaces.RELATION_TYPE_DIRECT,
+			RTID:               id,
+			RTName:             name,
+			Type:               interfaces.RELATION_TYPE_DIRECT,
+			SourceObjectTypeID: "ot_order",
+			TargetObjectTypeID: "ot_customer",
 		},
 	}
 }
@@ -124,7 +126,10 @@ func TestResolveLabelSelfMatchIsNotAmbiguous(t *testing.T) {
 }
 
 func TestResolveRelationType(t *testing.T) {
-	src := &fakeSchemaSource{relationTypes: []*interfaces.RelationType{
+	src := &fakeSchemaSource{objectTypes: []*interfaces.ObjectType{
+		objectType("ot_order", "Order", resource("res_order", "orders")),
+		objectType("ot_customer", "Customer", resource("res_customer", "customers")),
+	}, relationTypes: []*interfaces.RelationType{
 		relationType("rt_placed", "PLACED"),
 		relationType("rt_shadow", "rt_placed"),
 	}}

--- a/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
@@ -7,6 +7,7 @@
 package cypher
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -21,10 +22,13 @@ func modelSchema(t *testing.T) *Schema {
 
 	order := objectType("ot_order", "Order", resource("res_order", "orders"),
 		dataProperty("id", "f_id"),
+		dataProperty("previous_id", "f_prev"),
 		dataProperty("customer_code", "f_cust_code"),
 		dataProperty("region", "f_region"),
 		dataProperty("amount", "f_total"),
 	)
+	order.PrimaryKeys = []string{"id"}
+
 	customer := objectType("ot_customer", "Customer", resource("res_customer", "customers"),
 		dataProperty("code", "f_code"),
 		dataProperty("region", "f_region"),
@@ -46,6 +50,30 @@ func modelSchema(t *testing.T) *Schema {
 		},
 	}
 
+	item := objectType("ot_item", "Item", resource("res_item", "items"),
+		dataProperty("id", "f_id"),
+		dataProperty("order_id", "f_order"),
+	)
+	item.PrimaryKeys = []string{"id"}
+
+	belongsTo := relationType("rt_belongs_to", "BELONGS_TO")
+	belongsTo.SourceObjectTypeID = "ot_item"
+	belongsTo.TargetObjectTypeID = "ot_order"
+	belongsTo.MappingRules = []interfaces.Mapping{{
+		SourceProp: interfaces.SimpleProperty{Name: "order_id"},
+		TargetProp: interfaces.SimpleProperty{Name: "id"},
+	}}
+
+	// A relation from an object type to itself: an undirected pattern over it
+	// cannot be settled by the object types, so both readings stay open.
+	follows := relationType("rt_follows", "FOLLOWS")
+	follows.SourceObjectTypeID = "ot_order"
+	follows.TargetObjectTypeID = "ot_order"
+	follows.MappingRules = []interfaces.Mapping{{
+		SourceProp: interfaces.SimpleProperty{Name: "id"},
+		TargetProp: interfaces.SimpleProperty{Name: "previous_id"},
+	}}
+
 	nearby := relationType("rt_nearby", "NEARBY")
 	nearby.Type = interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN
 	nearby.SourceObjectTypeID = "ot_order"
@@ -57,8 +85,8 @@ func modelSchema(t *testing.T) *Schema {
 	unmapped.TargetObjectTypeID = "ot_customer"
 
 	return testSchema(t, &fakeSchemaSource{
-		objectTypes:   []*interfaces.ObjectType{order, customer},
-		relationTypes: []*interfaces.RelationType{placedBy, nearby, unmapped},
+		objectTypes:   []*interfaces.ObjectType{order, customer, item},
+		relationTypes: []*interfaces.RelationType{placedBy, belongsTo, follows, nearby, unmapped},
 	})
 }
 
@@ -72,7 +100,7 @@ func compile(t *testing.T, query string, options GenerateOptions) (string, error
 	if err != nil {
 		return "", err
 	}
-	plan, err := Compile(analyzed, modelSchema(t))
+	plan, err := Compile(analyzed, modelSchema(t), CompileOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -123,10 +151,22 @@ func TestCompileJoinIncoming(t *testing.T) {
 	}
 }
 
+// Sorting by a returned value stays allowed under DISTINCT, whether it is
+// named by its alias in RETURN or written out again in ORDER BY.
+func TestCompileDistinctSortedByReturnedValue(t *testing.T) {
+	got := mustCompile(t, "MATCH (o:Order) RETURN DISTINCT o.region AS r ORDER BY o.region DESC")
+	want := "SELECT DISTINCT t0.`f_region` AS `r` FROM {{.res_order}} t0 ORDER BY t0.`f_region` DESC"
+	if got != want {
+		t.Fatalf("got  %s\nwant %s", got, want)
+	}
+}
+
+// Without DISTINCT, sorting by a column that is not returned is ordinary SQL
+// and stays allowed.
 func TestCompileClauses(t *testing.T) {
-	got := mustCompile(t, `MATCH (o:Order) RETURN DISTINCT o.region AS region
+	got := mustCompile(t, `MATCH (o:Order) RETURN o.region AS region
 		ORDER BY o.region DESC, o.amount SKIP 20 LIMIT 10`)
-	want := "SELECT DISTINCT t0.`f_region` AS `region` FROM {{.res_order}} t0 " +
+	want := "SELECT t0.`f_region` AS `region` FROM {{.res_order}} t0 " +
 		"ORDER BY t0.`f_region` DESC, t0.`f_total` LIMIT 10 OFFSET 20"
 	if got != want {
 		t.Fatalf("got  %s\nwant %s", got, want)
@@ -224,7 +264,7 @@ func TestGeneratePostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
-	plan, err := Compile(analyzed, modelSchema(t))
+	plan, err := Compile(analyzed, modelSchema(t), CompileOptions{})
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -274,7 +314,7 @@ func TestCompileRejections(t *testing.T) {
 		{
 			name:  "relationship written backwards",
 			query: "MATCH (c:Customer)-[:PLACED_BY]->(o:Order) RETURN o.id",
-			want:  "but the pattern starts it at",
+			want:  "does not connect",
 		},
 		{
 			name:  "filtered cross join",
@@ -285,6 +325,11 @@ func TestCompileRejections(t *testing.T) {
 			name:  "relation without key mapping",
 			query: "MATCH (o:Order)-[:UNMAPPED]->(c:Customer) RETURN o.id",
 			want:  "no key mapping",
+		},
+		{
+			name:  "distinct sorted by something it does not return",
+			query: "MATCH (o:Order) RETURN DISTINCT o.region AS r ORDER BY o.amount",
+			want:  "DISTINCT can only be sorted by a returned value",
 		},
 		{
 			name:  "unknown relation type",
@@ -314,5 +359,144 @@ func TestCompileRejectionCarriesPosition(t *testing.T) {
 	}
 	if planError.Pos.Line != 2 {
 		t.Fatalf("line = %d, want 2", planError.Pos.Line)
+	}
+}
+
+// An undirected relationship leaves open which node is the relation's source.
+// Where the object types settle it, the join is the one reading that fits;
+// where they do not, it is either.
+func TestCompileUndirected(t *testing.T) {
+	t.Run("object types settle the direction", func(t *testing.T) {
+		got := mustCompile(t, "MATCH (o:Order)-[:PLACED_BY]-(c:Customer) RETURN o.id AS id")
+		want := "SELECT t0.`f_id` AS `id` FROM {{.res_order}} t0 " +
+			"JOIN {{.res_customer}} t1 ON t0.`f_cust_code` = t1.`f_code` AND t0.`f_region` = t1.`f_region`"
+		if got != want {
+			t.Fatalf("got  %s\nwant %s", got, want)
+		}
+	})
+
+	t.Run("written the other way round is the same join", func(t *testing.T) {
+		got := mustCompile(t, "MATCH (c:Customer)-[:PLACED_BY]-(o:Order) RETURN o.id AS id")
+		want := "SELECT t1.`f_id` AS `id` FROM {{.res_customer}} t0 " +
+			"JOIN {{.res_order}} t1 ON t0.`f_code` = t1.`f_cust_code` AND t0.`f_region` = t1.`f_region`"
+		if got != want {
+			t.Fatalf("got  %s\nwant %s", got, want)
+		}
+	})
+
+	t.Run("a self relation matches either reading", func(t *testing.T) {
+		got := mustCompile(t, "MATCH (a:Order)-[:FOLLOWS]-(b:Order) RETURN a.id AS id")
+		want := "SELECT t0.`f_id` AS `id` FROM {{.res_order}} t0 " +
+			"JOIN {{.res_order}} t1 ON (t0.`f_id` = t1.`f_prev`) OR (t0.`f_prev` = t1.`f_id`)"
+		if got != want {
+			t.Fatalf("got  %s\nwant %s", got, want)
+		}
+	})
+}
+
+// A path of several hops becomes a chain of joins in pattern order. The
+// interesting part is not the chain but what Cypher requires on top of it: one
+// pattern may not traverse the same relationship twice.
+func TestCompileMultiHop(t *testing.T) {
+	t.Run("two hops over different relations", func(t *testing.T) {
+		got := mustCompile(t,
+			"MATCH (i:Item)-[:BELONGS_TO]->(o:Order)-[:PLACED_BY]->(c:Customer) RETURN c.name AS customer")
+		want := "SELECT t2.`f_name` AS `customer` FROM {{.res_item}} t0 " +
+			"JOIN {{.res_order}} t1 ON t0.`f_order` = t1.`f_id` " +
+			"JOIN {{.res_customer}} t2 ON t1.`f_cust_code` = t2.`f_code` AND t1.`f_region` = t2.`f_region`"
+		if got != want {
+			t.Fatalf("got  %s\nwant %s", got, want)
+		}
+	})
+
+	t.Run("hops meeting a node from the same side cannot be the same edge", func(t *testing.T) {
+		// Both hops arrive at the middle order, so the two outer items would
+		// otherwise be free to be the same row -- which is the same
+		// relationship walked out and back.
+		got := mustCompile(t,
+			"MATCH (a:Item)-[:BELONGS_TO]->(o:Order)<-[:BELONGS_TO]-(b:Item) RETURN a.id AS a, b.id AS b")
+		want := "SELECT t0.`f_id` AS `a`, t2.`f_id` AS `b` FROM {{.res_item}} t0 " +
+			"JOIN {{.res_order}} t1 ON t0.`f_order` = t1.`f_id` " +
+			"JOIN {{.res_item}} t2 ON t1.`f_id` = t2.`f_order` " +
+			"WHERE NOT t0.`f_id` = t2.`f_id`"
+		if got != want {
+			t.Fatalf("got  %s\nwant %s", got, want)
+		}
+	})
+
+	// Two hops in the same direction coincide on a row that points at itself,
+	// so they need the condition as much as opposing hops do.
+	t.Run("hops going the same way over a self relation", func(t *testing.T) {
+		got := mustCompile(t,
+			"MATCH (a:Order)-[:FOLLOWS]->(b:Order)-[:FOLLOWS]->(c:Order) RETURN a.id AS id")
+		want := "WHERE NOT (t0.`f_id` = t1.`f_id` AND t1.`f_id` = t2.`f_id`)"
+		if !strings.Contains(got, want) {
+			t.Fatalf("got  %s\nwant it to contain %s", got, want)
+		}
+	})
+
+	// Hops with another hop between them can be the same relationship too, so
+	// every pair is compared rather than only neighbours.
+	t.Run("hops that are not neighbours", func(t *testing.T) {
+		got := mustCompile(t,
+			"MATCH (a:Order)-[:FOLLOWS]->(b:Order)-[:FOLLOWS]->(c:Order)-[:FOLLOWS]->(d:Order) RETURN a.id AS id")
+		for _, want := range []string{
+			"NOT (t0.`f_id` = t1.`f_id` AND t1.`f_id` = t2.`f_id`)",
+			"NOT (t0.`f_id` = t2.`f_id` AND t1.`f_id` = t3.`f_id`)",
+			"NOT (t1.`f_id` = t2.`f_id` AND t2.`f_id` = t3.`f_id`)",
+		} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("got  %s\nwant it to contain %s", got, want)
+			}
+		}
+	})
+
+	t.Run("a distinctness condition joins the query's own", func(t *testing.T) {
+		got := mustCompile(t,
+			"MATCH (a:Item)-[:BELONGS_TO]->(o:Order)<-[:BELONGS_TO]-(b:Item) WHERE o.amount > 10 RETURN a.id AS a")
+		if !strings.Contains(got, "WHERE NOT t0.`f_id` = t2.`f_id` AND t1.`f_total` > 10") {
+			t.Fatalf("got %s", got)
+		}
+	})
+}
+
+func TestCompileMultiHopRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "an undirected hop beside one of the same type",
+			query: "MATCH (a:Item)-[:BELONGS_TO]-(o:Order)-[:BELONGS_TO]-(b:Item) RETURN a.id",
+			want:  "cannot have one of them undirected",
+		},
+		{
+			name:  "a middle node the relations do not connect",
+			query: "MATCH (i:Item)-[:BELONGS_TO]->(o:Order)-[:BELONGS_TO]->(c:Customer) RETURN i.id",
+			want:  "does not connect",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compile(t, tc.query, GenerateOptions{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}
+
+// Every relationship is a join, and the row limit bounds what comes back
+// rather than what the database does to produce it.
+func TestCompileRefusesAVeryLongPath(t *testing.T) {
+	query := "MATCH (n0:Order)"
+	for i := 1; i <= interfaces.CYPHER_MAX_PATH_LENGTH+1; i++ {
+		query += fmt.Sprintf("-[:FOLLOWS]->(n%d:Order)", i)
+	}
+	query += " RETURN n0.id"
+
+	_, err := compile(t, query, GenerateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "a path this long") {
+		t.Fatalf("compile = %v, want a rejection naming the path length", err)
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/cypher/grammar_coverage_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/grammar_coverage_test.go
@@ -1,0 +1,142 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"bufio"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/antlr4-go/antlr/v4"
+
+	"bkn-backend/logics/cypher/parsing"
+)
+
+// The corpus in testdata carries one query for every rule of the openCypher
+// grammar. These tests state the property that corpus exists for: the compiler
+// has an answer for the whole language, not only for the part it implements.
+
+func grammarCorpus(t *testing.T) []string {
+	t.Helper()
+
+	file, err := os.Open("testdata/grammar_corpus.cypher")
+	if err != nil {
+		t.Fatalf("open corpus: %v", err)
+	}
+	defer file.Close()
+
+	var queries []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		queries = append(queries, line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read corpus: %v", err)
+	}
+	return queries
+}
+
+// Every rule of the grammar has to be reached by something in the corpus.
+// A rule nothing reaches is a construct nobody has ever handed the compiler,
+// which is where an unhandled shape hides -- the whole point of keeping a
+// corpus rather than only the cases the subset accepts.
+func TestCorpusReachesEveryGrammarRule(t *testing.T) {
+	lexer := parsing.NewCypherLexer(antlr.NewInputStream(""))
+	ruleNames := parsing.NewCypherParser(antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)).GetRuleNames()
+
+	reached := make(map[int]bool, len(ruleNames))
+	for _, query := range grammarCorpus(t) {
+		tree, err := Parse(query)
+		if err != nil {
+			// A query the grammar itself rejects reaches no rule; the corpus
+			// keeps a few on purpose, for the syntax-error path.
+			continue
+		}
+		markRules(tree, reached)
+	}
+
+	var missing []string
+	for index, name := range ruleNames {
+		if !reached[index] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Fatalf("%d of %d grammar rules are not reached by the corpus: %s",
+			len(missing), len(ruleNames), strings.Join(missing, ", "))
+	}
+}
+
+func markRules(tree antlr.Tree, reached map[int]bool) {
+	if ctx, ok := tree.(antlr.ParserRuleContext); ok {
+		reached[ctx.GetRuleIndex()] = true
+	}
+	for i := 0; i < tree.GetChildCount(); i++ {
+		markRules(tree.GetChild(i), reached)
+	}
+}
+
+// Whatever the corpus contains, the answer is a compiled query or a refusal
+// that carries a position -- never a panic, and never an error of a type the
+// service does not know how to turn into a status.
+func TestCorpusIsAlwaysAnsweredOrRefusedByName(t *testing.T) {
+	for _, query := range grammarCorpus(t) {
+		t.Run(truncate(query), func(t *testing.T) {
+			tree, err := Parse(query)
+			if err != nil {
+				var syntaxErrors SyntaxErrors
+				if !asSyntaxErrors(err, &syntaxErrors) {
+					t.Fatalf("parse error of type %T, want SyntaxErrors: %v", err, err)
+				}
+				if len(syntaxErrors) == 0 {
+					t.Fatal("a parse failure reported no error")
+				}
+				return
+			}
+
+			analyzed, err := Analyze(tree)
+			if err == nil {
+				if analyzed == nil {
+					t.Fatal("analyze returned neither a query nor an error")
+				}
+				return
+			}
+			unsupported, ok := err.(*Unsupported)
+			if !ok {
+				t.Fatalf("analyze error of type %T, want *Unsupported: %v", err, err)
+			}
+			if unsupported.Feature == "" {
+				t.Fatalf("a refusal that does not name the construct: %v", err)
+			}
+			if unsupported.Pos.Line == 0 {
+				t.Fatalf("a refusal without a position: %v", err)
+			}
+		})
+	}
+}
+
+func asSyntaxErrors(err error, target *SyntaxErrors) bool {
+	errs, ok := err.(SyntaxErrors)
+	if ok {
+		*target = errs
+	}
+	return ok
+}
+
+func truncate(query string) string {
+	if len(query) <= 60 {
+		return query
+	}
+	return query[:60]
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/parameters.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/parameters.go
@@ -1,0 +1,61 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
+// Parameters are values, never identifiers. A parameter can change which rows
+// come back; it can never change which resource or column is read, because it
+// is bound into a literal and escaped by the same rules as one written in the
+// query. That is the whole reason to offer them: a caller with values to pass
+// no longer has to build query text.
+//
+// literalFromParameter maps one supplied value onto the literal kinds the
+// generator knows how to write. A type it cannot map is refused by name rather
+// than rendered as whatever fmt makes of it.
+func literalFromParameter(value any) (Literal, error) {
+	switch typed := value.(type) {
+	case string:
+		return Literal{Kind: LiteralString, String: typed}, nil
+	case bool:
+		return Literal{Kind: LiteralBoolean, Boolean: typed}, nil
+	case int:
+		return Literal{Kind: LiteralInteger, Integer: int64(typed)}, nil
+	case int64:
+		return Literal{Kind: LiteralInteger, Integer: typed}, nil
+	case json.Number:
+		return literalFromJSONNumber(typed)
+	case float64:
+		// JSON has one number type, so an integer arrives as a float unless
+		// the decoder was told otherwise. A value that is exactly an integer
+		// is carried as one: writing 42 as 42.0 changes what an equality
+		// against an integer column matches.
+		if typed == math.Trunc(typed) && math.Abs(typed) <= math.MaxInt64 {
+			return Literal{Kind: LiteralInteger, Integer: int64(typed)}, nil
+		}
+		return Literal{Kind: LiteralFloat, Float: typed}, nil
+	case nil:
+		return Literal{}, fmt.Errorf("is null; write IS NULL instead of comparing to a null parameter")
+	default:
+		return Literal{}, fmt.Errorf("is a %T; parameters must be a string, a number or a boolean", value)
+	}
+}
+
+func literalFromJSONNumber(number json.Number) (Literal, error) {
+	if integer, err := number.Int64(); err == nil {
+		return Literal{Kind: LiteralInteger, Integer: integer}, nil
+	}
+	float, err := number.Float64()
+	if err != nil {
+		return Literal{}, fmt.Errorf("is not a number this interface can carry")
+	}
+	return Literal{Kind: LiteralFloat, Float: float}, nil
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/parameters_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/parameters_test.go
@@ -1,0 +1,200 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func compileWithParameters(t *testing.T, query string, parameters map[string]any) (string, error) {
+	t.Helper()
+	tree, err := Parse(query)
+	if err != nil {
+		return "", err
+	}
+	analyzed, err := Analyze(tree)
+	if err != nil {
+		return "", err
+	}
+	plan, err := Compile(analyzed, modelSchema(t), CompileOptions{Parameters: parameters})
+	if err != nil {
+		return "", err
+	}
+	return Generate(plan, GenerateOptions{})
+}
+
+// A parameter is a value. It reaches the statement through the same escaping
+// as a literal written in the query, which is what makes it safe to accept.
+func TestCompileParameters(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		where      string
+		parameters map[string]any
+		want       string
+	}{
+		{
+			name:       "string",
+			where:      "o.region = $region",
+			parameters: map[string]any{"region": "eu"},
+			want:       "t0.`f_region` = 'eu'",
+		},
+		{
+			name:       "a value that would end the literal",
+			where:      "o.region = $region",
+			parameters: map[string]any{"region": `a'; DROP TABLE x --`},
+			want:       "t0.`f_region` = 'a''; DROP TABLE x --'",
+		},
+		{
+			name:       "a value ending in a backslash",
+			where:      "o.region = $region",
+			parameters: map[string]any{"region": `abc\`},
+			want:       "t0.`f_region` = 'abc\\\\'",
+		},
+		{
+			name:       "integer",
+			where:      "o.amount > $floor",
+			parameters: map[string]any{"floor": 100},
+			want:       "t0.`f_total` > 100",
+		},
+		{
+			// JSON has one number type, so an integer arrives as a float.
+			// Writing it back as 100.0 would stop it matching an integer key.
+			name:       "integer that arrived as a float",
+			where:      "o.amount > $floor",
+			parameters: map[string]any{"floor": float64(100)},
+			want:       "t0.`f_total` > 100",
+		},
+		{
+			name:       "float",
+			where:      "o.amount > $floor",
+			parameters: map[string]any{"floor": 1.5},
+			want:       "t0.`f_total` > 1.5",
+		},
+		{
+			name:       "boolean",
+			where:      "o.region = $flag",
+			parameters: map[string]any{"flag": true},
+			want:       "t0.`f_region` = TRUE",
+		},
+		{
+			name:       "json number keeps its precision",
+			where:      "o.amount = $exact",
+			parameters: map[string]any{"exact": json.Number("9223372036854775807")},
+			want:       "t0.`f_total` = 9223372036854775807",
+		},
+		{
+			name:       "inside IN",
+			where:      "o.region IN [$first, 'us']",
+			parameters: map[string]any{"first": "eu"},
+			want:       "t0.`f_region` IN ('eu', 'us')",
+		},
+		{
+			name:       "backticked name",
+			where:      "o.region = $`the region`",
+			parameters: map[string]any{"the region": "eu"},
+			want:       "t0.`f_region` = 'eu'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, err := compileWithParameters(t,
+				"MATCH (o:Order) WHERE "+tc.where+" RETURN o.id AS id", tc.parameters)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			if !strings.Contains(sql, tc.want) {
+				t.Fatalf("got  %s\nwant it to contain %s", sql, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileParameterRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		query      string
+		parameters map[string]any
+		want       string
+	}{
+		{
+			name:  "not supplied",
+			query: "MATCH (o:Order) WHERE o.region = $region RETURN o.id",
+			want:  `parameter "region" was not supplied`,
+		},
+		{
+			name:       "null",
+			query:      "MATCH (o:Order) WHERE o.region = $region RETURN o.id",
+			parameters: map[string]any{"region": nil},
+			want:       "write IS NULL",
+		},
+		{
+			name:       "a type the statement cannot carry",
+			query:      "MATCH (o:Order) WHERE o.region = $region RETURN o.id",
+			parameters: map[string]any{"region": []string{"eu"}},
+			want:       "parameters must be a string, a number or a boolean",
+		},
+		{
+			// A parameter names a value, never a table or a column, so there
+			// is nowhere else in the statement it could appear.
+			name:  "in place of a label",
+			query: "MATCH (o:$label) RETURN o.id",
+			want:  "line 1",
+		},
+		{
+			name:  "positional",
+			query: "MATCH (o:Order) WHERE o.region = $0 RETURN o.id",
+			want:  "positional parameters",
+		},
+		{
+			name:  "negated",
+			query: "MATCH (o:Order) WHERE o.amount > -$floor RETURN o.id",
+			want:  "negating a parameter",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compileWithParameters(t, tc.query, tc.parameters)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}
+
+// JSON has one number type and no bound, so a value that is neither an integer
+// nor representable as a float has to be refused rather than truncated into
+// one that compares against the wrong rows.
+func TestParameterNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value json.Number
+		want  Literal
+	}{
+		{name: "integer", value: json.Number("42"), want: Literal{Kind: LiteralInteger, Integer: 42}},
+		{name: "float", value: json.Number("1.5"), want: Literal{Kind: LiteralFloat, Float: 1.5}},
+		{
+			name:  "beyond int64 falls back to a float",
+			value: json.Number("100000000000000000000"),
+			want:  Literal{Kind: LiteralFloat, Float: 1e20},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := literalFromParameter(tc.value)
+			if err != nil {
+				t.Fatalf("literalFromParameter(%s): %v", tc.value, err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+
+	if _, err := literalFromParameter(json.Number("not a number")); err == nil ||
+		!strings.Contains(err.Error(), "not a number this interface can carry") {
+		t.Fatalf("a malformed number must be refused, got %v", err)
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/plan.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/plan.go
@@ -23,7 +23,8 @@ import (
 type Plan struct {
 	Tables   []PlanTable
 	Joins    []PlanJoin
-	Where    []PlanCondition
+	Where    PlanPredicate
+	GroupBy  []PlanColumn
 	Select   []PlanColumn
 	Distinct bool
 	OrderBy  []PlanOrder
@@ -41,10 +42,14 @@ type PlanTable struct {
 }
 
 // PlanJoin joins two tables on the key pairs of a direct relation type.
+//
+// Readings holds one set of key pairs per way the relation can be read. A
+// directed pattern has one; an undirected one between two nodes of the same
+// object type has two, and a row matches if either holds.
 type PlanJoin struct {
-	Left  int
-	Right int
-	Keys  []PlanJoinKey
+	Left     int
+	Right    int
+	Readings [][]PlanJoinKey
 }
 
 // PlanJoinKey is one equality between a column of the left table and a column
@@ -54,14 +59,32 @@ type PlanJoinKey struct {
 	RightColumn string
 }
 
-// PlanColumn is one output column.
+// PlanColumn is one output column: a column of a table, or an aggregate over
+// one. Exactly one of the two is set.
 type PlanColumn struct {
-	Table  int
-	Column string
-	Alias  string
+	Table     int
+	Column    string
+	Alias     string
+	Aggregate *PlanAggregate
 }
 
-// PlanCondition is one WHERE term.
+// PlanAggregate is COUNT, SUM, AVG, MIN or MAX. Star is count(*), which counts
+// rows and names no column.
+type PlanAggregate struct {
+	Function string
+	Distinct bool
+	Star     bool
+	Table    int
+	Column   string
+}
+
+// PlanPredicate is the WHERE tree with every name resolved and every parameter
+// bound. Generation walks it and formats; it looks nothing up.
+type PlanPredicate interface {
+	planPredicate()
+}
+
+// PlanCondition is one comparison of a column against a value.
 type PlanCondition struct {
 	Table    int
 	Column   string
@@ -69,10 +92,63 @@ type PlanCondition struct {
 	Value    Literal
 }
 
-// PlanOrder is one ORDER BY term.
+func (PlanCondition) planPredicate() {}
+
+// PlanLogical is AND or OR over two or more conditions.
+type PlanLogical struct {
+	Operator string
+	Operands []PlanPredicate
+}
+
+func (PlanLogical) planPredicate() {}
+
+// PlanNegation is NOT over one condition.
+type PlanNegation struct {
+	Operand PlanPredicate
+}
+
+func (PlanNegation) planPredicate() {}
+
+// PlanNullCheck is IS NULL, or IS NOT NULL when negated.
+type PlanNullCheck struct {
+	Table   int
+	Column  string
+	Negated bool
+}
+
+func (PlanNullCheck) planPredicate() {}
+
+// PlanMembership is IN over values written in the query.
+type PlanMembership struct {
+	Table   int
+	Column  string
+	Values  []Literal
+	Negated bool
+}
+
+func (PlanMembership) planPredicate() {}
+
+// PlanColumnComparison compares two columns. The analyzer does not produce one
+// -- a query comparing two properties is refused -- but the planner needs it
+// to say that two hops of a pattern did not traverse the same relationship.
+type PlanColumnComparison struct {
+	LeftTable   int
+	LeftColumn  string
+	Operator    string
+	RightTable  int
+	RightColumn string
+}
+
+func (PlanColumnComparison) planPredicate() {}
+
+// PlanOrder is one ORDER BY term: a column, an aggregate, or the name of an
+// output column. Ordering by the output name is how a grouped result is sorted
+// by something the query already computed, without computing it twice.
 type PlanOrder struct {
 	Table      int
 	Column     string
+	Aggregate  *PlanAggregate
+	Alias      string
 	Descending bool
 }
 
@@ -98,17 +174,32 @@ func planErrorf(pos Position, format string, args ...any) error {
 // built so far, and which variable names them.
 type planner struct {
 	schema     *Schema
+	parameters map[string]any
 	plan       *Plan
-	objectType []*interfaces.ObjectType // per table, parallel to plan.Tables
-	tableOf    map[string]int           // variable name to table index
+	// hops records what each relationship of the pattern ended up connecting,
+	// which is what the relationship-uniqueness rule compares.
+	hops []plannedHop
+	// distinctness holds the conditions that keep one pattern from traversing
+	// the same relationship twice. They are conditions, but they come from the
+	// pattern rather than from anything the author wrote.
+	distinctness []PlanPredicate
+	objectType   []*interfaces.ObjectType // per table, parallel to plan.Tables
+	tableOf      map[string]int           // variable name to table index
+}
+
+// CompileOptions carries what the query itself does not: the values its
+// parameters stand for.
+type CompileOptions struct {
+	Parameters map[string]any
 }
 
 // Compile binds a query to a knowledge network and produces its plan.
-func Compile(query *Query, schema *Schema) (*Plan, error) {
+func Compile(query *Query, schema *Schema, options CompileOptions) (*Plan, error) {
 	p := &planner{
-		schema:  schema,
-		plan:    &Plan{Distinct: query.Distinct, Skip: query.Skip, Limit: query.Limit},
-		tableOf: map[string]int{},
+		schema:     schema,
+		parameters: options.Parameters,
+		plan:       &Plan{Distinct: query.Distinct, Skip: query.Skip, Limit: query.Limit},
+		tableOf:    map[string]int{},
 	}
 	if err := p.planPattern(query.Pattern); err != nil {
 		return nil, err
@@ -136,7 +227,115 @@ func (p *planner) planPattern(pattern Pattern) error {
 			return err
 		}
 	}
+	return p.keepRelationshipsDistinct(pattern)
+}
+
+// keepRelationshipsDistinct adds what Cypher requires and SQL has no notion
+// of: one pattern may not traverse the same relationship twice.
+//
+// A relationship here is a pair of rows -- one on the relation's source side,
+// one on its target side -- so two hops over the same relation type are the
+// same relationship exactly when both pairs coincide. Every pair of such hops
+// is compared, not only neighbouring ones: hops with another hop between them
+// can coincide just as easily, and two hops in the same direction coincide on
+// a row that points at itself.
+func (p *planner) keepRelationshipsDistinct(pattern Pattern) error {
+	if err := p.refuseUndirectedRepeats(pattern); err != nil {
+		return err
+	}
+	for i := 0; i < len(p.hops); i++ {
+		for j := i + 1; j < len(p.hops); j++ {
+			if p.hops[i].relationType != p.hops[j].relationType {
+				continue
+			}
+			distinct, err := p.differentEdges(p.hops[i], p.hops[j])
+			if err != nil {
+				return err
+			}
+			p.distinctness = append(p.distinctness, distinct)
+		}
+	}
 	return nil
+}
+
+// refuseUndirectedRepeats turns away the one shape the rule cannot be stated
+// for: which reading of an undirected hop matched decides whether it repeats
+// another hop, and a condition cannot ask that after the fact.
+func (p *planner) refuseUndirectedRepeats(pattern Pattern) error {
+	for i, edge := range pattern.Edges {
+		if edge.Direction != Undirected {
+			continue
+		}
+		for j, other := range pattern.Edges {
+			if i == j || other.Type != edge.Type {
+				continue
+			}
+			return planErrorf(edge.Pos,
+				"a pattern with two hops over %q cannot have one of them undirected; write the directions out",
+				edge.Type)
+		}
+	}
+	return nil
+}
+
+// differentEdges says two hops did not traverse the same relationship: their
+// source rows and their target rows are not both the same.
+func (p *planner) differentEdges(first, second plannedHop) (PlanPredicate, error) {
+	var same []PlanPredicate
+	for _, side := range [][2]int{{first.source, second.source}, {first.target, second.target}} {
+		if side[0] == side[1] {
+			// Both hops meet the same table on this side, so the rows are the
+			// same by construction and there is nothing to compare.
+			continue
+		}
+		equal, err := p.sameRow(side[0], side[1], second.pos)
+		if err != nil {
+			return nil, err
+		}
+		same = append(same, equal...)
+	}
+	if len(same) == 1 {
+		return PlanNegation{Operand: same[0]}, nil
+	}
+	return PlanNegation{Operand: PlanLogical{Operator: "AND", Operands: same}}, nil
+}
+
+// sameRow compares two tables of one object type by primary key, which is the
+// only thing that identifies a row here.
+func (p *planner) sameRow(left, right int, pos Position) ([]PlanPredicate, error) {
+	keys := p.objectType[left].PrimaryKeys
+	if len(keys) == 0 {
+		return nil, planErrorf(pos,
+			"object type %q has no primary key, so this pattern cannot be checked for traversing the same relationship twice",
+			p.objectType[left].OTID)
+	}
+
+	equal := make([]PlanPredicate, 0, len(keys))
+	for _, key := range keys {
+		leftColumn, err := p.schema.Column(p.objectType[left], key)
+		if err != nil {
+			return nil, &PlanError{Pos: pos, Err: err}
+		}
+		rightColumn, err := p.schema.Column(p.objectType[right], key)
+		if err != nil {
+			return nil, &PlanError{Pos: pos, Err: err}
+		}
+		equal = append(equal, PlanColumnComparison{
+			LeftTable: left, LeftColumn: leftColumn,
+			Operator:   "=",
+			RightTable: right, RightColumn: rightColumn,
+		})
+	}
+	return equal, nil
+}
+
+// plannedHop is one relationship of the pattern after direction is settled:
+// which table holds the relation's source rows and which holds its targets.
+type plannedHop struct {
+	relationType string
+	source       int
+	target       int
+	pos          Position
 }
 
 func (p *planner) addTable(node NodeRef) error {
@@ -172,7 +371,9 @@ func (p *planner) addTable(node NodeRef) error {
 
 // addJoin turns one relationship of the pattern into a join. The relation type
 // decides which side is source and which is target; the arrow in the query
-// decides which pattern node plays which role, and the two must agree.
+// decides which pattern node plays which role. An undirected relationship
+// leaves that open, so every reading the object types allow is kept and the
+// row matches if any of them holds.
 func (p *planner) addJoin(edge EdgeRef, left, right int) error {
 	relationType, err := p.schema.ResolveRelationType(edge.Type)
 	if err != nil {
@@ -188,96 +389,360 @@ func (p *planner) addJoin(edge EdgeRef, left, right int) error {
 			relationType.RTName, relationType.Type)
 	}
 
-	source, target := left, right
-	if edge.Direction == Incoming {
-		source, target = right, left
-	}
-	if got, want := p.objectType[source].OTID, relationType.SourceObjectTypeID; got != want {
-		return planErrorf(edge.Pos,
-			"relation type %q goes from %q to %q, but the pattern starts it at %q",
-			relationType.RTName, relationType.SourceObjectTypeID, relationType.TargetObjectTypeID, got)
-	}
-	if got, want := p.objectType[target].OTID, relationType.TargetObjectTypeID; got != want {
-		return planErrorf(edge.Pos,
-			"relation type %q goes from %q to %q, but the pattern ends it at %q",
-			relationType.RTName, relationType.SourceObjectTypeID, relationType.TargetObjectTypeID, got)
-	}
-
 	mappings, ok := relationType.MappingRules.([]interfaces.Mapping)
 	if !ok || len(mappings) == 0 {
 		return planErrorf(edge.Pos, "relation type %q has no key mapping to join on", relationType.RTName)
 	}
 
 	join := PlanJoin{Left: left, Right: right}
-	for _, mapping := range mappings {
-		sourceColumn, err := p.schema.Column(p.objectType[source], mapping.SourceProp.Name)
+	for _, forwards := range p.readings(edge.Direction) {
+		source, target := left, right
+		if !forwards {
+			source, target = right, left
+		}
+		if p.objectType[source].OTID != relationType.SourceObjectTypeID ||
+			p.objectType[target].OTID != relationType.TargetObjectTypeID {
+			continue
+		}
+		keys, err := p.joinKeys(mappings, source, target, forwards)
 		if err != nil {
-			return &PlanError{Pos: edge.Pos, Err: err}
+			return err
 		}
-		targetColumn, err := p.schema.Column(p.objectType[target], mapping.TargetProp.Name)
-		if err != nil {
-			return &PlanError{Pos: edge.Pos, Err: err}
+		join.Readings = append(join.Readings, keys)
+		// One hop is recorded per edge, not per reading. An undirected edge
+		// has two readings and no recorded hop: a lone one has nothing to
+		// coincide with, and one beside another over the same relation type
+		// is refused before this.
+		if edge.Direction != Undirected {
+			p.hops = append(p.hops, plannedHop{
+				relationType: relationType.RTID,
+				source:       source,
+				target:       target,
+				pos:          edge.Pos,
+			})
 		}
-		// Keys are stored left-to-right in pattern order, so the generator
-		// does not have to know the direction again.
-		leftColumn, rightColumn := sourceColumn, targetColumn
-		if edge.Direction == Incoming {
-			leftColumn, rightColumn = targetColumn, sourceColumn
-		}
-		join.Keys = append(join.Keys, PlanJoinKey{LeftColumn: leftColumn, RightColumn: rightColumn})
+	}
+
+	if len(join.Readings) == 0 {
+		return planErrorf(edge.Pos,
+			"relation type %q goes from %q to %q, which does not connect %q and %q the way this pattern reads it",
+			relationType.RTName, relationType.SourceObjectTypeID, relationType.TargetObjectTypeID,
+			p.objectType[left].OTID, p.objectType[right].OTID)
 	}
 	p.plan.Joins = append(p.plan.Joins, join)
 	return nil
 }
 
-func (p *planner) planWhere(comparisons []Comparison) error {
-	for _, comparison := range comparisons {
-		table, column, err := p.resolveProperty(comparison.Left)
+// readings lists the ways an edge may be read: one for a directed pattern,
+// both for an undirected one.
+func (p *planner) readings(direction Direction) []bool {
+	switch direction {
+	case Outgoing:
+		return []bool{true}
+	case Incoming:
+		return []bool{false}
+	default:
+		return []bool{true, false}
+	}
+}
+
+func (p *planner) joinKeys(mappings []interfaces.Mapping, source, target int, forwards bool) ([]PlanJoinKey, error) {
+	keys := make([]PlanJoinKey, 0, len(mappings))
+	for _, mapping := range mappings {
+		sourceColumn, err := p.schema.Column(p.objectType[source], mapping.SourceProp.Name)
+		if err != nil {
+			return nil, &PlanError{Err: err}
+		}
+		targetColumn, err := p.schema.Column(p.objectType[target], mapping.TargetProp.Name)
+		if err != nil {
+			return nil, &PlanError{Err: err}
+		}
+		// Keys are stored left-to-right in pattern order, so the generator
+		// does not have to know the direction again.
+		leftColumn, rightColumn := sourceColumn, targetColumn
+		if !forwards {
+			leftColumn, rightColumn = targetColumn, sourceColumn
+		}
+		keys = append(keys, PlanJoinKey{LeftColumn: leftColumn, RightColumn: rightColumn})
+	}
+	return keys, nil
+}
+
+func (p *planner) planWhere(predicate Predicate) error {
+	conditions := p.distinctness
+	if predicate != nil {
+		planned, err := p.planPredicate(predicate)
 		if err != nil {
 			return err
 		}
-		p.plan.Where = append(p.plan.Where, PlanCondition{
-			Table:    table,
-			Column:   column,
-			Operator: comparison.Operator,
-			Value:    comparison.Right,
-		})
+		conditions = append(conditions, planned)
+	}
+
+	switch len(conditions) {
+	case 0:
+	case 1:
+		p.plan.Where = conditions[0]
+	default:
+		p.plan.Where = PlanLogical{Operator: "AND", Operands: conditions}
 	}
 	return nil
+}
+
+func (p *planner) planPredicate(predicate Predicate) (PlanPredicate, error) {
+	switch node := predicate.(type) {
+	case Comparison:
+		table, column, err := p.resolveProperty(node.Left)
+		if err != nil {
+			return nil, err
+		}
+		value, err := p.resolveValue(node.Right, node.Pos)
+		if err != nil {
+			return nil, err
+		}
+		return PlanCondition{Table: table, Column: column, Operator: node.Operator, Value: value}, nil
+
+	case LogicalOperator:
+		operands := make([]PlanPredicate, 0, len(node.Operands))
+		for _, operand := range node.Operands {
+			planned, err := p.planPredicate(operand)
+			if err != nil {
+				return nil, err
+			}
+			operands = append(operands, planned)
+		}
+		return PlanLogical{Operator: node.Operator, Operands: operands}, nil
+
+	case Negation:
+		operand, err := p.planPredicate(node.Operand)
+		if err != nil {
+			return nil, err
+		}
+		return PlanNegation{Operand: operand}, nil
+
+	case NullCheck:
+		table, column, err := p.resolveProperty(node.Property)
+		if err != nil {
+			return nil, err
+		}
+		return PlanNullCheck{Table: table, Column: column, Negated: node.Negated}, nil
+
+	case Membership:
+		table, column, err := p.resolveProperty(node.Property)
+		if err != nil {
+			return nil, err
+		}
+		values := make([]Literal, 0, len(node.Values))
+		for _, value := range node.Values {
+			resolved, err := p.resolveValue(value, node.Pos)
+			if err != nil {
+				return nil, err
+			}
+			values = append(values, resolved)
+		}
+		return PlanMembership{Table: table, Column: column, Values: values, Negated: node.Negated}, nil
+
+	default:
+		return nil, planErrorf(predicate.predicatePosition(), "unsupported predicate %T", predicate)
+	}
+}
+
+// resolveValue turns what the query wrote into the value the statement will
+// carry. A parameter is looked up here, once, so generation only ever sees
+// literals and the escaping rules apply to both the same way.
+func (p *planner) resolveValue(value Operand, pos Position) (Literal, error) {
+	if value.Literal != nil {
+		return *value.Literal, nil
+	}
+	if value.Parameter == nil {
+		return Literal{}, planErrorf(pos, "a comparison with no value")
+	}
+
+	name := value.Parameter.Name
+	supplied, ok := p.parameters[name]
+	if !ok {
+		return Literal{}, planErrorf(value.Parameter.Pos, "parameter %q was not supplied", name)
+	}
+	literal, err := literalFromParameter(supplied)
+	if err != nil {
+		return Literal{}, planErrorf(value.Parameter.Pos, "parameter %q %v", name, err)
+	}
+	literal.Pos = value.Parameter.Pos
+	return literal, nil
 }
 
 func (p *planner) planReturn(projections []Projection) error {
 	seen := make(map[string]bool, len(projections))
 	for _, projection := range projections {
-		table, column, err := p.resolveProperty(projection.Property)
+		column, err := p.planProjection(projection)
 		if err != nil {
 			return err
 		}
 		if seen[projection.Alias] {
 			// Two columns with one name would make the result unreadable by
 			// key, and the caller reads rows as objects.
-			return planErrorf(projection.Property.Pos,
+			return planErrorf(projectionPosition(projection),
 				"column name %q is returned twice; give one of them a different alias", projection.Alias)
 		}
 		seen[projection.Alias] = true
-		p.plan.Select = append(p.plan.Select, PlanColumn{Table: table, Column: column, Alias: projection.Alias})
+		p.plan.Select = append(p.plan.Select, *column)
 	}
+	p.planGrouping()
 	return nil
+}
+
+func (p *planner) planProjection(projection Projection) (*PlanColumn, error) {
+	if projection.Aggregate != nil {
+		aggregate, err := p.planAggregate(*projection.Aggregate)
+		if err != nil {
+			return nil, err
+		}
+		return &PlanColumn{Alias: projection.Alias, Aggregate: aggregate}, nil
+	}
+
+	table, column, err := p.resolveProperty(*projection.Property)
+	if err != nil {
+		return nil, err
+	}
+	return &PlanColumn{Table: table, Column: column, Alias: projection.Alias}, nil
+}
+
+func (p *planner) planAggregate(aggregate Aggregate) (*PlanAggregate, error) {
+	if aggregate.Property == nil {
+		return &PlanAggregate{Function: aggregate.Function, Star: true}, nil
+	}
+	table, column, err := p.resolveProperty(*aggregate.Property)
+	if err != nil {
+		return nil, err
+	}
+	return &PlanAggregate{
+		Function: aggregate.Function,
+		Distinct: aggregate.Distinct,
+		Table:    table,
+		Column:   column,
+	}, nil
+}
+
+// planGrouping derives GROUP BY from what is returned, which is where Cypher
+// puts it: aggregating anything groups by everything else returned. Deriving
+// it rather than accepting one is also what stops a statement from grouping by
+// something the caller never sees.
+func (p *planner) planGrouping() {
+	aggregates := 0
+	for _, column := range p.plan.Select {
+		if column.Aggregate != nil {
+			aggregates++
+		}
+	}
+	// Either nothing is aggregated, or everything is and the result is one
+	// row. Neither needs a GROUP BY.
+	if aggregates == 0 || aggregates == len(p.plan.Select) {
+		return
+	}
+	for _, column := range p.plan.Select {
+		if column.Aggregate == nil {
+			p.plan.GroupBy = append(p.plan.GroupBy, column)
+		}
+	}
+}
+
+func projectionPosition(projection Projection) Position {
+	if projection.Aggregate != nil {
+		return projection.Aggregate.Pos
+	}
+	return projection.Property.Pos
 }
 
 func (p *planner) planOrderBy(keys []SortKey) error {
 	for _, key := range keys {
-		table, column, err := p.resolveProperty(key.Property)
+		order, err := p.planSortKey(key)
 		if err != nil {
 			return err
 		}
-		p.plan.OrderBy = append(p.plan.OrderBy, PlanOrder{
-			Table:      table,
-			Column:     column,
-			Descending: key.Descending,
-		})
+		order.Descending = key.Descending
+		p.plan.OrderBy = append(p.plan.OrderBy, *order)
 	}
 	return nil
+}
+
+func (p *planner) planSortKey(key SortKey) (*PlanOrder, error) {
+	switch {
+	case key.Aggregate != nil:
+		// Sorting by an aggregate over a projection that has none would group
+		// the whole result into one row on the way to ordering it, quietly
+		// answering a different question than the one asked.
+		if !p.aggregating() {
+			return nil, planErrorf(key.Pos,
+				"sorting by %s needs the query to return an aggregate too; add it to RETURN",
+				key.Aggregate)
+		}
+		aggregate, err := p.planAggregate(*key.Aggregate)
+		if err != nil {
+			return nil, err
+		}
+		return &PlanOrder{Aggregate: aggregate}, nil
+
+	case key.Alias != "":
+		// An empty name never reaches here: the analyzer refuses one.
+		// A bare name in ORDER BY is a returned column. It is the only way to
+		// sort a grouped result by something the query already computed, and
+		// checking it here keeps an unknown name from reaching the database.
+		for _, column := range p.plan.Select {
+			if column.Alias == key.Alias {
+				return &PlanOrder{Alias: key.Alias}, nil
+			}
+		}
+		return nil, planErrorf(key.Pos,
+			"%q is not returned by this query, so there is nothing to sort by", key.Alias)
+
+	case key.Property != nil:
+		table, column, err := p.resolveProperty(*key.Property)
+		if err != nil {
+			return nil, err
+		}
+		// DISTINCT and aggregation both collapse rows before they are
+		// ordered, so sorting by a value that survived neither has no defined
+		// answer, and both MySQL and PostgreSQL refuse the statement. The
+		// test is on aggregating rather than on GROUP BY, because a query
+		// that aggregates every column derives no GROUP BY and collapses just
+		// as hard.
+		if (p.plan.Distinct || p.aggregating()) && !p.isProjected(table, column) {
+			collapsed := "DISTINCT"
+			if p.aggregating() {
+				collapsed = "an aggregate"
+			}
+			return nil, planErrorf(key.Property.Pos,
+				"%s is not returned, and a query with %s can only be sorted by a returned value; add it to RETURN",
+				key.Property, collapsed)
+		}
+		return &PlanOrder{Table: table, Column: column}, nil
+
+	default:
+		// The three forms above are the whole set the analyzer produces.
+		// Saying so here means a fourth one added later fails as an error
+		// rather than as a nil dereference in whichever branch it fell into.
+		return nil, planErrorf(key.Pos, "this sort key names nothing to sort by")
+	}
+}
+
+// aggregating reports whether the projection collapses rows. A GROUP BY is not
+// the test: aggregating every column derives no GROUP BY and still collapses
+// the result to a single row.
+func (p *planner) aggregating() bool {
+	for _, column := range p.plan.Select {
+		if column.Aggregate != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *planner) isProjected(table int, column string) bool {
+	for _, projected := range p.plan.Select {
+		if projected.Aggregate == nil && projected.Table == table && projected.Column == column {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *planner) resolveProperty(ref PropertyRef) (int, string, error) {

--- a/adp/bkn/bkn-backend/server/logics/cypher/predicate_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/predicate_test.go
@@ -1,0 +1,255 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"strings"
+	"testing"
+)
+
+func compileWhere(t *testing.T, where string) string {
+	t.Helper()
+	sql := mustCompile(t, "MATCH (o:Order) WHERE "+where+" RETURN o.id AS id")
+	const prefix = "SELECT t0.`f_id` AS `id` FROM {{.res_order}} t0 WHERE "
+	if !strings.HasPrefix(sql, prefix) {
+		t.Fatalf("unexpected statement shape: %s", sql)
+	}
+	return strings.TrimPrefix(sql, prefix)
+}
+
+// The generated condition should read like the one that was written: operators
+// in the same order, and parentheses only where nesting requires them.
+func TestCompilePredicates(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		where string
+		want  string
+	}{
+		{
+			name:  "or",
+			where: "o.region = 'eu' OR o.region = 'us'",
+			want:  "t0.`f_region` = 'eu' OR t0.`f_region` = 'us'",
+		},
+		{
+			name:  "and binds tighter than or",
+			where: "o.region = 'eu' AND o.amount > 10 OR o.region = 'us'",
+			want:  "(t0.`f_region` = 'eu' AND t0.`f_total` > 10) OR t0.`f_region` = 'us'",
+		},
+		{
+			name:  "not",
+			where: "NOT o.region = 'eu'",
+			want:  "NOT t0.`f_region` = 'eu'",
+		},
+		{
+			name:  "not over a group",
+			where: "NOT (o.region = 'eu' OR o.amount > 10)",
+			want:  "NOT (t0.`f_region` = 'eu' OR t0.`f_total` > 10)",
+		},
+		{
+			// Two negations cancel: the statement should read like the
+			// condition, not like its history.
+			name:  "double negation",
+			where: "NOT NOT o.region = 'eu'",
+			want:  "t0.`f_region` = 'eu'",
+		},
+		{
+			name:  "is null",
+			where: "o.region IS NULL",
+			want:  "t0.`f_region` IS NULL",
+		},
+		{
+			name:  "is not null",
+			where: "o.region IS NOT NULL",
+			want:  "t0.`f_region` IS NOT NULL",
+		},
+		{
+			name:  "in",
+			where: "o.region IN ['eu', 'us']",
+			want:  "t0.`f_region` IN ('eu', 'us')",
+		},
+		{
+			name:  "in over numbers",
+			where: "o.amount IN [1, 2.5, -3]",
+			want:  "t0.`f_total` IN (1, 2.5, -3)",
+		},
+		{
+			// Cypher says an empty list matches nothing. SQL has no empty IN,
+			// so it is written out rather than handed to the database.
+			name:  "in over an empty list",
+			where: "o.region IN []",
+			want:  "1 = 0",
+		},
+		{
+			name:  "in negated by not",
+			where: "NOT o.region IN ['eu']",
+			want:  "NOT t0.`f_region` IN ('eu')",
+		},
+		{
+			name:  "mixed tree",
+			where: "o.region IS NOT NULL AND (o.region IN ['eu'] OR NOT o.amount > 10)",
+			want:  "t0.`f_region` IS NOT NULL AND (t0.`f_region` IN ('eu') OR NOT t0.`f_total` > 10)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := compileWhere(t, tc.where); got != tc.want {
+				t.Fatalf("got  %s\nwant %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompilePredicateRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "xor has no portable spelling",
+			query: "MATCH (o:Order) WHERE o.region = 'eu' XOR o.amount > 1 RETURN o.id",
+			want:  "XOR",
+		},
+		{
+			name:  "in over a computed list",
+			query: "MATCH (o:Order) WHERE o.region IN o.id RETURN o.id",
+			want:  "IN over something other than a list",
+		},
+		{
+			name:  "in over a list holding a property",
+			query: "MATCH (o:Order) WHERE o.region IN [o.id] RETURN o.id",
+			want:  "a list holding something other than values",
+		},
+		{
+			name:  "null inside an in list",
+			query: "MATCH (o:Order) WHERE o.region IN ['eu', null] RETURN o.id",
+			want:  "null in an IN list",
+		},
+		{
+			name:  "is null on something that is not a property",
+			query: "MATCH (o:Order) WHERE 1 IS NULL RETURN o.id",
+			want:  "IN and IS NULL apply to variable.property",
+		},
+		{
+			name:  "comparing two conditions",
+			query: "MATCH (o:Order) WHERE (o.id IS NULL) = (o.region IS NULL) RETURN o.id",
+			want:  "comparing a condition",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compile(t, tc.query, GenerateOptions{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}
+
+// An empty list matches nothing, so its negation matches everything. Both are
+// written out because SQL has no empty IN to say either with.
+func TestCompileNegatedEmptyMembership(t *testing.T) {
+	if got := compileWhere(t, "NOT o.region IN []"); got != "NOT 1 = 0" {
+		t.Fatalf("got %s", got)
+	}
+
+	plan := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "id"}},
+		Where:  PlanMembership{Table: 0, Column: "f_region", Negated: true},
+	}
+	sql, err := Generate(plan, GenerateOptions{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.HasSuffix(sql, "WHERE 1 = 1") {
+		t.Fatalf("got %s, want a condition that matches everything", sql)
+	}
+}
+
+// Cypher defines an inline property map as the equalities it stands for, so
+// that is what it compiles to -- and it means the planner and the generator
+// have one shape to handle rather than two.
+func TestCompileInlineProperties(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "one property",
+			query: "MATCH (o:Order {region: 'eu'}) RETURN o.id AS id",
+			want:  "WHERE t0.`f_region` = 'eu'",
+		},
+		{
+			name:  "several properties",
+			query: "MATCH (o:Order {region: 'eu', amount: 100}) RETURN o.id AS id",
+			want:  "WHERE t0.`f_region` = 'eu' AND t0.`f_total` = 100",
+		},
+		{
+			name:  "alongside a WHERE",
+			query: "MATCH (o:Order {region: 'eu'}) WHERE o.amount > 10 RETURN o.id AS id",
+			want:  "WHERE t0.`f_region` = 'eu' AND t0.`f_total` > 10",
+		},
+		{
+			name:  "on an anonymous node",
+			query: "MATCH (o:Order)-[:PLACED_BY]->(:Customer {name: 'Acme'}) RETURN o.id AS id",
+			want:  "WHERE t1.`f_name` = 'Acme'",
+		},
+		{
+			name:  "on both ends",
+			query: "MATCH (o:Order {region: 'eu'})-[:PLACED_BY]->(c:Customer {name: 'Acme'}) RETURN o.id AS id",
+			want:  "WHERE t0.`f_region` = 'eu' AND t1.`f_name` = 'Acme'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mustCompile(t, tc.query)
+			if !strings.Contains(got, tc.want) {
+				t.Fatalf("got  %s\nwant it to contain %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileInlinePropertyRejections(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "unknown property",
+			query: "MATCH (o:Order {nope: 1}) RETURN o.id",
+			want:  `has no property "nope"`,
+		},
+		{
+			name:  "null",
+			query: "MATCH (o:Order {region: null}) RETURN o.id",
+			want:  "null in a property map",
+		},
+		{
+			name:  "a property instead of a value",
+			query: "MATCH (o:Order {region: o.id}) RETURN o.id",
+			want:  "a property map holding something other than a value",
+		},
+		{
+			name:  "a parameter in place of the whole map",
+			query: "MATCH (o:Order $props) RETURN o.id",
+			want:  "a parameter in place of a property map",
+		},
+		{
+			name:  "on a relationship, which has no properties here",
+			query: "MATCH (o:Order)-[:PLACED_BY {since: 1}]->(c:Customer) RETURN o.id",
+			want:  "inline property maps",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := compile(t, tc.query, GenerateOptions{})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("compile(%q) = %v, want a rejection mentioning %q", tc.query, err, tc.want)
+			}
+		})
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/query_service.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/query_service.go
@@ -78,7 +78,6 @@ func (s *cypherQueryService) Query(ctx context.Context, query interfaces.CypherQ
 	}, []string{interfaces.OPERATION_TYPE_QUERY_DATA}); err != nil {
 		return nil, err
 	}
-
 	sql, rowLimit, err := s.compile(ctx, query)
 	if err != nil {
 		return nil, err
@@ -143,7 +142,7 @@ func (s *cypherQueryService) compile(ctx context.Context, query interfaces.Cyphe
 		return "", 0, err
 	}
 
-	plan, err := Compile(analyzed, schema)
+	plan, err := Compile(analyzed, schema, CompileOptions{Parameters: query.Parameters})
 	if err != nil {
 		return "", 0, rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_Cypher_InvalidQuery).
 			WithErrorDetails(err.Error())
@@ -158,11 +157,25 @@ func (s *cypherQueryService) compile(ctx context.Context, query interfaces.Cyphe
 		return "", 0, rest.NewHTTPError(ctx, http.StatusInternalServerError, berrors.BknBackend_Cypher_InternalError)
 	}
 
-	rowLimit := int64(interfaces.CYPHER_DEFAULT_LIMIT)
-	if plan.Limit != nil {
-		rowLimit = *plan.Limit
+	return sql, pageSize(plan.Limit), nil
+}
+
+// pageSize is how many rows to ask vega-backend for. The statement's own LIMIT
+// governs the result; this only has to be wide enough not to cut it short.
+//
+// The limit is read into a local and bounded against the same local that is
+// converted, rather than relying on the ceiling checked several stages
+// earlier: int is 32 bits on some targets, and an argument for why a widening
+// conversion is safe should not live in another function.
+func pageSize(limit *int64) int {
+	if limit == nil {
+		return interfaces.CYPHER_DEFAULT_LIMIT
 	}
-	return sql, int(rowLimit), nil
+	rows := *limit
+	if rows <= 0 || rows > interfaces.CYPHER_MAX_LIMIT {
+		return interfaces.CYPHER_DEFAULT_LIMIT
+	}
+	return int(rows)
 }
 
 func validateQueryText(ctx context.Context, query string) error {

--- a/adp/bkn/bkn-backend/server/logics/cypher/query_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/query_service_test.go
@@ -36,6 +36,8 @@ func (v *recordingVega) RawQuery(_ context.Context, req *interfaces.RawQueryRequ
 	return &interfaces.RawQueryResponse{}, nil
 }
 
+// stubPermission answers the knowledge-network permission check the way the
+// permission service would.
 type stubPermission struct {
 	interfaces.PermissionService
 	resource   interfaces.PermissionResource
@@ -155,7 +157,7 @@ func TestQueryRejections(t *testing.T) {
 	}{
 		{name: "empty", query: "", status: http.StatusBadRequest},
 		{name: "syntax error", query: "MATCH (o:Order RETURN o.id", status: http.StatusBadRequest},
-		{name: "outside the subset", query: "MATCH (o:Order) RETURN count(*)", status: http.StatusBadRequest},
+		{name: "outside the subset", query: "MATCH (o:Order) RETURN lower(o.id)", status: http.StatusBadRequest},
 		{name: "not in the model", query: "MATCH (i:Invoice) RETURN i.id", status: http.StatusBadRequest},
 		{name: "writing", query: "CREATE (o:Order) RETURN o.id", status: http.StatusBadRequest},
 		{name: "limit above the ceiling", query: "MATCH (o:Order) RETURN o.id LIMIT 20000", status: http.StatusBadRequest},

--- a/adp/bkn/bkn-backend/server/logics/cypher/schema_source_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/schema_source_test.go
@@ -1,0 +1,56 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/interfaces"
+	bmock "bkn-backend/interfaces/mock"
+)
+
+func TestSchemaSourceReadsWholeNetwork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	objectTypes := bmock.NewMockObjectTypeService(ctrl)
+	relationTypes := bmock.NewMockRelationTypeService(ctrl)
+
+	objectTypes.EXPECT().
+		GetAllObjectTypesByKnID(gomock.Any(), "kn_1", "main").
+		Return(map[string]*interfaces.ObjectType{
+			"ot_order": objectType("ot_order", "Order", resource("res_order", "orders")),
+		}, nil)
+
+	// Limit -1 asks for every relation type. Paging here would hide some of
+	// them, and a pattern may name any one, so the query would fail with an
+	// unknown relationship type that the model does contain.
+	relationTypes.EXPECT().
+		ListRelationTypes(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, query interfaces.RelationTypesQueryParams) ([]*interfaces.RelationType, int, error) {
+			if query.Limit != -1 {
+				t.Fatalf("limit = %d, want -1 for the whole set", query.Limit)
+			}
+			if query.KNID != "kn_1" || query.Branch != "main" {
+				t.Fatalf("query = %+v, want the requested network and branch", query)
+			}
+			return []*interfaces.RelationType{relationType("rt_placed", "PLACED")}, 1, nil
+		})
+
+	source := NewSchemaSource(objectTypes, relationTypes)
+
+	gotObjectTypes, err := source.AllObjectTypes(context.Background(), "kn_1", "main")
+	if err != nil || len(gotObjectTypes) != 1 || gotObjectTypes[0].OTID != "ot_order" {
+		t.Fatalf("AllObjectTypes = %v, %v", gotObjectTypes, err)
+	}
+
+	gotRelationTypes, err := source.AllRelationTypes(context.Background(), "kn_1", "main")
+	if err != nil || len(gotRelationTypes) != 1 || gotRelationTypes[0].RTID != "rt_placed" {
+		t.Fatalf("AllRelationTypes = %v, %v", gotRelationTypes, err)
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/sqlgen.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/sqlgen.go
@@ -38,6 +38,11 @@ type GenerateOptions struct {
 	// DefaultLimit caps a query that did not ask for a limit. Without it a
 	// pattern over two large resources would stream an unbounded result
 	// through the whole path.
+	//
+	// It also keeps ORDER BY meaningful: vega-backend runs this statement
+	// inside a derived table, and MySQL is free to drop the ordering of one
+	// that has no LIMIT. Removing the default would therefore cost sorted
+	// results, not just a row cap.
 	DefaultLimit int64
 }
 
@@ -62,6 +67,7 @@ func Generate(plan *Plan, options GenerateOptions) (string, error) {
 	if err := g.writeWhere(); err != nil {
 		return "", err
 	}
+	g.writeGroupBy()
 	g.writeOrderBy()
 	g.writeLimit(options.DefaultLimit)
 	if g.err != nil {
@@ -86,9 +92,44 @@ func (g *generator) writeSelect() {
 		if i > 0 {
 			g.out.WriteString(", ")
 		}
-		g.out.WriteString(g.column(column.Table, column.Column))
+		g.out.WriteString(g.selectExpression(column))
 		g.out.WriteString(" AS ")
 		g.out.WriteString(g.identifier(column.Alias))
+	}
+}
+
+func (g *generator) selectExpression(column PlanColumn) string {
+	if column.Aggregate != nil {
+		return g.aggregate(*column.Aggregate)
+	}
+	return g.column(column.Table, column.Column)
+}
+
+// aggregate writes COUNT, SUM, AVG, MIN or MAX. The function name comes from a
+// fixed set rather than from the query, so nothing the caller wrote reaches
+// the statement as SQL.
+func (g *generator) aggregate(aggregate PlanAggregate) string {
+	if aggregate.Star {
+		return aggregate.Function + "(*)"
+	}
+	inner := g.column(aggregate.Table, aggregate.Column)
+	if aggregate.Distinct {
+		inner = "DISTINCT " + inner
+	}
+	return aggregate.Function + "(" + inner + ")"
+}
+
+// writeGroupBy writes the grouping the planner derived from what is returned.
+func (g *generator) writeGroupBy() {
+	if len(g.plan.GroupBy) == 0 {
+		return
+	}
+	g.out.WriteString(" GROUP BY ")
+	for i, column := range g.plan.GroupBy {
+		if i > 0 {
+			g.out.WriteString(", ")
+		}
+		g.out.WriteString(g.column(column.Table, column.Column))
 	}
 }
 
@@ -102,36 +143,133 @@ func (g *generator) writeFrom() {
 		g.out.WriteString(" JOIN ")
 		g.out.WriteString(g.table(join.Right))
 		g.out.WriteString(" ON ")
-		for i, key := range join.Keys {
-			if i > 0 {
-				g.out.WriteString(" AND ")
+		for r, reading := range join.Readings {
+			if r > 0 {
+				g.out.WriteString(" OR ")
 			}
-			g.out.WriteString(g.column(join.Left, key.LeftColumn))
-			g.out.WriteString(" = ")
-			g.out.WriteString(g.column(join.Right, key.RightColumn))
+			// One reading needs no parentheses; several do, because they are
+			// joined by OR and each is a conjunction of key pairs.
+			if len(join.Readings) > 1 {
+				g.out.WriteString("(")
+			}
+			for i, key := range reading {
+				if i > 0 {
+					g.out.WriteString(" AND ")
+				}
+				g.out.WriteString(g.column(join.Left, key.LeftColumn))
+				g.out.WriteString(" = ")
+				g.out.WriteString(g.column(join.Right, key.RightColumn))
+			}
+			if len(join.Readings) > 1 {
+				g.out.WriteString(")")
+			}
 		}
 	}
 }
 
 func (g *generator) writeWhere() error {
-	if len(g.plan.Where) == 0 {
+	if g.plan.Where == nil {
 		return nil
 	}
 	g.out.WriteString(" WHERE ")
-	for i, condition := range g.plan.Where {
-		if i > 0 {
-			g.out.WriteString(" AND ")
-		}
-		value, err := g.literal(condition.Value)
+	return g.writePredicate(g.plan.Where, false)
+}
+
+// writePredicate writes one node of the condition tree. Parentheses are added
+// where an operator sits inside another one, rather than everywhere: a reader
+// comparing the statement to the query should see the same shape.
+func (g *generator) writePredicate(predicate PlanPredicate, nested bool) error {
+	switch node := predicate.(type) {
+	case PlanCondition:
+		value, err := g.literal(node.Value)
 		if err != nil {
 			return err
 		}
-		g.out.WriteString(g.column(condition.Table, condition.Column))
+		g.out.WriteString(g.column(node.Table, node.Column))
 		g.out.WriteString(" ")
-		g.out.WriteString(condition.Operator)
+		g.out.WriteString(node.Operator)
 		g.out.WriteString(" ")
 		g.out.WriteString(value)
+		return nil
+
+	case PlanColumnComparison:
+		g.out.WriteString(g.column(node.LeftTable, node.LeftColumn))
+		g.out.WriteString(" ")
+		g.out.WriteString(node.Operator)
+		g.out.WriteString(" ")
+		g.out.WriteString(g.column(node.RightTable, node.RightColumn))
+		return nil
+
+	case PlanNullCheck:
+		g.out.WriteString(g.column(node.Table, node.Column))
+		if node.Negated {
+			g.out.WriteString(" IS NOT NULL")
+			return nil
+		}
+		g.out.WriteString(" IS NULL")
+		return nil
+
+	case PlanMembership:
+		return g.writeMembership(node)
+
+	case PlanNegation:
+		g.out.WriteString("NOT ")
+		return g.writePredicate(node.Operand, true)
+
+	case PlanLogical:
+		if nested {
+			g.out.WriteString("(")
+		}
+		for i, operand := range node.Operands {
+			if i > 0 {
+				g.out.WriteString(" ")
+				g.out.WriteString(node.Operator)
+				g.out.WriteString(" ")
+			}
+			if err := g.writePredicate(operand, true); err != nil {
+				return err
+			}
+		}
+		if nested {
+			g.out.WriteString(")")
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("cannot generate a %T condition", predicate)
 	}
+}
+
+func (g *generator) writeMembership(node PlanMembership) error {
+	if len(node.Values) == 0 {
+		// SQL has no empty IN list. Cypher says an empty list matches nothing,
+		// so that is written out as a constant rather than left to the parser
+		// of whichever database receives it.
+		if node.Negated {
+			g.out.WriteString("1 = 1")
+			return nil
+		}
+		g.out.WriteString("1 = 0")
+		return nil
+	}
+
+	g.out.WriteString(g.column(node.Table, node.Column))
+	if node.Negated {
+		g.out.WriteString(" NOT IN (")
+	} else {
+		g.out.WriteString(" IN (")
+	}
+	for i, value := range node.Values {
+		if i > 0 {
+			g.out.WriteString(", ")
+		}
+		written, err := g.literal(value)
+		if err != nil {
+			return err
+		}
+		g.out.WriteString(written)
+	}
+	g.out.WriteString(")")
 	return nil
 }
 
@@ -144,7 +282,17 @@ func (g *generator) writeOrderBy() {
 		if i > 0 {
 			g.out.WriteString(", ")
 		}
-		g.out.WriteString(g.column(order.Table, order.Column))
+		switch {
+		case order.Aggregate != nil:
+			g.out.WriteString(g.aggregate(*order.Aggregate))
+		case order.Alias != "":
+			// Sorting by the output name rather than by the expression: both
+			// dialects accept it, and it keeps a grouped result from
+			// computing the same aggregate twice.
+			g.out.WriteString(g.identifier(order.Alias))
+		default:
+			g.out.WriteString(g.column(order.Table, order.Column))
+		}
 		if order.Descending {
 			g.out.WriteString(" DESC")
 		}

--- a/adp/bkn/bkn-backend/server/logics/cypher/sqlgen_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/sqlgen_test.go
@@ -1,0 +1,101 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+// See the LICENSE file in the project root for details.
+
+package cypher
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateRejectsWhatItCannotWrite(t *testing.T) {
+	plan := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res", Label: "Order"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "id"}},
+	}
+
+	if _, err := Generate(plan, GenerateOptions{Dialect: "oracle"}); err == nil ||
+		!strings.Contains(err.Error(), "unsupported SQL dialect") {
+		t.Fatalf("an unknown dialect must be refused, got %v", err)
+	}
+	if _, err := Generate(&Plan{}, GenerateOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "empty plan") {
+		t.Fatalf("an empty plan must be refused, got %v", err)
+	}
+}
+
+// A null byte truncates the statement in the client libraries underneath, so
+// it must not reach them -- in a name or in a value.
+func TestGenerateRejectsNullBytes(t *testing.T) {
+	inAlias := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "a\x00b"}},
+	}
+	if _, err := Generate(inAlias, GenerateOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "null byte") {
+		t.Fatalf("a null byte in a name must be refused, got %v", err)
+	}
+
+	inValue := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "id"}},
+		Where: PlanCondition{
+			Table: 0, Column: "f_name", Operator: "=",
+			Value: Literal{Kind: LiteralString, String: "a\x00b"},
+		},
+	}
+	if _, err := Generate(inValue, GenerateOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "null byte") {
+		t.Fatalf("a null byte in a value must be refused, got %v", err)
+	}
+}
+
+// The analyzer refuses null comparisons, so reaching generation with one means
+// the stages disagree. It says that rather than writing SQL nobody asked for.
+func TestGenerateRefusesLiteralsTheAnalyzerNeverProduces(t *testing.T) {
+	plan := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "id"}},
+		Where: PlanCondition{
+			Table: 0, Column: "f_name", Operator: "=", Value: Literal{Kind: LiteralNull},
+		},
+	}
+	if _, err := Generate(plan, GenerateOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "null") {
+		t.Fatalf("want a refusal naming the literal, got %v", err)
+	}
+}
+
+func TestGenerateBooleanLiterals(t *testing.T) {
+	for _, tc := range []struct {
+		query string
+		want  string
+	}{
+		{"MATCH (o:Order) WHERE o.region = true RETURN o.id", "= TRUE"},
+		{"MATCH (o:Order) WHERE o.region = false RETURN o.id", "= FALSE"},
+	} {
+		got := mustCompile(t, tc.query)
+		if !strings.Contains(got, tc.want) {
+			t.Fatalf("got %s, want it to contain %s", got, tc.want)
+		}
+	}
+}
+
+// SKIP without a limit cannot be written as MySQL, and the service always
+// injects one; a plan that arrives without either is a disagreement between
+// the stages rather than a query anyone wrote.
+func TestGenerateRefusesSkipWithoutLimit(t *testing.T) {
+	skip := int64(10)
+	plan := &Plan{
+		Tables: []PlanTable{{Alias: "t0", ResourceID: "res"}},
+		Select: []PlanColumn{{Table: 0, Column: "f_id", Alias: "id"}},
+		Skip:   &skip,
+	}
+	if _, err := Generate(plan, GenerateOptions{}); err == nil ||
+		!strings.Contains(err.Error(), "SKIP requires a LIMIT") {
+		t.Fatalf("want a refusal, got %v", err)
+	}
+}

--- a/adp/bkn/bkn-backend/server/logics/cypher/testdata/grammar_corpus.cypher
+++ b/adp/bkn/bkn-backend/server/logics/cypher/testdata/grammar_corpus.cypher
@@ -1,0 +1,204 @@
+# Every construct of the openCypher M19 grammar, one query per line.
+#
+# This corpus exists to prove a property the unit tests cannot state on their
+# own: that the compiler has an answer for the whole language, not only for the
+# part it implements. The accompanying test asserts that every rule of the
+# grammar is reached by at least one query here, and that each query is either
+# compiled or refused by name -- never a panic, and never an error of a type
+# nobody maps to a status.
+#
+# Queries are written against the probe network used for live runs
+# (cypher_probe_fcj), so the same file can be replayed against a deployment.
+# Blank lines and lines starting with # are ignored.
+
+
+# projection
+MATCH (o:probe_order) RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) RETURN o.o_key LIMIT 1
+MATCH (o:probe_order) RETURN o.o_key AS k, o.o_state AS s, o.o_amount AS a LIMIT 2
+MATCH (o:probe_order) RETURN DISTINCT o.o_state AS s
+
+# clauses
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY o.o_key LIMIT 3
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY o.o_key DESC LIMIT 3
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY o.o_state, o.o_key DESC LIMIT 3
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY o.o_key SKIP 5 LIMIT 3
+MATCH (o:probe_order) RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) RETURN DISTINCT o.o_state AS s ORDER BY o.o_state
+
+# operators
+MATCH (o:probe_order) WHERE o.o_state = 'refunding' RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_state <> 'refunding' RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_amount < 100 RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_amount > 100 RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_amount <= 100 RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_amount >= 100 RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_amount > 10 AND o.o_state = 'refunding' AND o.o_chan >= 1 RETURN o.o_key AS k LIMIT 2
+
+# literals
+MATCH (o:probe_order) WHERE o.o_state = 'refunding' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = "refunding" RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_key = 10774 RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE o.o_amount > -1 RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_amount > 1.5 RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_key = 0x2A16 RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE o.o_key = 0o25126 RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE o.o_state = 'a\tb' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = '\u0041' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = '\U0001F600' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = 'O''Brien' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = 'a\'; DROP TABLE x --' RETURN o.o_key AS k LIMIT 1
+MATCH (o:probe_order) WHERE o.o_state = 'back\\slash' RETURN o.o_key AS k LIMIT 1
+
+# patterns
+MATCH (i:probe_item)-[:probe_direct]->(o:probe_order) RETURN i.i_key AS i, o.o_key AS o LIMIT 2
+MATCH (o:probe_order)<-[:probe_direct]-(i:probe_item) RETURN i.i_key AS i LIMIT 2
+MATCH (i:probe_item)-[:probe_direct]->(:probe_order) RETURN i.i_key AS i LIMIT 2
+MATCH ((o:probe_order)) RETURN o.o_key AS k LIMIT 1
+MATCH (i:probe_item)-[:probe_direct2]->(o:probe_order) RETURN i.i_key AS i, o.o_key AS o LIMIT 2
+MATCH (o:`探针订单`) RETURN o.o_key AS k LIMIT 1
+MATCH (i:probe_item)-[:`探针明细属于订单`]->(o:probe_order) RETURN o.o_key AS k LIMIT 1
+match (o:probe_order) return o.o_key as k limit 1
+MATCH (o:probe_order) RETURN o.o_key AS k LIMIT 1
+
+# reject-clause
+OPTIONAL MATCH (o:probe_order) RETURN o.o_key
+MATCH (o:probe_order) RETURN o.o_key UNION MATCH (p:probe_order) RETURN p.o_key
+MATCH (o:probe_order) WITH o RETURN o.o_key
+UNWIND [1, 2] AS x RETURN x
+CALL db.labels() YIELD label RETURN label
+MATCH (o:probe_order) MATCH (i:probe_item) RETURN o.o_key
+MATCH (o:probe_order), (i:probe_item) RETURN o.o_key
+MATCH p = (o:probe_order) RETURN o.o_key
+CALL db.labels()
+CALL db.labels() YIELD label AS l RETURN l
+CALL db.labels
+
+# reject-write
+CREATE (o:probe_order) RETURN o.o_key
+MATCH (o:probe_order) SET o.o_state = 'x' RETURN o.o_key
+MATCH (o:probe_order) DETACH DELETE o RETURN o.o_key
+MATCH (o:probe_order) REMOVE o.o_state RETURN o.o_key
+MERGE (o:probe_order) RETURN o.o_key
+MERGE (o:probe_order) ON CREATE SET o.o_state = 'x' RETURN o.o_key
+
+# patterns (phase three)
+MATCH (o:probe_order {o_state: 'refunding'}) RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order {o_state: 'refunding', o_chan: 1}) RETURN o.o_key AS k LIMIT 2
+MATCH (i:probe_item)-[:probe_direct]->(o:probe_order {o_state: 'refunding'}) RETURN i.i_key AS k LIMIT 2
+MATCH (i:probe_item)-[:probe_direct]-(o:probe_order) RETURN i.i_key AS k LIMIT 2
+MATCH (o:probe_order)-[:probe_direct]-(i:probe_item) RETURN i.i_key AS k LIMIT 2
+MATCH (a:probe_item)-[:probe_direct]->(o:probe_order)<-[:probe_direct]-(b:probe_item) RETURN a.i_key AS a, b.i_key AS b LIMIT 3
+
+# reject-pattern (phase three)
+MATCH (o:probe_order {nope: 1}) RETURN o.o_key
+MATCH (o:probe_order {o_state: null}) RETURN o.o_key
+MATCH (o:probe_order {o_state: o.o_chan}) RETURN o.o_key
+MATCH (o:probe_order $props) RETURN o.o_key
+MATCH (a:probe_item)-[:probe_direct]-(o:probe_order)-[:probe_direct]-(b:probe_item) RETURN a.i_key
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY ``
+MATCH (o:probe_order) RETURN o.o_key AS ``
+MATCH (o:probe_order) RETURN count(*) AS n ORDER BY o.o_amount
+MATCH (o:probe_order) RETURN o.o_key AS k ORDER BY count(*)
+
+# reject-pattern
+MATCH (o) RETURN o.o_key
+MATCH (o:probe_order:probe_item) RETURN o.o_key
+MATCH (i:probe_item)<-[:probe_direct]->(o:probe_order) RETURN i.i_key
+MATCH (i:probe_item)-->(o:probe_order) RETURN i.i_key
+MATCH (i:probe_item)-[r:probe_direct]->(o:probe_order) RETURN i.i_key
+MATCH (i:probe_item)-[:probe_direct*1..3]->(o:probe_order) RETURN i.i_key
+MATCH (i:probe_item)-[:probe_direct|:probe_direct2]->(o:probe_order) RETURN i.i_key
+MATCH (i:probe_item)-[:probe_direct {x: 1}]->(o:probe_order) RETURN i.i_key
+
+# aggregates
+MATCH (o:probe_order) RETURN count(*) AS n
+MATCH (o:probe_order) RETURN count(o.o_state) AS n
+MATCH (o:probe_order) RETURN count(DISTINCT o.o_state) AS n
+MATCH (o:probe_order) RETURN o.o_state AS s, count(*) AS n
+MATCH (o:probe_order) RETURN o.o_state AS s, count(*) AS n ORDER BY n DESC LIMIT 5
+MATCH (o:probe_order) RETURN o.o_state AS s, count(*) AS n ORDER BY count(*) DESC LIMIT 5
+MATCH (o:probe_order) RETURN sum(o.o_amount) AS total, avg(o.o_amount) AS mean, min(o.o_amount) AS lo, max(o.o_amount) AS hi
+MATCH (i:probe_item)-[:probe_direct]->(o:probe_order) RETURN o.o_state AS s, count(*) AS n
+MATCH (o:probe_order) WHERE o.o_amount > 100 RETURN o.o_state AS s, count(*) AS n
+
+# reject-aggregate
+MATCH (o:probe_order) RETURN o.o_state AS s, count(*) AS n ORDER BY o.o_amount
+MATCH (o:probe_order) RETURN o.o_state AS s, count(*) AS n ORDER BY nope
+MATCH (o:probe_order) RETURN sum(1) AS n
+MATCH (o:probe_order) RETURN collect(o.o_state) AS n
+MATCH (o:probe_order) RETURN max(o.o_amount, o.o_state) AS n
+
+# reject-expr
+MATCH (o:probe_order) RETURN *
+MATCH (o:probe_order) RETURN o
+MATCH (o:probe_order) RETURN lower(o.o_state)
+MATCH (o:probe_order) RETURN o.o_amount + 1
+MATCH (o:probe_order) RETURN (o.o_key)
+MATCH (o:probe_order) RETURN o.o_state[0]
+MATCH (o:probe_order) RETURN o.a.b
+MATCH (o:probe_order) RETURN 1
+MATCH (o:probe_order) RETURN CASE o.o_state WHEN 'a' THEN 1 ELSE 2 END
+MATCH (o:probe_order) RETURN [x IN [1, 2] | x]
+MATCH (o:probe_order) WHERE any(x IN [1] WHERE x = 1) RETURN o.o_key
+MATCH (o:probe_order) RETURN [(o)-[:probe_direct]->(i:probe_item) | i.i_key]
+
+# predicates
+MATCH (o:probe_order) WHERE o.o_key = 10774 OR o.o_key = 10963 RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE NOT o.o_state = 'refunding' RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE NOT NOT o.o_state = 'refunding' RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_key IN [10774, 10963] RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE NOT o.o_key IN [10774] RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_key IN [] RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE o.o_state IS NULL RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_state IS NOT NULL RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE (o.o_key = 10774 OR o.o_key = 10963) AND o.o_amount > 0 RETURN o.o_key AS k
+MATCH (o:probe_order) WHERE NOT (o.o_key = 10774 OR o.o_key = 10963) RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_state = $state RETURN o.o_key AS k LIMIT 2
+MATCH (o:probe_order) WHERE o.o_key IN [$first, 10963] RETURN o.o_key AS k
+
+# reject-where
+MATCH (o:probe_order) WHERE o.o_key = 1 XOR o.o_key = 2 RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key IN o.o_chan RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key IN [o.o_chan] RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key IN [1, null] RETURN o.o_key
+MATCH (o:probe_order) WHERE 1 IS NULL RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_amount > -$floor RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_state = $0 RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_state STARTS WITH 'a' RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_state CONTAINS 'a' RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key < o.o_chan < o.o_amount RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key = [1] RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key = null RETURN o.o_key
+MATCH (o:probe_order) WHERE (o)-[:probe_direct]->(:probe_item) RETURN o.o_key
+MATCH (o:probe_order) WHERE EXISTS { (o)-[:probe_direct]->(:probe_item) } RETURN o.o_key
+MATCH (o:probe_order) WHERE (o.o_key = 1) RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_key = o.o_chan RETURN o.o_key
+
+# reject-paging
+MATCH (o:probe_order) RETURN o.o_key LIMIT 1 + 1
+MATCH (o:probe_order) RETURN o.o_key LIMIT 'ten'
+MATCH (o:probe_order) RETURN o.o_key SKIP -1
+MATCH (o:probe_order) RETURN o.o_key LIMIT 20000
+MATCH (o:probe_order) RETURN DISTINCT o.o_state AS s ORDER BY o.o_amount
+MATCH (o:probe_order) RETURN o.o_key LIMIT true
+MATCH (o:probe_order) RETURN o.o_key LIMIT false
+
+# reject-literal
+MATCH (o:probe_order) WHERE o.o_state = '\uFFFFFFFF' RETURN o.o_key
+MATCH (o:probe_order) WHERE o.o_state = '\uD800' RETURN o.o_key
+
+# reject-model
+MATCH (o:no_such_label) RETURN o.x
+MATCH (o:probe_order) RETURN o.no_such_property
+MATCH (o:probe_order) RETURN x.o_key
+MATCH (o:probe_order)-[:probe_direct]->(o:probe_item) RETURN o.o_key
+MATCH (o:probe_order) RETURN o.o_key AS a, o.o_state AS a
+MATCH (o:probe_order)-[:probe_direct]->(i:probe_item) RETURN o.o_key
+MATCH (c:probe_channel)-[:probe_fcj]->(o:probe_order) RETURN c.c_key
+MATCH (i:probe_item)-[:no_such_relation]->(o:probe_order) RETURN i.i_key
+MATCH (o:probe_order) RETURN o.`订单状态`
+MATCH (o:probe_order) RETURN o.order_status
+MATCH (o:probe_order RETURN o.o_key
+MATCH (o:ALL) RETURN o.o_key

--- a/docs/api/bkn/cypher-queries.yaml
+++ b/docs/api/bkn/cypher-queries.yaml
@@ -6,9 +6,9 @@ info:
   description: |-
     Read-only Cypher queries over the instance data of a knowledge network.
     A query is compiled into a single SQL statement and executed through vega-backend, so the
-    subset accepted here is what compiles that way: one MATCH over a path of at most one
-    relationship, a WHERE of properties compared against literals, and a projection of
-    properties. Everything else is refused by name rather than approximated.
+    subset accepted here is what compiles that way: one MATCH over a single path, a WHERE over
+    properties, and a projection of properties and aggregates of them. Everything else is
+    refused by name rather than approximated.
     Paging is written in the query itself with SKIP and LIMIT; there is no paging parameter.
     Exposed under /api/bkn-backend/v1 (OAuth2) and /api/ontology-manager/v1 (alias), with the
     branch query parameter defaulting to main.
@@ -113,19 +113,49 @@ components:
       required:
         - query
       properties:
+        parameters:
+          type: object
+          additionalProperties: true
+          description: |-
+            Values for the $name references in the query. A parameter is a value and never an
+            identifier: it can change which rows come back, never which resource or column is
+            read. Strings, numbers and booleans are accepted; a null is refused, because IS
+            NULL says that and a comparison against null never matches.
+          example:
+            region: "eu"
+            floor: 100
         query:
           type: string
           maxLength: 8192
           description: |-
             The Cypher query. Supported shape:
-            MATCH (a:Label)[-[:RELATION]->(b:Label)]
-            [WHERE a.property <op> literal AND ...]
-            RETURN [DISTINCT] a.property [AS alias], ...
-            [ORDER BY a.property [DESC]] [SKIP n] [LIMIT n]
-            Comparison operators are =, <>, <, >, <= and >=, with a literal on the right.
-            Relationships must be directed and name exactly one relation type; nodes must
-            name exactly one object type.
-          example: "MATCH (o:order)-[:rel_order_item_order]->(i:order_item) WHERE o.amount > 100 RETURN o.order_id AS id, i.item_id AS item ORDER BY o.amount DESC LIMIT 20"
+            MATCH (a:Label [{property: value, ...}]) [-[:RELATION]-(b:Label) ...]
+            [WHERE <condition>]
+            RETURN [DISTINCT] a.property | aggregate(a.property) [AS alias], ...
+            [ORDER BY a.property | alias | aggregate(a.property) [DESC]] [SKIP n] [LIMIT n]
+
+            A condition compares a property with =, <>, <, >, <= or >= against a literal or a
+            parameter, or tests it with IN [ ... ], IS NULL or IS NOT NULL. Conditions combine
+            with AND, OR and NOT, and parentheses group them. XOR is not supported.
+
+            Aggregates are count, sum, avg, min and max, each also in its DISTINCT form, plus
+            count(*). Cypher has no GROUP BY: aggregating anything groups by everything else
+            the query returns. A grouped or DISTINCT result can only be sorted by a value it
+            returns.
+
+            A path may contain several relationships. Each names exactly one relation type and
+            may be written -[:R]->, <-[:R]- or undirected as -[:R]-; each node names exactly
+            one object type and may carry an inline property map, which means the equalities
+            it stands for.
+
+            Cypher forbids one pattern from traversing the same relationship twice, and that
+            is enforced: every pair of hops over one relation type must differ in its source
+            row or its target row, which needs those object types to have a primary key.
+            Where one of the hops is undirected the requirement cannot be stated, and the
+            query is refused rather than answered with paths Cypher would not return. A path
+            may hold at most eight relationships, because each one is a join and the row
+            limit bounds what comes back rather than what it costs to produce.
+          example: "MATCH (o:order)-[:rel_order_item_order]->(i:order_item) WHERE o.status IN ['paid', 'shipped'] AND o.amount > $floor RETURN o.status AS status, count(*) AS orders ORDER BY orders DESC LIMIT 20"
     CypherQueryResult:
       type: object
       properties:


### PR DESCRIPTION
# Pull Request

## What Changed

Brings this release line up to the Cypher subset as merged on main.

- [x] Conditions as a tree: `OR`, `NOT`, `IN`, `IS NULL` / `IS NOT NULL`, parentheses to group them (#1408)
- [x] Parameters: `$name` in the query, values in a `parameters` object on the request (#1408)
- [x] Aggregation: `count`, `sum`, `avg`, `min`, `max`, their `DISTINCT` forms and `count(*)`, grouped the way Cypher groups (#1408)
- [x] Inline property maps, undirected relationships, multi-hop paths (#1411)
- [x] The fixes that came out of review on both: empty names refused where a name is required, ordering tested for aggregation rather than for `GROUP BY`, relationship uniqueness compared over every pair of hops, unicode escapes checked against the last code point, page size bounded where it is converted, and a cap of eight relationships per path
- [x] `docs/api/bkn/cypher-queries.yaml` and the grammar corpus

---

## Why

- Related Issue: [#1210](https://github.com/openbkn-ai/bkn-foundry/issues/1210)
- This line already carries the first batch (#1402, as its five original commits). Without the rest, a caller here can filter and sort a single hop and nothing else — no count, no `OR`, no `IN`, nowhere to put their values — which sends them back to the SQL tool for most questions.

---

## How

Content comes from main, where all three batches merged (#1402, #1408, #1411) and were verified end to end. **One thing is deliberately not brought across.**

On main the endpoint authorizes each object type and relation type a query touches, because main models a network's children as their own resources in bkn-safe. This line has no such model — `RESOURCE_TYPE_OBJECT_TYPE`, `KNChildResourceIDs` and `FilterKNChildResourceIDs` do not exist here — so the port keeps the check this line already had: `query_data` on the knowledge network, with vega-backend still checking `view_detail` per resource under the caller's own identity.

The visibility layer is therefore **absent rather than ported and disabled**: `visibility.go` is not added, `LoadSchema` keeps its two-argument form, and the API contract describes the authorization this line actually performs. That is the whole of the difference from main; everything else is the merged content.

Breaking changes: none. `parameters` is a new optional field; every query that compiled here before compiles the same way.

---

## Testing

- [x] Unit tests passed locally — 41 packages, no failures
- [ ] Integration tests — not applicable
- [x] Verified in test environment

Live on the development VM, which runs this line (`bkn-backend:0.1.4-yf-release`), against `worldcup_vega_catalog_bkn`: **25 checks, 25 pass**, each an HTTP request answered through the compiler, vega-backend and a real database.

The answers were checked against each other, not just for status:

| Check | Result |
|---|---|
| `country_name = 'Italy' OR = 'Brazil'` vs `IN ['Italy', 'Brazil']` | both 43 |
| `NOT country_name = 'Italy'` + `= 'Italy'` | 470 + 23 = 493 |
| `count(*)` and `IS NOT NULL` | 493 each |
| `IN []` | 0 |
| inline map `{country_name: 'Italy'}` vs the same as a parameter | 23 each |
| undirected, directed and two-hop over the same relation | 1248 each |
| Injection payload passed as a parameter | treated as a string, 0 rows, table intact |

Refusals checked on the same deployment: a missing parameter, ordering a grouped result by something it does not return, an empty backtick name, a path past the eight-relationship cap, a write clause, `XOR`, and a request with no identity (403 before anything is compiled).

---

## Risk & Rollback

- **The authorization difference is the thing to look at.** This line grants at the knowledge network; main grants per concept. A reviewer who expects main's behaviour here would find the endpoint more permissive than main by exactly that difference — which is the same permission the rest of this line's read paths use.
- **Aggregation moves work into the database.** A `GROUP BY` over a large resource is a heavier statement than a filtered read; the default limit caps rows returned, not work done.
- **`OR` and `NOT` change which rows come back.** The generated condition is asserted as a whole string against the query that produced it, including where the parentheses fall, so a change in precedence fails a test rather than a report.

Rollback: revert this commit. The line keeps the first batch and the endpoint keeps working without these constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
