### PR TITLE
fix(cypher): scope relationship uniqueness to one MATCH

### DIFF
--- a/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/analyze.go
@@ -143,14 +143,21 @@ type patternBuilder struct {
 	inline    []Predicate
 	nodeOf    map[string]int
 	anonymous int
+	// clause counts the MATCH clauses read so far, and stamps the
+	// relationships each one writes. Nodes are deliberately not stamped: a
+	// variable is one node wherever it is written, which is what makes several
+	// MATCH clauses one shape.
+	clause int
 }
 
 func newPatternBuilder() *patternBuilder {
 	return &patternBuilder{nodeOf: map[string]int{}}
 }
 
-// addPattern reads one MATCH's worth of comma-separated paths.
+// addPattern reads one MATCH's worth of comma-separated paths. Everything it
+// reads belongs to one clause, which is what the uniqueness rule is scoped to.
 func (b *patternBuilder) addPattern(ctx parsing.IOC_PatternContext) error {
+	defer func() { b.clause++ }()
 	for _, part := range ctx.AllOC_PatternPart() {
 		if part.OC_Variable() != nil {
 			return unsupported(part, "path variables")
@@ -191,6 +198,7 @@ func (b *patternBuilder) addPath(element parsing.IOC_PatternElementContext) erro
 				interfaces.CYPHER_MAX_PATH_LENGTH)
 		}
 		edge.Left, edge.Right = left, right
+		edge.Clause = b.clause
 		b.pattern.Edges = append(b.pattern.Edges, *edge)
 		left = right
 	}

--- a/adp/bkn/bkn-backend/server/logics/cypher/ast.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/ast.go
@@ -76,7 +76,12 @@ type EdgeRef struct {
 	Direction Direction
 	Left      int
 	Right     int
-	Pos       Position
+	// Clause is which MATCH wrote this relationship. Several MATCH clauses
+	// describe one shape, but Cypher's rule that a pattern may not traverse
+	// the same relationship twice holds inside a single MATCH and not between
+	// two of them, so the hops have to remember where they came from.
+	Clause int
+	Pos    Position
 }
 
 // PropertyRef is a variable.property reference.

--- a/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/compile_test.go
@@ -460,6 +460,42 @@ func TestCompileMultiHop(t *testing.T) {
 	})
 }
 
+// openCypher scopes the uniqueness rule to one MATCH. Applying it across
+// clauses would drop rows a caller asked for, and the two shapes below are how
+// a caller asks for them.
+func TestCompileUniquenessIsScopedToOneMatch(t *testing.T) {
+	t.Run("two MATCH clauses may reach the same row", func(t *testing.T) {
+		got := mustCompile(t,
+			"MATCH (i:Item)-[:BELONGS_TO]->(b:Order) MATCH (i)-[:BELONGS_TO]->(c:Order) RETURN b.id AS b, c.id AS c")
+		if strings.Contains(got, "NOT") {
+			t.Fatalf("uniqueness leaked across MATCH clauses: %s", got)
+		}
+	})
+
+	t.Run("comma-separated parts of one MATCH may not", func(t *testing.T) {
+		// The same two paths written in one clause are one pattern, so the
+		// rule applies and b and c have to differ.
+		got := mustCompile(t,
+			"MATCH (i:Item)-[:BELONGS_TO]->(b:Order), (i)-[:BELONGS_TO]->(c:Order) RETURN b.id AS b, c.id AS c")
+		if !strings.Contains(got, "WHERE NOT t1.`f_id` = t2.`f_id`") {
+			t.Fatalf("got %s", got)
+		}
+	})
+
+	t.Run("an undirected hop is only refused beside one in its own MATCH", func(t *testing.T) {
+		if _, err := compile(t,
+			"MATCH (a:Order)-[:FOLLOWS]-(b:Order) MATCH (c:Order)-[:FOLLOWS]-(d:Order) RETURN a.id AS a, c.id AS c",
+			GenerateOptions{}); err != nil {
+			t.Fatalf("compile = %v, want two undirected hops in separate clauses accepted", err)
+		}
+		if _, err := compile(t,
+			"MATCH (a:Order)-[:FOLLOWS]-(b:Order), (c:Order)-[:FOLLOWS]-(d:Order) RETURN a.id AS a",
+			GenerateOptions{}); err == nil {
+			t.Fatal("compile = nil, want the same two hops refused inside one MATCH")
+		}
+	})
+}
+
 func TestCompileMultiHopRejections(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/adp/bkn/bkn-backend/server/logics/cypher/plan.go
+++ b/adp/bkn/bkn-backend/server/logics/cypher/plan.go
@@ -238,21 +238,27 @@ func (p *planner) planPattern(pattern Pattern) error {
 }
 
 // keepRelationshipsDistinct adds what Cypher requires and SQL has no notion
-// of: one pattern may not traverse the same relationship twice.
+// of: one MATCH may not traverse the same relationship twice.
 //
 // A relationship here is a pair of rows -- one on the relation's source side,
 // one on its target side -- so two hops over the same relation type are the
 // same relationship exactly when both pairs coincide. Every pair of such hops
-// is compared, not only neighbouring ones: hops with another hop between them
-// can coincide just as easily, and two hops in the same direction coincide on
-// a row that points at itself.
+// within one MATCH is compared, not only neighbouring ones: hops with another
+// hop between them can coincide just as easily, and two hops in the same
+// direction coincide on a row that points at itself.
+//
+// Hops from different MATCH clauses are left alone. The rule is scoped to a
+// clause in openCypher, and applying it across clauses would quietly drop rows
+// a caller asked for: `MATCH (a)-[:R]->(b) MATCH (a)-[:R]->(c)` is how one asks
+// for every pair of things a reaches, b = c included.
 func (p *planner) keepRelationshipsDistinct(pattern Pattern) error {
 	if err := p.refuseUndirectedRepeats(pattern); err != nil {
 		return err
 	}
 	for i := 0; i < len(p.hops); i++ {
 		for j := i + 1; j < len(p.hops); j++ {
-			if p.hops[i].relationType != p.hops[j].relationType {
+			if p.hops[i].clause != p.hops[j].clause ||
+				p.hops[i].relationType != p.hops[j].relationType {
 				continue
 			}
 			distinct, err := p.differentEdges(p.hops[i], p.hops[j])
@@ -267,14 +273,16 @@ func (p *planner) keepRelationshipsDistinct(pattern Pattern) error {
 
 // refuseUndirectedRepeats turns away the one shape the rule cannot be stated
 // for: which reading of an undirected hop matched decides whether it repeats
-// another hop, and a condition cannot ask that after the fact.
+// another hop, and a condition cannot ask that after the fact. Like the rule
+// itself this looks inside one MATCH only -- two undirected hops in separate
+// clauses never had to be distinct.
 func (p *planner) refuseUndirectedRepeats(pattern Pattern) error {
 	for i, edge := range pattern.Edges {
 		if edge.Direction != Undirected {
 			continue
 		}
 		for j, other := range pattern.Edges {
-			if i == j || other.Type != edge.Type {
+			if i == j || other.Clause != edge.Clause || other.Type != edge.Type {
 				continue
 			}
 			return planErrorf(edge.Pos,
@@ -349,6 +357,7 @@ type plannedHop struct {
 	relationType string
 	source       int
 	target       int
+	clause       int
 	pos          Position
 }
 
@@ -432,6 +441,7 @@ func (p *planner) addJoin(edge EdgeRef, left, right int) error {
 				relationType: relationType.RTID,
 				source:       source,
 				target:       target,
+				clause:       edge.Clause,
 				pos:          edge.Pos,
 			})
 		}

--- a/docs/api/bkn/cypher-queries.yaml
+++ b/docs/api/bkn/cypher-queries.yaml
@@ -161,11 +161,14 @@ components:
             one object type and may carry an inline property map, which means the equalities
             it stands for.
 
-            Cypher forbids one pattern from traversing the same relationship twice, and that
-            is enforced: every pair of hops over one relation type must differ in its source
-            row or its target row, which needs those object types to have a primary key.
-            Where one of the hops is undirected the requirement cannot be stated, and the
-            query is refused rather than answered with paths Cypher would not return. One query's patterns
+            Cypher forbids one MATCH from traversing the same relationship twice, and that
+            is enforced: within one MATCH, every pair of hops over one relation type must
+            differ in its source row or its target row, which needs those object types to
+            have a primary key. Where one of the hops is undirected the requirement cannot
+            be stated, and the query is refused rather than answered with paths Cypher would
+            not return. Hops in different MATCH clauses are not compared: writing
+            `MATCH (a)-[:R]->(b) MATCH (a)-[:R]->(c)` is how one asks for every pair of
+            things a reaches, b and c being the same included. One query's patterns
             may hold at most eight relationships and nine nodes, because each relationship is
             a join and each node is a table -- one that no relationship reaches is joined to
             the rest by nothing -- and the row limit bounds what comes back rather than what


### PR DESCRIPTION
Raised as a 待确认项 in review of #1451. The 0.1.4-yf half is #1459.

## The defect

Cypher's rule that a pattern may not traverse the same relationship twice was applied across the whole query rather than within one MATCH. Several MATCH clauses became one shape when multi-pattern support landed, and the rule silently came along.

That drops rows the caller asked for:

```
MATCH (i:Item)-[:BELONGS_TO]->(b:Order) MATCH (i)-[:BELONGS_TO]->(c:Order) RETURN b.id, c.id
→ ... WHERE NOT t1.`f_id` = t2.`f_id`
```

Asking for every pair of orders an item reaches — `b = c` included — is exactly what two MATCH clauses mean, and the answer came back missing those rows with nothing to say so. Two undirected hops in separate clauses were refused outright for the same reason, though neither ever had to be distinct from the other.

## The fix

Relationships carry which MATCH wrote them (`EdgeRef.Clause`), and both the distinctness condition and the undirected refusal look inside one clause. Nodes deliberately carry nothing: a variable is one node wherever it is written, which is what makes several MATCH clauses describe one shape in the first place.

## Testing

Bug reproduced first, then fixed. New tests assert all three directions: two MATCH clauses may reach the same row; the same two paths written comma-separated in one MATCH still may not; an undirected hop is refused only beside one in its own MATCH. `go test ./logics/cypher/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)