### PR TITLE
fix(mf-model-manager): allow empty model overview

### DIFF
--- a/infra/mf-model-manager/app/controller/llm_controller.py
+++ b/infra/mf-model-manager/app/controller/llm_controller.py
@@ -1114,17 +1114,15 @@ async def get_overview_data(userId, language, model_id, start_time, end_time, ro
                 if not await permission_manager.check_display(userId, role, "large_model", model_id):
                     return JSONResponse(status_code=403, content=NotPermissionError)
             else:
-                # authorized is an admission check for at least one model, preventing a misleading zero overview.
-                # The aggregate is not narrowed to the authorized model set; the DAO filters by caller.
-                # Non-admin queries add d.f_user_id='{userId}' in llm_model_dao.
-                # The overview aggregates the caller's own cross-model usage and does not expose other users.
-                # Lists are grant-filtered, while overviews are caller-filtered.
                 candidate_ids = [m['f_model_id'] for m in llm_model_dao.get_all_model_list()]
-                authorized = await permission_manager.filter_authorized_ids(
-                    user_id=userId, role=role, candidate_ids=candidate_ids,
-                    resource_type="large_model", resource_name="大模型", operation="display")
-                if not authorized:
-                    return JSONResponse(status_code=403, content=NotPermissionError)
+                # An empty inventory has no model data to protect. Return the empty overview
+                # instead of treating the absence of candidate IDs as an authorization failure.
+                if candidate_ids:
+                    authorized = await permission_manager.filter_authorized_ids(
+                        user_id=userId, role=role, candidate_ids=candidate_ids,
+                        resource_type="large_model", resource_name="大模型", operation="display")
+                    if not authorized:
+                        return JSONResponse(status_code=403, content=NotPermissionError)
         if not start_time:
             error_dict = error_with_message(
                 ModelFactory_Router_ParamError_ParamMissing_Error,

--- a/infra/mf-model-manager/app/test/test_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_model_controller.py
@@ -690,10 +690,31 @@ class TestEditDefaultModel(TestCase):
 class TestModelOverviewData(TestCase):
     def setUp(self) -> None:
         self.get_overview_data = llm_model_dao.get_overview_data
+        self.get_all_model_list = llm_model_dao.get_all_model_list
+        self.filter_authorized_ids = llm_controller.permission_manager.filter_authorized_ids
+        self.auth_enabled = llm_controller.base_config.AUTH_ENABLED
 
     def tearDown(self) -> None:
         llm_model_dao.get_overview_data = self.get_overview_data
+        llm_model_dao.get_all_model_list = self.get_all_model_list
+        llm_controller.permission_manager.filter_authorized_ids = self.filter_authorized_ids
+        llm_controller.base_config.AUTH_ENABLED = self.auth_enabled
         StandLogger.stand_log_shutdown()
+
+    def test_get_overview_data_allows_empty_model_inventory(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        llm_controller.base_config.AUTH_ENABLED = True
+        llm_model_dao.get_all_model_list = mock.Mock(return_value=[])
+        llm_model_dao.get_overview_data = mock.Mock(return_value=([], [], []))
+        llm_controller.permission_manager.filter_authorized_ids = mock.AsyncMock()
+
+        res = loop.run_until_complete(
+            llm_controller.get_overview_data("ordinary-user", "zh", "", "2026-07-13", "2026-07-14"))
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(json.loads(res.body)["summary"], {})
+        llm_controller.permission_manager.filter_authorized_ids.assert_not_awaited()
 
     def test_get_overview_data_rejects_reversed_date_range(self):
         loop = asyncio.new_event_loop()


### PR DESCRIPTION
# Pull Request

## What Changed

- [x] Fix `mf-model-manager` monitoring overview authorization for an empty large-model inventory.
- [x] Add regression coverage for the empty-inventory scenario.
- [ ] Docs/doc 1 — Not applicable.

---

## Why

- Related Issue: Not applicable.
- Related Feature: Model monitoring overview.
- Background: A non-administrator requesting `GET /v1/llm/monitor/overview` received `403` when no large models existed. An empty candidate model list was incorrectly treated as “no display permission”.

---

## How

- Skip model-level authorization filtering when the large-model inventory is empty, and return the existing empty overview response.
- Keep the existing `403` behavior when models exist but the caller has no `large_model:display` permission.
- Preserve selected-model permission validation.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally — Blocked by missing local Python dependency: `sse_starlette`.
- [ ] Integration tests passed locally — Not run.
- [ ] Verified in test environment — Not run.

Test notes:

- Added `test_get_overview_data_allows_empty_model_inventory`.
- `python3 -m py_compile app/controller/llm_controller.py app/test/test_model_controller.py` passed.
- `git diff --check` passed.
- `python3 -m pytest app/test/test_model_controller.py::TestModelOverviewData -q` could not start because `sse_starlette` is not installed in the local environment.

---

## Risk & Rollback

- Potential risks: Users without model permissions can access only an empty overview when no large models are configured; no model data is exposed.
- Rollback plan: Revert commit `3702f968`.

---

## Additional Notes

- Branch: `fix/model-overview-empty-inventory`
- Commit: `3702f968 fix(mf-model-manager): allow empty model overview`