### PR TITLE
fix(docs): restore the accessor schema in the property grant patch request

### DIFF
--- a/docs/api/bkn-safe/property-grants.yaml
+++ b/docs/api/bkn-safe/property-grants.yaml
@@ -187,11 +187,10 @@ components:
       additionalProperties: false
       properties:
         accessor:
+          $ref: '#/components/schemas/Subject'
         object_type_ref:
           type: string
           pattern: '^[a-z0-9][a-z0-9_-]{0,39}/[a-z0-9][a-z0-9_-]{0,39}$'
-        object_type_ref:
-          type: string
         reason:
           type: string
           minLength: 1


### PR DESCRIPTION
## What

`docs/api/bkn-safe/property-grants.yaml` has `PatchRequest.accessor` with no value and `object_type_ref` written twice:

```yaml
        accessor:
        object_type_ref:
          type: string
          pattern: '^[a-z0-9][a-z0-9_-]{0,39}/[a-z0-9][a-z0-9_-]{0,39}$'
        object_type_ref:
          type: string
```

YAML refuses a duplicated mapping key, so redocly never gets to validate it:

```
Failed to parse API description at docs/api/bkn-safe/property-grants.yaml:
  - duplicated mapping key in ... (193:9)
```

That aborts `make api-docs-lint`, so the `lint` job is red on **every** PR touching `docs/api` — and the file it fails on is not the file those PRs changed. Seen on #1460; the same job passes once this is fixed.

## The fix

Give `accessor` back its `$ref: Subject` — the shape the `GrantSnapshot` response beside it already uses, and the one the `required: [accessor, ...]` list implies — and keep the single `object_type_ref` that carries the pattern.

Introduced in #1420. `npx @redocly/cli lint` on the file is clean with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)