### PR TITLE
feat(bkn-safe): add stable grant identities

### DIFF
--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -17,6 +17,7 @@
 package authz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
@@ -110,17 +111,11 @@ func New(db *gorm.DB) (*Enforcer, error) {
 		Update("v3", EffectAllow).Error; err != nil {
 		return nil, fmt.Errorf("normalize legacy casbin policies: %w", err)
 	}
-	// Provenance classification belongs to the coordinated offline migration.
-	// Refuse to load a mixed/unknown policy store instead of guessing a source
-	// during startup and silently changing production authorization semantics.
-	var rows []casbinPolicyRow
-	if err := db.Table("casbin_rule").Where("ptype = ?", "p").Find(&rows).Error; err != nil {
-		return nil, fmt.Errorf("validate casbin policy provenance: %w", err)
-	}
-	for _, row := range rows {
-		if err := validatePolicyProvenance(PolicySource(row.V4), AuthoritySource(row.V5)); err != nil {
-			return nil, fmt.Errorf("%w: policy id %d: %v", ErrPolicySourceMigrationRequired, row.ID, err)
-		}
+	// Provenance classification and stable grant IDs belong to the coordinated
+	// offline migration. Refuse to load an unclassified or partially projected
+	// store instead of guessing ownership during startup.
+	if err := (&Enforcer{db: db}).validateGrantProjection(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrPolicySourceMigrationRequired, err)
 	}
 	m, err := model.NewModelFromString(modelConf)
 	if err != nil {
@@ -298,26 +293,23 @@ func (en *Enforcer) AllowedOps(accessorID, resourceType, resourceID string, cand
 // GrantRolePermission grants a role an op over a resource-type instance pattern
 // (id may be "*" for the whole type). Idempotent.
 func (en *Enforcer) GrantRolePermission(roleID, resourceType, idPattern, op string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(roleID, obj(resourceType, idPattern), op, EffectAllow, PolicySourceRolePermission, AuthoritySourceAdminAuthz)
+	return en.addDefaultGrant(context.Background(), roleID, obj(resourceType, idPattern), op, EffectAllow,
+		PolicySourceRolePermission, AuthoritySourceAdminAuthz)
 }
 
 // RevokeRolePermission removes a role's op over a resource-type instance
 // pattern (the inverse of GrantRolePermission). Idempotent.
 func (en *Enforcer) RevokeRolePermission(roleID, resourceType, idPattern, op string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.removePolicy(roleID, obj(resourceType, idPattern), op, EffectAllow, PolicySourceRolePermission, AuthoritySourceAdminAuthz)
+	return en.removeDefaultGrant(context.Background(), roleID, obj(resourceType, idPattern), op, EffectAllow,
+		PolicySourceRolePermission, AuthoritySourceAdminAuthz)
 }
 
 // Grant adds a raw (sub, obj, act) policy. obj is the full object pattern
 // (e.g. "agent:*" or "*" for everything); act may be ActAll ("*"). Used by the
 // seed for the super-admin wildcard. Idempotent.
 func (en *Enforcer) Grant(sub, obj, act string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(sub, obj, act, EffectAllow, PolicySourceRolePermission, AuthoritySourceSystem)
+	return en.addDefaultGrant(context.Background(), sub, obj, act, EffectAllow,
+		PolicySourceRolePermission, AuthoritySourceSystem)
 }
 
 // GrantObjectPermission is the compatibility writer for call sites that
@@ -325,27 +317,27 @@ func (en *Enforcer) Grant(sub, obj, act string) error {
 // invents a Community bundle. New lifecycle and management flows use the
 // source-specific writers in policy_source.go. Idempotent.
 func (en *Enforcer) GrantObjectPermission(accessorID, resourceType, resourceID, op string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(accessorID, obj(resourceType, resourceID), op, EffectAllow, PolicySourceLegacy, AuthoritySourceMigration)
+	return en.addDefaultGrant(context.Background(), accessorID, obj(resourceType, resourceID), op, EffectAllow,
+		PolicySourceLegacy, AuthoritySourceMigration)
 }
 
 // DenyObjectPermission adds an explicit per-object exception. Deny overrides
 // every ordinary allow source; only membership in SuperAdminRoleID bypasses it.
 func (en *Enforcer) DenyObjectPermission(accessorID, resourceType, resourceID, op string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(accessorID, obj(resourceType, resourceID), op, EffectDeny, PolicySourceLegacy, AuthoritySourceMigration)
+	return en.addDefaultGrant(context.Background(), accessorID, obj(resourceType, resourceID), op, EffectDeny,
+		PolicySourceLegacy, AuthoritySourceMigration)
 }
 
 // RevokeObjectPermission removes every allow source for one concrete tuple.
 // It is retained for lifecycle reconciliation code written before policies had
 // provenance. New management flows that mean "one source" use RevokePolicy.
 func (en *Enforcer) RevokeObjectPermission(accessorID, resourceType, resourceID, op string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	_, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), op, EffectAllow)
-	return err
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		_, err := tx.enforcer.removePolicyGrants(PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID), Operation: op, Effect: EffectAllow,
+		})
+		return err
+	})
 }
 
 // CanAdmin reports whether the accessor may use the admin API. The seeded
@@ -676,13 +668,13 @@ func hasOp(ops []string, want string) bool {
 // (grouping g-lines with role=roleID) and its own permission grants (p-lines
 // with sub=roleID). Called when a custom role is deleted. Idempotent.
 func (en *Enforcer) RemoveRoleCompletely(roleID string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	if _, err := en.e.RemoveFilteredGroupingPolicy(1, roleID); err != nil {
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		if _, err := tx.enforcer.e.RemoveFilteredGroupingPolicy(1, roleID); err != nil {
+			return err
+		}
+		_, err := tx.enforcer.removePolicyGrants(PolicyFilter{AccessorID: roleID})
 		return err
-	}
-	_, err := en.e.RemoveFilteredPolicy(0, roleID)
-	return err
+	})
 }
 
 // RenameOperation rewrites every policy row on a resource type that grants the
@@ -696,36 +688,36 @@ func (en *Enforcer) RemoveRoleCompletely(roleID string) error {
 // This is the migration for those, and it is idempotent: once no row holds the
 // old spelling, it does nothing.
 func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, error) {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	rows, err := en.e.GetFilteredPolicy(2, oldOp)
-	if err != nil {
-		return 0, err
-	}
-	prefix := resourceType + ":"
 	moved := 0
-	for _, row := range rows {
-		if len(row) < 3 {
-			continue
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var rows []safemodel.AuthorizationGrant
+		if err := tx.db.Where("operation = ? AND object LIKE ?", oldOp, resourceType+":%").
+			Order("grant_id").Find(&rows).Error; err != nil {
+			return err
 		}
-		object := row[1]
-		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
-			continue
+		prefix := resourceType + ":"
+		for _, row := range rows {
+			if len(row.Object) <= len(prefix) || row.Object[:len(prefix)] != prefix {
+				continue
+			}
+			createdAt := row.CreatedAt
+			if _, _, err := tx.enforcer.revokePolicyGrant(row.GrantID); err != nil {
+				return err
+			}
+			grant := policyGrant(row)
+			grant.Operation = newOp
+			if _, err := tx.enforcer.addPolicyGrant(grant); err != nil {
+				return err
+			}
+			if err := tx.db.Model(&safemodel.AuthorizationGrant{}).Where("grant_id = ?", row.GrantID).
+				Update("created_at", createdAt).Error; err != nil {
+				return err
+			}
+			moved++
 		}
-		effect := EffectAllow
-		if len(row) >= 4 && row[3] != "" {
-			effect = row[3]
-		}
-		source, authority := policySourceOf(row), authoritySourceOf(row)
-		if _, err := en.e.RemovePolicy(row[0], object, oldOp, effect, string(source), string(authority)); err != nil {
-			return moved, err
-		}
-		if err := en.addPolicy(row[0], object, newOp, effect, source, authority); err != nil {
-			return moved, err
-		}
-		moved++
-	}
-	return moved, nil
+		return nil
+	})
+	return moved, err
 }
 
 // BackfilledGrant names one policy row that gained an implied operation, so the
@@ -751,52 +743,51 @@ type BackfilledGrant struct {
 // Idempotent: once every holder row carries the implied operation it adds
 // nothing, at the cost of one filtered read per declared implication per start.
 func (en *Enforcer) BackfillImpliedOperation(resourceType, holderOp, impliedOp string) ([]BackfilledGrant, error) {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	rows, err := en.e.GetFilteredPolicy(2, holderOp)
-	if err != nil {
-		return nil, err
-	}
-	prefix := resourceType + ":"
 	var added []BackfilledGrant
-	for _, row := range rows {
-		if len(row) < 3 || (len(row) >= 4 && row[3] == EffectDeny) {
-			continue
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var rows []safemodel.AuthorizationGrant
+		if err := tx.db.Where("operation = ? AND object LIKE ?", holderOp, resourceType+":%").
+			Order("grant_id").Find(&rows).Error; err != nil {
+			return err
 		}
-		object := row[1]
-		if len(object) <= len(prefix) || object[:len(prefix)] != prefix {
-			continue
+		prefix := resourceType + ":"
+		for _, row := range rows {
+			if row.Effect == EffectDeny || len(row.Object) <= len(prefix) || row.Object[:len(prefix)] != prefix {
+				continue
+			}
+			source := PolicySource(row.PolicySource)
+			// Compatibility and logical-bundle rows are immutable snapshots of their
+			// own contracts. Runtime requires (#1429) handles reachability without
+			// expanding legacy, and bundle expansion belongs only in the grant index.
+			if source == PolicySourceLegacy || source == PolicySourceCommunityBundle {
+				continue
+			}
+			grant := policyGrant(row)
+			grant.GrantID = deterministicGrantID(row.GrantID, row.Object, impliedOp, EffectAllow,
+				source, AuthoritySource(row.AuthoritySource))
+			grant.Operation = impliedOp
+			grant.Effect = EffectAllow
+			created, err := tx.enforcer.addPolicyGrant(grant)
+			if err != nil {
+				return err
+			}
+			if created {
+				added = append(added, BackfilledGrant{AccessorID: row.AccessorID, ResourceID: row.Object[len(prefix):]})
+			}
 		}
-		source, authority := policySourceOf(row), authoritySourceOf(row)
-		// Compatibility and logical-bundle rows are immutable snapshots of their
-		// own contracts. Runtime requires (#1429) handles reachability without
-		// expanding legacy, and bundle expansion belongs only in the grant index.
-		if source == PolicySourceLegacy || source == PolicySourceCommunityBundle {
-			continue
-		}
-		has, err := en.e.HasPolicy(row[0], object, impliedOp, EffectAllow, string(source), string(authority))
-		if err != nil {
-			return added, err
-		}
-		if has {
-			continue
-		}
-		if err := en.addPolicy(row[0], object, impliedOp, EffectAllow, source, authority); err != nil {
-			return added, err
-		}
-		added = append(added, BackfilledGrant{AccessorID: row[0], ResourceID: object[len(prefix):]})
-	}
-	return added, nil
+		return nil
+	})
+	return added, err
 }
 
 // RemoveRolePermissions purges only the p-lines owned by a role, preserving its
 // member bindings. Seed uses this before re-applying the built-in permission
 // matrix so removed grants do not linger across upgrades.
 func (en *Enforcer) RemoveRolePermissions(roleID string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	_, err := en.e.RemoveFilteredPolicy(0, roleID)
-	return err
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		_, err := tx.enforcer.removePolicyGrants(PolicyFilter{AccessorID: roleID})
+		return err
+	})
 }
 
 // RemoveAccessor purges every casbin trace of an accessor: its role bindings
@@ -804,13 +795,13 @@ func (en *Enforcer) RemoveRolePermissions(roleID string) error {
 // directly to it (p-lines with sub=accessor). Called when a user is deleted so
 // no orphaned grants linger. Idempotent.
 func (en *Enforcer) RemoveAccessor(accessorID string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	if _, err := en.e.RemoveFilteredGroupingPolicy(0, accessorID); err != nil {
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		if _, err := tx.enforcer.e.RemoveFilteredGroupingPolicy(0, accessorID); err != nil {
+			return err
+		}
+		_, err := tx.enforcer.removePolicyGrants(PolicyFilter{AccessorID: accessorID})
 		return err
-	}
-	_, err := en.e.RemoveFilteredPolicy(0, accessorID)
-	return err
+	})
 }
 
 // RemoveResourcePolicies drops policies targeting a concrete resource instance
@@ -818,11 +809,9 @@ func (en *Enforcer) RemoveAccessor(accessorID string) error {
 // exclusively to proxy-grant sources, and the KN deletion flow must remove
 // those sources before generic resource policy cleanup.
 func (en *Enforcer) RemoveResourcePolicies(resourceType, resourceID string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	if en.db != nil {
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
 		var activeSources int64
-		if err := en.db.Model(&safemodel.ProxyGrantSource{}).
+		if err := tx.db.Model(&safemodel.ProxyGrantSource{}).
 			Where("resource_type = ? AND resource_id = ? AND lifecycle_status = ?", resourceType, resourceID, "active").
 			Count(&activeSources).Error; err != nil {
 			return err
@@ -830,9 +819,9 @@ func (en *Enforcer) RemoveResourcePolicies(resourceType, resourceID string) erro
 		if activeSources > 0 {
 			return ErrManagedProxyPolicies
 		}
-	}
-	_, err := en.e.RemoveFilteredPolicy(1, obj(resourceType, resourceID))
-	return err
+		_, err := tx.enforcer.removePolicyGrants(PolicyFilter{Object: obj(resourceType, resourceID)})
+		return err
+	})
 }
 
 // AccessibleResources lists the concrete resource-instance IDs of a given type
@@ -1047,22 +1036,21 @@ func (en *Enforcer) SetObjectPermissions(accessorID, resourceType, resourceID st
 // source. The edition-aware management API migrates to
 // SetProfessionalObjectPermissions in #1430.
 func (en *Enforcer) SetObjectPermissionsForEffect(accessorID, resourceType, resourceID string, ops []string, effect string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
 	if effect != EffectAllow && effect != EffectDeny {
 		return fmt.Errorf("invalid policy effect %q", effect)
 	}
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
-		string(PolicySourceLegacy), string(AuthoritySourceMigration)); err != nil {
-		return err
-	}
-	for _, op := range ops {
-		if err := en.addPolicy(accessorID, obj(resourceType, resourceID), op, effect,
-			PolicySourceLegacy, AuthoritySourceMigration); err != nil {
-			return err
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		filter := PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID), Effect: effect,
+			PolicySource: PolicySourceLegacy, AuthoritySource: AuthoritySourceMigration,
 		}
-	}
-	return nil
+		desired := make([]PolicyGrant, 0, len(ops))
+		for _, op := range ops {
+			desired = append(desired, deterministicPolicyGrant(accessorID, obj(resourceType, resourceID), op,
+				effect, PolicySourceLegacy, AuthoritySourceMigration))
+		}
+		return tx.enforcer.replacePolicyGrantSlice(filter, desired)
+	})
 }
 
 func policyEffect(row []string) string {
@@ -1083,9 +1071,15 @@ func policyEffect(row []string) string {
 // either way — but the audit trail needs the distinction: "revoked 3 ops" and
 // "matched nothing" are different administrative facts.
 func (en *Enforcer) RemoveAccessorResourcePolicies(accessorID, resourceType, resourceID string) (int, error) {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.removeAccessorResourcePolicies(accessorID, resourceType, resourceID)
+	removed := 0
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var err error
+		removed, err = tx.enforcer.removePolicyGrants(PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID),
+		})
+		return err
+	})
+	return removed, err
 }
 
 // RemoveAccessorResourcePoliciesForEffect removes only allow or deny rows,
@@ -1094,33 +1088,15 @@ func (en *Enforcer) RemoveAccessorResourcePoliciesForEffect(accessorID, resource
 	if effect != EffectAllow && effect != EffectDeny {
 		return 0, fmt.Errorf("invalid policy effect %q", effect)
 	}
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect)
-	if err != nil {
-		return 0, err
-	}
-	if len(rows) == 0 {
-		return 0, nil
-	}
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect); err != nil {
-		return 0, err
-	}
-	return len(rows), nil
-}
-
-func (en *Enforcer) removeAccessorResourcePolicies(accessorID, resourceType, resourceID string) (int, error) {
-	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID))
-	if err != nil {
-		return 0, err
-	}
-	if len(rows) == 0 {
-		return 0, nil
-	}
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID)); err != nil {
-		return 0, err
-	}
-	return len(rows), nil
+	removed := 0
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var err error
+		removed, err = tx.enforcer.removePolicyGrants(PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID), Effect: effect,
+		})
+		return err
+	})
+	return removed, err
 }
 
 // splitObjectKey splits a casbin object key "type:id" on the FIRST colon (the

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -115,7 +115,10 @@ func New(db *gorm.DB) (*Enforcer, error) {
 	// offline migration. Refuse to load an unclassified or partially projected
 	// store instead of guessing ownership during startup.
 	if err := (&Enforcer{db: db}).validateGrantProjection(); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrPolicySourceMigrationRequired, err)
+		if errors.Is(err, ErrPolicySourceMigrationRequired) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("validate authorization grant projection: %w", err)
 	}
 	m, err := model.NewModelFromString(modelConf)
 	if err != nil {
@@ -700,18 +703,26 @@ func (en *Enforcer) RenameOperation(resourceType, oldOp, newOp string) (int, err
 			if len(row.Object) <= len(prefix) || row.Object[:len(prefix)] != prefix {
 				continue
 			}
+			source, authority := PolicySource(row.PolicySource), AuthoritySource(row.AuthoritySource)
+			derivedID := row.GrantID == deterministicGrantID(row.AccessorID, row.Object, oldOp, row.Effect, source, authority)
 			createdAt := row.CreatedAt
 			if _, _, err := tx.enforcer.revokePolicyGrant(row.GrantID); err != nil {
 				return err
 			}
 			grant := policyGrant(row)
 			grant.Operation = newOp
-			if _, err := tx.enforcer.addPolicyGrant(grant); err != nil {
+			if derivedID {
+				grant.GrantID = deterministicGrantID(row.AccessorID, row.Object, newOp, row.Effect, source, authority)
+			}
+			created, err := tx.enforcer.addPolicyGrant(grant)
+			if err != nil {
 				return err
 			}
-			if err := tx.db.Model(&safemodel.AuthorizationGrant{}).Where("grant_id = ?", row.GrantID).
-				Update("created_at", createdAt).Error; err != nil {
-				return err
+			if created {
+				if err := tx.db.Model(&safemodel.AuthorizationGrant{}).Where("grant_id = ?", grant.GrantID).
+					Update("created_at", createdAt).Error; err != nil {
+					return err
+				}
 			}
 			moved++
 		}

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -148,6 +148,13 @@ func TestLegacyPolicyWithoutEffectIsNormalizedToAllow(t *testing.T) {
 	).Error; err != nil {
 		t.Fatalf("insert legacy policy: %v", err)
 	}
+	if err := db.Create(&model.AuthorizationGrant{
+		GrantID: "migrated-legacy-grant", AccessorID: "legacy-user", Object: "resource:r-1",
+		Operation: "view_detail", Effect: EffectAllow, PolicySource: string(PolicySourceLegacy),
+		AuthoritySource: string(AuthoritySourceMigration), CreatedBy: string(AuthoritySourceMigration),
+	}).Error; err != nil {
+		t.Fatalf("insert migrated grant identity: %v", err)
+	}
 	reloaded, err := New(db)
 	if err != nil {
 		t.Fatalf("reload legacy policy: %v", err)

--- a/bkn-safe/server/internal/authz/authz_test.go
+++ b/bkn-safe/server/internal/authz/authz_test.go
@@ -149,7 +149,10 @@ func TestLegacyPolicyWithoutEffectIsNormalizedToAllow(t *testing.T) {
 		t.Fatalf("insert legacy policy: %v", err)
 	}
 	if err := db.Create(&model.AuthorizationGrant{
-		GrantID: "migrated-legacy-grant", AccessorID: "legacy-user", Object: "resource:r-1",
+		GrantID: "migrated-legacy-grant",
+		ProjectionKey: policyProjectionKey("legacy-user", "resource:r-1", "view_detail", EffectAllow,
+			PolicySourceLegacy, AuthoritySourceMigration),
+		AccessorID: "legacy-user", Object: "resource:r-1",
 		Operation: "view_detail", Effect: EffectAllow, PolicySource: string(PolicySourceLegacy),
 		AuthoritySource: string(AuthoritySourceMigration), CreatedBy: string(AuthoritySourceMigration),
 	}).Error; err != nil {

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -5,12 +5,19 @@
 package authz
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
+	safemodel "github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
 	"github.com/openbkn-ai/licverify"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // PolicySource identifies the product or lifecycle layer that owns a policy.
@@ -46,26 +53,44 @@ const (
 
 var (
 	// ErrPolicySourceMigrationRequired is returned before Casbin loads when a
-	// persisted business policy has not been assigned trusted provenance. The
-	// offline migration owns that classification; startup must not infer it.
+	// persisted business policy has not been assigned trusted provenance and a
+	// stable grant identity. The offline migration owns that classification;
+	// startup must not infer or synthesize it.
 	ErrPolicySourceMigrationRequired = errors.New("casbin policy provenance migration required")
 )
 
-// PolicyRecord is the durable identity and provenance of one Casbin p-line.
-// ID is the adapter's stable primary key. Active is derived from the live
-// edition at read time and is never persisted.
-type PolicyRecord struct {
-	ID              uint
+// PolicyGrant is one independently managed Core grant. GrantID and CreatedBy
+// are mandatory for source-aware writers; compatibility writers derive a
+// deterministic ID and use their trusted authority as the creator identity.
+type PolicyGrant struct {
+	GrantID         string
 	AccessorID      string
 	Object          string
 	Operation       string
 	Effect          string
 	PolicySource    PolicySource
 	AuthoritySource AuthoritySource
+	CreatedBy       string
+}
+
+// PolicyRecord is the durable identity and provenance of one Core grant.
+// Active is derived from the live edition at read time and is never persisted.
+// Several records may project to the same Casbin p-line.
+type PolicyRecord struct {
+	GrantID         string
+	AccessorID      string
+	Object          string
+	Operation       string
+	Effect          string
+	PolicySource    PolicySource
+	AuthoritySource AuthoritySource
+	CreatedBy       string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
 	Active          bool
 }
 
-// PolicyFilter narrows a provenance listing. Zero fields match every p-line.
+// PolicyFilter narrows a provenance listing. Zero fields match every grant.
 type PolicyFilter struct {
 	AccessorID      string
 	Object          string
@@ -89,6 +114,15 @@ type casbinPolicyRow struct {
 }
 
 func (casbinPolicyRow) TableName() string { return "casbin_rule" }
+
+type policyTupleKey struct {
+	AccessorID      string
+	Object          string
+	Operation       string
+	Effect          string
+	PolicySource    string
+	AuthoritySource string
+}
 
 func validatePolicySource(source PolicySource) error {
 	switch source {
@@ -159,23 +193,290 @@ func activePolicyRowsForEdition(rows [][]string, edition licverify.Edition) [][]
 	return out
 }
 
+func validatePolicyGrant(grant PolicyGrant) error {
+	if strings.TrimSpace(grant.GrantID) == "" || len(grant.GrantID) > 64 {
+		return fmt.Errorf("invalid grant id")
+	}
+	if strings.TrimSpace(grant.AccessorID) == "" || len(grant.AccessorID) > 64 {
+		return fmt.Errorf("invalid grant accessor")
+	}
+	if strings.TrimSpace(grant.Object) == "" || len(grant.Object) > 255 {
+		return fmt.Errorf("invalid grant object")
+	}
+	if strings.TrimSpace(grant.Operation) == "" || len(grant.Operation) > 64 {
+		return fmt.Errorf("invalid grant operation")
+	}
+	if strings.TrimSpace(grant.CreatedBy) == "" || len(grant.CreatedBy) > 64 {
+		return fmt.Errorf("invalid grant creator")
+	}
+	if grant.Effect != EffectAllow && grant.Effect != EffectDeny {
+		return fmt.Errorf("invalid policy effect %q", grant.Effect)
+	}
+	return validatePolicyProvenance(grant.PolicySource, grant.AuthoritySource)
+}
+
+func deterministicGrantID(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		sub, object, operation, effect, string(source), string(authority),
+	}, "\x00")))
+	return hex.EncodeToString(sum[:])
+}
+
+func deterministicPolicyGrant(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) PolicyGrant {
+	return PolicyGrant{
+		GrantID:    deterministicGrantID(sub, object, operation, effect, source, authority),
+		AccessorID: sub, Object: object, Operation: operation, Effect: effect,
+		PolicySource: source, AuthoritySource: authority, CreatedBy: string(authority),
+	}
+}
+
+func grantModel(grant PolicyGrant) safemodel.AuthorizationGrant {
+	return safemodel.AuthorizationGrant{
+		GrantID: grant.GrantID, AccessorID: grant.AccessorID, Object: grant.Object,
+		Operation: grant.Operation, Effect: grant.Effect, PolicySource: string(grant.PolicySource),
+		AuthoritySource: string(grant.AuthoritySource), CreatedBy: grant.CreatedBy,
+	}
+}
+
+func policyGrant(row safemodel.AuthorizationGrant) PolicyGrant {
+	return PolicyGrant{
+		GrantID: row.GrantID, AccessorID: row.AccessorID, Object: row.Object,
+		Operation: row.Operation, Effect: row.Effect, PolicySource: PolicySource(row.PolicySource),
+		AuthoritySource: AuthoritySource(row.AuthoritySource), CreatedBy: row.CreatedBy,
+	}
+}
+
+func samePolicyGrant(left, right PolicyGrant) bool {
+	return left.GrantID == right.GrantID && left.AccessorID == right.AccessorID &&
+		left.Object == right.Object && left.Operation == right.Operation && left.Effect == right.Effect &&
+		left.PolicySource == right.PolicySource && left.AuthoritySource == right.AuthoritySource &&
+		left.CreatedBy == right.CreatedBy
+}
+
+func (en *Enforcer) addPolicyGrant(grant PolicyGrant) (bool, error) {
+	if err := validatePolicyGrant(grant); err != nil {
+		return false, err
+	}
+	row := grantModel(grant)
+	result := en.db.Clauses(clause.OnConflict{DoNothing: true}).Create(&row)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		var existing safemodel.AuthorizationGrant
+		if err := en.db.First(&existing, "grant_id = ?", grant.GrantID).Error; err != nil {
+			return false, err
+		}
+		if !samePolicyGrant(grant, policyGrant(existing)) {
+			return false, fmt.Errorf("grant id %q already belongs to another policy", grant.GrantID)
+		}
+		return false, nil
+	}
+	has, err := en.e.HasPolicy(grant.AccessorID, grant.Object, grant.Operation, grant.Effect,
+		string(grant.PolicySource), string(grant.AuthoritySource))
+	if err != nil {
+		return false, err
+	}
+	if !has {
+		if _, err := en.e.AddPolicy(grant.AccessorID, grant.Object, grant.Operation, grant.Effect,
+			string(grant.PolicySource), string(grant.AuthoritySource)); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 func (en *Enforcer) addPolicy(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
-	if effect != EffectAllow && effect != EffectDeny {
-		return fmt.Errorf("invalid policy effect %q", effect)
-	}
-	if err := validatePolicyProvenance(source, authority); err != nil {
-		return err
-	}
-	_, err := en.e.AddPolicy(sub, object, operation, effect, string(source), string(authority))
+	_, err := en.addPolicyGrant(deterministicPolicyGrant(sub, object, operation, effect, source, authority))
 	return err
 }
 
-func (en *Enforcer) removePolicy(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
-	if err := validatePolicyProvenance(source, authority); err != nil {
+// GrantPolicy stores an explicit stable grant identity. It is the source-aware
+// entry point for management services; identical tuples with distinct GrantID
+// values remain independently revocable.
+func (en *Enforcer) GrantPolicy(ctx context.Context, grant PolicyGrant) (bool, error) {
+	var created bool
+	err := en.Transaction(ctx, func(tx *PolicyTransaction) error {
+		var err error
+		created, err = tx.enforcer.addPolicyGrant(grant)
+		return err
+	})
+	return created, err
+}
+
+func (en *Enforcer) revokePolicyGrant(grantID string) (bool, bool, error) {
+	var target safemodel.AuthorizationGrant
+	err := en.db.First(&target, "grant_id = ?", grantID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	// Lock every sibling in a stable order before deleting one. The existence
+	// decision and Casbin projection removal therefore share this transaction.
+	var siblings []safemodel.AuthorizationGrant
+	if err := en.db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("accessor_id = ? AND object = ? AND operation = ? AND effect = ? AND policy_source = ? AND authority_source = ?",
+			target.AccessorID, target.Object, target.Operation, target.Effect, target.PolicySource, target.AuthoritySource).
+		Order("grant_id").Find(&siblings).Error; err != nil {
+		return false, false, err
+	}
+	found := false
+	for _, sibling := range siblings {
+		if sibling.GrantID == grantID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, false, nil
+	}
+	if err := en.db.Delete(&safemodel.AuthorizationGrant{}, "grant_id = ?", grantID).Error; err != nil {
+		return false, false, err
+	}
+	if len(siblings) > 1 {
+		return true, false, nil
+	}
+	removed, err := en.e.RemovePolicy(target.AccessorID, target.Object, target.Operation, target.Effect,
+		target.PolicySource, target.AuthoritySource)
+	return true, removed, err
+}
+
+func applyPolicyFilter(q *gorm.DB, filter PolicyFilter) *gorm.DB {
+	if filter.AccessorID != "" {
+		q = q.Where("accessor_id = ?", filter.AccessorID)
+	}
+	if filter.Object != "" {
+		q = q.Where("object = ?", filter.Object)
+	}
+	if filter.Operation != "" {
+		q = q.Where("operation = ?", filter.Operation)
+	}
+	if filter.Effect != "" {
+		q = q.Where("effect = ?", filter.Effect)
+	}
+	if filter.PolicySource != "" {
+		q = q.Where("policy_source = ?", filter.PolicySource)
+	}
+	if filter.AuthoritySource != "" {
+		q = q.Where("authority_source = ?", filter.AuthoritySource)
+	}
+	return q
+}
+
+func (en *Enforcer) removePolicyGrants(filter PolicyFilter) (int, error) {
+	var rows []safemodel.AuthorizationGrant
+	if err := applyPolicyFilter(en.db.Model(&safemodel.AuthorizationGrant{}), filter).
+		Order("grant_id").Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	removedProjections := 0
+	for _, row := range rows {
+		_, projectionRemoved, err := en.revokePolicyGrant(row.GrantID)
+		if err != nil {
+			return removedProjections, err
+		}
+		if projectionRemoved {
+			removedProjections++
+		}
+	}
+	return removedProjections, nil
+}
+
+func (en *Enforcer) replacePolicyGrantSlice(filter PolicyFilter, desired []PolicyGrant) error {
+	var existing []safemodel.AuthorizationGrant
+	if err := applyPolicyFilter(en.db.Model(&safemodel.AuthorizationGrant{}), filter).
+		Order("grant_id").Find(&existing).Error; err != nil {
 		return err
 	}
-	_, err := en.e.RemovePolicy(sub, object, operation, effect, string(source), string(authority))
+	wanted := make(map[string]PolicyGrant, len(desired))
+	for _, grant := range desired {
+		if err := validatePolicyGrant(grant); err != nil {
+			return err
+		}
+		wanted[grant.GrantID] = grant
+	}
+	for _, row := range existing {
+		grant, keep := wanted[row.GrantID]
+		if keep && samePolicyGrant(policyGrant(row), grant) {
+			delete(wanted, row.GrantID)
+			continue
+		}
+		if _, _, err := en.revokePolicyGrant(row.GrantID); err != nil {
+			return err
+		}
+	}
+	for _, grant := range desired {
+		if _, pending := wanted[grant.GrantID]; !pending {
+			continue
+		}
+		if _, err := en.addPolicyGrant(grant); err != nil {
+			return err
+		}
+		delete(wanted, grant.GrantID)
+	}
+	return nil
+}
+
+func (en *Enforcer) removePolicy(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
+	_, err := en.removePolicyGrants(PolicyFilter{
+		AccessorID: sub, Object: object, Operation: operation, Effect: effect,
+		PolicySource: source, AuthoritySource: authority,
+	})
 	return err
+}
+
+func (en *Enforcer) addDefaultGrant(ctx context.Context, sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
+	return en.Transaction(ctx, func(tx *PolicyTransaction) error {
+		return tx.enforcer.addPolicy(sub, object, operation, effect, source, authority)
+	})
+}
+
+func (en *Enforcer) removeDefaultGrant(ctx context.Context, sub, object, operation, effect string, source PolicySource, authority AuthoritySource) error {
+	return en.Transaction(ctx, func(tx *PolicyTransaction) error {
+		return tx.enforcer.removePolicy(sub, object, operation, effect, source, authority)
+	})
+}
+
+func (en *Enforcer) validateGrantProjection() error {
+	var policyRows []casbinPolicyRow
+	if err := en.db.Table("casbin_rule").Where("ptype = ?", "p").Find(&policyRows).Error; err != nil {
+		return err
+	}
+	var grantRows []safemodel.AuthorizationGrant
+	if err := en.db.Find(&grantRows).Error; err != nil {
+		return err
+	}
+	projectionCounts := make(map[policyTupleKey]int, len(policyRows))
+	grantCounts := make(map[policyTupleKey]int, len(grantRows))
+	key := func(sub, object, operation, effect, source, authority string) policyTupleKey {
+		return policyTupleKey{sub, object, operation, effect, source, authority}
+	}
+	for _, row := range policyRows {
+		if err := validatePolicyProvenance(PolicySource(row.V4), AuthoritySource(row.V5)); err != nil {
+			return fmt.Errorf("policy id %d: %w", row.ID, err)
+		}
+		projectionCounts[key(row.V0, row.V1, row.V2, row.V3, row.V4, row.V5)]++
+	}
+	for _, row := range grantRows {
+		grant := policyGrant(row)
+		if err := validatePolicyGrant(grant); err != nil {
+			return fmt.Errorf("grant id %q: %w", row.GrantID, err)
+		}
+		grantCounts[key(row.AccessorID, row.Object, row.Operation, row.Effect, row.PolicySource, row.AuthoritySource)]++
+	}
+	for tuple, count := range projectionCounts {
+		if count != 1 || grantCounts[tuple] == 0 {
+			return fmt.Errorf("casbin projection has %d rows and %d grants", count, grantCounts[tuple])
+		}
+	}
+	for tuple, count := range grantCounts {
+		if count > 0 && projectionCounts[tuple] != 1 {
+			return fmt.Errorf("grant tuple has %d grants and %d casbin projections", count, projectionCounts[tuple])
+		}
+	}
+	return nil
 }
 
 // GrantProfessionalObjectPermission writes a trusted Professional rule. The
@@ -185,16 +486,14 @@ func (en *Enforcer) GrantProfessionalObjectPermission(accessorID, resourceType, 
 	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
 		return fmt.Errorf("professional rule authority %q is not permitted", authority)
 	}
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(accessorID, obj(resourceType, resourceID), operation, effect, PolicySourceProfessionalRule, authority)
+	return en.addDefaultGrant(context.Background(), accessorID, obj(resourceType, resourceID), operation, effect,
+		PolicySourceProfessionalRule, authority)
 }
 
 // GrantSystemObjectPermission records a lifecycle-derived permission.
 func (en *Enforcer) GrantSystemObjectPermission(accessorID, resourceType, resourceID, operation string) error {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow, PolicySourceSystemDerived, AuthoritySourceSystem)
+	return en.addDefaultGrant(context.Background(), accessorID, obj(resourceType, resourceID), operation, EffectAllow,
+		PolicySourceSystemDerived, AuthoritySourceSystem)
 }
 
 // GrantCommunityBundle records the one logical Community grant. Expansion of
@@ -203,9 +502,8 @@ func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID st
 	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
 		return fmt.Errorf("community bundle authority %q is not permitted", authority)
 	}
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	return en.addPolicy(accessorID, obj(resourceType, resourceID), ActFullBusinessAccess, EffectAllow, PolicySourceCommunityBundle, authority)
+	return en.addDefaultGrant(context.Background(), accessorID, obj(resourceType, resourceID), ActFullBusinessAccess,
+		EffectAllow, PolicySourceCommunityBundle, authority)
 }
 
 // SetProfessionalObjectPermissions replaces only one trusted source slice. An
@@ -218,18 +516,18 @@ func (en *Enforcer) SetProfessionalObjectPermissions(accessorID, resourceType, r
 	if effect != EffectAllow && effect != EffectDeny {
 		return fmt.Errorf("invalid policy effect %q", effect)
 	}
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
-		string(PolicySourceProfessionalRule), string(authority)); err != nil {
-		return err
-	}
-	for _, operation := range operations {
-		if err := en.addPolicy(accessorID, obj(resourceType, resourceID), operation, effect, PolicySourceProfessionalRule, authority); err != nil {
-			return err
+	return en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		filter := PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID), Effect: effect,
+			PolicySource: PolicySourceProfessionalRule, AuthoritySource: authority,
 		}
-	}
-	return nil
+		desired := make([]PolicyGrant, 0, len(operations))
+		for _, operation := range operations {
+			desired = append(desired, deterministicPolicyGrant(accessorID, obj(resourceType, resourceID), operation,
+				effect, PolicySourceProfessionalRule, authority))
+		}
+		return tx.enforcer.replacePolicyGrantSlice(filter, desired)
+	})
 }
 
 // RemoveProfessionalObjectPermissions removes only the slice managed by one
@@ -242,53 +540,34 @@ func (en *Enforcer) RemoveProfessionalObjectPermissions(accessorID, resourceType
 	if effect != EffectAllow && effect != EffectDeny {
 		return 0, fmt.Errorf("invalid policy effect %q", effect)
 	}
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	rows, err := en.e.GetFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
-		string(PolicySourceProfessionalRule), string(authority))
-	if err != nil || len(rows) == 0 {
-		return 0, err
-	}
-	if _, err := en.e.RemoveFilteredPolicy(0, accessorID, obj(resourceType, resourceID), "", effect,
-		string(PolicySourceProfessionalRule), string(authority)); err != nil {
-		return 0, err
-	}
-	return len(rows), nil
+	removed := 0
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var err error
+		removed, err = tx.enforcer.removePolicyGrants(PolicyFilter{
+			AccessorID: accessorID, Object: obj(resourceType, resourceID), Effect: effect,
+			PolicySource: PolicySourceProfessionalRule, AuthoritySource: authority,
+		})
+		return err
+	})
+	return removed, err
 }
 
 // PolicyRecords lists persisted policy configuration, including inactive
 // Professional rows and legacy rows. It never rewrites configuration.
 func (en *Enforcer) PolicyRecords(filter PolicyFilter) ([]PolicyRecord, error) {
-	q := en.db.Table("casbin_rule").Where("ptype = ?", "p")
-	if filter.AccessorID != "" {
-		q = q.Where("v0 = ?", filter.AccessorID)
-	}
-	if filter.Object != "" {
-		q = q.Where("v1 = ?", filter.Object)
-	}
-	if filter.Operation != "" {
-		q = q.Where("v2 = ?", filter.Operation)
-	}
-	if filter.Effect != "" {
-		q = q.Where("v3 = ?", filter.Effect)
-	}
-	if filter.PolicySource != "" {
-		q = q.Where("v4 = ?", filter.PolicySource)
-	}
-	if filter.AuthoritySource != "" {
-		q = q.Where("v5 = ?", filter.AuthoritySource)
-	}
-	var rows []casbinPolicyRow
-	if err := q.Order("id").Find(&rows).Error; err != nil {
+	var rows []safemodel.AuthorizationGrant
+	if err := applyPolicyFilter(en.db.Model(&safemodel.AuthorizationGrant{}), filter).
+		Order("created_at, grant_id").Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	edition := entitlement.Current()
 	out := make([]PolicyRecord, 0, len(rows))
 	for _, row := range rows {
-		source := PolicySource(row.V4)
+		source := PolicySource(row.PolicySource)
 		out = append(out, PolicyRecord{
-			ID: row.ID, AccessorID: row.V0, Object: row.V1, Operation: row.V2,
-			Effect: row.V3, PolicySource: source, AuthoritySource: AuthoritySource(row.V5),
+			GrantID: row.GrantID, AccessorID: row.AccessorID, Object: row.Object, Operation: row.Operation,
+			Effect: row.Effect, PolicySource: source, AuthoritySource: AuthoritySource(row.AuthoritySource),
+			CreatedBy: row.CreatedBy, CreatedAt: row.CreatedAt, UpdatedAt: row.UpdatedAt,
 			Active: policySourceActive(source, edition),
 		})
 	}
@@ -298,17 +577,12 @@ func (en *Enforcer) PolicyRecords(filter PolicyFilter) ([]PolicyRecord, error) {
 // RevokePolicy removes exactly one stable policy identity. It is the only
 // mutation supported for legacy rows and cannot remove a sibling source with
 // the same subject/resource/operation tuple.
-func (en *Enforcer) RevokePolicy(id uint) (bool, error) {
-	en.transactionMu.Lock()
-	defer en.transactionMu.Unlock()
-	var row casbinPolicyRow
-	err := en.db.Table("casbin_rule").Where("id = ? AND ptype = ?", id, "p").Take(&row).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	removed, err := en.e.RemovePolicy(row.V0, row.V1, row.V2, row.V3, row.V4, row.V5)
+func (en *Enforcer) RevokePolicy(grantID string) (bool, error) {
+	var removed bool
+	err := en.Transaction(context.Background(), func(tx *PolicyTransaction) error {
+		var err error
+		removed, _, err = tx.enforcer.revokePolicyGrant(grantID)
+		return err
+	})
 	return removed, err
 }

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -215,11 +215,15 @@ func validatePolicyGrant(grant PolicyGrant) error {
 	return validatePolicyProvenance(grant.PolicySource, grant.AuthoritySource)
 }
 
-func deterministicGrantID(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) string {
+func policyProjectionKey(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		sub, object, operation, effect, string(source), string(authority),
 	}, "\x00")))
 	return hex.EncodeToString(sum[:])
+}
+
+func deterministicGrantID(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) string {
+	return policyProjectionKey(sub, object, operation, effect, source, authority)
 }
 
 func deterministicPolicyGrant(sub, object, operation, effect string, source PolicySource, authority AuthoritySource) PolicyGrant {
@@ -232,7 +236,10 @@ func deterministicPolicyGrant(sub, object, operation, effect string, source Poli
 
 func grantModel(grant PolicyGrant) safemodel.AuthorizationGrant {
 	return safemodel.AuthorizationGrant{
-		GrantID: grant.GrantID, AccessorID: grant.AccessorID, Object: grant.Object,
+		GrantID: grant.GrantID,
+		ProjectionKey: policyProjectionKey(grant.AccessorID, grant.Object, grant.Operation, grant.Effect,
+			grant.PolicySource, grant.AuthoritySource),
+		AccessorID: grant.AccessorID, Object: grant.Object,
 		Operation: grant.Operation, Effect: grant.Effect, PolicySource: string(grant.PolicySource),
 		AuthoritySource: string(grant.AuthoritySource), CreatedBy: grant.CreatedBy,
 	}
@@ -317,8 +324,9 @@ func (en *Enforcer) revokePolicyGrant(grantID string) (bool, bool, error) {
 	// decision and Casbin projection removal therefore share this transaction.
 	var siblings []safemodel.AuthorizationGrant
 	if err := en.db.Clauses(clause.Locking{Strength: "UPDATE"}).
-		Where("accessor_id = ? AND object = ? AND operation = ? AND effect = ? AND policy_source = ? AND authority_source = ?",
-			target.AccessorID, target.Object, target.Operation, target.Effect, target.PolicySource, target.AuthoritySource).
+		Where("projection_key = ? AND accessor_id = ? AND object = ? AND operation = ? AND effect = ? AND policy_source = ? AND authority_source = ?",
+			target.ProjectionKey, target.AccessorID, target.Object, target.Operation, target.Effect,
+			target.PolicySource, target.AuthoritySource).
 		Order("grant_id").Find(&siblings).Error; err != nil {
 		return false, false, err
 	}
@@ -455,25 +463,32 @@ func (en *Enforcer) validateGrantProjection() error {
 	}
 	for _, row := range policyRows {
 		if err := validatePolicyProvenance(PolicySource(row.V4), AuthoritySource(row.V5)); err != nil {
-			return fmt.Errorf("policy id %d: %w", row.ID, err)
+			return fmt.Errorf("%w: policy id %d: %v", ErrPolicySourceMigrationRequired, row.ID, err)
 		}
 		projectionCounts[key(row.V0, row.V1, row.V2, row.V3, row.V4, row.V5)]++
 	}
 	for _, row := range grantRows {
 		grant := policyGrant(row)
 		if err := validatePolicyGrant(grant); err != nil {
-			return fmt.Errorf("grant id %q: %w", row.GrantID, err)
+			return fmt.Errorf("%w: grant id %q: %v", ErrPolicySourceMigrationRequired, row.GrantID, err)
+		}
+		wantProjectionKey := policyProjectionKey(row.AccessorID, row.Object, row.Operation, row.Effect,
+			PolicySource(row.PolicySource), AuthoritySource(row.AuthoritySource))
+		if row.ProjectionKey != wantProjectionKey {
+			return fmt.Errorf("%w: grant id %q has an invalid projection key", ErrPolicySourceMigrationRequired, row.GrantID)
 		}
 		grantCounts[key(row.AccessorID, row.Object, row.Operation, row.Effect, row.PolicySource, row.AuthoritySource)]++
 	}
 	for tuple, count := range projectionCounts {
 		if count != 1 || grantCounts[tuple] == 0 {
-			return fmt.Errorf("casbin projection has %d rows and %d grants", count, grantCounts[tuple])
+			return fmt.Errorf("%w: casbin projection has %d rows and %d grants",
+				ErrPolicySourceMigrationRequired, count, grantCounts[tuple])
 		}
 	}
 	for tuple, count := range grantCounts {
 		if count > 0 && projectionCounts[tuple] != 1 {
-			return fmt.Errorf("grant tuple has %d grants and %d casbin projections", count, projectionCounts[tuple])
+			return fmt.Errorf("%w: grant tuple has %d grants and %d casbin projections",
+				ErrPolicySourceMigrationRequired, count, projectionCounts[tuple])
 		}
 	}
 	return nil

--- a/bkn-safe/server/internal/authz/policy_source_test.go
+++ b/bkn-safe/server/internal/authz/policy_source_test.go
@@ -96,7 +96,10 @@ func TestNewRejectsStableGrantWithoutPolicyProjection(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := db.Create(&safemodel.AuthorizationGrant{
-		GrantID: "grant-1", AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail",
+		GrantID: "grant-1",
+		ProjectionKey: policyProjectionKey("u-1", "resource:r-1", "view_detail", EffectAllow,
+			PolicySourceProfessionalRule, AuthoritySourceAdminAuthz),
+		AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail",
 		Effect: EffectAllow, PolicySource: string(PolicySourceProfessionalRule),
 		AuthoritySource: string(AuthoritySourceAdminAuthz), CreatedBy: "admin-1",
 	}).Error; err != nil {
@@ -106,6 +109,27 @@ func TestNewRejectsStableGrantWithoutPolicyProjection(t *testing.T) {
 	_, err = New(db)
 	if !errors.Is(err, ErrPolicySourceMigrationRequired) {
 		t.Fatalf("New() error = %v, want ErrPolicySourceMigrationRequired", err)
+	}
+}
+
+func TestNewDoesNotReportDatabaseFailureAsMigrationRequired(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Migrator().DropTable(&safemodel.AuthorizationGrant{}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = New(db)
+	if err == nil || errors.Is(err, ErrPolicySourceMigrationRequired) {
+		t.Fatalf("New() error = %v, want a database error distinct from migration required", err)
 	}
 }
 
@@ -355,6 +379,45 @@ func TestGrantIDCannotBeReusedForAnotherPolicy(t *testing.T) {
 	allowed, checkErr := e.Check("u-1", "resource", "r-1", "view_detail")
 	if checkErr != nil || !allowed {
 		t.Fatalf("conflict changed original grant: allowed=%v err=%v", allowed, checkErr)
+	}
+}
+
+func TestRenameOperationRekeysDerivedGrantAndPreservesExplicitGrantID(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.GrantObjectPermission("u-derived", "resource", "r-1", "old_operation"))
+	explicit := PolicyGrant{
+		GrantID: "explicit-grant", AccessorID: "u-explicit", Object: "resource:r-1", Operation: "old_operation",
+		Effect: EffectAllow, PolicySource: PolicySourceProfessionalRule,
+		AuthoritySource: AuthoritySourceAdminAuthz, CreatedBy: "admin-1",
+	}
+	created, err := e.GrantPolicy(t.Context(), explicit)
+	if err != nil || !created {
+		t.Fatalf("GrantPolicy(explicit) = %v, %v; want created", created, err)
+	}
+
+	moved, err := e.RenameOperation("resource", "old_operation", "new_operation")
+	if err != nil || moved != 2 {
+		t.Fatalf("RenameOperation() = %d, %v; want two", moved, err)
+	}
+	derived, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-derived"})
+	wantDerivedID := deterministicGrantID("u-derived", "resource:r-1", "new_operation", EffectAllow,
+		PolicySourceLegacy, AuthoritySourceMigration)
+	if err != nil || len(derived) != 1 || derived[0].GrantID != wantDerivedID || derived[0].Operation != "new_operation" {
+		t.Fatalf("renamed derived grant = %+v, %v; want id %q", derived, err, wantDerivedID)
+	}
+	explicitRows, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-explicit"})
+	if err != nil || len(explicitRows) != 1 || explicitRows[0].GrantID != explicit.GrantID ||
+		explicitRows[0].Operation != "new_operation" {
+		t.Fatalf("renamed explicit grant = %+v, %v; want stable explicit id", explicitRows, err)
+	}
+
+	// A stale caller may still submit the old spelling. It must create its old
+	// deterministic identity instead of colliding with the renamed grant.
+	mustNoErr(t, e.GrantObjectPermission("u-derived", "resource", "r-1", "old_operation"))
+	rows, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-derived"})
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("old spelling replay after rename = %+v, %v; want two independent grants", rows, err)
 	}
 }
 

--- a/bkn-safe/server/internal/authz/policy_source_test.go
+++ b/bkn-safe/server/internal/authz/policy_source_test.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	safemodel "github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
 func useEdition(t *testing.T, initial licverify.Edition) *licverify.Edition {
@@ -55,6 +56,56 @@ func TestNewRejectsUnclassifiedPolicyWithoutMutatingItsSource(t *testing.T) {
 	}
 	if classified != 0 {
 		t.Fatal("startup inferred provenance; offline migration must own classification")
+	}
+}
+
+func TestNewRejectsPolicyProjectionWithoutStableGrant(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Exec(
+		"INSERT INTO casbin_rule (ptype, v0, v1, v2, v3, v4, v5) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		"p", "u-1", "resource:r-1", "view_detail", EffectAllow,
+		PolicySourceProfessionalRule, AuthoritySourceAdminAuthz,
+	).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = New(db)
+	if !errors.Is(err, ErrPolicySourceMigrationRequired) {
+		t.Fatalf("New() error = %v, want ErrPolicySourceMigrationRequired", err)
+	}
+}
+
+func TestNewRejectsStableGrantWithoutPolicyProjection(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(db); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&safemodel.AuthorizationGrant{
+		GrantID: "grant-1", AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail",
+		Effect: EffectAllow, PolicySource: string(PolicySourceProfessionalRule),
+		AuthoritySource: string(AuthoritySourceAdminAuthz), CreatedBy: "admin-1",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = New(db)
+	if !errors.Is(err, ErrPolicySourceMigrationRequired) {
+		t.Fatalf("New() error = %v, want ErrPolicySourceMigrationRequired", err)
 	}
 }
 
@@ -110,7 +161,7 @@ func TestPolicySourcesFollowLiveEditionWithoutRewritingRows(t *testing.T) {
 	if records[0].Active {
 		t.Fatal("Professional row reported active in Community")
 	}
-	id := records[0].ID
+	id := records[0].GrantID
 
 	for _, paid := range []licverify.Edition{
 		licverify.EditionProfessional, licverify.EditionEnterprise, licverify.EditionIndustry,
@@ -128,8 +179,8 @@ func TestPolicySourcesFollowLiveEditionWithoutRewritingRows(t *testing.T) {
 		t.Fatal(err)
 	}
 	reloadedRecords, err := reloaded.PolicyRecords(PolicyFilter{AccessorID: "u-professional"})
-	if err != nil || len(reloadedRecords) != 1 || reloadedRecords[0].ID != id {
-		t.Fatalf("stable identity after reload = %+v, %v; want id %d", reloadedRecords, err, id)
+	if err != nil || len(reloadedRecords) != 1 || reloadedRecords[0].GrantID != id {
+		t.Fatalf("stable identity after reload = %+v, %v; want id %s", reloadedRecords, err, id)
 	}
 }
 
@@ -169,10 +220,10 @@ func TestSameTupleSourcesAreIndependentAndOwnerSaveIsScoped(t *testing.T) {
 		t.Fatalf("source-scoped replacement changed sibling rows: %+v", afterSave)
 	}
 
-	var legacyID uint
+	var legacyID string
 	for _, record := range afterSave {
 		if record.PolicySource == PolicySourceLegacy {
-			legacyID = record.ID
+			legacyID = record.GrantID
 		}
 	}
 	removed, err := e.RevokePolicy(legacyID)
@@ -186,6 +237,124 @@ func TestSameTupleSourcesAreIndependentAndOwnerSaveIsScoped(t *testing.T) {
 	allowed, err := e.Check(user, "resource", "r-1", "view_detail")
 	if err != nil || !allowed {
 		t.Fatalf("revoking legacy removed sibling sources: allowed=%v err=%v", allowed, err)
+	}
+}
+
+func TestSourceSliceReplayPreservesStableGrantIdentity(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	mustNoErr(t, e.SetProfessionalObjectPermissions(
+		"u-1", "resource", "r-1", []string{"view_detail", "modify"}, EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	before, err := e.PolicyRecords(PolicyFilter{
+		AccessorID: "u-1", Object: "resource:r-1", PolicySource: PolicySourceProfessionalRule,
+		AuthoritySource: AuthoritySourceAdminAuthz,
+	})
+	if err != nil || len(before) != 2 {
+		t.Fatalf("initial source slice = %+v, %v; want two", before, err)
+	}
+	mustNoErr(t, e.SetProfessionalObjectPermissions(
+		"u-1", "resource", "r-1", []string{"modify", "view_detail"}, EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	after, err := e.PolicyRecords(PolicyFilter{
+		AccessorID: "u-1", Object: "resource:r-1", PolicySource: PolicySourceProfessionalRule,
+		AuthoritySource: AuthoritySourceAdminAuthz,
+	})
+	if err != nil || len(after) != 2 {
+		t.Fatalf("replayed source slice = %+v, %v; want two", after, err)
+	}
+	for i := range before {
+		if before[i].GrantID != after[i].GrantID || !before[i].CreatedAt.Equal(after[i].CreatedAt) {
+			t.Fatalf("source replay replaced stable grant: before=%+v after=%+v", before, after)
+		}
+	}
+}
+
+func TestIdenticalTupleGrantIDsRemainIndependentUntilFinalRevoke(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e, db := newTestEnforcerDB(t)
+	base := PolicyGrant{
+		AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail", Effect: EffectAllow,
+		PolicySource: PolicySourceProfessionalRule, AuthoritySource: AuthoritySourceAdminAuthz,
+		CreatedBy: "admin-1",
+	}
+	first := base
+	first.GrantID = "grant-1"
+	second := base
+	second.GrantID = "grant-2"
+
+	created, err := e.GrantPolicy(t.Context(), first)
+	if err != nil || !created {
+		t.Fatalf("GrantPolicy(first) = %v, %v; want created", created, err)
+	}
+	created, err = e.GrantPolicy(t.Context(), first)
+	if err != nil || created {
+		t.Fatalf("GrantPolicy(first replay) = %v, %v; want idempotent no-op", created, err)
+	}
+	created, err = e.GrantPolicy(t.Context(), second)
+	if err != nil || !created {
+		t.Fatalf("GrantPolicy(second) = %v, %v; want created", created, err)
+	}
+	records, err := e.PolicyRecords(PolicyFilter{AccessorID: base.AccessorID, Object: base.Object})
+	if err != nil || len(records) != 2 {
+		t.Fatalf("independent grants = %+v, %v; want two", records, err)
+	}
+	var projections int64
+	if err := db.Table("casbin_rule").Where(
+		"ptype = ? AND v0 = ? AND v1 = ? AND v2 = ? AND v3 = ? AND v4 = ? AND v5 = ?",
+		"p", base.AccessorID, base.Object, base.Operation, base.Effect,
+		base.PolicySource, base.AuthoritySource,
+	).Count(&projections).Error; err != nil || projections != 1 {
+		t.Fatalf("shared projection count = %d, %v; want one", projections, err)
+	}
+
+	removed, err := e.RevokePolicy(first.GrantID)
+	if err != nil || !removed {
+		t.Fatalf("RevokePolicy(first) = %v, %v; want true", removed, err)
+	}
+	allowed, err := e.Check(base.AccessorID, "resource", "r-1", base.Operation)
+	if err != nil || !allowed {
+		t.Fatalf("sibling grant did not preserve access: allowed=%v err=%v", allowed, err)
+	}
+	if err := db.Table("casbin_rule").Where("ptype = ? AND v0 = ? AND v1 = ?", "p", base.AccessorID, base.Object).
+		Count(&projections).Error; err != nil || projections != 1 {
+		t.Fatalf("projection after first revoke = %d, %v; want one", projections, err)
+	}
+
+	removed, err = e.RevokePolicy(second.GrantID)
+	if err != nil || !removed {
+		t.Fatalf("RevokePolicy(second) = %v, %v; want true", removed, err)
+	}
+	allowed, err = e.Check(base.AccessorID, "resource", "r-1", base.Operation)
+	if err != nil || allowed {
+		t.Fatalf("final revoke did not remove access: allowed=%v err=%v", allowed, err)
+	}
+	if err := db.Table("casbin_rule").Where("ptype = ? AND v0 = ? AND v1 = ?", "p", base.AccessorID, base.Object).
+		Count(&projections).Error; err != nil || projections != 0 {
+		t.Fatalf("projection after final revoke = %d, %v; want zero", projections, err)
+	}
+}
+
+func TestGrantIDCannotBeReusedForAnotherPolicy(t *testing.T) {
+	useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+	grant := PolicyGrant{
+		GrantID: "grant-1", AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail",
+		Effect: EffectAllow, PolicySource: PolicySourceProfessionalRule,
+		AuthoritySource: AuthoritySourceAdminAuthz, CreatedBy: "admin-1",
+	}
+	created, err := e.GrantPolicy(t.Context(), grant)
+	if err != nil || !created {
+		t.Fatalf("GrantPolicy() = %v, %v; want created", created, err)
+	}
+	grant.Object = "resource:r-2"
+	created, err = e.GrantPolicy(t.Context(), grant)
+	if err == nil || created {
+		t.Fatalf("conflicting GrantPolicy() = %v, %v; want rejected", created, err)
+	}
+	allowed, checkErr := e.Check("u-1", "resource", "r-1", "view_detail")
+	if checkErr != nil || !allowed {
+		t.Fatalf("conflict changed original grant: allowed=%v err=%v", allowed, checkErr)
 	}
 }
 

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -43,6 +43,15 @@ func (tx *PolicyTransaction) HasObjectPermission(accessorID, resourceType, resou
 	return len(activePolicyRows(rows)) > 0, nil
 }
 
+func (tx *PolicyTransaction) GrantPolicy(grant PolicyGrant) (bool, error) {
+	return tx.enforcer.addPolicyGrant(grant)
+}
+
+func (tx *PolicyTransaction) RevokePolicy(grantID string) (bool, error) {
+	removed, _, err := tx.enforcer.revokePolicyGrant(grantID)
+	return removed, err
+}
+
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
 	return tx.enforcer.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
 		PolicySourceSystemDerived, AuthoritySourceSystem)

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -52,6 +52,19 @@ func (tx *PolicyTransaction) RevokePolicy(grantID string) (bool, error) {
 	return removed, err
 }
 
+// GrantSeedPolicy and RemoveSeedRolePermissions let startup reconcile the
+// complete built-in role matrix in two batch transactions rather than opening
+// and reloading Casbin once per operation.
+func (tx *PolicyTransaction) GrantSeedPolicy(roleID, object, operation string) error {
+	return tx.enforcer.addPolicy(roleID, object, operation, EffectAllow,
+		PolicySourceRolePermission, AuthoritySourceSystem)
+}
+
+func (tx *PolicyTransaction) RemoveSeedRolePermissions(roleID string) error {
+	_, err := tx.enforcer.removePolicyGrants(PolicyFilter{AccessorID: roleID})
+	return err
+}
+
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
 	return tx.enforcer.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
 		PolicySourceSystemDerived, AuthoritySourceSystem)

--- a/bkn-safe/server/internal/authz/transaction_test.go
+++ b/bkn-safe/server/internal/authz/transaction_test.go
@@ -5,6 +5,7 @@
 package authz
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -61,6 +62,41 @@ func TestPolicyTransactionSerializesOrdinaryPolicyWrites(t *testing.T) {
 		if err != nil || !allowed {
 			t.Fatalf("Check(%q, %q, %q) = %v, %v", check.accessor, check.resource, check.operation, allowed, err)
 		}
+	}
+}
+
+func TestPolicyTransactionRollsBackGrantIdentityAndProjectionTogether(t *testing.T) {
+	e, db := newTestEnforcerDB(t)
+	rollback := errors.New("force rollback")
+	grant := PolicyGrant{
+		GrantID: "grant-rollback", AccessorID: "u-1", Object: "resource:r-1", Operation: "view_detail",
+		Effect: EffectAllow, PolicySource: PolicySourceProfessionalRule,
+		AuthoritySource: AuthoritySourceAdminAuthz, CreatedBy: "admin-1",
+	}
+	err := e.Transaction(t.Context(), func(tx *PolicyTransaction) error {
+		created, err := tx.GrantPolicy(grant)
+		if err != nil || !created {
+			t.Fatalf("transactional GrantPolicy() = %v, %v; want created", created, err)
+		}
+		return rollback
+	})
+	if !errors.Is(err, rollback) {
+		t.Fatalf("Transaction() error = %v, want rollback", err)
+	}
+	var grants, projections int64
+	if err := db.Table("authorization_grant").Where("grant_id = ?", grant.GrantID).Count(&grants).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Table("casbin_rule").Where("ptype = ? AND v0 = ? AND v1 = ?", "p", grant.AccessorID, grant.Object).
+		Count(&projections).Error; err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 || projections != 0 {
+		t.Fatalf("rolled-back state: grants=%d projections=%d; want both zero", grants, projections)
+	}
+	allowed, checkErr := e.Check("u-1", "resource", "r-1", "view_detail")
+	if checkErr != nil || allowed {
+		t.Fatalf("rolled-back grant visible: allowed=%v err=%v", allowed, checkErr)
 	}
 }
 

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -4,8 +4,9 @@
 
 // Package model holds bkn-safe's GORM domain model. This is a CLEAN redesign
 // (not the ISF schema): users/credentials/departments/groups/roles/memberships
-// plus the resource-type + operation catalog. Casbin policies live in the
-// adapter's own table (casbin_rule), not here.
+// plus the resource-type + operation catalog. Casbin's matcher projection lives
+// in the adapter-owned casbin_rule table; AuthorizationGrant is the durable
+// identity and provenance of each independently managed grant.
 package model
 
 import "time"
@@ -143,6 +144,26 @@ type ProxyGrantAuditLog struct {
 }
 
 func (ProxyGrantAuditLog) TableName() string { return "proxy_grant_audit_log" }
+
+// AuthorizationGrant is the authoritative Core grant record. Several rows may
+// intentionally carry the same authorization tuple: grant_id identifies the
+// independently managed source, while Casbin needs only one projection of that
+// tuple for runtime matching. A revoke deletes the shared projection only after
+// the final matching grant row disappears.
+type AuthorizationGrant struct {
+	GrantID         string `json:"grant_id" gorm:"primaryKey;size:64"`
+	AccessorID      string `json:"accessor_id" gorm:"size:64;index:idx_authorization_grant_tuple,priority:1"`
+	Object          string `json:"object" gorm:"size:255;index:idx_authorization_grant_tuple,priority:2"`
+	Operation       string `json:"operation" gorm:"size:64;index:idx_authorization_grant_tuple,priority:3"`
+	Effect          string `json:"effect" gorm:"size:16;index:idx_authorization_grant_tuple,priority:4"`
+	PolicySource    string `json:"policy_source" gorm:"size:32;index:idx_authorization_grant_tuple,priority:5"`
+	AuthoritySource string `json:"authority_source" gorm:"size:32;index:idx_authorization_grant_tuple,priority:6"`
+	CreatedBy       string `json:"created_by" gorm:"size:64;index"`
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+func (AuthorizationGrant) TableName() string { return "authorization_grant" }
 
 // Role source values. system|business roles are SEEDED built-ins (their UUIDs
 // are hardcoded in DA/flow-automation, such as application, data, and AI administrators) and are
@@ -358,6 +379,6 @@ func AllModels() []any {
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
 		&AuditLog{}, &AccessLog{}, &APIKey{}, &License{}, &ResourceParent{},
 		&ManagedProxyAccount{}, &ProxyGrantSource{}, &ProxyGrantPolicy{},
-		&ProxyGrantAuditLog{},
+		&ProxyGrantAuditLog{}, &AuthorizationGrant{},
 	}
 }

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -149,15 +149,18 @@ func (ProxyGrantAuditLog) TableName() string { return "proxy_grant_audit_log" }
 // intentionally carry the same authorization tuple: grant_id identifies the
 // independently managed source, while Casbin needs only one projection of that
 // tuple for runtime matching. A revoke deletes the shared projection only after
-// the final matching grant row disappears.
+// the final matching grant row disappears. ProjectionKey is a fixed-width hash
+// used only to narrow exact-tuple lookups; the query still verifies every tuple
+// field, so correctness never depends on hash uniqueness.
 type AuthorizationGrant struct {
 	GrantID         string `json:"grant_id" gorm:"primaryKey;size:64"`
-	AccessorID      string `json:"accessor_id" gorm:"size:64;index:idx_authorization_grant_tuple,priority:1"`
-	Object          string `json:"object" gorm:"size:255;index:idx_authorization_grant_tuple,priority:2"`
-	Operation       string `json:"operation" gorm:"size:64;index:idx_authorization_grant_tuple,priority:3"`
-	Effect          string `json:"effect" gorm:"size:16;index:idx_authorization_grant_tuple,priority:4"`
-	PolicySource    string `json:"policy_source" gorm:"size:32;index:idx_authorization_grant_tuple,priority:5"`
-	AuthoritySource string `json:"authority_source" gorm:"size:32;index:idx_authorization_grant_tuple,priority:6"`
+	ProjectionKey   string `json:"projection_key" gorm:"size:64;index"`
+	AccessorID      string `json:"accessor_id" gorm:"size:64;index:idx_authorization_grant_scope,priority:1"`
+	Object          string `json:"object" gorm:"size:255"`
+	Operation       string `json:"operation" gorm:"size:64"`
+	Effect          string `json:"effect" gorm:"size:16;index:idx_authorization_grant_scope,priority:2"`
+	PolicySource    string `json:"policy_source" gorm:"size:32;index:idx_authorization_grant_scope,priority:3"`
+	AuthoritySource string `json:"authority_source" gorm:"size:32;index:idx_authorization_grant_scope,priority:4"`
 	CreatedBy       string `json:"created_by" gorm:"size:64;index"`
 	CreatedAt       time.Time
 	UpdatedAt       time.Time

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -136,7 +136,7 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := ReconcileWithdrawnNormalUserRole(db, enforcer); err != nil {
 		return fmt.Errorf("reconcile withdrawn normal user role: %w", err)
 	}
-	if err := reconcileSeedRoles(db, enforcer); err != nil {
+	if err := reconcileSeedRoles(enforcer); err != nil {
 		return fmt.Errorf("reconcile seed roles: %w", err)
 	}
 	if err := renameLegacyOperations(enforcer); err != nil {
@@ -293,19 +293,19 @@ func seedRoles(db *gorm.DB) error {
 	}).Create(&rows).Error
 }
 
-func reconcileSeedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
+func reconcileSeedRoles(enforcer *authz.Enforcer) error {
 	var roles []roleSeed
 	if err := json.Unmarshal(rolesJSON, &roles); err != nil {
 		return err
 	}
-
-	for _, r := range roles {
-		if err := enforcer.RemoveRolePermissions(r.ID); err != nil {
-			return err
+	return enforcer.Transaction(context.Background(), func(tx *authz.PolicyTransaction) error {
+		for _, r := range roles {
+			if err := tx.RemoveSeedRolePermissions(r.ID); err != nil {
+				return err
+			}
 		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func seedCatalog(db *gorm.DB) error {
@@ -632,22 +632,23 @@ func seedGrants(enforcer *authz.Enforcer) error {
 	if err := json.Unmarshal(grantsJSON, &g); err != nil {
 		return err
 	}
-	for _, gr := range g.Grants {
-		// Build the object pattern. Empty resource_type => a pure wildcard
-		// object (e.g. "*"), used for the super-admin "do everything" grant;
-		// otherwise "type:idPattern".
-		obj := gr.ResourceType + ":" + gr.IDPattern
-		if gr.ResourceType == "" {
-			obj = gr.IDPattern
-		}
-		for _, op := range gr.Operations {
-			// AddPolicy is idempotent (no-op if the rule already exists).
-			if err := enforcer.Grant(gr.RoleID, obj, op); err != nil {
-				return err
+	return enforcer.Transaction(context.Background(), func(tx *authz.PolicyTransaction) error {
+		for _, gr := range g.Grants {
+			// Build the object pattern. Empty resource_type => a pure wildcard
+			// object (e.g. "*"), used for the super-admin "do everything" grant;
+			// otherwise "type:idPattern".
+			object := gr.ResourceType + ":" + gr.IDPattern
+			if gr.ResourceType == "" {
+				object = gr.IDPattern
+			}
+			for _, operation := range gr.Operations {
+				if err := tx.GrantSeedPolicy(gr.RoleID, object, operation); err != nil {
+					return err
+				}
 			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 // seedRoleBindings binds accessors (users/apps) to roles via Casbin's grouping


### PR DESCRIPTION
## What Changed

Brief description of changes:

- [x] Add an authoritative `authorization_grant` model with stable grant IDs, provenance, creator, and audit timestamps
- [x] Keep independently owned grants for identical policy tuples while sharing one Casbin runtime projection
- [x] Make grant creation, scoped replacement, revocation, and Casbin projection updates transactional
- [x] Add startup consistency checks and focused regression coverage for independent revocation and rollback
- [ ] Docs/doc 1 — Not applicable; this PR implements the approved authorization design

---

## Why

- Related Issue: Closes #1445
- Related Feature: Edition-aware authorization boundaries
- Background: Casbin adapter row IDs identify runtime projections, not independently managed grant sources. Stable grant identities are required so one source can be replaced or revoked without deleting a sibling source with the same semantic policy.

---

## How

- Key implementation points:
  - Persist every Core grant in `authorization_grant`, keyed by `grant_id`
  - Derive deterministic IDs for compatibility writers while exposing an explicit source-aware grant API
  - Materialize one Casbin row per exact policy tuple and remove it only after the final matching grant disappears
  - Preserve unchanged grant IDs and creation timestamps during source-scoped whole-set replacement
  - Validate the metadata/projection invariant before loading Casbin
- Breaking changes (API, config, database, etc.):
  - Adds the `authorization_grant` table
  - Existing non-empty policy stores require the coordinated offline backfill before this version starts; partially migrated stores fail closed with `ErrPolicySourceMigrationRequired`

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment — Not run locally

Test notes:

- `go test ./internal/authz`
- `go test ./internal/proxygrant`
- `go test ./internal/seed`
- `go test ./internal/httpapi`
- `git diff --check`

---

## Risk & Rollback

- Potential risks:
  - Startup intentionally fails when legacy Casbin rows have not been backfilled with stable grant metadata
  - Grant mutations now update metadata and Casbin projection in one transaction and reload the live policy cache after commit
- Rollback plan:
  - Roll back the application binary to the previous version; the additive `authorization_grant` table can remain unused
  - If rollout has not started, do not run the offline backfill until the matching application version is ready

---

## Additional Notes

- Production data migration is intentionally out of scope for this issue and remains owned by the separate offline migration task.
