### PR TITLE
fix(cypher): bound the tables a pattern reads, not only its relationships (0.1.4-yf)

### DIFF
--- a/adp/bkn/bkn-backend/server/interfaces/cypher_query_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/cypher_query_service.go
@@ -21,6 +21,13 @@ const (
 	// hold. Each is a join, and the row limit bounds what comes back rather
 	// than what it costs to produce, so the number of joins is bounded here.
 	CYPHER_MAX_PATH_LENGTH = 8
+	// CYPHER_MAX_PATTERN_NODES bounds how many nodes one query's patterns may
+	// hold. Relationships are not the only cost: a node that no relationship
+	// reaches is a table of its own, joined to the rest with nothing to
+	// constrain it, so bounding relationships alone leaves the number of
+	// tables open. Nine is what a path of CYPHER_MAX_PATH_LENGTH
+	// relationships needs.
+	CYPHER_MAX_PATTERN_NODES = CYPHER_MAX_PATH_LENGTH + 1
 )
 
 // CypherQuery is one read-only query against a knowledge network.

--- a/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
@@ -228,6 +228,17 @@ func (b *patternBuilder) addNode(ctx parsing.IOC_NodePatternContext) (int, error
 			"the first mention of a node must name its object type, as in (n:ObjectType)")
 	}
 
+	if len(b.pattern.Nodes) >= interfaces.CYPHER_MAX_PATTERN_NODES {
+		// Every node is a table. One that no relationship reaches is joined to
+		// the rest by nothing at all, so it multiplies the rows the database
+		// walks; an aggregate then leaves the trailing LIMIT with nothing to
+		// cut. The relationship bound above does not see those nodes, so the
+		// count of tables is bounded here.
+		return 0, unsupportedf(ctx, "a pattern this large",
+			"a pattern may name at most %d nodes",
+			interfaces.CYPHER_MAX_PATTERN_NODES)
+	}
+
 	index := len(b.pattern.Nodes)
 	b.pattern.Nodes = append(b.pattern.Nodes, *node)
 	if node.Variable != "" {

--- a/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
@@ -501,6 +501,33 @@ func TestCompileRefusesAVeryLargePattern(t *testing.T) {
 	}
 }
 
+// Relationships are not the only cost. A node that no relationship reaches is
+// a table joined to the rest by nothing, and an aggregate leaves the trailing
+// LIMIT with nothing to cut, so the tables have to be bounded too.
+func TestCompileRefusesTooManyNodes(t *testing.T) {
+	query := "MATCH (n0:Order)"
+	for i := 1; i <= interfaces.CYPHER_MAX_PATTERN_NODES; i++ {
+		query += ", (:Order)"
+	}
+	query += " RETURN count(*) AS n"
+
+	_, err := compile(t, query, GenerateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "a pattern this large") {
+		t.Fatalf("compile = %v, want a rejection naming the pattern size", err)
+	}
+
+	// The bound is on the tables, not on how the query is written: a path of
+	// the longest allowed length names exactly CYPHER_MAX_PATTERN_NODES nodes
+	// and still compiles.
+	longest := "MATCH (n0:Order)"
+	for i := 1; i <= interfaces.CYPHER_MAX_PATH_LENGTH; i++ {
+		longest += fmt.Sprintf("-[:FOLLOWS]->(n%d:Order)", i)
+	}
+	if _, err := compile(t, longest+" RETURN n0.id", GenerateOptions{}); err != nil {
+		t.Fatalf("compile(longest allowed path) = %v, want it accepted", err)
+	}
+}
+
 // A variable written twice is one node, whether the second mention is in
 // another comma-separated path or in another MATCH. That is what lets a query
 // describe a shape that is not a single chain: one node with two

--- a/docs/api/bkn/cypher-queries.yaml
+++ b/docs/api/bkn/cypher-queries.yaml
@@ -158,9 +158,11 @@ components:
             is enforced: every pair of hops over one relation type must differ in its source
             row or its target row, which needs those object types to have a primary key.
             Where one of the hops is undirected the requirement cannot be stated, and the
-            query is refused rather than answered with paths Cypher would not return. One pattern
-            may hold at most eight relationships, because each one is a join and the row
-            limit bounds what comes back rather than what it costs to produce.
+            query is refused rather than answered with paths Cypher would not return. One query's patterns
+            may hold at most eight relationships and nine nodes, because each relationship is
+            a join and each node is a table -- one that no relationship reaches is joined to
+            the rest by nothing -- and the row limit bounds what comes back rather than what
+            it costs to produce.
           example: "MATCH (o:order)-[:rel_order_item_order]->(i:order_item) WHERE o.status IN ['paid', 'shipped'] AND o.amount > $floor RETURN o.status AS status, count(*) AS orders ORDER BY orders DESC LIMIT 20"
     CypherQueryResult:
       type: object


### PR DESCRIPTION
Cherry-pick of the fix that landed on main with #1451, for the same hole on this line (#1447).

## The hole

The pattern size limit counted relationships only. A node that no relationship reaches is never counted, and each one is a table: the generator finds nothing to join it on and writes a `CROSS JOIN`. Reproduced on this branch before fixing:

```
MATCH (n0:Order), (:Order) x40 RETURN count(*) AS n
→ 41 tables in one FROM, 40 CROSS JOINs
```

An aggregate leaves the trailing `LIMIT` with nothing to cut, so the database walks the whole product. Every `, (:Order)` costs nine bytes of an 8192-byte query, so this reaches thousands of tables.

Confirmed live on the dev VM against the merged 0.1.4-yf build: `MATCH (t:teams), (:teams), (:teams) RETURN count(*)` answered `681472` — 88³, the cube of the team count.

## The fix

Bound the nodes directly, at `CYPHER_MAX_PATTERN_NODES = CYPHER_MAX_PATH_LENGTH + 1 = 9` — what a path of the longest allowed length needs. Comma-separated paths and several MATCH clauses are what made this reachable: before them a node could only enter the pattern behind a relationship, so bounding relationships bounded the tables too.

The regression test asserts both directions: too many nodes is refused, and the longest allowed path — exactly nine nodes — still compiles. The API contract states both limits.

## Testing

`go build ./...` and `go test ./logics/cypher/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)