### PR TITLE
feat(bkn-safe): implement Community access bundles

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -790,13 +790,15 @@ func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp s
 	return added, nil
 }
 
-// RemoveRolePermissions purges only the p-lines owned by a role, preserving its
-// member bindings. Seed uses this before re-applying the built-in permission
-// matrix so removed grants do not linger across upgrades.
+// RemoveRolePermissions purges only the role_permission p-lines owned by a
+// role, preserving both its member bindings and independently managed policy
+// sources. Seed uses this before re-applying the built-in permission matrix so
+// removed seeded grants do not linger across upgrades without erasing a
+// Community bundle or another resource grant assigned to the same role.
 func (en *Enforcer) RemoveRolePermissions(roleID string) error {
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
-	_, err := en.e.RemoveFilteredPolicy(0, roleID)
+	_, err := en.e.RemoveFilteredPolicy(0, roleID, "", "", "", string(PolicySourceRolePermission))
 	return err
 }
 

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -407,7 +407,7 @@ func (en *Enforcer) RolePermissions(roleID string) ([]RoleGrant, error) {
 	if err != nil {
 		return nil, err
 	}
-	return groupGrantsByObject(activePolicyRows(rows)), nil
+	return groupGrantsByObject(projectCommunityBundleRows(activePolicyRows(rows), false)), nil
 }
 
 // groupGrantsByObject collapses raw (sub, obj, act) policy rows into per-object
@@ -491,6 +491,7 @@ func (en *Enforcer) EffectivePermissions(accessorID string, q PermQuery) (hasWil
 		return false, nil, err
 	}
 	rows = activePolicyRows(rows)
+	rows = projectCommunityBundleRows(rows, true)
 	grouped := groupGrantsByObject(rows)
 	superAdmin, err := en.hasSuperAdminRole(accessorID)
 	if err != nil {
@@ -889,7 +890,7 @@ func (en *Enforcer) accessibleResources(accessorID, resourceType, op string, vis
 			continue
 		}
 		o, act := p[1], p[2]
-		if act != op && act != ActAll {
+		if act != op && act != ActAll && !isCommunityBundleRow(p) {
 			continue
 		}
 		if len(o) <= len(prefix) || o[:len(prefix)] != prefix {
@@ -934,6 +935,7 @@ func (en *Enforcer) ResourcePolicies(resourceType, resourceID string) ([]Resourc
 		return nil, err
 	}
 	rows = activePolicyRows(rows)
+	rows = projectCommunityBundleRows(rows, false)
 	bySub := map[string][]string{}
 	deniedBySub := map[string][]string{}
 	seenSub := map[string]bool{}
@@ -989,6 +991,7 @@ func (en *Enforcer) ListObjectGrants(accessorID, resourceType, resourceID string
 		return nil, err
 	}
 	rows = activePolicyRows(rows)
+	rows = projectCommunityBundleRows(rows, false)
 	type key struct{ sub, rtype, rid string }
 	ops := map[key][]string{}
 	deniedOps := map[key][]string{}

--- a/bkn-safe/server/internal/authz/community_bundle.go
+++ b/bkn-safe/server/internal/authz/community_bundle.go
@@ -73,11 +73,18 @@ func communityBundleAllows(resourceType, operation string) bool {
 func projectCommunityBundleRows(rows [][]string, combineSubjects bool) [][]string {
 	out := make([][]string, 0, len(rows))
 	type bundleKey struct{ subject, object string }
-	bundles := make([]bundleKey, 0)
+	type bundleProjection struct {
+		key         bundleKey
+		emitSubject string
+	}
+	bundles := make([]bundleProjection, 0)
 	seenBundle := map[bundleKey]bool{}
-	rowsBySubject := map[string][][]string{}
+	var rowsBySubject map[string][][]string
+	if !combineSubjects {
+		rowsBySubject = map[string][][]string{}
+	}
 	for _, row := range rows {
-		if len(row) > 0 {
+		if !combineSubjects && len(row) > 0 {
 			rowsBySubject[row[0]] = append(rowsBySubject[row[0]], row)
 		}
 		if !isCommunityBundleSourceRow(row) {
@@ -101,25 +108,31 @@ func projectCommunityBundleRows(rows [][]string, combineSubjects bool) [][]strin
 			continue
 		}
 		seenBundle[key] = true
-		bundles = append(bundles, key)
+		bundles = append(bundles, bundleProjection{key: key, emitSubject: row[0]})
 	}
-	combined := newGrantIndex(rows, false)
+	if len(bundles) == 0 {
+		return out
+	}
+	var combined *grantIndex
+	if combineSubjects {
+		combined = newGrantIndex(rows, false)
+	}
 	for _, bundle := range bundles {
-		resourceType, resourceID := splitObjectKey(bundle.object)
+		resourceType, resourceID := splitObjectKey(bundle.key.object)
 		ops, ok := CommunityBundleOperations(resourceType)
 		if !ok || resourceID == "" || hasWildcard(resourceID) {
 			continue
 		}
 		idx := combined
 		if !combineSubjects {
-			idx = newGrantIndex(rowsBySubject[bundle.subject], false)
+			idx = newGrantIndex(rowsBySubject[bundle.key.subject], false)
 		}
 		decision := idx.decide(ResourceRef{Type: resourceType, ID: resourceID}, ops)
 		for _, op := range ops {
 			if decision[op] != EffectAllow {
 				continue
 			}
-			out = append(out, []string{bundle.subject, bundle.object, op, EffectAllow,
+			out = append(out, []string{bundle.emitSubject, bundle.key.object, op, EffectAllow,
 				string(PolicySourceCommunityBundle), string(AuthoritySourceSystem)})
 		}
 	}

--- a/bkn-safe/server/internal/authz/community_bundle.go
+++ b/bkn-safe/server/internal/authz/community_bundle.go
@@ -1,0 +1,137 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import "fmt"
+
+// communityBundleOperations is the reviewed Community business-operation
+// contract. It is deliberately an explicit per-root whitelist: the operation
+// directory also contains create, authorization, public-access, system and
+// cross-owner operations that must never be acquired by scanning it.
+//
+// Keep the slice order stable. It is used by permission-read projections and
+// therefore becomes the order returned to API consumers.
+var communityBundleOperations = map[string][]string{
+	"catalog":              {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
+	"knowledge_network":    {"view_detail", "modify", "delete", "query_data", "execute"},
+	"stream_data_pipeline": {"view_detail", "modify", "delete", "query_data"},
+	"connector_type":       {"view_detail", "modify", "delete", "task_manage"},
+	"tool_box":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"mcp":                  {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"operator":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"skill":                {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"small_model":          {"display", "modify", "delete", "execute"},
+	"large_model":          {"display", "modify", "delete", "execute"},
+	"agent": {
+		"use", "publish", "unpublish", "publish_to_be_skill_agent",
+		"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+		"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+	},
+	"agent_tpl": {"publish", "unpublish"},
+}
+
+// CommunityBundleOperations returns a copy of the reviewed operation whitelist
+// for one top-level resource type. The bool is false for child, administrative
+// or otherwise unsupported resource types.
+func CommunityBundleOperations(resourceType string) ([]string, bool) {
+	ops, ok := communityBundleOperations[resourceType]
+	if !ok {
+		return nil, false
+	}
+	return append([]string(nil), ops...), true
+}
+
+func isCommunityBundleRow(row []string) bool {
+	return len(row) >= 6 && row[2] == ActFullBusinessAccess &&
+		policyEffect(row) == EffectAllow && policySourceOf(row) == PolicySourceCommunityBundle
+}
+
+func isCommunityBundleSourceRow(row []string) bool {
+	return policySourceOf(row) == PolicySourceCommunityBundle
+}
+
+func communityBundleAllows(resourceType, operation string) bool {
+	for _, allowed := range communityBundleOperations[resourceType] {
+		if allowed == operation {
+			return true
+		}
+	}
+	return false
+}
+
+// projectCommunityBundleRows replaces logical bundle rows with the concrete
+// operations decided by grantIndex.decide. When combineSubjects is true, rows
+// already represent all policies effective for one accessor (direct and role
+// derived) and must be decided together. Direct policy-table reads keep each
+// subject separate.
+//
+// No whitelist operation is granted here directly: this function only supplies
+// candidates to the shared decision layer, which remains the unique expansion
+// point.
+func projectCommunityBundleRows(rows [][]string, combineSubjects bool) [][]string {
+	out := make([][]string, 0, len(rows))
+	type bundleKey struct{ subject, object string }
+	bundles := make([]bundleKey, 0)
+	seenBundle := map[bundleKey]bool{}
+	rowsBySubject := map[string][][]string{}
+	for _, row := range rows {
+		if len(row) > 0 {
+			rowsBySubject[row[0]] = append(rowsBySubject[row[0]], row)
+		}
+		if !isCommunityBundleSourceRow(row) {
+			out = append(out, row)
+			continue
+		}
+		// Invalid community_bundle rows are deliberately absent from both the
+		// runtime index and permission projections. The trusted writer below
+		// cannot create one; a malformed migrated row therefore fails closed.
+		if !isCommunityBundleRow(row) {
+			continue
+		}
+		if len(row) < 2 {
+			continue
+		}
+		key := bundleKey{subject: row[0], object: row[1]}
+		if combineSubjects {
+			key.subject = ""
+		}
+		if seenBundle[key] {
+			continue
+		}
+		seenBundle[key] = true
+		bundles = append(bundles, key)
+	}
+	combined := newGrantIndex(rows, false)
+	for _, bundle := range bundles {
+		resourceType, resourceID := splitObjectKey(bundle.object)
+		ops, ok := CommunityBundleOperations(resourceType)
+		if !ok || resourceID == "" || hasWildcard(resourceID) {
+			continue
+		}
+		idx := combined
+		if !combineSubjects {
+			idx = newGrantIndex(rowsBySubject[bundle.subject], false)
+		}
+		decision := idx.decide(ResourceRef{Type: resourceType, ID: resourceID}, ops)
+		for _, op := range ops {
+			if decision[op] != EffectAllow {
+				continue
+			}
+			out = append(out, []string{bundle.subject, bundle.object, op, EffectAllow,
+				string(PolicySourceCommunityBundle), string(AuthoritySourceSystem)})
+		}
+	}
+	return out
+}
+
+func validateCommunityBundleTarget(resourceType, resourceID string) error {
+	if resourceID == "" || hasWildcard(resourceID) {
+		return fmt.Errorf("community bundle requires a concrete resource id")
+	}
+	if _, ok := CommunityBundleOperations(resourceType); !ok {
+		return fmt.Errorf("resource type %q is not a Community authorization root", resourceType)
+	}
+	return nil
+}

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -1,0 +1,278 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/openbkn-ai/licverify"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestCommunityBundleWhitelistIsExplicitAndDefensive(t *testing.T) {
+	want := map[string][]string{
+		"catalog":              {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
+		"knowledge_network":    {"view_detail", "modify", "delete", "query_data", "execute"},
+		"stream_data_pipeline": {"view_detail", "modify", "delete", "query_data"},
+		"connector_type":       {"view_detail", "modify", "delete", "task_manage"},
+		"tool_box":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"mcp":                  {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"operator":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"skill":                {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"small_model":          {"display", "modify", "delete", "execute"},
+		"large_model":          {"display", "modify", "delete", "execute"},
+		"agent": {
+			"use", "publish", "unpublish", "publish_to_be_skill_agent",
+			"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+			"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+		},
+		"agent_tpl": {"publish", "unpublish"},
+	}
+	for resourceType, expected := range want {
+		got, ok := CommunityBundleOperations(resourceType)
+		if !ok || !reflect.DeepEqual(got, expected) {
+			t.Errorf("CommunityBundleOperations(%q) = %v, %v; want %v, true", resourceType, got, ok, expected)
+		}
+		if len(got) > 0 {
+			got[0] = "caller_mutation"
+			again, _ := CommunityBundleOperations(resourceType)
+			if len(again) > 0 && again[0] == "caller_mutation" {
+				t.Fatalf("CommunityBundleOperations(%q) exposed its stored whitelist", resourceType)
+			}
+		}
+	}
+	for _, unsupported := range []string{"resource", "object_type", "admin-authz", "safe_admin", "unknown"} {
+		if got, ok := CommunityBundleOperations(unsupported); ok || got != nil {
+			t.Errorf("unsupported type %q returned %v, %v", unsupported, got, ok)
+		}
+	}
+}
+
+func TestCommunityBundlePersistsOneLogicalPolicyAndExpandsOnlyApprovedOps(t *testing.T) {
+	edition := useEdition(t, licverify.EditionCommunity)
+	e := newTestEnforcer(t)
+	const user = "bundle-holder"
+
+	mustNoErr(t, e.GrantCommunityBundle(user, "knowledge_network", "kn-1", AuthoritySourceAdminAuthz))
+	mustNoErr(t, e.GrantCommunityBundle(user, "knowledge_network", "kn-1", AuthoritySourceAdminAuthz))
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Operation != ActFullBusinessAccess ||
+		records[0].PolicySource != PolicySourceCommunityBundle || records[0].Effect != EffectAllow {
+		t.Fatalf("persisted bundle = %+v; want one logical community_bundle row", records)
+	}
+
+	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "execute"} {
+		allowed, err := e.Check(user, "knowledge_network", "kn-1", op)
+		if err != nil || !allowed {
+			t.Errorf("bundle Check(%q) = %v, %v; want true", op, allowed, err)
+		}
+	}
+	for _, excluded := range []string{"create", "authorize", "task_manage", "public_access", ActFullBusinessAccess} {
+		allowed, err := e.Check(user, "knowledge_network", "kn-1", excluded)
+		if err != nil || allowed {
+			t.Errorf("bundle Check(excluded %q) = %v, %v; want false", excluded, allowed, err)
+		}
+	}
+	allowed, err := e.Check(user, "knowledge_network", "kn-2", "view_detail")
+	if err != nil || allowed {
+		t.Fatalf("bundle leaked to sibling: allowed=%v err=%v", allowed, err)
+	}
+	for _, upgraded := range []licverify.Edition{
+		licverify.EditionProfessional, licverify.EditionEnterprise, licverify.EditionIndustry,
+	} {
+		*edition = upgraded
+		allowed, err := e.Check(user, "knowledge_network", "kn-1", "execute")
+		if err != nil || !allowed {
+			t.Errorf("bundle stopped after upgrade to %q: allowed=%v err=%v", upgraded, allowed, err)
+		}
+	}
+	afterReads, err := e.PolicyRecords(PolicyFilter{AccessorID: user})
+	if err != nil || len(afterReads) != 1 || afterReads[0].Operation != ActFullBusinessAccess {
+		t.Fatalf("permission reads materialized bundle operations: %+v, %v", afterReads, err)
+	}
+}
+
+func TestCommunityBundleDecisionPathsAndParentFallbackAgree(t *testing.T) {
+	useEdition(t, licverify.EditionCommunity)
+	e, db := newTestEnforcerDB(t)
+	for _, row := range []model.ResourceType{
+		{ID: "knowledge_network"},
+		{ID: "object_type", ParentTypeID: "knowledge_network"},
+	} {
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for child, parent := range map[string]string{
+		"view_detail": "view_detail",
+		"query_data":  "query_data",
+		"modify":      "modify",
+		"delete":      "modify",
+	} {
+		if err := db.Create(&model.Operation{ResourceTypeID: "object_type", ID: child, ParentOperationID: parent}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "object_type", ResourceID: "kn-1/customer",
+		ParentTypeID: "knowledge_network", ParentID: "kn-1",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	const user = "bundle-holder"
+	mustNoErr(t, e.GrantCommunityBundle(user, "knowledge_network", "kn-1", AuthoritySourceAdminAuthz))
+	candidates := []string{"view_detail", "modify", "delete", "query_data", "execute", "authorize"}
+
+	for _, op := range candidates[:5] {
+		allowed, err := e.Check(user, "knowledge_network", "kn-1", op)
+		if err != nil || !allowed {
+			t.Fatalf("Check(%q) = %v, %v; want true", op, allowed, err)
+		}
+	}
+	allowedOps, err := e.AllowedOps(user, "knowledge_network", "kn-1", candidates)
+	if err != nil || !reflect.DeepEqual(allowedOps, candidates[:5]) {
+		t.Fatalf("AllowedOps = %v, %v; want %v", allowedOps, err, candidates[:5])
+	}
+	filtered, err := e.FilterResourceOps(user,
+		[]ResourceRef{{Type: "knowledge_network", ID: "kn-1"}, {Type: "knowledge_network", ID: "kn-2"}},
+		[]string{"view_detail"}, candidates)
+	if err != nil || len(filtered) != 1 || filtered[0].ID != "kn-1" || !reflect.DeepEqual(filtered[0].Operations, candidates[:5]) {
+		t.Fatalf("FilterResourceOps = %+v, %v; want only expanded kn-1", filtered, err)
+	}
+	ids, err := e.AccessibleResources(user, "knowledge_network", "view_detail")
+	if err != nil || !reflect.DeepEqual(ids, []string{"kn-1"}) {
+		t.Fatalf("AccessibleResources(root) = %v, %v; want [kn-1]", ids, err)
+	}
+	childIDs, err := e.AccessibleResources(user, "object_type", "view_detail")
+	if err != nil || !reflect.DeepEqual(childIDs, []string{"kn-1/customer"}) {
+		t.Fatalf("AccessibleResources(child) = %v, %v; want inherited child", childIDs, err)
+	}
+	for _, op := range []string{"view_detail", "query_data", "modify", "delete"} {
+		allowed, err := e.Check(user, "object_type", "kn-1/customer", op)
+		if err != nil || !allowed {
+			t.Errorf("inherited child Check(%q) = %v, %v; want true", op, allowed, err)
+		}
+	}
+
+	_, effective, err := e.EffectivePermissions(user, PermQuery{ResourceType: "knowledge_network"})
+	if err != nil || len(effective) != 1 || effective[0].Object != "knowledge_network:kn-1" {
+		t.Fatalf("EffectivePermissions = %+v, %v", effective, err)
+	}
+	assertBusinessOps(t, effective[0].Operations, candidates[:5])
+	policies, err := e.ResourcePolicies("knowledge_network", "kn-1")
+	if err != nil || len(policies) != 1 || policies[0].AccessorID != user {
+		t.Fatalf("ResourcePolicies = %+v, %v", policies, err)
+	}
+	assertBusinessOps(t, policies[0].Operations, candidates[:5])
+	grants, err := e.ListObjectGrants(user, "knowledge_network", "kn-1")
+	if err != nil || len(grants) != 1 {
+		t.Fatalf("ListObjectGrants = %+v, %v", grants, err)
+	}
+	assertBusinessOps(t, grants[0].Operations, candidates[:5])
+}
+
+func TestCommunityBundleProfessionalDenyAndLegacyRemainIndependent(t *testing.T) {
+	edition := useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	const user = "mixed-holder"
+	mustNoErr(t, e.GrantCommunityBundle(user, "knowledge_network", "kn-1", AuthoritySourceAdminAuthz))
+	mustNoErr(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "legacy_only"))
+	mustNoErr(t, e.GrantSystemObjectPermission(user, "knowledge_network", "kn-1", "authorize"))
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		user, "knowledge_network", "kn-1", "query_data", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+
+	queryAllowed, err := e.Check(user, "knowledge_network", "kn-1", "query_data")
+	if err != nil || queryAllowed {
+		t.Fatalf("Professional deny did not override bundle: allowed=%v err=%v", queryAllowed, err)
+	}
+	if ok, err := e.Check(user, "knowledge_network", "kn-1", "legacy_only"); err != nil || !ok {
+		t.Fatalf("legacy rule stopped participating: allowed=%v err=%v", ok, err)
+	}
+	if ok, err := e.Check(user, "knowledge_network", "kn-1", "authorize"); err != nil || !ok {
+		t.Fatalf("system-derived rule stopped participating: allowed=%v err=%v", ok, err)
+	}
+	*edition = licverify.EditionCommunity
+	if ok, err := e.Check(user, "knowledge_network", "kn-1", "query_data"); err != nil || !ok {
+		t.Fatalf("Community did not recover bundle operation: allowed=%v err=%v", ok, err)
+	}
+
+	removed, err := e.RemoveCommunityBundle(user, "knowledge_network", "kn-1", AuthoritySourceAdminAuthz)
+	if err != nil || !removed {
+		t.Fatalf("RemoveCommunityBundle = %v, %v; want true", removed, err)
+	}
+	if ok, err := e.Check(user, "knowledge_network", "kn-1", "view_detail"); err != nil || ok {
+		t.Fatalf("revoked bundle still effective: allowed=%v err=%v", ok, err)
+	}
+	for _, op := range []string{"legacy_only", "authorize"} {
+		if ok, err := e.Check(user, "knowledge_network", "kn-1", op); err != nil || !ok {
+			t.Errorf("revoking bundle removed %q sibling source: allowed=%v err=%v", op, ok, err)
+		}
+	}
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: user})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, record := range records {
+		if record.PolicySource == PolicySourceCommunityBundle {
+			t.Fatalf("bundle row survived source-scoped revoke: %+v", records)
+		}
+	}
+}
+
+func TestCommunityBundleDoesNotExpandLegacyOrAcceptChildTargets(t *testing.T) {
+	useEdition(t, licverify.EditionCommunity)
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.GrantObjectPermission("legacy-holder", "knowledge_network", "kn-1", "view_detail"))
+	mustNoErr(t, e.GrantCommunityBundle("bundle-holder", "knowledge_network", "kn-1", AuthoritySourceAdminAuthz))
+
+	const newlyApproved = "newly_approved_operation"
+	if ok, err := e.Check("bundle-holder", "knowledge_network", "kn-1", newlyApproved); err != nil || ok {
+		t.Fatalf("unapproved operation was available before whitelist update: allowed=%v err=%v", ok, err)
+	}
+	original := communityBundleOperations["knowledge_network"]
+	communityBundleOperations["knowledge_network"] = append(append([]string(nil), original...), newlyApproved)
+	t.Cleanup(func() { communityBundleOperations["knowledge_network"] = original })
+	if ok, err := e.Check("bundle-holder", "knowledge_network", "kn-1", newlyApproved); err != nil || !ok {
+		t.Fatalf("existing bundle did not acquire newly approved operation: allowed=%v err=%v", ok, err)
+	}
+	if ok, err := e.Check("legacy-holder", "knowledge_network", "kn-1", newlyApproved); err != nil || ok {
+		t.Fatalf("legacy holder acquired new bundle operation: allowed=%v err=%v", ok, err)
+	}
+
+	for _, target := range []struct{ resourceType, resourceID string }{
+		{"object_type", "kn-1/customer"},
+		{"resource", "r-1"},
+		{"knowledge_network", ""},
+		{"knowledge_network", "*"},
+		{"knowledge_network", "kn-*"},
+	} {
+		if err := e.GrantCommunityBundle("u-1", target.resourceType, target.resourceID, AuthoritySourceAdminAuthz); err == nil {
+			t.Errorf("GrantCommunityBundle(%q,%q) succeeded; want rejection", target.resourceType, target.resourceID)
+		}
+	}
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-1"})
+	if err != nil || len(records) != 0 {
+		t.Fatalf("invalid targets produced policies: %+v, %v", records, err)
+	}
+}
+
+func assertBusinessOps(t *testing.T, got, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("business operations = %v; want %v", got, want)
+	}
+}

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -180,6 +180,23 @@ func TestCommunityBundleDecisionPathsAndParentFallbackAgree(t *testing.T) {
 	assertBusinessOps(t, grants[0].Operations, candidates[:5])
 }
 
+func TestCommunityBundleCombinedProjectionPreservesAnOriginSubject(t *testing.T) {
+	rows := [][]string{{
+		"bundle-role", "knowledge_network:kn-1", ActFullBusinessAccess,
+		EffectAllow, string(PolicySourceCommunityBundle), string(AuthoritySourceAdminAuthz),
+	}}
+
+	projected := projectCommunityBundleRows(rows, true)
+	if len(projected) == 0 {
+		t.Fatal("combined bundle projection is empty")
+	}
+	for _, row := range projected {
+		if len(row) == 0 || row[0] != "bundle-role" {
+			t.Fatalf("combined bundle projection = %+v; want subject bundle-role", row)
+		}
+	}
+}
+
 func TestCommunityBundleProfessionalDenyAndLegacyRemainIndependent(t *testing.T) {
 	edition := useEdition(t, licverify.EditionProfessional)
 	e := newTestEnforcer(t)

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -176,6 +176,7 @@ type grantRow struct {
 	object string
 	act    string
 	effect string
+	source PolicySource
 }
 
 // grantIndex is an accessor's effective grant set, split by whether the object
@@ -215,8 +216,12 @@ func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
 	edition := entitlement.Current()
 	rows = activePolicyRowsForEdition(rows, edition)
 	public = activePolicyRowsForEdition(public, edition)
+	return newGrantIndex(append(rows, public...), superAdmin), nil
+}
+
+func newGrantIndex(rows [][]string, superAdmin bool) *grantIndex {
 	idx := &grantIndex{exact: make(map[string][]grantRow, len(rows)), superAdmin: superAdmin}
-	for _, row := range append(rows, public...) {
+	for _, row := range rows {
 		if len(row) < 4 {
 			continue
 		}
@@ -224,14 +229,14 @@ func (en *Enforcer) grantIndex(accessorID string) (*grantIndex, error) {
 		if effect == "" {
 			effect = EffectAllow
 		}
-		rule := grantRow{object: object, act: act, effect: effect}
+		rule := grantRow{object: object, act: act, effect: effect, source: policySourceOf(row)}
 		if hasWildcard(object) {
 			idx.wildcard = append(idx.wildcard, rule)
 			continue
 		}
 		idx.exact[object] = append(idx.exact[object], rule)
 	}
-	return idx, nil
+	return idx
 }
 
 // allowed reports, for one resource, which of ops the grants cover. It mirrors
@@ -247,6 +252,20 @@ func (idx *grantIndex) decide(r ResourceRef, ops []string) map[string]string {
 	}
 	object := obj(r.Type, r.ID)
 	apply := func(rule grantRow) {
+		if rule.source == PolicySourceCommunityBundle {
+			// A bundle is valid only as one exact, allow-only logical policy.
+			// Keeping the check here makes malformed wildcard/concrete-op bundle
+			// rows fail closed rather than acquiring ordinary Casbin semantics.
+			if rule.object != object || rule.act != ActFullBusinessAccess || rule.effect != EffectAllow {
+				return
+			}
+			for _, op := range ops {
+				if communityBundleAllows(r.Type, op) && out[op] == "" {
+					out[op] = EffectAllow
+				}
+			}
+			return
+		}
 		if rule.act == ActAll {
 			for _, op := range ops {
 				if rule.effect == EffectDeny || out[op] == "" {

--- a/bkn-safe/server/internal/authz/hierarchy.go
+++ b/bkn-safe/server/internal/authz/hierarchy.go
@@ -328,7 +328,7 @@ func (en *Enforcer) publicInstances(resourceType, op string) ([]string, error) {
 			continue
 		}
 		o, act := row[1], row[2]
-		if act != op && act != ActAll {
+		if act != op && act != ActAll && !isCommunityBundleRow(row) {
 			continue
 		}
 		if len(o) <= len(prefix) || o[:len(prefix)] != prefix {

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -197,15 +197,34 @@ func (en *Enforcer) GrantSystemObjectPermission(accessorID, resourceType, resour
 	return en.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow, PolicySourceSystemDerived, AuthoritySourceSystem)
 }
 
-// GrantCommunityBundle records the one logical Community grant. Expansion of
-// full_business_access belongs to #1427's shared grant-index implementation.
+// GrantCommunityBundle records one logical Community grant on a reviewed
+// top-level resource. It never materializes the whitelist into operation rows.
 func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID string, authority AuthoritySource) error {
 	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
 		return fmt.Errorf("community bundle authority %q is not permitted", authority)
 	}
+	if err := validateCommunityBundleTarget(resourceType, resourceID); err != nil {
+		return err
+	}
 	en.transactionMu.Lock()
 	defer en.transactionMu.Unlock()
 	return en.addPolicy(accessorID, obj(resourceType, resourceID), ActFullBusinessAccess, EffectAllow, PolicySourceCommunityBundle, authority)
+}
+
+// RemoveCommunityBundle removes only the logical bundle owned by one trusted
+// authority. Legacy, system-derived and Professional rows on the same resource
+// remain untouched.
+func (en *Enforcer) RemoveCommunityBundle(accessorID, resourceType, resourceID string, authority AuthoritySource) (bool, error) {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+		return false, fmt.Errorf("community bundle authority %q is not permitted", authority)
+	}
+	if err := validateCommunityBundleTarget(resourceType, resourceID); err != nil {
+		return false, err
+	}
+	en.transactionMu.Lock()
+	defer en.transactionMu.Unlock()
+	return en.e.RemovePolicy(accessorID, obj(resourceType, resourceID), ActFullBusinessAccess,
+		EffectAllow, string(PolicySourceCommunityBundle), string(authority))
 }
 
 // SetProfessionalObjectPermissions replaces only one trusted source slice. An

--- a/bkn-safe/server/internal/authz/policy_source_test.go
+++ b/bkn-safe/server/internal/authz/policy_source_test.go
@@ -66,7 +66,7 @@ func TestPolicySourcesFollowLiveEditionWithoutRewritingRows(t *testing.T) {
 	mustNoErr(t, e.GrantSystemObjectPermission("u-system", "resource", "r-1", "view_detail"))
 	mustNoErr(t, e.GrantRolePermission("role-reader", "resource", "r-1", "view_detail"))
 	mustNoErr(t, e.AssignRole("u-role", "role-reader"))
-	mustNoErr(t, e.GrantCommunityBundle("u-bundle", "resource", "r-1", AuthoritySourceAdminAuthz))
+	mustNoErr(t, e.GrantCommunityBundle("u-bundle", "catalog", "c-1", AuthoritySourceAdminAuthz))
 	mustNoErr(t, e.GrantProfessionalObjectPermission(
 		"u-professional", "resource", "r-1", "view_detail", EffectAllow, AuthoritySourceAdminAuthz,
 	))
@@ -77,9 +77,13 @@ func TestPolicySourcesFollowLiveEditionWithoutRewritingRows(t *testing.T) {
 		{"u-legacy", "view_detail"},
 		{"u-system", "view_detail"},
 		{"u-role", "view_detail"},
-		{"u-bundle", ActFullBusinessAccess},
+		{"u-bundle", "view_detail"},
 	} {
-		allowed, err := e.Check(tc.user, "resource", "r-1", tc.operation)
+		resourceType, resourceID := "resource", "r-1"
+		if tc.user == "u-bundle" {
+			resourceType, resourceID = "catalog", "c-1"
+		}
+		allowed, err := e.Check(tc.user, resourceType, resourceID, tc.operation)
 		if err != nil || !allowed {
 			t.Fatalf("Community Check(%s,%s) = %v, %v; want true", tc.user, tc.operation, allowed, err)
 		}

--- a/bkn-safe/server/internal/httpapi/community_bundle_test.go
+++ b/bkn-safe/server/internal/httpapi/community_bundle_test.go
@@ -1,0 +1,147 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestCommunityBundleHTTPReadPathsAgree(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	const user = "bundle-http-user"
+	if err := db.Create(&model.User{ID: user, Account: user, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	approved := []string{"view_detail", "modify", "delete", "query_data", "execute"}
+	seedCatalogOps(t, db, "knowledge_network",
+		"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute")
+	if err := e.GrantCommunityBundle(user, "knowledge_network", "kn-1", authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+
+	check := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", map[string]any{
+		"accessor_id": user,
+		"resource":    map[string]string{"type": "knowledge_network", "id": "kn-1"},
+		"operation":   "execute",
+	})
+	if check.Code != http.StatusOK || !jsonBool(t, check.Body.Bytes(), "allowed") {
+		t.Fatalf("check = %d %s; want allowed", check.Code, check.Body.String())
+	}
+
+	operations := do(t, r, http.MethodPost, "/api/safe/v1/authz/operations", map[string]any{
+		"accessor_id": user,
+		"resource":    map[string]string{"type": "knowledge_network", "id": "kn-1"},
+	})
+	assertJSONOperations(t, operations.Code, operations.Body.Bytes(), approved)
+
+	filtered := postFilter(t, r, map[string]any{
+		"accessor_id":           user,
+		"resource_type":         "knowledge_network",
+		"resource_ids":          []string{"kn-1", "kn-2"},
+		"visibility_operations": []string{"view_detail"},
+		"candidate_operations":  []string{"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"},
+	})
+	if len(filtered) != 1 || filtered[0].ResourceID != "kn-1" {
+		t.Fatalf("resource-filter = %+v; want only kn-1", filtered)
+	}
+	assertSameOperations(t, filtered[0].Operations, approved)
+
+	resources := do(t, r, http.MethodGet,
+		"/api/safe/v1/authz/resources?accessor_id="+user+"&resource_type=knowledge_network&operation=view_detail", nil)
+	if resources.Code != http.StatusOK {
+		t.Fatalf("resources = %d %s", resources.Code, resources.Body.String())
+	}
+	var resourceResponse struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.Unmarshal(resources.Body.Bytes(), &resourceResponse); err != nil || !reflect.DeepEqual(resourceResponse.IDs, []string{"kn-1"}) {
+		t.Fatalf("resources = %v, %v; want [kn-1]", resourceResponse.IDs, err)
+	}
+
+	policies := do(t, r, http.MethodGet,
+		"/api/safe/v1/authz/policies?resource_type=knowledge_network&resource_id=kn-1", nil)
+	if policies.Code != http.StatusOK {
+		t.Fatalf("policies = %d %s", policies.Code, policies.Body.String())
+	}
+	var policyResponse struct {
+		Entries []struct {
+			AccessorID string   `json:"accessor_id"`
+			Operations []string `json:"operations"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(policies.Body.Bytes(), &policyResponse); err != nil ||
+		len(policyResponse.Entries) != 1 || policyResponse.Entries[0].AccessorID != user {
+		t.Fatalf("policies = %+v, %v", policyResponse, err)
+	}
+	assertSameOperations(t, policyResponse.Entries[0].Operations, approved)
+
+	mePermissions := tokReq(t, r, http.MethodGet,
+		"/api/safe/v1/me/permissions?resource_type=knowledge_network&resource_id=kn-1", nil, user)
+	if mePermissions.Code != http.StatusOK {
+		t.Fatalf("me permissions = %d %s", mePermissions.Code, mePermissions.Body.String())
+	}
+	var meResponse struct {
+		Permissions []struct {
+			Operations []string `json:"operations"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(mePermissions.Body.Bytes(), &meResponse); err != nil || len(meResponse.Permissions) != 1 {
+		t.Fatalf("me permissions = %+v, %v", meResponse, err)
+	}
+	assertSameOperations(t, meResponse.Permissions[0].Operations, approved)
+
+	knGrants := tokReq(t, r, http.MethodGet, "/api/safe/v1/me/knowledge-network-grants", nil, user)
+	if knGrants.Code != http.StatusOK {
+		t.Fatalf("knowledge-network-grants = %d %s", knGrants.Code, knGrants.Body.String())
+	}
+	var grantResponse struct {
+		Grants []struct {
+			KnowledgeNetworkID string   `json:"knowledge_network_id"`
+			Operations         []string `json:"operations"`
+		} `json:"grants"`
+	}
+	if err := json.Unmarshal(knGrants.Body.Bytes(), &grantResponse); err != nil ||
+		len(grantResponse.Grants) != 1 || grantResponse.Grants[0].KnowledgeNetworkID != "kn-1" {
+		t.Fatalf("knowledge-network-grants = %+v, %v", grantResponse, err)
+	}
+	assertSameOperations(t, grantResponse.Grants[0].Operations, approved)
+}
+
+func assertJSONOperations(t *testing.T, status int, body []byte, want []string) {
+	t.Helper()
+	if status != http.StatusOK {
+		t.Fatalf("operations = %d %s", status, body)
+	}
+	var response struct {
+		Operations []string `json:"operations"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		t.Fatal(err)
+	}
+	assertSameOperations(t, response.Operations, want)
+}
+
+func assertSameOperations(t *testing.T, got, want []string) {
+	t.Helper()
+	got = append([]string(nil), got...)
+	want = append([]string(nil), want...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("operations = %v; want %v", got, want)
+	}
+	for _, op := range got {
+		if op == authz.ActFullBusinessAccess {
+			t.Fatal("logical full_business_access leaked through an HTTP permission read")
+		}
+	}
+}

--- a/bkn-safe/server/internal/seed/community_bundle_test.go
+++ b/bkn-safe/server/internal/seed/community_bundle_test.go
@@ -1,0 +1,45 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package seed
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+)
+
+// The Community whitelist is intentionally maintained in code rather than
+// derived from catalog.json. This cross-check only prevents an approved entry
+// from becoming a dead operation after a catalog edit; it never adds catalog
+// operations to the bundle.
+func TestCommunityBundleWhitelistOperationsExistInCatalog(t *testing.T) {
+	var c catalog
+	if err := json.Unmarshal(catalogJSON, &c); err != nil {
+		t.Fatal(err)
+	}
+	registered := map[string]map[string]bool{}
+	for _, resourceType := range c.ResourceTypes {
+		registered[resourceType.ID] = map[string]bool{}
+		for _, operation := range resourceType.Operations {
+			registered[resourceType.ID][operation.ID] = true
+		}
+	}
+	for _, resourceType := range []string{
+		"catalog", "knowledge_network", "stream_data_pipeline", "connector_type",
+		"tool_box", "mcp", "operator", "skill", "small_model", "large_model", "agent", "agent_tpl",
+	} {
+		operations, ok := authz.CommunityBundleOperations(resourceType)
+		if !ok {
+			t.Errorf("reviewed Community root %q is missing its explicit whitelist", resourceType)
+			continue
+		}
+		for _, operation := range operations {
+			if !registered[resourceType][operation] {
+				t.Errorf("Community whitelist contains unregistered operation %s:%s", resourceType, operation)
+			}
+		}
+	}
+}

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -603,3 +603,34 @@ func TestNetworkBuilderPermissionMatrixMatchesBusinessBuilderRole(t *testing.T) 
 		t.Fatalf("network_builder grants = %#v, want %#v", got, want)
 	}
 }
+
+func TestSeedReconciliationPreservesCommunityBundleAssignedToBuiltInRole(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	const roleID = "1572fb82-526f-11f0-bde6-e674ec8dde71"
+	if err := e.GrantCommunityBundle(roleID, "knowledge_network", "kn-role-bundle", authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := e.PolicyRecords(authz.PolicyFilter{
+		AccessorID:   roleID,
+		Object:       "knowledge_network:kn-role-bundle",
+		PolicySource: authz.PolicySourceCommunityBundle,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].Operation != authz.ActFullBusinessAccess {
+		t.Fatalf("bundle after seed reconciliation = %+v; want one logical bundle", records)
+	}
+}


### PR DESCRIPTION
# Pull Request

## What Changed

Implemented the logical Community full-business-access bundle in bkn-safe's shared authorization decision layer.

- [x] Added explicit reviewed Community operation whitelists for every approved top-level resource type.
- [x] Expanded logical bundle decisions only through the shared grant index without materializing per-operation policy rows.
- [x] Applied the same bundle decision to single checks, allowed-operation projection, batch filtering, resource enumeration, hierarchy fallback, effective permissions, and policy reads.
- [x] Added source-scoped bundle revocation and focused authorization, seed-catalog, and HTTP consistency tests.

---

## Why

- Related Issue: Closes #1427
- Related Feature: Four-edition authorization boundaries
- Background: Community grants must remain one indivisible top-level business bundle while Professional and higher editions retain independently stored fine-grained rules. Casbin cannot match the logical operation against concrete operations directly, so every decision path must share one reviewed expansion point.

---

## How

- Key implementation points:
  - Stores one full_business_access policy with policy_source=community_bundle on a concrete approved authorization root.
  - Keeps the reviewed whitelist in code and returns defensive copies; no operation directory scanning or exclusion-list inference is used.
  - Teaches grantIndex.decide to interpret a valid exact bundle row and fail closed for malformed bundle rows.
  - Projects permission-management reads through the same grant-index decision rather than exposing the logical operation to clients.
  - Treats bundle rows as resource-enumeration candidates, then relies on the normal batch decision to filter unsupported operations.
  - Allows an approved whitelist update to affect existing bundles while legacy rows remain unchanged.
- Breaking changes: None for public request or response schemas. This stacked change requires the policy-provenance foundation in PR #1440.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- Ran: go test -p 1 ./internal/authz ./internal/seed ./internal/httpapi
- Ran: go vet ./internal/authz ./internal/seed ./internal/httpapi
- Ran: git diff --check
- The focused suites cover persistence shape, explicit whitelist boundaries, edition upgrades and recovery, Professional deny composition, source-scoped revocation, legacy non-expansion, parent fallback, and HTTP read-path parity.
- The full repository suite was not run locally, following repository guidance to prefer focused checks during development.

---

## Risk & Rollback

- Potential risks:
  - A missing or incorrect whitelist entry would narrow or widen every existing bundle for that resource type after a software update.
  - A permission read that bypasses the shared projection could expose full_business_access instead of concrete operations.
  - The change depends on the provenance columns introduced by PR #1440.
- Rollback plan:
  - Revert commit 49961c4ba and redeploy the previous bkn-safe version.
  - This PR does not migrate or modify production authorization data and does not materialize bundle operations, so no data rollback is required.

---

## Additional Notes

- This is a stacked PR based on feature/1426-policy-provenance and must be rebased or retargeted to main after PR #1440 merges.
- The authz explain endpoint is introduced by #1430; its implementation must consume this same shared decision path.
- Direct-resource and wildcard precedence remain scoped to #1428, and runtime operation prerequisites remain scoped to #1429.
