### PR TITLE
fix(mf-model-manager): allow private model reads

### DIFF
--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -307,15 +307,16 @@ async def get_info_list(order, rule, page, size, model_name, model_type, model_s
         return JSONResponse(status_code=400, content=error_dict)
 
 
-async def get_info(model_id, user_id, role):
+async def get_info(model_id, user_id, role, private=False):
     try:
         try:
-            permission = await permission_manager.check_single_permission(user_id=user_id, resource_id=model_id,
-                                                                          operations="display",
-                                                                          resource_type="small_model",
-                                                                          role=role)
-            if not permission:
-                return JSONResponse(status_code=403, content=NotPermissionError)
+            if not private:
+                permission = await permission_manager.check_single_permission(user_id=user_id, resource_id=model_id,
+                                                                              operations="display",
+                                                                              resource_type="small_model",
+                                                                              role=role)
+                if not permission:
+                    return JSONResponse(status_code=403, content=NotPermissionError)
             original_res = small_model_dao.get_model_info_by_id(model_id)
         except Exception as e:
             StandLogger.error(ModelFactory_MyPymysqlPool_Connection_ConnectError_Error["description"])

--- a/infra/mf-model-manager/app/controller/small_model_controller.py
+++ b/infra/mf-model-manager/app/controller/small_model_controller.py
@@ -307,10 +307,10 @@ async def get_info_list(order, rule, page, size, model_name, model_type, model_s
         return JSONResponse(status_code=400, content=error_dict)
 
 
-async def get_info(model_id, user_id, role, private=False):
+async def get_info(model_id, user_id, role, trusted_app=False):
     try:
         try:
-            if not private:
+            if not trusted_app:
                 permission = await permission_manager.check_single_permission(user_id=user_id, resource_id=model_id,
                                                                               operations="display",
                                                                               resource_type="small_model",

--- a/infra/mf-model-manager/app/routers/private_route.py
+++ b/infra/mf-model-manager/app/routers/private_route.py
@@ -286,7 +286,7 @@ async def delete_model(request: Request, model_para: dict = Body(...)):
 @private_route.get("/small-model/get")
 async def get_info(request: Request, model_id):
     userId, language, role = await get_user_info(request)
-    return await small_model_controller.get_info(model_id, userId, role, private=True)
+    return await small_model_controller.get_info(model_id, userId, role, trusted_app=(role == "app"))
 
 
 @private_route.get("/small-model/list")

--- a/infra/mf-model-manager/app/routers/private_route.py
+++ b/infra/mf-model-manager/app/routers/private_route.py
@@ -286,7 +286,7 @@ async def delete_model(request: Request, model_para: dict = Body(...)):
 @private_route.get("/small-model/get")
 async def get_info(request: Request, model_id):
     userId, language, role = await get_user_info(request)
-    return await small_model_controller.get_info(model_id, userId, role)
+    return await small_model_controller.get_info(model_id, userId, role, private=True)
 
 
 @private_route.get("/small-model/list")

--- a/infra/mf-model-manager/app/test/test_external_small_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_controller.py
@@ -303,10 +303,48 @@ class TestGetInfoList(TestCase):
 class TestGetInfo(TestCase):
     def setUp(self) -> None:
         self.get_model_info_by_id = small_model_dao.get_model_info_by_id
+        self.check_single_permission = small_model_controller.permission_manager.check_single_permission
 
     def tearDown(self) -> None:
         small_model_dao.get_model_info_by_id = self.get_model_info_by_id
+        small_model_controller.permission_manager.check_single_permission = self.check_single_permission
         StandLogger.stand_log_shutdown()
+
+    @staticmethod
+    def _model_row():
+        return {
+            "f_model_id": "1",
+            "f_model_name": "1",
+            "f_model_type": "embedding",
+            "f_model_config": "{}",
+            "f_create_time": datetime.today(),
+            "f_update_time": datetime.today(),
+            "f_adapter": 0,
+            "f_adapter_code": None,
+            "f_batch_size": 16,
+            "f_max_tokens": 512,
+            "f_embedding_dim": 768,
+            "f_default": 0,
+        }
+
+    def test_get_info_private_skips_display_permission(self):
+        small_model_dao.get_model_info_by_id = mock.Mock(return_value=[self._model_row()])
+        small_model_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=False)
+
+        res = asyncio.run(small_model_controller.get_info("1", "kn-app", "app", private=True))
+
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(json.loads(res.body)["model_id"], "1")
+        small_model_controller.permission_manager.check_single_permission.assert_not_awaited()
+
+    def test_get_info_public_still_requires_display_permission(self):
+        small_model_dao.get_model_info_by_id = mock.Mock(return_value=[self._model_row()])
+        small_model_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=False)
+
+        res = asyncio.run(small_model_controller.get_info("1", "user-1", "user"))
+
+        self.assertEqual(res.status_code, 403)
+        small_model_dao.get_model_info_by_id.assert_not_called()
 
     def test_get_info_success(self):
         loop = asyncio.new_event_loop()

--- a/infra/mf-model-manager/app/test/test_external_small_model_controller.py
+++ b/infra/mf-model-manager/app/test/test_external_small_model_controller.py
@@ -327,15 +327,24 @@ class TestGetInfo(TestCase):
             "f_default": 0,
         }
 
-    def test_get_info_private_skips_display_permission(self):
+    def test_get_info_trusted_app_skips_display_permission(self):
         small_model_dao.get_model_info_by_id = mock.Mock(return_value=[self._model_row()])
         small_model_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=False)
 
-        res = asyncio.run(small_model_controller.get_info("1", "kn-app", "app", private=True))
+        res = asyncio.run(small_model_controller.get_info("1", "kn-app", "app", trusted_app=True))
 
         self.assertEqual(res.status_code, 200)
         self.assertEqual(json.loads(res.body)["model_id"], "1")
         small_model_controller.permission_manager.check_single_permission.assert_not_awaited()
+
+    def test_get_info_private_user_still_requires_display_permission(self):
+        small_model_dao.get_model_info_by_id = mock.Mock(return_value=[self._model_row()])
+        small_model_controller.permission_manager.check_single_permission = mock.AsyncMock(return_value=False)
+
+        res = asyncio.run(small_model_controller.get_info("1", "user-1", "user", trusted_app=False))
+
+        self.assertEqual(res.status_code, 403)
+        small_model_dao.get_model_info_by_id.assert_not_called()
 
     def test_get_info_public_still_requires_display_permission(self):
         small_model_dao.get_model_info_by_id = mock.Mock(return_value=[self._model_row()])


### PR DESCRIPTION
Bypass display authorization only for the private small-model detail endpoint used by trusted service-to-service callers. Keep public model reads and all other model operations unchanged, and add regression coverage.

# Pull Request

## What Changed

- [x] Allow trusted private callers to read a small-model detail without requiring `small_model:display`.
- [x] Keep public small-model detail reads subject to the existing `display` permission check.
- [x] Add regression tests for private allow and public deny behavior.
- [ ] Docs/doc 1 — Not applicable.

---

## Why

- Related Issue: #1415
- Related Feature: Knowledge-network proxy vector search.
- Background: Vega reads the embedding model through the private model-manager endpoint while acting as a KN App. The endpoint incorrectly applied public `small_model:display` authorization, causing otherwise authorized resource queries to fail before embedding execution.

---

## How

- The private `GET /api/private/mf-model-manager/v1/small-model/get` route explicitly marks the request as private.
- `small_model_controller.get_info` skips the `display` authorization check only for this private route.
- The public `/small-model/get` route and all other model APIs retain their existing authorization behavior.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [ ] Unit tests passed locally — Blocked by missing local Python dependency: `fastapi`.
- [ ] Integration tests passed locally — Not run.
- [ ] Verified in test environment — Not run.

Test notes:

- Added coverage that private reads succeed even when `display` would be denied.
- Added coverage that public reads remain `403` when `display` is denied.
- `python3 -m py_compile` passed.
- `git diff --check` passed.
- `python3 -m pytest app/test/test_external_small_model_controller.py::TestGetInfo -q` could not start because `fastapi` is not installed locally.

---

## Risk & Rollback

- Potential risks: Any caller able to reach the trusted private route can read sanitized small-model metadata without a `display` grant. The model API key remains masked.
- Rollback plan: Revert commit `878d8220`.

---

## Additional Notes

- The change relies on `/api/private/...` being restricted to trusted in-cluster service-to-service traffic.
- Branch: `fix/private-model-read-access`
- Commit: `878d8220 fix(mf-model-manager): allow private model reads`