### PR TITLE
fix(authz): remove retired resource types

### DIFF
--- a/bkn-safe/server/internal/authz/community_bundle.go
+++ b/bkn-safe/server/internal/authz/community_bundle.go
@@ -14,22 +14,15 @@ import "fmt"
 // Keep the slice order stable. It is used by permission-read projections and
 // therefore becomes the order returned to API consumers.
 var communityBundleOperations = map[string][]string{
-	"catalog":              {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
-	"knowledge_network":    {"view_detail", "modify", "delete", "query_data", "execute"},
-	"stream_data_pipeline": {"view_detail", "modify", "delete", "query_data"},
-	"connector_type":       {"view_detail", "modify", "delete", "task_manage"},
-	"tool_box":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
-	"mcp":                  {"view", "modify", "delete", "publish", "unpublish", "execute"},
-	"operator":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
-	"skill":                {"view", "modify", "delete", "publish", "unpublish", "execute"},
-	"small_model":          {"display", "modify", "delete", "execute"},
-	"large_model":          {"display", "modify", "delete", "execute"},
-	"agent": {
-		"use", "publish", "unpublish", "publish_to_be_skill_agent",
-		"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
-		"publish_to_be_data_flow_agent", "see_trajectory_analysis",
-	},
-	"agent_tpl": {"publish", "unpublish"},
+	"catalog":           {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
+	"knowledge_network": {"view_detail", "modify", "delete", "query_data", "execute"},
+	"connector_type":    {"view_detail", "modify", "delete", "task_manage"},
+	"tool_box":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"mcp":               {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"operator":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"skill":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+	"small_model":       {"display", "modify", "delete", "execute"},
+	"large_model":       {"display", "modify", "delete", "execute"},
 }
 
 // CommunityBundleOperations returns a copy of the reviewed operation whitelist

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -16,22 +16,15 @@ import (
 
 func TestCommunityBundleWhitelistIsExplicitAndDefensive(t *testing.T) {
 	want := map[string][]string{
-		"catalog":              {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
-		"knowledge_network":    {"view_detail", "modify", "delete", "query_data", "execute"},
-		"stream_data_pipeline": {"view_detail", "modify", "delete", "query_data"},
-		"connector_type":       {"view_detail", "modify", "delete", "task_manage"},
-		"tool_box":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
-		"mcp":                  {"view", "modify", "delete", "publish", "unpublish", "execute"},
-		"operator":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
-		"skill":                {"view", "modify", "delete", "publish", "unpublish", "execute"},
-		"small_model":          {"display", "modify", "delete", "execute"},
-		"large_model":          {"display", "modify", "delete", "execute"},
-		"agent": {
-			"use", "publish", "unpublish", "publish_to_be_skill_agent",
-			"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
-			"publish_to_be_data_flow_agent", "see_trajectory_analysis",
-		},
-		"agent_tpl": {"publish", "unpublish"},
+		"catalog":           {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
+		"knowledge_network": {"view_detail", "modify", "delete", "query_data", "execute"},
+		"connector_type":    {"view_detail", "modify", "delete", "task_manage"},
+		"tool_box":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"mcp":               {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"operator":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"skill":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
+		"small_model":       {"display", "modify", "delete", "execute"},
+		"large_model":       {"display", "modify", "delete", "execute"},
 	}
 	for resourceType, expected := range want {
 		got, ok := CommunityBundleOperations(resourceType)

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -392,6 +392,26 @@ func (en *Enforcer) removePolicyGrants(filter PolicyFilter) (int, error) {
 	return removedProjections, nil
 }
 
+func (en *Enforcer) removePolicyGrantsByObjectPrefix(prefix string) (int, error) {
+	var rows []safemodel.AuthorizationGrant
+	if err := en.db.Model(&safemodel.AuthorizationGrant{}).
+		Where("object LIKE ?", prefix+"%").
+		Order("grant_id").Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	removedProjections := 0
+	for _, row := range rows {
+		_, projectionRemoved, err := en.revokePolicyGrant(row.GrantID)
+		if err != nil {
+			return removedProjections, err
+		}
+		if projectionRemoved {
+			removedProjections++
+		}
+	}
+	return removedProjections, nil
+}
+
 func (en *Enforcer) replacePolicyGrantSlice(filter PolicyFilter, desired []PolicyGrant) error {
 	var existing []safemodel.AuthorizationGrant
 	if err := applyPolicyFilter(en.db.Model(&safemodel.AuthorizationGrant{}), filter).

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -67,6 +67,21 @@ func (tx *PolicyTransaction) RemoveSeedRolePermissions(roleID string) error {
 	return err
 }
 
+// RemovePoliciesForResourceTypes removes every durable grant and its Casbin
+// projection for the supplied resource-type prefixes. It is reserved for
+// startup migrations that withdraw an entire resource type from the platform.
+func (tx *PolicyTransaction) RemovePoliciesForResourceTypes(resourceTypes ...string) (int, error) {
+	removed := 0
+	for _, resourceType := range resourceTypes {
+		count, err := tx.enforcer.removePolicyGrantsByObjectPrefix(resourceType + ":")
+		if err != nil {
+			return removed, err
+		}
+		removed += count
+	}
+	return removed, nil
+}
+
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
 	return tx.enforcer.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
 		PolicySourceSystemDerived, AuthoritySourceSystem)

--- a/bkn-safe/server/internal/seed/community_bundle_test.go
+++ b/bkn-safe/server/internal/seed/community_bundle_test.go
@@ -28,8 +28,7 @@ func TestCommunityBundleWhitelistOperationsExistInCatalog(t *testing.T) {
 		}
 	}
 	for _, resourceType := range []string{
-		"catalog", "knowledge_network", "stream_data_pipeline", "connector_type",
-		"tool_box", "mcp", "operator", "skill", "small_model", "large_model", "agent", "agent_tpl",
+		"catalog", "knowledge_network", "connector_type", "tool_box", "mcp", "operator", "skill", "small_model", "large_model",
 	} {
 		operations, ok := authz.CommunityBundleOperations(resourceType)
 		if !ok {

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -2,45 +2,6 @@
   "_comment": "Resource-type + operation catalog, extracted from each service's enums/consts (2026-06-03). Exact op id strings are the seed source of truth. NOTE: 'view' (exec-factory, flow-automation) and 'view_detail' (vega/bkn/pipeline) are DIFFERENT op strings and are not normalized. Role-to-permission grants are maintained in grants.json for the Studio 0.1.0 role model.",
   "resource_types": [
     {
-      "id": "agent",
-      "name": "数据智能体",
-      "operations": [
-        {"id": "use", "name": "使用Agent"},
-        {"id": "publish", "name": "发布Agent"},
-        {"id": "unpublish", "name": "取消发布Agent"},
-        {"id": "unpublish_other_user_agent", "name": "取消发布其他用户的Agent"},
-        {"id": "publish_to_be_skill_agent", "name": "发布为技能Agent"},
-        {"id": "publish_to_be_web_sdk_agent", "name": "发布为Web SDK Agent"},
-        {"id": "publish_to_be_api_agent", "name": "发布为API Agent"},
-        {"id": "publish_to_be_data_flow_agent", "name": "发布为数据流Agent"},
-        {"id": "create_system_agent", "name": "创建系统Agent"},
-        {"id": "mgnt_built_in_agent", "name": "内置Agent管理"},
-        {"id": "see_trajectory_analysis", "name": "查看轨迹分析"}
-      ]
-    },
-    {
-      "id": "agent_tpl",
-      "name": "数据智能体模板",
-      "operations": [
-        {"id": "publish", "name": "发布Agent模板"},
-        {"id": "unpublish", "name": "取消发布Agent模板"},
-        {"id": "unpublish_other_user_agent_tpl", "name": "取消发布其他用户Agent模板"}
-      ]
-    },
-    {
-      "id": "stream_data_pipeline",
-      "name": "流式数据管道",
-      "_source": "pipeline-mgmt",
-      "operations": [
-        {"id": "view_detail", "name": "查看详情"},
-        {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
-        {"id": "authorize", "name": "授权"},
-        {"id": "query_data", "name": "数据查询"}
-      ]
-    },
-    {
       "id": "catalog",
       "name": "数据目录",
       "_source": "vega",

--- a/bkn-safe/server/internal/seed/hierarchy_test.go
+++ b/bkn-safe/server/internal/seed/hierarchy_test.go
@@ -201,8 +201,8 @@ func TestValidateHierarchyAcceptsShippedCatalog(t *testing.T) {
 	}
 }
 
-// TestSeedMigratesLegacyOperationSpelling: 知识网络与流式数据管道上的「数据查询」
-// 原本拼作 data_query，而目录/资源侧是 query_data。统一成后者时，角色授权会随种子
+// TestSeedMigratesLegacyOperationSpelling: 知识网络上的「数据查询」原本拼作
+// data_query，而目录/资源侧是 query_data。统一成后者时，角色授权会随种子
 // 重建自动跟上，但管理员在**单个对象**上发过的授权带的还是旧拼写——不迁移的话，
 // 用户的体验是「我发过的权限凭空消失了」。
 func TestSeedMigratesLegacyOperationSpelling(t *testing.T) {
@@ -214,7 +214,6 @@ func TestSeedMigratesLegacyOperationSpelling(t *testing.T) {
 	// 升级前的对象级授权：管理员在某个知识网络上发过 data_query。
 	const user = "u-1"
 	mustNoErrSeed(t, e.GrantObjectPermission(user, "knowledge_network", "kn-1", "data_query"))
-	mustNoErrSeed(t, e.GrantObjectPermission(user, "stream_data_pipeline", "p-1", "data_query"))
 	// 同名但不同类型的授权不该被动到：catalog 侧从来就叫 query_data。
 	mustNoErrSeed(t, e.GrantObjectPermission(user, "catalog", "c-1", "query_data"))
 
@@ -222,10 +221,7 @@ func TestSeedMigratesLegacyOperationSpelling(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, tc := range []struct{ rtype, id string }{
-		{"knowledge_network", "kn-1"},
-		{"stream_data_pipeline", "p-1"},
-	} {
+	for _, tc := range []struct{ rtype, id string }{{"knowledge_network", "kn-1"}} {
 		ok, err := e.Check(user, tc.rtype, tc.id, "query_data")
 		if err != nil {
 			t.Fatal(err)

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -31,8 +31,7 @@ func TestRoleResourceMatrix(t *testing.T) {
 
 	// a representative, granted op per resource type (positive case uses these).
 	repOp := map[string]string{
-		"agent": "use", "agent_tpl": "publish",
-		"stream_data_pipeline": "create", "catalog": "authorize",
+		"catalog": "authorize",
 		// 数据表上不再有 create/modify/delete：建表判目录的 resource_manage，
 		// 改删判这张表再回落到目录（#801）。
 		"resource":       "view_detail",

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -54,6 +54,12 @@ var deprecatedSeedRoleIDs = []string{
 	"3fb94948-5169-11f0-b662-3a7bdba2913f", // AI administrator
 }
 
+var withdrawnResourceTypes = []string{
+	"agent",
+	"agent_tpl",
+	"stream_data_pipeline",
+}
+
 const normalUserRoleID = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 
 // AdminUserID is the built-in admin user's id, exported so callers can protect
@@ -127,6 +133,9 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := seedRoles(db); err != nil {
 		return fmt.Errorf("seed roles: %w", err)
 	}
+	if err := reconcileWithdrawnResourceTypes(enforcer); err != nil {
+		return fmt.Errorf("reconcile withdrawn resource types: %w", err)
+	}
 	if err := seedCatalog(db); err != nil {
 		return fmt.Errorf("seed catalog: %w", err)
 	}
@@ -158,6 +167,33 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 		return fmt.Errorf("seed business provenance owner: %w", err)
 	}
 	return nil
+}
+
+// reconcileWithdrawnResourceTypes removes resource types that are no longer
+// supported, including every persisted role/object grant that could otherwise
+// survive an upgrade without a matching catalog entry. Audit records are kept.
+func reconcileWithdrawnResourceTypes(enforcer *authz.Enforcer) error {
+	return enforcer.Transaction(context.Background(), func(tx *authz.PolicyTransaction) error {
+		removedPolicies, err := tx.RemovePoliciesForResourceTypes(withdrawnResourceTypes...)
+		if err != nil {
+			return err
+		}
+		db := tx.DB()
+		if err := db.Where("resource_type_id IN ? OR parent_type_id IN ?", withdrawnResourceTypes, withdrawnResourceTypes).
+			Delete(&model.ResourceParent{}).Error; err != nil {
+			return err
+		}
+		if err := db.Where("resource_type_id IN ?", withdrawnResourceTypes).Delete(&model.Operation{}).Error; err != nil {
+			return err
+		}
+		if err := db.Where("id IN ?", withdrawnResourceTypes).Delete(&model.ResourceType{}).Error; err != nil {
+			return err
+		}
+		if removedPolicies > 0 {
+			slog.Info("removed policies for withdrawn resource types", "resource_types", withdrawnResourceTypes, "projections", removedPolicies)
+		}
+		return nil
+	})
 }
 
 func reconcileDeprecatedSeedRoles(db *gorm.DB, enforcer *authz.Enforcer) error {
@@ -678,10 +714,9 @@ var legacyOperationRenames = []struct {
 	resourceType string
 	from, to     string
 }{
-	// Data query was spelled data_query on these two types and query_data on
+	// Data query was spelled data_query on knowledge networks and query_data on
 	// catalog/resource. One vocabulary, one spelling.
 	{"knowledge_network", "data_query", "query_data"},
-	{"stream_data_pipeline", "data_query", "query_data"},
 }
 
 // renameLegacyOperations migrates object grants onto the corrected spellings.

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -70,12 +70,8 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		t.Errorf("network_builder description = %q", networkBuilder.Description)
 	}
 
-	// agent and Studio admin resource types + their operations seeded.
+	// Retained Studio admin resource types and their operations are seeded.
 	var opCount int64
-	db.Model(&model.Operation{}).Where("resource_type_id = ?", "agent").Count(&opCount)
-	if opCount == 0 {
-		t.Error("expected agent operations seeded")
-	}
 	db.Model(&model.Operation{}).Where("resource_type_id = ?", "admin-user").Count(&opCount)
 	if opCount == 0 {
 		t.Error("expected admin-user operations seeded")
@@ -92,6 +88,65 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 	}
 	if !ok {
 		t.Error("network_builder should be able to create knowledge networks after seed")
+	}
+}
+
+// TestApplyRemovesWithdrawnResourceTypes proves an upgraded deployment does
+// not retain the retired vocabulary or any role/object grant that names it.
+func TestApplyRemovesWithdrawnResourceTypes(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := map[string]string{
+		"agent": "use", "agent_tpl": "publish", "stream_data_pipeline": "view_detail",
+	}
+	for resourceType, operation := range legacy {
+		if err := db.Create(&model.ResourceType{ID: resourceType, Name: resourceType}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Create(&model.Operation{ResourceTypeID: resourceType, ID: operation, Name: operation}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := e.GrantObjectPermission("legacy-user", resourceType, "old-1", operation); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.GrantRolePermission("legacy-role", resourceType, "*", operation); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply upgrade seed: %v", err)
+	}
+	for resourceType, operation := range legacy {
+		var typeCount, operationCount, grantCount int64
+		if err := db.Model(&model.ResourceType{}).Where("id = ?", resourceType).Count(&typeCount).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Model(&model.Operation{}).Where("resource_type_id = ?", resourceType).Count(&operationCount).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Model(&model.AuthorizationGrant{}).Where("object LIKE ?", resourceType+":%").Count(&grantCount).Error; err != nil {
+			t.Fatal(err)
+		}
+		if typeCount != 0 || operationCount != 0 || grantCount != 0 {
+			t.Errorf("withdrawn %s remains: types=%d operations=%d grants=%d", resourceType, typeCount, operationCount, grantCount)
+		}
+		if ok, err := e.Check("legacy-user", resourceType, "old-1", operation); err != nil || ok {
+			t.Errorf("direct %s permission remains: allow=%v err=%v", resourceType, ok, err)
+		}
+	}
+	if err := e.AssignRole("legacy-role-user", "legacy-role"); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := e.Check("legacy-role-user", "agent", "old-1", "use"); err != nil || ok {
+		t.Errorf("role permission for withdrawn type remains: allow=%v err=%v", ok, err)
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("second apply must remain idempotent: %v", err)
 	}
 }
 
@@ -134,7 +189,7 @@ func TestSeededRoleGrants(t *testing.T) {
 		{"network-builder manages catalog", networkBuilder, "catalog", "x", "create", true},
 		{"network-builder manages skill", networkBuilder, "skill", "s1", "publish", true},
 		{"network-builder not system users", networkBuilder, "admin-user", "x", "create", false},
-		{"super-admin does anything (agent)", superAdmin, "agent", "x", "use", true},
+		{"super-admin does anything (withdrawn type)", superAdmin, "agent", "x", "use", true},
 		{"super-admin does anything (any type/op)", superAdmin, "whatever", "z", "some_random_op", true},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
Remove agent, agent_tpl, and stream_data_pipeline from the authorization catalog and community bundle. Reconcile their persisted policies and catalog rows during startup so upgraded deployments match fresh installs.

# Pull Request

## What Changed

Brief description of changes:

- [x] 移除已废弃的 `agent`、`agent_tpl`、`stream_data_pipeline` 资源类型及其操作目录。
- [x] 移除上述资源在 Community 授权包中的授权操作白名单。
- [x] 增加启动 seed 升级清理：删除废弃类型关联的角色级/对象级授权、Casbin 投影、操作、资源类型及关联资源父子关系。
- [x] 更新相关资源目录、社区授权、权限矩阵和历史操作迁移测试。
- [ ] Docs/doc 1（不涉及用户文档）

---

## Why

- Related Issue: N/A
- Related Feature: 权限资源类型收敛
- Background:

已确认 `agent`、`agent_tpl` 和 `stream_data_pipeline` 不再被业务使用。仅从资源目录删除会造成新装环境与升级环境不一致：升级库仍可能保留资源类型、操作及历史授权。

---

## How

- Key implementation points:
  - 从 `catalog.json` 删除三类废弃资源及其操作。
  - 在 `seed.Apply` 中新增幂等资源类型清理。
  - 清理在同一授权事务中执行，先移除授权原始记录及 Casbin 投影，再删除操作、资源类型和关联父子关系。
  - 保留审计日志，避免删除历史审计证据。
  - 增加升级场景回归测试，验证对象授权、角色授权、操作和资源类型均被清理，重复启动保持幂等。

- Breaking changes (API, config, database, etc.):
  - 资源类型 `agent`、`agent_tpl`、`stream_data_pipeline` 及对应操作不再存在。
  - 启用 seed 的升级部署首次启动时，会不可逆清理上述三类历史授权数据。
  - 已确认这些资源类型不再有业务使用方。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally（本次未涉及外部依赖集成测试）
- [ ] Verified in test environment（待部署验证）

Test notes:

```text
cd bkn-safe/server && go test ./internal/seed ./internal/authz

测试通过。
Risk & Rollback
- Potential risks:
  - 若存在未识别的外部服务仍调用上述资源类型，升级后会因资源和授权被清理而鉴权失败。
  - 已清理的历史授权无法通过应用回滚自动恢复。
- Rollback plan:
  - 上线前：回退本 PR，可阻止清理逻辑执行。
  - 上线后：需先恢复升级前数据库备份，再回退应用版本；仅回退代码无法恢复已删除的历史授权。
Additional Notes
- 清理范围严格限定为 agent、agent_tpl、stream_data_pipeline，不影响其他资源类型、角色、用户或审计日志。