### PR TITLE
feat(bkn-safe): add edition-aware policy provenance

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -33,6 +33,7 @@ import (
 // modelConf is the RBAC + resource-instance Casbin model.
 //
 //	r = sub, obj, act   sub=accessorID, obj="type:id", act=operation
+//	p = sub, obj, act, eft, policy_source, authority_source
 //	g = _, _            user/app -> role (UUID-preserved)
 //
 // The matcher also accepts policies whose subject is PublicAccessorID: ISF's
@@ -45,7 +46,7 @@ const modelConf = `
 r = sub, obj, act
 
 [policy_definition]
-p = sub, obj, act, eft
+p = sub, obj, act, eft, policy_source, authority_source
 
 [role_definition]
 g = _, _
@@ -108,6 +109,18 @@ func New(db *gorm.DB) (*Enforcer, error) {
 	if err := db.Table("casbin_rule").Where("ptype = ? AND (v3 IS NULL OR v3 = '')", "p").
 		Update("v3", EffectAllow).Error; err != nil {
 		return nil, fmt.Errorf("normalize legacy casbin policies: %w", err)
+	}
+	// Provenance classification belongs to the coordinated offline migration.
+	// Refuse to load a mixed/unknown policy store instead of guessing a source
+	// during startup and silently changing production authorization semantics.
+	var rows []casbinPolicyRow
+	if err := db.Table("casbin_rule").Where("ptype = ?", "p").Find(&rows).Error; err != nil {
+		return nil, fmt.Errorf("validate casbin policy provenance: %w", err)
+	}
+	for _, row := range rows {
+		if err := validatePolicyProvenance(PolicySource(row.V4), AuthoritySource(row.V5)); err != nil {
+			return nil, fmt.Errorf("%w: policy id %d: %v", ErrPolicySourceMigrationRequired, row.ID, err)
+		}
 	}
 	m, err := model.NewModelFromString(modelConf)
 	if err != nil {
@@ -287,8 +300,7 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(roleID, obj(resourceType, idPattern), op, EffectAllow)
-	return err
+	return en.addPolicy(roleID, obj(resourceType, idPattern), op, EffectAllow, PolicySourceRolePermission, AuthoritySourceAdminAuthz)
 }
 
 // RevokeRolePermission removes a role's op over a resource-type instance
@@ -296,8 +308,7 @@ func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op stri
 func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.RemovePolicy(roleID, obj(resourceType, idPattern), op, EffectAllow)
-	return err
+	return en.removePolicy(roleID, obj(resourceType, idPattern), op, EffectAllow, PolicySourceRolePermission, AuthoritySourceAdminAuthz)
 }
 
 // Grant adds a raw (sub, obj, act) policy. obj is the full object pattern
@@ -306,17 +317,17 @@ func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op str
 func (en *Enforcer) Grant(sub, obj, act string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(sub, obj, act, EffectAllow)
-	return err
+	return en.addPolicy(sub, obj, act, EffectAllow, PolicySourceRolePermission, AuthoritySourceSystem)
 }
 
-// GrantObjectPermission grants an accessor an op over one concrete resource
-// instance (the CreateResources pattern). Idempotent.
+// GrantObjectPermission is the compatibility writer for call sites that
+// predate trusted provenance. It marks their rows legacy/migration so it never
+// invents a Community bundle. New lifecycle and management flows use the
+// source-specific writers in policy_source.go. Idempotent.
 func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow)
-	return err
+	return en.addPolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow, PolicySourceLegacy, AuthoritySourceMigration)
 }
 
 // DenyObjectPermission adds an explicit per-object exception. Deny overrides
@@ -324,15 +335,16 @@ func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, 
 func (en *Enforcer) DenyObjectPermission(accessorID, resourceType, resourceID, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, EffectDeny)
-	return err
+	return en.addPolicy(accessorID, obj(resourceType, resourceID), op, EffectDeny, PolicySourceLegacy, AuthoritySourceMigration)
 }
 
-// RevokeObjectPermission removes a concrete per-object grant.
+// RevokeObjectPermission removes every allow source for one concrete tuple.
+// It is retained for lifecycle reconciliation code written before policies had
+// provenance. New management flows that mean "one source" use RevokePolicy.
 func (en *Enforcer) RevokeObjectPermission(accessorID, resourceType, resourceID, op string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.RemovePolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow)
+	_, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), op, EffectAllow)
 	return err
 }
 
@@ -395,7 +407,7 @@ func (en *Enforcer) RolePermissions(roleID string) ([]RoleGrant, error) {
 	if err != nil {
 		return nil, err
 	}
-	return groupGrantsByObject(rows), nil
+	return groupGrantsByObject(activePolicyRows(rows)), nil
 }
 
 // groupGrantsByObject collapses raw (sub, obj, act) policy rows into per-object
@@ -478,6 +490,7 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 	if err != nil {
 		return false, nil, err
 	}
+	rows = activePolicyRows(rows)
 	grouped := groupGrantsByObject(rows)
 	superAdmin, err := en.hasSuperAdminRole(accessorID)
 	if err != nil {
@@ -703,10 +716,11 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 		if len(row) >= 4 && row[3] != "" {
 			effect = row[3]
 		}
-		if _, err := en.e.RemovePolicy(row[0], object, oldOp, effect); err != nil {
+		source, authority := policySourceOf(row), authoritySourceOf(row)
+		if _, err := en.e.RemovePolicy(row[0], object, oldOp, effect, string(source), string(authority)); err != nil {
 			return moved, err
 		}
-		if _, err := en.e.AddPolicy(row[0], object, newOp, effect); err != nil {
+		if err := en.addPolicy(row[0], object, newOp, effect, source, authority); err != nil {
 			return moved, err
 		}
 		moved++
@@ -753,14 +767,21 @@ func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp s
 		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
 			continue
 		}
-		has, err := en.e.HasPolicy(row[0], object, impliedOp, EffectAllow)
+		source, authority := policySourceOf(row), authoritySourceOf(row)
+		// Compatibility and logical-bundle rows are immutable snapshots of their
+		// own contracts. Runtime requires (#1429) handles reachability without
+		// expanding legacy, and bundle expansion belongs only in the grant index.
+		if source == PolicySourceLegacy || source == PolicySourceCommunityBundle {
+			continue
+		}
+		has, err := en.e.HasPolicy(row[0], object, impliedOp, EffectAllow, string(source), string(authority))
 		if err != nil {
 			return added, err
 		}
 		if has {
 			continue
 		}
-		if _, err := en.e.AddPolicy(row[0], object, impliedOp, EffectAllow); err != nil {
+		if err := en.addPolicy(row[0], object, impliedOp, EffectAllow, source, authority); err != nil {
 			return added, err
 		}
 		added = append(added, BackfilledGrant{AccessorID: row[0], ResourceID: object[len(prefix):]})
@@ -859,6 +880,7 @@ func (en *Enforcer) accessibleResources(accessorID, resourceType, op string, vis
 	if err != nil {
 		return nil, err
 	}
+	perms = activePolicyRows(perms)
 	prefix := resourceType + ":"
 	seen := map[string]bool{}
 	out := make([]string, 0, len(perms))
@@ -911,6 +933,7 @@ func (en *Enforcer) ResourcePolicies(resourceType, resourceID string) ([]Resourc
 	if err != nil {
 		return nil, err
 	}
+	rows = activePolicyRows(rows)
 	bySub := map[string][]string{}
 	deniedBySub := map[string][]string{}
 	seenSub := map[string]bool{}
@@ -965,6 +988,7 @@ func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string
 	if err != nil {
 		return nil, err
 	}
+	rows = activePolicyRows(rows)
 	type key struct{ sub, rtype, rid string }
 	ops := map[key][]string{}
 	deniedOps := map[key][]string{}
@@ -1018,19 +1042,23 @@ func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID st
 	return en.SetObjectPermissionsForEffect(accessorID, resourceType, resourceID, ops, EffectAllow)
 }
 
-// SetObjectPermissionsForEffect replaces only one effect's operation set. This
-// preserves deny exceptions while legacy callers update allows, and vice versa.
+// SetObjectPermissionsForEffect is the compatibility whole-set writer. It only
+// replaces the legacy/migration slice, preserving every independently owned
+// source. The edition-aware management API migrates to
+// SetProfessionalObjectPermissions in #1430.
 func (en *Enforcer) SetObjectPermissionsForEffect(accessorID, resourceType, resourceID string, ops []string, effect string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
 	if effect != EffectAllow && effect != EffectDeny {
 		return fmt.Errorf("invalid policy effect %q", effect)
 	}
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect); err != nil {
+	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
+		string(PolicySourceLegacy), string(AuthoritySourceMigration)); err != nil {
 		return err
 	}
 	for _, op := range ops {
-		if _, err := en.e.AddPolicy(accessorID, obj(resourceType, resourceID), op, effect); err != nil {
+		if err := en.addPolicy(accessorID, obj(resourceType, resourceID), op, effect,
+			PolicySourceLegacy, AuthoritySourceMigration); err != nil {
 			return err
 		}
 	}

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -143,8 +143,8 @@ func TestLegacyPolicyWithoutEffectIsNormalizedToAllow(t *testing.T) {
 	e, db := newTestEnforcerDB(t)
 	_ = e
 	if err := db.Exec(
-		"INSERT INTO casbin_rule (ptype, v0, v1, v2, v3) VALUES (?, ?, ?, ?, '')",
-		"p", "legacy-user", "resource:r-1", "view_detail",
+		"INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, v4, v5) VALUES (?, ?, ?, ?, '', ?, ?)",
+		"p", "legacy-user", "resource:r-1", "view_detail", PolicySourceLegacy, AuthoritySourceMigration,
 	).Error; err != nil {
 		t.Fatalf("insert legacy policy: %v", err)
 	}

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -6,6 +6,7 @@ package authz
 
 import (
 	"github.com/casbin/casbin/v2/util"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
 )
 
 // ResourceRef names one concrete resource instance ("type:id").
@@ -211,6 +212,9 @@ func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
 	if err != nil {
 		return nil, err
 	}
+	edition := entitlement.Current()
+	rows = activePolicyRowsForEdition(rows, edition)
+	public = activePolicyRowsForEdition(public, edition)
 	idx := &grantIndex{exact: make(map[string][]grantRow, len(rows)), superAdmin: superAdmin}
 	for _, row := range append(rows, public...) {
 		if len(row) < 4 {

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -267,11 +267,11 @@ func (en *Enforcer) inheritedResources(accessorID, resourceType, op string, visi
 	// and the size question has to be answered there rather than by quietly
 	// truncating it: a short list would read as "these are the tables you may
 	// see".
-	wide, err := en.e.Enforce(accessorID, obj(parentType, "*"), parentOp)
+	idx, err := en.grantIndex(accessorID)
 	if err != nil {
 		return nil, err
 	}
-	if wide {
+	if idx.decide(ResourceRef{Type: parentType, ID: "*"}, []string{parentOp})[parentOp] == EffectAllow {
 		return en.childrenOf(resourceType, parentType, nil)
 	}
 
@@ -319,6 +319,7 @@ func (en *Enforcer) publicInstances(resourceType, op string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	rows = activePolicyRows(rows)
 	prefix := resourceType + ":"
 	seen := map[string]bool{}
 	out := make([]string, 0, len(rows))
@@ -574,6 +575,10 @@ func (en *Enforcer) PreviewOwnership(resourceType, parentType string, links map[
 			have[c.ID] = set
 		}
 
+		directIdx, err := en.grantIndex(sub)
+		if err != nil {
+			return nil, 0, err
+		}
 		for _, child := range children {
 			gained := map[string]bool{}
 			for _, childOp := range childOps {
@@ -597,11 +602,7 @@ func (en *Enforcer) PreviewOwnership(resourceType, parentType string, links map[
 				if !have[child][op] || gained[op] {
 					continue
 				}
-				direct, err := en.e.Enforce(sub, obj(resourceType, child), op)
-				if err != nil {
-					return nil, 0, err
-				}
-				if !direct {
+				if directIdx.decide(ResourceRef{Type: resourceType, ID: child}, []string{op})[op] != EffectAllow {
 					record(sub, child, op, FlipRevoke)
 				}
 			}

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -1,0 +1,314 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+)
+
+// PolicySource identifies the product or lifecycle layer that owns a policy.
+// It is persisted in Casbin v4; it is not accepted from an authorization HTTP
+// request. Enterprise property policy remains in the EE-owned store and is not
+// represented by this Core policy vocabulary.
+type PolicySource string
+
+const (
+	PolicySourceCommunityBundle  PolicySource = "community_bundle"
+	PolicySourceProfessionalRule PolicySource = "professional_rule"
+	PolicySourceLegacy           PolicySource = "legacy"
+	PolicySourceSystemDerived    PolicySource = "system_derived"
+	PolicySourceRolePermission   PolicySource = "role_permission"
+)
+
+// ActFullBusinessAccess is the persisted logical Community operation. Its
+// reviewed per-resource expansion is implemented by the shared grant index in
+// #1427; it must never be materialized into ordinary operation rows.
+const ActFullBusinessAccess = "full_business_access"
+
+// AuthoritySource identifies the trusted server path that wrote a policy. It
+// controls who may manage a rule; it deliberately has no runtime precedence.
+// It is persisted in Casbin v5.
+type AuthoritySource string
+
+const (
+	AuthoritySourceAdminAuthz    AuthoritySource = "admin_authz"
+	AuthoritySourceOwnerDelegate AuthoritySource = "owner_delegate"
+	AuthoritySourceSystem        AuthoritySource = "system"
+	AuthoritySourceMigration     AuthoritySource = "migration"
+)
+
+var (
+	// ErrPolicySourceMigrationRequired is returned before Casbin loads when a
+	// persisted business policy has not been assigned trusted provenance. The
+	// offline migration owns that classification; startup must not infer it.
+	ErrPolicySourceMigrationRequired = errors.New("casbin policy provenance migration required")
+)
+
+// PolicyRecord is the durable identity and provenance of one Casbin p-line.
+// ID is the adapter's stable primary key. Active is derived from the live
+// edition at read time and is never persisted.
+type PolicyRecord struct {
+	ID              uint
+	AccessorID      string
+	Object          string
+	Operation       string
+	Effect          string
+	PolicySource    PolicySource
+	AuthoritySource AuthoritySource
+	Active          bool
+}
+
+// PolicyFilter narrows a provenance listing. Zero fields match every p-line.
+type PolicyFilter struct {
+	AccessorID      string
+	Object          string
+	Operation       string
+	Effect          string
+	PolicySource    PolicySource
+	AuthoritySource AuthoritySource
+}
+
+// casbinPolicyRow mirrors the adapter table without making the adapter's
+// concrete model part of bkn-safe's API.
+type casbinPolicyRow struct {
+	ID    uint
+	Ptype string
+	V0    string
+	V1    string
+	V2    string
+	V3    string
+	V4    string
+	V5    string
+}
+
+func (casbinPolicyRow) TableName() string { return "casbin_rule" }
+
+func validatePolicySource(source PolicySource) error {
+	switch source {
+	case PolicySourceCommunityBundle, PolicySourceProfessionalRule, PolicySourceLegacy,
+		PolicySourceSystemDerived, PolicySourceRolePermission:
+		return nil
+	default:
+		return fmt.Errorf("unknown policy source %q", source)
+	}
+}
+
+func validateAuthoritySource(source AuthoritySource) error {
+	switch source {
+	case AuthoritySourceAdminAuthz, AuthoritySourceOwnerDelegate, AuthoritySourceSystem, AuthoritySourceMigration:
+		return nil
+	default:
+		return fmt.Errorf("unknown authority source %q", source)
+	}
+}
+
+func validatePolicyProvenance(source PolicySource, authority AuthoritySource) error {
+	if err := validatePolicySource(source); err != nil {
+		return err
+	}
+	return validateAuthoritySource(authority)
+}
+
+// policySourceActive implements the effective-layer formula. Professional
+// configuration is retained but inactive in Community. Every other Core source
+// remains active at every tier; Enterprise property narrowing is composed by
+// the existing EE extension after this decision.
+func policySourceActive(source PolicySource, edition licverify.Edition) bool {
+	switch source {
+	case PolicySourceProfessionalRule:
+		return edition.AtLeast(licverify.EditionProfessional)
+	case PolicySourceCommunityBundle, PolicySourceLegacy, PolicySourceSystemDerived, PolicySourceRolePermission:
+		return true
+	default:
+		return false
+	}
+}
+
+func policySourceOf(row []string) PolicySource {
+	if len(row) <= 4 {
+		return ""
+	}
+	return PolicySource(row[4])
+}
+
+func authoritySourceOf(row []string) AuthoritySource {
+	if len(row) <= 5 {
+		return ""
+	}
+	return AuthoritySource(row[5])
+}
+
+func activePolicyRows(rows [][]string) [][]string {
+	return activePolicyRowsForEdition(rows, entitlement.Current())
+}
+
+func activePolicyRowsForEdition(rows [][]string, edition licverify.Edition) [][]string {
+	out := make([][]string, 0, len(rows))
+	for _, row := range rows {
+		if policySourceActive(policySourceOf(row), edition) {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func (en *Enforcer) addPolicy(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
+	if effect != EffectAllow && effect != EffectDeny {
+		return fmt.Errorf("invalid policy effect %q", effect)
+	}
+	if err := validatePolicyProvenance(source, authority); err != nil {
+		return err
+	}
+	_, err := en.e.AddPolicy(sub, object, operation, effect, string(source), string(authority))
+	return err
+}
+
+func (en *Enforcer) removePolicy(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
+	if err := validatePolicyProvenance(source, authority); err != nil {
+		return err
+	}
+	_, err := en.e.RemovePolicy(sub, object, operation, effect, string(source), string(authority))
+	return err
+}
+
+// GrantProfessionalObjectPermission writes a trusted Professional rule. The
+// caller supplies only which already-authenticated server authority performed
+// the write; ordinary HTTP request bodies do not expose this parameter.
+func (en *Enforcer) GrantProfessionalObjectPermission(accessorID, resourceType, resourceID, operation, effect string, authority AuthoritySource) error {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+		return fmt.Errorf("professional rule authority %q is not permitted", authority)
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	return en.addPolicy(accessorID, obj(resourceType, resourceID), operation, effect, PolicySourceProfessionalRule, authority)
+}
+
+// GrantSystemObjectPermission records a lifecycle-derived permission.
+func (en *Enforcer) GrantSystemObjectPermission(accessorID, resourceType, resourceID, operation string) error {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	return en.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow, PolicySourceSystemDerived, AuthoritySourceSystem)
+}
+
+// GrantCommunityBundle records the one logical Community grant. Expansion of
+// full_business_access belongs to #1427's shared grant-index implementation.
+func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID string, authority AuthoritySource) error {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+		return fmt.Errorf("community bundle authority %q is not permitted", authority)
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	return en.addPolicy(accessorID, obj(resourceType, resourceID), ActFullBusinessAccess, EffectAllow, PolicySourceCommunityBundle, authority)
+}
+
+// SetProfessionalObjectPermissions replaces only one trusted source slice. An
+// owner save cannot delete an administrator rule, and neither can touch a
+// bundle, legacy, system-derived or role row.
+func (en *Enforcer) SetProfessionalObjectPermissions(accessorID, resourceType, resourceID string, operations []string, effect string, authority AuthoritySource) error {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+		return fmt.Errorf("professional rule authority %q is not permitted", authority)
+	}
+	if effect != EffectAllow && effect != EffectDeny {
+		return fmt.Errorf("invalid policy effect %q", effect)
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
+		string(PolicySourceProfessionalRule), string(authority)); err != nil {
+		return err
+	}
+	for _, operation := range operations {
+		if err := en.addPolicy(accessorID, obj(resourceType, resourceID), operation, effect, PolicySourceProfessionalRule, authority); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveProfessionalObjectPermissions removes only the slice managed by one
+// trusted authority. In particular, an owner revoke cannot erase an
+// administrator's deny or allow for the same tuple.
+func (en *Enforcer) RemoveProfessionalObjectPermissions(accessorID, resourceType, resourceID, effect string, authority AuthoritySource) (int, error) {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+		return 0, fmt.Errorf("professional rule authority %q is not permitted", authority)
+	}
+	if effect != EffectAllow && effect != EffectDeny {
+		return 0, fmt.Errorf("invalid policy effect %q", effect)
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
+		string(PolicySourceProfessionalRule), string(authority))
+	if err != nil || len(rows) == 0 {
+		return 0, err
+	}
+	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
+		string(PolicySourceProfessionalRule), string(authority)); err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}
+
+// PolicyRecords lists persisted policy configuration, including inactive
+// Professional rows and legacy rows. It never rewrites configuration.
+func (en *Enforcer) PolicyRecords(filter PolicyFilter) ([]PolicyRecord, error) {
+	q := en.db.Table("casbin_rule").Where("ptype = ?", "p")
+	if filter.AccessorID != "" {
+		q = q.Where("v0 = ?", filter.AccessorID)
+	}
+	if filter.Object != "" {
+		q = q.Where("v1 = ?", filter.Object)
+	}
+	if filter.Operation != "" {
+		q = q.Where("v2 = ?", filter.Operation)
+	}
+	if filter.Effect != "" {
+		q = q.Where("v3 = ?", filter.Effect)
+	}
+	if filter.PolicySource != "" {
+		q = q.Where("v4 = ?", filter.PolicySource)
+	}
+	if filter.AuthoritySource != "" {
+		q = q.Where("v5 = ?", filter.AuthoritySource)
+	}
+	var rows []casbinPolicyRow
+	if err := q.Order("id").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	edition := entitlement.Current()
+	out := make([]PolicyRecord, 0, len(rows))
+	for _, row := range rows {
+		source := PolicySource(row.V4)
+		out = append(out, PolicyRecord{
+			ID: row.ID, AccessorID: row.V0, Object: row.V1, Operation: row.V2,
+			Effect: row.V3, PolicySource: source, AuthoritySource: AuthoritySource(row.V5),
+			Active: policySourceActive(source, edition),
+		})
+	}
+	return out, nil
+}
+
+// RevokePolicy removes exactly one stable policy identity. It is the only
+// mutation supported for legacy rows and cannot remove a sibling source with
+// the same subject/resource/operation tuple.
+func (en *Enforcer) RevokePolicy(id uint) (bool, error) {
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	var row casbinPolicyRow
+	err := en.db.Table("casbin_rule").Where("id = ? AND ptype = ?", id, "p").Take(&row).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	removed, err := en.e.RemovePolicy(row.V0, row.V1, row.V2, row.V3, row.V4, row.V5)
+	return removed, err
+}

--- a/bkn-safe/server/internal/authz/policy_source_test.go
+++ b/bkn-safe/server/internal/authz/policy_source_test.go
@@ -1,0 +1,229 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+)
+
+func useEdition(t *testing.T, initial licverify.Edition) *licverify.Edition {
+	t.Helper()
+	edition := initial
+	entitlement.SetGateForTest(entitlement.GateFunc(func() entitlement.Snapshot {
+		return entitlement.Snapshot{Edition: edition}
+	}))
+	t.Cleanup(entitlement.ResetForTest)
+	return &edition
+}
+
+func TestNewRejectsUnclassifiedPolicyWithoutMutatingItsSource(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	// Create the adapter-owned table, then emulate a pre-migration business row.
+	if _, err := New(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(
+		"INSERT INTO casbin_rule (ptype, v0, v1, v2, v3) VALUES (?, ?, ?, ?, ?)",
+		"p", "legacy-user", "resource:r-1", "view_detail", EffectAllow,
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = New(db)
+	if !errors.Is(err, ErrPolicySourceMigrationRequired) {
+		t.Fatalf("New() error = %v, want ErrPolicySourceMigrationRequired", err)
+	}
+	var classified int64
+	if err := db.Table("casbin_rule").Where("v0 = ? AND v4 IS NOT NULL AND v4 <> ''", "legacy-user").Count(&classified).Error; err != nil {
+		t.Fatal(err)
+	}
+	if classified != 0 {
+		t.Fatal("startup inferred provenance; offline migration must own classification")
+	}
+}
+
+func TestPolicySourcesFollowLiveEditionWithoutRewritingRows(t *testing.T) {
+	edition := useEdition(t, licverify.EditionCommunity)
+	e, _ := newTestEnforcerDB(t)
+
+	mustNoErr(t, e.GrantObjectPermission("u-legacy", "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.GrantSystemObjectPermission("u-system", "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.GrantRolePermission("role-reader", "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.AssignRole("u-role", "role-reader"))
+	mustNoErr(t, e.GrantCommunityBundle("u-bundle", "resource", "r-1", AuthoritySourceAdminAuthz))
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		"u-professional", "resource", "r-1", "view_detail", EffectAllow, AuthoritySourceAdminAuthz,
+	))
+
+	for _, tc := range []struct {
+		user, operation string
+	}{
+		{"u-legacy", "view_detail"},
+		{"u-system", "view_detail"},
+		{"u-role", "view_detail"},
+		{"u-bundle", ActFullBusinessAccess},
+	} {
+		allowed, err := e.Check(tc.user, "resource", "r-1", tc.operation)
+		if err != nil || !allowed {
+			t.Fatalf("Community Check(%s,%s) = %v, %v; want true", tc.user, tc.operation, allowed, err)
+		}
+	}
+	assertAllowed := func(want bool) {
+		t.Helper()
+		allowed, err := e.Check("u-professional", "resource", "r-1", "view_detail")
+		if err != nil || allowed != want {
+			t.Fatalf("edition %q professional decision = %v, %v; want %v", *edition, allowed, err, want)
+		}
+		_, effective, err := e.EffectivePermissions("u-professional", PermQuery{ResourceType: "resource"})
+		listed := len(effective) == 1 && hasOp(effective[0].Operations, "view_detail")
+		if err != nil || listed != want {
+			t.Fatalf("edition %q effective permissions = %+v, %v; want listed=%v", *edition, effective, err, want)
+		}
+		direct, err := e.ListObjectGrants("u-professional", "resource", "r-1")
+		listed = len(direct) == 1 && hasOp(direct[0].Operations, "view_detail")
+		if err != nil || listed != want {
+			t.Fatalf("edition %q object grants = %+v, %v; want listed=%v", *edition, direct, err, want)
+		}
+	}
+	assertAllowed(false)
+
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-professional"})
+	if err != nil || len(records) != 1 {
+		t.Fatalf("professional records = %+v, %v; want one retained row", records, err)
+	}
+	if records[0].Active {
+		t.Fatal("Professional row reported active in Community")
+	}
+	id := records[0].ID
+
+	for _, paid := range []licverify.Edition{
+		licverify.EditionProfessional, licverify.EditionEnterprise, licverify.EditionIndustry,
+	} {
+		*edition = paid
+		assertAllowed(true)
+	}
+	*edition = licverify.EditionCommunity
+	assertAllowed(false)
+	*edition = licverify.EditionProfessional
+	assertAllowed(true)
+
+	reloaded, err := New(e.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reloadedRecords, err := reloaded.PolicyRecords(PolicyFilter{AccessorID: "u-professional"})
+	if err != nil || len(reloadedRecords) != 1 || reloadedRecords[0].ID != id {
+		t.Fatalf("stable identity after reload = %+v, %v; want id %d", reloadedRecords, err, id)
+	}
+}
+
+func TestSameTupleSourcesAreIndependentAndOwnerSaveIsScoped(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	const user = "u-1"
+
+	mustNoErr(t, e.GrantObjectPermission(user, "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		user, "resource", "r-1", "view_detail", EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		user, "resource", "r-1", "view_detail", EffectAllow, AuthoritySourceOwnerDelegate,
+	))
+	mustNoErr(t, e.GrantSystemObjectPermission(user, "resource", "r-1", "view_detail"))
+
+	before, err := e.PolicyRecords(PolicyFilter{AccessorID: user, Object: "resource:r-1", Operation: "view_detail"})
+	if err != nil || len(before) != 4 {
+		t.Fatalf("same-tuple records = %+v, %v; want four independently stored sources", before, err)
+	}
+
+	// Replacing the owner's slice must leave the administrator, migration and
+	// system rows intact (A-48/A-49).
+	mustNoErr(t, e.SetProfessionalObjectPermissions(
+		user, "resource", "r-1", []string{"modify"}, EffectAllow, AuthoritySourceOwnerDelegate,
+	))
+	afterSave, err := e.PolicyRecords(PolicyFilter{AccessorID: user, Object: "resource:r-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := map[AuthoritySource]int{}
+	for _, record := range afterSave {
+		counts[record.AuthoritySource]++
+	}
+	if counts[AuthoritySourceAdminAuthz] != 1 || counts[AuthoritySourceMigration] != 1 || counts[AuthoritySourceSystem] != 1 || counts[AuthoritySourceOwnerDelegate] != 1 {
+		t.Fatalf("source-scoped replacement changed sibling rows: %+v", afterSave)
+	}
+
+	var legacyID uint
+	for _, record := range afterSave {
+		if record.PolicySource == PolicySourceLegacy {
+			legacyID = record.ID
+		}
+	}
+	removed, err := e.RevokePolicy(legacyID)
+	if err != nil || !removed {
+		t.Fatalf("RevokePolicy(legacy) = %v, %v; want true", removed, err)
+	}
+	remaining, err := e.PolicyRecords(PolicyFilter{AccessorID: user, Object: "resource:r-1"})
+	if err != nil || len(remaining) != 3 {
+		t.Fatalf("remaining records = %+v, %v; want three", remaining, err)
+	}
+	allowed, err := e.Check(user, "resource", "r-1", "view_detail")
+	if err != nil || !allowed {
+		t.Fatalf("revoking legacy removed sibling sources: allowed=%v err=%v", allowed, err)
+	}
+}
+
+func TestProfessionalDenyIsInactiveOnDowngradeAndRestoredOnRecovery(t *testing.T) {
+	edition := useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.GrantObjectPermission("u-1", "resource", "r-1", "view_detail"))
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		"u-1", "resource", "r-1", "view_detail", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+
+	allowed, err := e.Check("u-1", "resource", "r-1", "view_detail")
+	if err != nil || allowed {
+		t.Fatalf("Professional decision = %v, %v; want deny", allowed, err)
+	}
+	*edition = licverify.EditionCommunity
+	allowed, err = e.Check("u-1", "resource", "r-1", "view_detail")
+	if err != nil || !allowed {
+		t.Fatalf("Community decision = %v, %v; want legacy allow", allowed, err)
+	}
+	*edition = licverify.EditionIndustry
+	allowed, err = e.Check("u-1", "resource", "r-1", "view_detail")
+	if err != nil || allowed {
+		t.Fatalf("Industry decision = %v, %v; want restored Professional deny", allowed, err)
+	}
+}
+
+func TestLegacyPolicyCannotBeExpandedInPlace(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.GrantObjectPermission("u-1", "catalog", "c-1", "resource_manage"))
+
+	added, err := e.BackfillImpliedOperation("catalog", "resource_manage", "view_detail")
+	if err != nil || len(added) != 0 {
+		t.Fatalf("legacy backfill = %+v, %v; want no in-place expansion", added, err)
+	}
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-1", Object: "catalog:c-1"})
+	if err != nil || len(records) != 1 || records[0].Operation != "resource_manage" {
+		t.Fatalf("legacy records changed in place: %+v, %v", records, err)
+	}
+}

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -36,17 +36,21 @@ func (tx *PolicyTransaction) Check(accessorID, resourceType, resourceID, operati
 }
 
 func (tx *PolicyTransaction) HasObjectPermission(accessorID, resourceType, resourceID, operation string) (bool, error) {
-	return tx.enforcer.e.HasPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
+	rows, err := tx.enforcer.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID), operation, EffectAllow)
+	if err != nil {
+		return false, err
+	}
+	return len(activePolicyRows(rows)) > 0, nil
 }
 
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
-	_, err := tx.enforcer.e.AddPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
-	return err
+	return tx.enforcer.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
+		PolicySourceSystemDerived, AuthoritySourceSystem)
 }
 
 func (tx *PolicyTransaction) RevokeObjectPermission(accessorID, resourceType, resourceID, operation string) error {
-	_, err := tx.enforcer.e.RemovePolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow)
-	return err
+	return tx.enforcer.removePolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
+		PolicySourceSystemDerived, AuthoritySourceSystem)
 }
 
 // Transaction runs fn inside the gorm-adapter transaction used by Casbin. The

--- a/bkn-safe/server/internal/authz/transaction_test.go
+++ b/bkn-safe/server/internal/authz/transaction_test.go
@@ -25,7 +25,8 @@ func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
 		})
 	}()
 	<-entered
-	allowed, err := e.e.HasPolicy("proxy", obj("resource", "r-1"), "query_data", EffectAllow)
+	allowed, err := e.e.HasPolicy("proxy", obj("resource", "r-1"), "query_data", EffectAllow,
+		string(PolicySourceSystemDerived), string(AuthoritySourceSystem))
 	if err != nil || allowed {
 		t.Fatalf("uncommitted policy was visible: allowed=%v err=%v", allowed, err)
 	}
@@ -49,11 +50,14 @@ func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
 	}
 	for _, check := range []struct {
 		accessor, resource, operation string
+		source                        PolicySource
+		authority                     AuthoritySource
 	}{
-		{"proxy", "r-1", "query_data"},
-		{"user", "r-2", "view_detail"},
+		{"proxy", "r-1", "query_data", PolicySourceSystemDerived, AuthoritySourceSystem},
+		{"user", "r-2", "view_detail", PolicySourceLegacy, AuthoritySourceMigration},
 	} {
-		allowed, err := e.e.HasPolicy(check.accessor, obj("resource", check.resource), check.operation, EffectAllow)
+		allowed, err := e.e.HasPolicy(check.accessor, obj("resource", check.resource), check.operation, EffectAllow,
+			string(check.source), string(check.authority))
 		if err != nil || !allowed {
 			t.Fatalf("Check(%q, %q, %q) = %v, %v", check.accessor, check.resource, check.operation, allowed, err)
 		}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -261,7 +261,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		for _, op := range ops {
-			if err := e.GrantObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
+			if err := e.GrantSystemObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
 				serverError(c, err)
 				return
 			}

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -261,7 +261,12 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		for _, op := range ops {
-			if err := e.GrantSystemObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
+			// Keep the existing generic create-resource route on its compatibility
+			// source until #1430 replaces the request contract with explicit
+			// edition-aware bundle and Professional writers. Classifying every
+			// operation arriving here as lifecycle-derived would make it immune to
+			// the current object-grant whole-set editor.
+			if err := e.GrantObjectPermission(req.AccessorID, req.Resource.Type, req.Resource.ID, op); err != nil {
 				serverError(c, err)
 				return
 			}

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -827,13 +827,13 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		}
 		outcome["effect"] = req.Effect
 		setAuditOutcome(c, outcome)
-		policyAuthority := authz.AuthoritySourceOwnerDelegate
-		if authority == authorityAdminAuthz {
-			policyAuthority = authz.AuthoritySourceAdminAuthz
-		}
-		if err := e.SetProfessionalObjectPermissions(
-			req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect, policyAuthority,
-		); err != nil {
+		// #1426 introduces trusted provenance and edition-aware decision APIs but
+		// does not change this route's public write contract. Keep writes in the
+		// active legacy compatibility slice until #1430 atomically adds Community
+		// bundle-only validation and the Professional capability gate. Writing a
+		// Professional row here today would return 204 in Community while storing
+		// a rule that Check and every permission read intentionally ignore.
+		if err := e.SetObjectPermissionsForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect); err != nil {
 			serverError(c, err)
 			return
 		}
@@ -899,14 +899,6 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		var removed int
 		if req.Effect == "" && authority == authorityAdminAuthz {
 			removed, err = e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
-		} else if authority != authorityAdminAuthz {
-			effect := req.Effect
-			if effect == "" {
-				effect = authz.EffectAllow
-			}
-			removed, err = e.RemoveProfessionalObjectPermissions(
-				req.AccessorID, req.Resource.Type, req.Resource.ID, effect, authz.AuthoritySourceOwnerDelegate,
-			)
 		} else {
 			effect := req.Effect
 			if effect == "" {

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -827,7 +827,13 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		}
 		outcome["effect"] = req.Effect
 		setAuditOutcome(c, outcome)
-		if err := e.SetObjectPermissionsForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect); err != nil {
+		policyAuthority := authz.AuthoritySourceOwnerDelegate
+		if authority == authorityAdminAuthz {
+			policyAuthority = authz.AuthoritySourceAdminAuthz
+		}
+		if err := e.SetProfessionalObjectPermissions(
+			req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect, policyAuthority,
+		); err != nil {
 			serverError(c, err)
 			return
 		}
@@ -893,6 +899,14 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		var removed int
 		if req.Effect == "" && authority == authorityAdminAuthz {
 			removed, err = e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
+		} else if authority != authorityAdminAuthz {
+			effect := req.Effect
+			if effect == "" {
+				effect = authz.EffectAllow
+			}
+			removed, err = e.RemoveProfessionalObjectPermissions(
+				req.AccessorID, req.Resource.Type, req.Resource.ID, effect, authz.AuthoritySourceOwnerDelegate,
+			)
 		} else {
 			effect := req.Effect
 			if effect == "" {

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
 )
 
 // seedCatalogOps registers operation ids for a resource type so the
@@ -95,14 +97,15 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	if ok, _ := e.Check("u-1", "catalog", "c1", "modify"); !ok {
 		t.Fatal("grant did not take effect at enforce time")
 	}
-	// Provenance is a server-side property. Unknown JSON fields are ignored and
-	// cannot turn this administrator write into a bundle or owner-owned rule.
+	// Provenance is a server-side property. Until #1430 switches this existing
+	// route to the edition-aware request contract, unknown JSON fields cannot
+	// turn its compatibility write into a bundle or Professional rule.
 	records, err := e.PolicyRecords(authz.PolicyFilter{AccessorID: "u-1", Object: "catalog:c1"})
 	if err != nil || len(records) != 2 {
 		t.Fatalf("policy provenance = %+v, %v; want two server-derived rows", records, err)
 	}
 	for _, record := range records {
-		if record.PolicySource != authz.PolicySourceProfessionalRule || record.AuthoritySource != authz.AuthoritySourceAdminAuthz {
+		if record.PolicySource != authz.PolicySourceLegacy || record.AuthoritySource != authz.AuthoritySourceMigration {
 			t.Fatalf("ordinary request forged policy provenance: %+v", record)
 		}
 	}
@@ -152,6 +155,35 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	}
 	if got := listObjectGrants(t, r, ""); len(got) != 0 {
 		t.Fatalf("list after revoke: %+v", got)
+	}
+}
+
+func TestCommunityObjectGrantCompatibilityWriteIsImmediatelyEffective(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+	t.Cleanup(entitlement.ResetForTest)
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+	if err := db.Create(&model.User{ID: "community-user", Account: "community-user", Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "community-user",
+		"resource":    map[string]any{"type": "catalog", "id": "c-community"},
+		"operations":  []string{"view_detail", "modify"},
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Community grant = %d %s; want 204", w.Code, w.Body.String())
+	}
+	for _, operation := range []string{"view_detail", "modify"} {
+		allowed, err := e.Check("community-user", "catalog", "c-community", operation)
+		if err != nil || !allowed {
+			t.Fatalf("Community grant Check(%q) = %v, %v; want true", operation, allowed, err)
+		}
+	}
+	grants := listObjectGrants(t, r, "?accessor_id=community-user&resource_type=catalog&resource_id=c-community")
+	if len(grants) != 1 || len(grants[0].Operations) != 2 {
+		t.Fatalf("Community grant listing = %+v; want one visible two-operation grant", grants)
 	}
 }
 
@@ -791,9 +823,7 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	}
 
 	// A plain grantee stays revocable — undoing a share is the point.
-	if err := e.GrantProfessionalObjectPermission(
-		"u-mate", "knowledge_network", "kn-mine", "view_detail", authz.EffectAllow, authz.AuthoritySourceOwnerDelegate,
-	); err != nil {
+	if err := e.GrantObjectPermission("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil {
 		t.Fatal(err)
 	}
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -83,15 +83,28 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 
 	// set: grant u-1 two ops on catalog c1
 	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
-		"accessor_id": "u-1",
-		"resource":    map[string]any{"type": "catalog", "id": "c1"},
-		"operations":  []string{"view_detail", "modify"},
+		"accessor_id":      "u-1",
+		"resource":         map[string]any{"type": "catalog", "id": "c1"},
+		"operations":       []string{"view_detail", "modify"},
+		"policy_source":    "community_bundle",
+		"authority_source": "owner_delegate",
 	})
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
 	if ok, _ := e.Check("u-1", "catalog", "c1", "modify"); !ok {
 		t.Fatal("grant did not take effect at enforce time")
+	}
+	// Provenance is a server-side property. Unknown JSON fields are ignored and
+	// cannot turn this administrator write into a bundle or owner-owned rule.
+	records, err := e.PolicyRecords(authz.PolicyFilter{AccessorID: "u-1", Object: "catalog:c1"})
+	if err != nil || len(records) != 2 {
+		t.Fatalf("policy provenance = %+v, %v; want two server-derived rows", records, err)
+	}
+	for _, record := range records {
+		if record.PolicySource != authz.PolicySourceProfessionalRule || record.AuthoritySource != authz.AuthoritySourceAdminAuthz {
+			t.Fatalf("ordinary request forged policy provenance: %+v", record)
+		}
 	}
 
 	// list (no filter) returns the grant
@@ -778,7 +791,9 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	}
 
 	// A plain grantee stays revocable — undoing a share is the point.
-	if err := e.GrantObjectPermission("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil {
+	if err := e.GrantProfessionalObjectPermission(
+		"u-mate", "knowledge_network", "kn-mine", "view_detail", authz.EffectAllow, authz.AuthoritySourceOwnerDelegate,
+	); err != nil {
 		t.Fatal(err)
 	}
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
@@ -787,6 +802,9 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	}, "u-stranger")
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("revoking a plain grantee: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
+		t.Fatal("delegate revoke left its owner-managed grant effective")
 	}
 
 	// The grant side erases just as thoroughly: POST replaces the whole op set, so

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
 )
 
 func TestValidateImplicationsRejectsAuthoringMistakes(t *testing.T) {
@@ -119,6 +121,8 @@ func TestSeedPersistsImplications(t *testing.T) {
 // resource_manage, reaches nothing, and nobody tells the administrator to
 // re-save it.
 func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionProfessional))
+	t.Cleanup(entitlement.ResetForTest)
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -130,11 +134,15 @@ func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
 
 	// The shape an operator could produce before #1121: management without the
 	// visibility every management route needs.
-	if err := e.GrantObjectPermission("u-1", "catalog", "c1", "resource_manage"); err != nil {
+	if err := e.GrantProfessionalObjectPermission(
+		"u-1", "catalog", "c1", "resource_manage", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
 		t.Fatal(err)
 	}
 	// An unrelated grant on the same type must come through untouched.
-	if err := e.GrantObjectPermission("u-2", "catalog", "c2", "query_data"); err != nil {
+	if err := e.GrantProfessionalObjectPermission(
+		"u-2", "catalog", "c2", "query_data", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -192,6 +200,8 @@ func TestBackfillRepairsGrantsWrittenBeforeTheRule(t *testing.T) {
 // construction will never contain it. GET /object-grants excludes role
 // subjects, the public accessor and type-wide "type:*" rows alike.
 func TestBackfillAuditLabelsMatchTheSurfaceThatShowsTheGrant(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionProfessional))
+	t.Cleanup(entitlement.ResetForTest)
 	db := newDB(t)
 	e, err := authz.New(db)
 	if err != nil {
@@ -206,13 +216,15 @@ func TestBackfillAuditLabelsMatchTheSurfaceThatShowsTheGrant(t *testing.T) {
 
 	// One row of each shape, all holding the management verb without the
 	// visibility it implies.
-	if err := e.GrantObjectPermission("u-1", "catalog", "c1", "resource_manage"); err != nil {
+	if err := e.GrantProfessionalObjectPermission(
+		"u-1", "catalog", "c1", "resource_manage", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
 		t.Fatal(err)
 	}
 	if err := e.GrantRolePermission("role-x", "catalog", "*", "resource_manage"); err != nil {
 		t.Fatal(err)
 	}
-	if err := e.GrantObjectPermission(authz.PublicAccessorID, "catalog", "c2", "resource_manage"); err != nil {
+	if err := e.GrantSystemObjectPermission(authz.PublicAccessorID, "catalog", "c2", "resource_manage"); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
# Pull Request

## What Changed

Added provenance-aware authorization policies and edition-aware runtime filtering for bkn-safe.

- [x] Added stable policy and authority source metadata to persisted Casbin policy rows.
- [x] Added live edition filtering across permission checks, listings, effective permissions, hierarchy fallback, and accessible-resource queries.
- [x] Added source-scoped grant, replacement, listing, and exact-revocation behavior.
- [x] Added focused persistence, runtime, seed, transaction, and HTTP regression coverage.

---

## Why

- Related Issue: Closes #1426
- Related Feature: Four-edition permission boundary implementation
- Background: The authorization service must preserve policy provenance so Community, Professional, Enterprise, and Industry can activate the correct configuration layer without deleting inactive configuration.

---

## How

- Key implementation points:
  - Extends persisted policy rows with policy_source and authority_source while keeping the adapter row ID as the stable policy identity.
  - Refuses to start when a persisted policy row has missing or unknown provenance, preventing runtime inference from silently changing existing authorization semantics.
  - Centralizes live edition filtering in the authorization decision index and applies the same rule to direct checks, hierarchy fallback, permission listings, and accessible-resource discovery.
  - Separates Professional grants by server-derived authority source so administrator and owner-delegated changes cannot overwrite each other.
  - Keeps legacy and system-derived policies active across editions; Professional rules become inactive in Community and reactivate after entitlement restoration.
- Breaking changes:
  - Persisted Casbin policy rows now require valid provenance columns. Existing installations must run the separate offline migration tracked by #1431 before starting this version.
  - No new client-controlled provenance fields are accepted by the HTTP API.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran: go test -p 1 ./internal/authz ./internal/seed ./internal/proxygrant ./internal/httpapi ./extension/adminwrite ./app
- All focused impacted packages passed. The full repository suite was not run locally, in accordance with the repository guidance to prefer focused checks during development.

---

## Risk & Rollback

- Potential risks:
  - A source-less existing policy database will fail closed at startup until the offline migration is completed.
  - Professional policies intentionally disappear from effective decisions in Community and reactivate when the entitlement is restored.
- Rollback plan:
  - For a coordinated deployment, restore the pre-migration policy backup and the previous application version. Do not deploy this change alone against an unclassified policy database.
  - This PR does not execute any production migration or modify shared authorization data.

---

## Additional Notes

- Logical Community bundle expansion remains scoped to #1427.
- Offline provenance classification and migration-marker handling remain scoped to #1431.
