### PR TITLE
feat(bkn-safe): add edition-aware object grant APIs

### DIFF
--- a/bkn-safe/server/extension/finegrained/finegrained.go
+++ b/bkn-safe/server/extension/finegrained/finegrained.go
@@ -1,0 +1,62 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package finegrained is the assembly marker for the shared
+// perm_fine_grained object-grant surface.
+//
+// The handlers live in Core because Community and paid editions share one
+// route. An Enterprise assembly registers this marker unconditionally; each
+// request then combines the compiled-in marker with the live entitlement.
+// Community builds never register it, while an unlicensed or downgraded EE
+// build keeps it assembled but unavailable.
+package finegrained
+
+import (
+	"sync"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+)
+
+const Capability = "perm_fine_grained"
+
+var (
+	mu         sync.RWMutex
+	minEdition licverify.Edition
+)
+
+// Register declares that this binary contains the Professional object-grant
+// request shapes. It must run during EE assembly, before entitlement.Freeze.
+func Register(min licverify.Edition) {
+	mu.Lock()
+	defer mu.Unlock()
+	if minEdition != "" {
+		panic("finegrained: capability already registered")
+	}
+	entitlement.MustBeAssembling("finegrained")
+	entitlement.MarkAssembled(Capability, min)
+	minEdition = min
+}
+
+// Assembled reports only whether the paid request shapes are compiled into the
+// current binary. It deliberately says nothing about the live licence.
+func Assembled() bool {
+	mu.RLock()
+	defer mu.RUnlock()
+	return minEdition != ""
+}
+
+// Available reports whether the paid request shapes may be used now.
+func Available() bool {
+	mu.RLock()
+	min := minEdition
+	mu.RUnlock()
+	return min != "" && entitlement.AtLeast(min)
+}
+
+func reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	minEdition = ""
+}

--- a/bkn-safe/server/extension/finegrained/finegrained_test.go
+++ b/bkn-safe/server/extension/finegrained/finegrained_test.go
@@ -1,0 +1,72 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package finegrained
+
+import (
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
+)
+
+func TestAvailabilityRequiresAssemblyAndLiveEdition(t *testing.T) {
+	entitlement.ResetForTest()
+	reset()
+	t.Cleanup(func() {
+		reset()
+		entitlement.ResetForTest()
+	})
+
+	edition := licverify.EditionCommunity
+	entitlement.SetGateForTest(entitlement.GateFunc(func() entitlement.Snapshot {
+		return entitlement.Snapshot{Edition: edition, Licensed: edition != licverify.EditionCommunity}
+	}))
+	if Assembled() || Available() {
+		t.Fatal("Community binary reported the paid shape as assembled or available")
+	}
+
+	Register(licverify.EditionProfessional)
+	if !Assembled() || Available() {
+		t.Fatal("assembled capability became available below Professional")
+	}
+	registered := false
+	for _, capability := range entitlement.Assembled() {
+		if capability.Name == Capability && capability.MinEdition == licverify.EditionProfessional {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		t.Fatalf("%q was not registered at Professional: %+v", Capability, entitlement.Assembled())
+	}
+	edition = licverify.EditionProfessional
+	if !Available() {
+		t.Fatal("Professional licence did not enable the assembled capability")
+	}
+	edition = licverify.EditionIndustry
+	if !Available() {
+		t.Fatal("Industry did not inherit the Professional capability")
+	}
+	edition = licverify.EditionCommunity
+	if Available() {
+		t.Fatal("downgrade did not close the paid request shape")
+	}
+}
+
+func TestRegisterRejectsDuplicateAssembly(t *testing.T) {
+	entitlement.ResetForTest()
+	reset()
+	t.Cleanup(func() {
+		reset()
+		entitlement.ResetForTest()
+	})
+	Register(licverify.EditionProfessional)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("duplicate registration did not panic")
+		}
+	}()
+	Register(licverify.EditionProfessional)
+}

--- a/bkn-safe/server/extension/finegrained/testsupport.go
+++ b/bkn-safe/server/extension/finegrained/testsupport.go
@@ -1,0 +1,8 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package finegrained
+
+// ResetForTest clears the process-global assembly marker.
+func ResetForTest() { reset() }

--- a/bkn-safe/server/extension/permobject/management.go
+++ b/bkn-safe/server/extension/permobject/management.go
@@ -1,0 +1,101 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package permobject
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/licverify"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+)
+
+// InventoryEntry is the non-sensitive management projection of one historical
+// Enterprise object rule. The private implementation keeps the rule payload;
+// Core receives only fields required to classify, audit and revoke it.
+// RuntimeEligible is the final management result after authoritative subject
+// classification, not merely the intrinsic validity of the persisted row.
+type InventoryEntry struct {
+	GrantID         string     `json:"grant_id"`
+	RuleID          string     `json:"rule_id"`
+	AccessorID      string     `json:"accessor_id"`
+	SubjectType     string     `json:"subject_type"`
+	ResourceType    string     `json:"resource_type"`
+	ResourceID      string     `json:"resource_id"`
+	Operation       string     `json:"operation"`
+	Effect          string     `json:"effect"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	Classification  string     `json:"classification"`
+	ActivationState string     `json:"activation_state"`
+	RuntimeEligible bool       `json:"runtime_eligible"`
+	InactiveReason  string     `json:"inactive_reason,omitempty"`
+}
+
+// Manager is implemented by openbkn-ee. No create or update operation is
+// present: this compatibility surface is deliberately read/revoke-only.
+type Manager interface {
+	Inventory(ctx context.Context, now time.Time) ([]InventoryEntry, error)
+	Revoke(ctx context.Context, grantID, operatorID, reason string, revokedAt time.Time) error
+}
+
+var management atomic.Value // Manager
+var managementMinEdition licverify.Edition
+
+// RegisterManager plugs the Enterprise lifecycle manager into the Core-owned
+// admin route during assembly.
+func RegisterManager(min licverify.Edition, manager Manager) {
+	if manager == nil {
+		panic("permobject: RegisterManager(nil)")
+	}
+	if management.Load() != nil {
+		panic("permobject: manager already registered")
+	}
+	if load() == nil || minEdition == "" {
+		panic("permobject: authorizer must be registered before manager")
+	}
+	if min != minEdition {
+		panic("permobject: manager and authorizer minimum editions differ")
+	}
+	entitlement.MustBeAssembling("permobject management")
+	managementMinEdition = min
+	management.Store(manager)
+}
+
+func ManagementRegistered() bool { return management.Load() != nil }
+
+func ManagementGate() gin.HandlerFunc {
+	min := managementMinEdition
+	return func(c *gin.Context) {
+		if min != "" && entitlement.AtLeast(min) {
+			c.Next()
+			return
+		}
+		slog.Info("permobject: management route hidden, licence below the required tier",
+			"capability", Capability, "edition", string(entitlement.Current()),
+			"method", c.Request.Method, "path", c.Request.URL.Path)
+		c.Abort()
+		c.Data(http.StatusNotFound, gin.MIMEPlain, []byte("404 page not found"))
+	}
+}
+
+func Inventory(ctx context.Context, now time.Time) ([]InventoryEntry, error) {
+	manager, _ := management.Load().(Manager)
+	return manager.Inventory(ctx, now)
+}
+
+func Revoke(ctx context.Context, grantID, operatorID, reason string, revokedAt time.Time) error {
+	manager, _ := management.Load().(Manager)
+	return manager.Revoke(ctx, grantID, operatorID, reason, revokedAt)
+}
+
+func resetManagement() {
+	management = atomic.Value{}
+	managementMinEdition = ""
+}

--- a/bkn-safe/server/extension/permobject/permobject.go
+++ b/bkn-safe/server/extension/permobject/permobject.go
@@ -211,4 +211,5 @@ func load() Authorizer {
 func reset() {
 	impl = atomic.Value{}
 	minEdition = ""
+	resetManagement()
 }

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -330,6 +330,13 @@ func TestCommunityBundleDoesNotExpandLegacyOrAcceptChildTargets(t *testing.T) {
 			t.Errorf("GrantCommunityBundle(%q,%q) succeeded; want rejection", target.resourceType, target.resourceID)
 		}
 	}
+	if err := e.GrantCommunityBundle("u-1", "knowledge_network", "kn-1", AuthoritySourceOwnerDelegate); err == nil {
+		t.Error("owner delegate wrote the protected Community bundle source")
+	}
+	if removed, err := e.RemoveCommunityBundle("bundle-holder", "knowledge_network", "kn-1",
+		AuthoritySourceOwnerDelegate); err == nil || removed {
+		t.Fatalf("owner delegate removed the protected Community bundle: removed=%v err=%v", removed, err)
+	}
 	records, err := e.PolicyRecords(PolicyFilter{AccessorID: "u-1"})
 	if err != nil || len(records) != 0 {
 		t.Fatalf("invalid targets produced policies: %+v, %v", records, err)

--- a/bkn-safe/server/internal/authz/decision.go
+++ b/bkn-safe/server/internal/authz/decision.go
@@ -61,12 +61,12 @@ const (
 
 // Evaluation is one structured authorization result.
 type Evaluation struct {
-	Scope             EvaluationScope
-	Decision          Decision
-	Basis             DecisionBasis
-	Requirements      []string
-	DeniedRequirement string
-	RequirementBasis  DecisionBasis
+	Scope             EvaluationScope `json:"scope"`
+	Decision          Decision        `json:"decision"`
+	Basis             DecisionBasis   `json:"basis"`
+	Requirements      []string        `json:"requires,omitempty"`
+	DeniedRequirement string          `json:"denied_requirement,omitempty"`
+	RequirementBasis  DecisionBasis   `json:"requirement_basis,omitempty"`
 }
 
 func (d Evaluation) Allowed() bool { return d.Decision == DecisionAllow }

--- a/bkn-safe/server/internal/authz/explain.go
+++ b/bkn-safe/server/internal/authz/explain.go
@@ -1,0 +1,208 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package authz
+
+import (
+	"context"
+	"errors"
+
+	"github.com/casbin/casbin/v2/util"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// ExplanationGrant is the non-sensitive provenance needed to identify a Core
+// rule that participated in an explanation. It intentionally omits CreatedBy
+// and every Enterprise property-rule payload.
+type ExplanationGrant struct {
+	GrantID         string          `json:"grant_id"`
+	SubjectID       string          `json:"subject_id"`
+	SubjectKind     string          `json:"subject_kind"`
+	Object          string          `json:"object"`
+	Operation       string          `json:"operation"`
+	Effect          string          `json:"effect"`
+	PolicySource    PolicySource    `json:"policy_source"`
+	AuthoritySource AuthoritySource `json:"authority_source"`
+	Match           string          `json:"match"`
+}
+
+// ExplanationStep is one local lookup in the child-to-parent walk.
+type ExplanationStep struct {
+	ResourceType    string             `json:"resource_type"`
+	ResourceID      string             `json:"resource_id"`
+	Operation       string             `json:"operation"`
+	Decision        Decision           `json:"decision"`
+	Basis           DecisionBasis      `json:"basis"`
+	MatchedGrants   []ExplanationGrant `json:"matched_grants"`
+	InheritedFrom   *ResourceRef       `json:"inherited_from,omitempty"`
+	ParentOperation string             `json:"parent_operation,omitempty"`
+}
+
+// RequirementExplanation carries the direct prerequisite's own base trace.
+type RequirementExplanation struct {
+	Operation string            `json:"operation"`
+	Decision  Evaluation        `json:"evaluation"`
+	Steps     []ExplanationStep `json:"steps"`
+}
+
+// OperationExplanation is generated on demand and is never persisted.
+type OperationExplanation struct {
+	AccessorID   string                   `json:"accessor_id"`
+	ResourceType string                   `json:"resource_type"`
+	ResourceID   string                   `json:"resource_id"`
+	Operation    string                   `json:"operation"`
+	Evaluation   Evaluation               `json:"evaluation"`
+	Steps        []ExplanationStep        `json:"steps"`
+	Requirements []RequirementExplanation `json:"requirements"`
+}
+
+// ExplainOperation returns the final operation decision plus the local,
+// wildcard, parent and direct-requirement evidence that produced it.
+func (en *Enforcer) ExplainOperation(ctx context.Context, accessorID, resourceType, resourceID, operation string) (OperationExplanation, error) {
+	final, err := en.OperationDecision(ctx, accessorID, resourceType, resourceID, operation)
+	if err != nil {
+		return OperationExplanation{}, err
+	}
+	idx, err := en.grantIndex(accessorID)
+	if err != nil {
+		return OperationExplanation{}, err
+	}
+	steps, err := en.explainBaseWalk(ctx, idx, accessorID, ResourceRef{Type: resourceType, ID: resourceID}, operation)
+	if err != nil {
+		return OperationExplanation{}, err
+	}
+	requirements, err := en.DirectRequirements(ctx, resourceType, []string{operation})
+	if err != nil {
+		return OperationExplanation{}, err
+	}
+	requirementExplanations := make([]RequirementExplanation, 0, len(requirements[operation]))
+	for _, required := range requirements[operation] {
+		decision, err := en.baseEffectiveDecisionForExplain(ctx, accessorID, idx,
+			ResourceRef{Type: resourceType, ID: resourceID}, required)
+		if err != nil {
+			return OperationExplanation{}, err
+		}
+		requiredSteps, err := en.explainBaseWalk(ctx, idx, accessorID,
+			ResourceRef{Type: resourceType, ID: resourceID}, required)
+		if err != nil {
+			return OperationExplanation{}, err
+		}
+		requirementExplanations = append(requirementExplanations, RequirementExplanation{
+			Operation: required, Decision: decision, Steps: requiredSteps,
+		})
+	}
+	return OperationExplanation{
+		AccessorID: accessorID, ResourceType: resourceType, ResourceID: resourceID,
+		Operation: operation, Evaluation: final, Steps: steps, Requirements: requirementExplanations,
+	}, nil
+}
+
+func (en *Enforcer) baseEffectiveDecisionForExplain(ctx context.Context, accessorID string, idx *grantIndex,
+	resource ResourceRef, operation string) (Evaluation, error) {
+	decisions, err := en.baseEffectiveDecisionsWithIndex(ctx, accessorID, idx,
+		map[ResourceRef][]string{resource: {operation}})
+	if err != nil {
+		return Evaluation{}, err
+	}
+	return decisions[resource][operation], nil
+}
+
+func (en *Enforcer) explainBaseWalk(ctx context.Context, idx *grantIndex, accessorID string,
+	resource ResourceRef, operation string) ([]ExplanationStep, error) {
+	current, currentOperation := resource, operation
+	visited := map[ResourceRef]bool{}
+	steps := make([]ExplanationStep, 0, 2)
+	for depth := 0; depth < maxHierarchyDepth && !visited[current]; depth++ {
+		visited[current] = true
+		local, err := en.localDecisions(ctx, accessorID, idx, current, []string{currentOperation})
+		if err != nil {
+			return nil, err
+		}
+		decision := local[currentOperation]
+		grants, err := en.explanationGrants(idx, current, currentOperation)
+		if err != nil {
+			return nil, err
+		}
+		step := ExplanationStep{
+			ResourceType: current.Type, ResourceID: current.ID, Operation: currentOperation,
+			Decision: decision.Decision, Basis: decision.Basis, MatchedGrants: grants,
+		}
+		steps = append(steps, step)
+		if decision.Decision != DecisionNone && !(decision.Decision == DecisionAllow && decision.Basis == BasisWildcard) {
+			break
+		}
+		mapping, err := en.parentOpMap(current.Type)
+		if err != nil {
+			return nil, err
+		}
+		parentOperation, inherits := mapping[currentOperation]
+		if !inherits {
+			break
+		}
+		var parent model.ResourceParent
+		err = en.db.WithContext(ctx).First(&parent,
+			"resource_type_id = ? AND resource_id = ?", current.Type, current.ID).Error
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		next := ResourceRef{Type: parent.ParentTypeID, ID: parent.ParentID}
+		steps[len(steps)-1].InheritedFrom = &next
+		steps[len(steps)-1].ParentOperation = parentOperation
+		current, currentOperation = next, parentOperation
+	}
+	return steps, nil
+}
+
+func (en *Enforcer) explanationGrants(idx *grantIndex, resource ResourceRef, operation string) ([]ExplanationGrant, error) {
+	subjects := make(map[string]string, len(idx.subjects))
+	records := make([]PolicyRecord, 0)
+	for position, subject := range idx.subjects {
+		kind := "role"
+		switch subject {
+		case PublicAccessorID:
+			kind = "public"
+		default:
+			if position == 0 {
+				kind = "user"
+			}
+		}
+		subjects[subject] = kind
+		subjectRecords, err := en.PolicyRecords(PolicyFilter{AccessorID: subject})
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, subjectRecords...)
+	}
+	object := obj(resource.Type, resource.ID)
+	out := make([]ExplanationGrant, 0)
+	for _, record := range records {
+		kind, subjectMatch := subjects[record.AccessorID]
+		if !subjectMatch || !record.Active || !util.KeyMatch(object, record.Object) {
+			continue
+		}
+		match := "direct"
+		operationMatch := record.Operation == operation || record.Operation == ActAll
+		if record.PolicySource == PolicySourceCommunityBundle {
+			operationMatch = record.Object == object && record.Operation == ActFullBusinessAccess &&
+				record.Effect == EffectAllow && communityBundleAllows(resource.Type, operation)
+			match = "bundle"
+		} else if record.Object != object {
+			match = "wildcard"
+		}
+		if !operationMatch {
+			continue
+		}
+		out = append(out, ExplanationGrant{
+			GrantID: record.GrantID, SubjectID: record.AccessorID, SubjectKind: kind,
+			Object: record.Object, Operation: record.Operation, Effect: record.Effect,
+			PolicySource: record.PolicySource, AuthoritySource: record.AuthoritySource, Match: match,
+		})
+	}
+	return out, nil
+}

--- a/bkn-safe/server/internal/authz/filter.go
+++ b/bkn-safe/server/internal/authz/filter.go
@@ -16,8 +16,8 @@ import (
 
 // ResourceRef names one concrete resource instance ("type:id").
 type ResourceRef struct {
-	Type string
-	ID   string
+	Type string `json:"type"`
+	ID   string `json:"id"`
 }
 
 // FilteredResource is one visible resource plus the subset of the candidate

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -92,6 +92,7 @@ type PolicyRecord struct {
 
 // PolicyFilter narrows a provenance listing. Zero fields match every grant.
 type PolicyFilter struct {
+	GrantID         string
 	AccessorID      string
 	Object          string
 	Operation       string
@@ -352,6 +353,9 @@ func (en *Enforcer) revokePolicyGrant(grantID string) (bool, bool, error) {
 }
 
 func applyPolicyFilter(q *gorm.DB, filter PolicyFilter) *gorm.DB {
+	if filter.GrantID != "" {
+		q = q.Where("grant_id = ?", filter.GrantID)
+	}
 	if filter.AccessorID != "" {
 		q = q.Where("accessor_id = ?", filter.AccessorID)
 	}
@@ -534,7 +538,7 @@ func (en *Enforcer) GrantSystemObjectPermission(accessorID, resourceType, resour
 // GrantCommunityBundle records one logical Community grant on a reviewed
 // top-level resource. It never materializes the whitelist into operation rows.
 func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID string, authority AuthoritySource) error {
-	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceSystem {
 		return fmt.Errorf("community bundle authority %q is not permitted", authority)
 	}
 	if err := validateCommunityBundleTarget(resourceType, resourceID); err != nil {
@@ -548,7 +552,7 @@ func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID st
 // authority. Legacy, system-derived and Professional rows on the same resource
 // remain untouched.
 func (en *Enforcer) RemoveCommunityBundle(accessorID, resourceType, resourceID string, authority AuthoritySource) (bool, error) {
-	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceOwnerDelegate {
+	if authority != AuthoritySourceAdminAuthz && authority != AuthoritySourceSystem {
 		return false, fmt.Errorf("community bundle authority %q is not permitted", authority)
 	}
 	if err := validateCommunityBundleTarget(resourceType, resourceID); err != nil {

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/finegrained"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
@@ -73,10 +74,12 @@ func newAdminServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB, *auth
 	// chain, so they register the routes and put the tier in force — the
 	// entitlement layer has its own tests in extension/adminwrite.
 	adminwrite.ResetForTest()
+	finegrained.ResetForTest()
 	entitlement.SetGateForTest(entitlement.GateFunc(func() entitlement.Snapshot {
 		return entitlement.Snapshot{Licensed: true, Edition: licverify.EditionProfessional}
 	}))
 	adminwrite.RegisterMounter(licverify.EditionProfessional, adminwrite.Routes)
+	finegrained.Register(licverify.EditionProfessional)
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
 		Audit:         audit.New(db),
@@ -207,7 +210,7 @@ func TestThreeAdminRolesUseEndpointLevelPermissions(t *testing.T) {
 		"resource":    gin.H{"type": "catalog", "id": "c1"},
 		"operations":  []string{"view_detail"},
 	}
-	revokeObject := gin.H{"accessor_id": "grant-target-user", "resource": gin.H{"type": "catalog", "id": "c1"}}
+	revokeObject := gin.H{"grant_id": "unknown-grant"}
 	rolePermission := gin.H{"resource": gin.H{"type": "catalog", "id": "*"}, "operations": []string{"view_detail"}}
 	const (
 		rolePermsPath = "/api/safe/v1/admin/roles/target-role/permissions"

--- a/bkn-safe/server/internal/httpapi/adminwrite_gating_test.go
+++ b/bkn-safe/server/internal/httpapi/adminwrite_gating_test.go
@@ -5,18 +5,23 @@
 package httpapi
 
 import (
+	"bytes"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/finegrained"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+	"github.com/openbkn-ai/licverify"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
@@ -48,12 +53,96 @@ func newCommunityServer(t *testing.T) (*gin.Engine, *authz.Enforcer) {
 	}
 	// Explicitly clear the socket and register NOTHING — the community build.
 	adminwrite.ResetForTest()
+	finegrained.ResetForTest()
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: auth.NewUserStore(db),
 		Audit:         audit.New(db),
 		TokenVerifier: stubVerifier{},
 	})
 	return r, e
+}
+
+func TestUnavailableFineGrainedShapesHaveIdenticalResponse(t *testing.T) {
+	shapes := []struct {
+		name    string
+		request gin.H
+	}{
+		{
+			name: "operations",
+			request: gin.H{
+				"accessor_id": adminSub,
+				"resource":    gin.H{"type": "catalog", "id": "c-1"},
+				"operations":  []string{"view_detail"},
+			},
+		},
+		{
+			name: "deny",
+			request: gin.H{
+				"accessor_id": adminSub,
+				"resource":    gin.H{"type": "catalog", "id": "c-1"},
+				"operations":  []string{"view_detail"},
+				"effect":      authz.EffectDeny,
+			},
+		},
+		{
+			name: "child resource",
+			request: gin.H{
+				"accessor_id": adminSub,
+				"resource":    gin.H{"type": "object_type", "id": "kn-1/order"},
+				"bundle":      authz.ActFullBusinessAccess,
+			},
+		},
+		{
+			name: "paid shape is gated before target validation",
+			request: gin.H{
+				"accessor_id": adminSub,
+				"resource":    gin.H{"type": "catalog", "id": "*"},
+				"operations":  []string{"view_detail"},
+			},
+		},
+	}
+	t.Cleanup(entitlement.ResetForTest)
+
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			community, _ := newCommunityServer(t)
+			entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+			communityResponse := adminReq(t, community, http.MethodPost,
+				"/api/safe/v1/admin/object-grants", shape.request)
+
+			unassembledEE, _ := newCommunityServer(t)
+			entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionProfessional))
+			unassembledResponse := adminReq(t, unassembledEE, http.MethodPost,
+				"/api/safe/v1/admin/object-grants", shape.request)
+
+			assembledLow, _, _, _ := newAdminServer(t)
+			entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+			assembledLowResponse := adminReq(t, assembledLow, http.MethodPost,
+				"/api/safe/v1/admin/object-grants", shape.request)
+
+			responses := []*httptest.ResponseRecorder{communityResponse, unassembledResponse, assembledLowResponse}
+			for _, response := range responses {
+				if response.Code != http.StatusBadRequest || !bytes.Equal(response.Body.Bytes(), communityResponse.Body.Bytes()) {
+					t.Fatalf("unavailable shape response = %d %q; want byte-identical 400 %q",
+						response.Code, response.Body.Bytes(), communityResponse.Body.Bytes())
+				}
+			}
+			if !bytes.Contains(communityResponse.Body.Bytes(), []byte(`"error_code":"unsupported_grant_shape"`)) {
+				t.Fatalf("response lacks stable error code: %s", communityResponse.Body.String())
+			}
+		})
+	}
+
+	community, _ := newCommunityServer(t)
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionCommunity))
+	legalCommunity := adminReq(t, community, http.MethodPost, "/api/safe/v1/admin/object-grants", gin.H{
+		"accessor_id": adminSub,
+		"resource":    gin.H{"type": "catalog", "id": "c-1"},
+		"bundle":      authz.ActFullBusinessAccess,
+	})
+	if legalCommunity.Code != http.StatusNoContent {
+		t.Fatalf("legal Community bundle = %d %s", legalCommunity.Code, legalCommunity.Body.String())
+	}
 }
 
 // TestCommunityBuildOmitsRbacBasicWriteRoutes is the two-binary contract: with

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -320,7 +320,14 @@ func auditDetailTargetID(resource, detail string) string {
 		return ""
 	}
 	switch resource {
-	case "object-grants":
+	case "object-grants", "enterprise-object-grants":
+		ref, _ := body["resource"].(map[string]any)
+		id, _ := ref["id"].(string)
+		if id == "" {
+			id, _ = body["grant_id"].(string)
+		}
+		return id
+	case "explain":
 		ref, _ := body["resource"].(map[string]any)
 		id, _ := ref["id"].(string)
 		return id
@@ -363,7 +370,7 @@ func accessorNameByID(ctx context.Context, dir *directory.Service, id string) st
 // Method (carried separately) distinguishes create/update/delete.
 func auditTarget(fullPath string) (resource, action string) {
 	rest := fullPath
-	for _, prefix := range []string{adminPathPrefix, "/api/safe/v1/me/"} {
+	for _, prefix := range []string{adminPathPrefix, "/api/safe/v1/me/", "/api/safe/v1/authz/"} {
 		if strings.HasPrefix(fullPath, prefix) {
 			rest = strings.TrimPrefix(fullPath, prefix)
 			break
@@ -408,6 +415,15 @@ func auditAction(method, fullPath string) string {
 			return "revoke"
 		}
 		return "grant"
+	case "/api/safe/v1/me/object-grants":
+		if method == http.MethodDelete {
+			return "revoke"
+		}
+		return "grant"
+	case "/api/safe/v1/admin/enterprise-object-grants":
+		return "revoke"
+	case "/api/safe/v1/authz/explain":
+		return "explain"
 	case "/api/safe/v1/admin/roles/:id/permissions":
 		if method == http.MethodDelete {
 			return "revoke_permission"

--- a/bkn-safe/server/internal/httpapi/audit_semantics_test.go
+++ b/bkn-safe/server/internal/httpapi/audit_semantics_test.go
@@ -25,6 +25,10 @@ func TestAuditActionUsesStableBusinessSemantics(t *testing.T) {
 		{http.MethodDelete, "/api/safe/v1/admin/role-bindings", "unbind_role"},
 		{http.MethodPost, "/api/safe/v1/admin/object-grants", "grant"},
 		{http.MethodDelete, "/api/safe/v1/admin/object-grants", "revoke"},
+		{http.MethodPost, "/api/safe/v1/me/object-grants", "grant"},
+		{http.MethodDelete, "/api/safe/v1/me/object-grants", "revoke"},
+		{http.MethodDelete, "/api/safe/v1/admin/enterprise-object-grants", "revoke"},
+		{http.MethodPost, "/api/safe/v1/authz/explain", "explain"},
 		{http.MethodPost, "/api/safe/v1/admin/roles/:id/permissions", "grant_permission"},
 		{http.MethodDelete, "/api/safe/v1/admin/roles/:id/permissions", "revoke_permission"},
 		{http.MethodPost, "/api/safe/v1/admin/license/import", "import"},
@@ -46,6 +50,9 @@ func TestAuditDetailTargetPromotesBusinessObjectIdentifiers(t *testing.T) {
 		wantID   string
 	}{
 		{"object-grants", `{"accessor_id":"user-a","resource":{"type":"knowledge_network","id":"supplychain_hd0202"}}`, "supplychain_hd0202"},
+		{"object-grants", `{"grant_id":"grant-a"}`, "grant-a"},
+		{"enterprise-object-grants", `{"grant_id":"ee-grant-a"}`, "ee-grant-a"},
+		{"explain", `{"accessor_id":"user-a","resource":{"type":"catalog","id":"catalog-a"}}`, "catalog-a"},
 		{"role-bindings", `{"accessor_id":"user-a","role_id":"role-a"}`, "user-a"},
 	}
 	for _, test := range tests {

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -437,6 +437,45 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 	}
 }
 
+// registerAuthzExplain mounts the authenticated administrator-only diagnostic
+// endpoint separately from the tokenless ClusterIP authorization surface.
+func registerAuthzExplain(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
+	g.POST("/explain", RequirePermission(e, "admin-authz", "view"), func(c *gin.Context) {
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+			Operation  string      `json:"operation" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		active, err := activeAccount(c, db, req.AccessorID)
+		if err != nil {
+			replyPublicError(c, http.StatusServiceUnavailable)
+			return
+		}
+		if !active {
+			c.JSON(http.StatusOK, gin.H{
+				"accessor_id": req.AccessorID, "resource_type": req.Resource.Type,
+				"resource_id": req.Resource.ID, "operation": req.Operation,
+				"evaluation": gin.H{
+					"scope": authz.ScopeEffective, "decision": authz.DecisionDeny, "basis": authz.BasisDefault,
+				},
+				"steps": []authz.ExplanationStep{}, "requirements": []authz.RequirementExplanation{},
+				"account_active": false,
+			})
+			return
+		}
+		explanation, err := e.ExplainOperation(c.Request.Context(), req.AccessorID,
+			req.Resource.Type, req.Resource.ID, req.Operation)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, explanation)
+	})
+}
+
 // registerRoleBindings mounts the accessor↔role binding endpoints (bind / list /
 // unbind). Admin-only — mounted under the /admin group behind RequireAdmin.
 func registerRoleBindings(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {

--- a/bkn-safe/server/internal/httpapi/authzpoints_test.go
+++ b/bkn-safe/server/internal/httpapi/authzpoints_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
@@ -51,7 +52,7 @@ func TestAdminConsoleGateAloneAuthorizesNothing(t *testing.T) {
 		"resource":    gin.H{"type": "catalog", "id": "c1"},
 		"operations":  []string{"view_detail"},
 	}
-	revokeBody := gin.H{"accessor_id": "grantee-1", "resource": gin.H{"type": "catalog", "id": "c1"}}
+	revokeBody := gin.H{"grant_id": "unknown-grant"}
 	bindBody := gin.H{"accessor_id": "grantee-1", "role_id": roleID}
 	permBody := gin.H{"resource": gin.H{"type": "catalog", "id": "*"}, "operations": []string{"view_detail"}}
 	rolePerms := "/api/safe/v1/admin/roles/" + roleID + "/permissions"
@@ -225,8 +226,7 @@ func TestPolicyReadPoints(t *testing.T) {
 	}
 }
 
-// Revoke is idempotent for the caller (204 whether or not it matched) but the
-// difference is recorded for the auditor: Detail carries _outcome.removed.
+// Revoke is stable-identity scoped and idempotent for platform administrators.
 func TestObjectGrantRevokeSemantics(t *testing.T) {
 	r, e, db, users := newAdminServer(t)
 	if err := users.CreateLocalUser(t.Context(),
@@ -240,32 +240,36 @@ func TestObjectGrantRevokeSemantics(t *testing.T) {
 		}
 	}
 
-	// An unregistered resource type is a typo, not a no-op revoke.
+	// The former tuple-shaped delete contract is rejected; callers must select a
+	// stable grant identity from a direct read.
 	if w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{
 		"accessor_id": "grantee-1", "resource": gin.H{"type": "nope", "id": "c1"},
 	}); w.Code != http.StatusBadRequest {
-		t.Fatalf("unknown type: want 400, got %d: %s", w.Code, w.Body.String())
+		t.Fatalf("tuple revoke: want 400, got %d: %s", w.Code, w.Body.String())
 	}
+	grantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "grantee-1", Object: "catalog:c1", Operation: "view_detail",
+	})
 
 	clearAuditLog(t, db)
-	if w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{
-		"accessor_id": "grantee-1", "resource": gin.H{"type": "catalog", "id": "c1"},
-	}); w.Code != http.StatusNoContent {
+	if w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{"grant_id": grantID}); w.Code != http.StatusNoContent {
 		t.Fatalf("revoke: want 204, got %d: %s", w.Code, w.Body.String())
 	}
-	if detail := onlyAuditDetail(t, db); !strings.Contains(detail, `"removed":2`) {
-		t.Fatalf("effective revoke: want _outcome.removed=2 in audit detail, got %s", detail)
+	if detail := onlyAuditDetail(t, db); !strings.Contains(detail, `"removed":true`) ||
+		!strings.Contains(detail, `"grant_id":"`+grantID+`"`) {
+		t.Fatalf("effective revoke: want stable identity and removed=true, got %s", detail)
+	}
+	if allowed, _ := e.Check("grantee-1", "catalog", "c1", "modify"); !allowed {
+		t.Fatal("revoking one grant removed its sibling operation")
 	}
 
 	// Same request again: still 204, but the audit trail shows it matched nothing.
 	clearAuditLog(t, db)
-	if w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{
-		"accessor_id": "grantee-1", "resource": gin.H{"type": "catalog", "id": "c1"},
-	}); w.Code != http.StatusNoContent {
+	if w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{"grant_id": grantID}); w.Code != http.StatusNoContent {
 		t.Fatalf("repeat revoke: want 204, got %d: %s", w.Code, w.Body.String())
 	}
-	if detail := onlyAuditDetail(t, db); !strings.Contains(detail, `"removed":0`) {
-		t.Fatalf("repeat revoke: want _outcome.removed=0 in audit detail, got %s", detail)
+	if detail := onlyAuditDetail(t, db); !strings.Contains(detail, `"removed":false`) {
+		t.Fatalf("repeat revoke: want _outcome.removed=false in audit detail, got %s", detail)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/enterprise_object_grants.go
+++ b/bkn-safe/server/internal/httpapi/enterprise_object_grants.go
@@ -1,0 +1,50 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permobject"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+)
+
+func registerEnterpriseObjectGrants(g *gin.RouterGroup, e *authz.Enforcer) {
+	g.GET("/enterprise-object-grants", RequirePermission(e, "admin-authz", "view"), func(c *gin.Context) {
+		entries, err := permobject.Inventory(c.Request.Context(), time.Now().UTC())
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"entries": entries, "total": len(entries)})
+	})
+
+	g.DELETE("/enterprise-object-grants", RequirePermission(e, "admin-authz", "revoke"), func(c *gin.Context) {
+		var req struct {
+			GrantID string `json:"grant_id" binding:"required"`
+			Reason  string `json:"reason" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		req.GrantID = strings.TrimSpace(req.GrantID)
+		req.Reason = strings.TrimSpace(req.Reason)
+		if req.GrantID == "" || len(req.GrantID) > 64 || req.Reason == "" || len(req.Reason) > 512 {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if err := permobject.Revoke(c.Request.Context(), req.GrantID,
+			c.GetString(ctxAccessorID), req.Reason, time.Now().UTC()); err != nil {
+			serverError(c, err)
+			return
+		}
+		setAuditOutcome(c, map[string]any{"grant_id": req.GrantID, "removed": true})
+		c.Status(http.StatusNoContent)
+	})
+}

--- a/bkn-safe/server/internal/httpapi/enterprise_object_grants_test.go
+++ b/bkn-safe/server/internal/httpapi/enterprise_object_grants_test.go
@@ -1,0 +1,83 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openbkn-ai/licverify"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permobject"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
+)
+
+type inventoryAuthorizer struct{}
+
+func (inventoryAuthorizer) Decide(context.Context, permobject.Request) (permobject.LocalOpinion, error) {
+	return permobject.LocalOpinion{}, nil
+}
+
+type inventoryManager struct {
+	entries  []permobject.InventoryEntry
+	revoked  string
+	operator string
+	reason   string
+}
+
+func (m *inventoryManager) Inventory(context.Context, time.Time) ([]permobject.InventoryEntry, error) {
+	return append([]permobject.InventoryEntry(nil), m.entries...), nil
+}
+
+func (m *inventoryManager) Revoke(_ context.Context, grantID, operatorID, reason string, _ time.Time) error {
+	m.revoked, m.operator, m.reason = grantID, operatorID, reason
+	return nil
+}
+
+func TestEnterpriseObjectGrantInventoryAndExactRevoke(t *testing.T) {
+	permobject.ResetForTest()
+	entitlement.ResetForTest()
+	t.Cleanup(func() {
+		permobject.ResetForTest()
+		entitlement.ResetForTest()
+	})
+	community, _ := newCommunityServer(t)
+	communityResponse := adminReq(t, community, http.MethodGet,
+		"/api/safe/v1/admin/enterprise-object-grants", nil)
+
+	manager := &inventoryManager{entries: []permobject.InventoryEntry{
+		{GrantID: "ee-grant-1", RuleID: "rule-1", AccessorID: "user-1", SubjectType: "user",
+			ResourceType: "catalog", ResourceID: "c-1", Operation: "view_detail", Effect: "allow",
+			Classification: "dormant_experimental", ActivationState: "dormant",
+			RuntimeEligible: false, InactiveReason: "administrator confirmation required"},
+	}}
+	permobject.Register(licverify.EditionEnterprise, inventoryAuthorizer{})
+	permobject.RegisterManager(licverify.EditionEnterprise, manager)
+	r, _, _, _ := newAdminServer(t)
+
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionProfessional))
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/enterprise-object-grants", nil); w.Code != http.StatusNotFound ||
+		communityResponse.Code != http.StatusNotFound || !bytes.Equal(w.Body.Bytes(), communityResponse.Body.Bytes()) {
+		t.Fatalf("Professional inventory = %d %q; want Community-identical 404 %q",
+			w.Code, w.Body.String(), communityResponse.Body.String())
+	}
+
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionEnterprise))
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/enterprise-object-grants", nil); w.Code != http.StatusOK {
+		t.Fatalf("Enterprise inventory = %d %s", w.Code, w.Body.String())
+	}
+	w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/enterprise-object-grants", map[string]any{
+		"grant_id": "ee-grant-1", "reason": "access review",
+	})
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("Enterprise revoke = %d %s", w.Code, w.Body.String())
+	}
+	if manager.revoked != "ee-grant-1" || manager.operator != adminSub || manager.reason != "access review" {
+		t.Fatalf("exact revoke call = (%q, %q, %q)", manager.revoked, manager.operator, manager.reason)
+	}
+}

--- a/bkn-safe/server/internal/httpapi/error_response.go
+++ b/bkn-safe/server/internal/httpapi/error_response.go
@@ -33,6 +33,10 @@ func replyPublicErrorDetails(c *gin.Context, status int, details any) {
 	writeLocalizedError(c, status, details)
 }
 
+func replyUnsupportedGrantShape(c *gin.Context) {
+	httperrors.WriteCode(c, http.StatusBadRequest, httperrors.UnsupportedGrantShape, nil)
+}
+
 func replyInternalError(c *gin.Context) {
 	replyPublicError(c, http.StatusInternalServerError)
 }

--- a/bkn-safe/server/internal/httpapi/explain_test.go
+++ b/bkn-safe/server/internal/httpapi/explain_test.go
@@ -1,0 +1,150 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func TestAuthzExplainRequiresAdminViewAndShowsRequirementDenial(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: "explain-target", Account: "explain-target", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: "ordinary-user", Account: "ordinary-user", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "catalog", "modify").
+		Update("implied_operation_ids", "view_detail").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantProfessionalObjectPermission("explain-target", "catalog", "c-1", "modify",
+		authz.EffectAllow, authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantProfessionalObjectPermission("explain-target", "catalog", "c-1", "view_detail",
+		authz.EffectDeny, authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+	body := map[string]any{
+		"accessor_id": "explain-target",
+		"resource":    map[string]any{"type": "catalog", "id": "c-1"},
+		"operation":   "modify",
+	}
+	path := "/api/safe/v1/authz/explain"
+	if w := tokReq(t, r, http.MethodPost, path, body, ""); w.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated explain = %d", w.Code)
+	}
+	if w := tokReq(t, r, http.MethodPost, path, body, "ordinary-user"); w.Code != http.StatusForbidden {
+		t.Fatalf("ordinary explain = %d %s", w.Code, w.Body.String())
+	}
+
+	w := adminReq(t, r, http.MethodPost, path, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("admin explain = %d %s", w.Code, w.Body.String())
+	}
+	var response struct {
+		Evaluation struct {
+			Decision          string `json:"decision"`
+			Basis             string `json:"basis"`
+			DeniedRequirement string `json:"denied_requirement"`
+			RequirementBasis  string `json:"requirement_basis"`
+		} `json:"evaluation"`
+		Steps []struct {
+			MatchedGrants []struct {
+				GrantID string `json:"grant_id"`
+			} `json:"matched_grants"`
+		} `json:"steps"`
+		Requirements []json.RawMessage `json:"requirements"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Evaluation.Decision != "deny" || response.Evaluation.Basis != "requires" ||
+		response.Evaluation.DeniedRequirement != "view_detail" || response.Evaluation.RequirementBasis != "direct" {
+		t.Fatalf("evaluation = %+v", response.Evaluation)
+	}
+	if len(response.Steps) != 1 || len(response.Steps[0].MatchedGrants) != 1 ||
+		response.Steps[0].MatchedGrants[0].GrantID == "" || len(response.Requirements) != 1 {
+		t.Fatalf("proof shape = %+v", response)
+	}
+	if strings.Contains(w.Body.String(), "property_name") || strings.Contains(w.Body.String(), "mask") {
+		t.Fatalf("explain leaked a property-level payload: %s", w.Body.String())
+	}
+
+	if err := e.GrantCommunityBundle("explain-target", "knowledge_network", "kn-bundle",
+		authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+	bundleBody := map[string]any{
+		"accessor_id": "explain-target",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-bundle"},
+		"operation":   "query_data",
+	}
+	w = adminReq(t, r, http.MethodPost, path, bundleBody)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"basis":"bundle"`) ||
+		!strings.Contains(w.Body.String(), `"match":"bundle"`) {
+		t.Fatalf("bundle explanation = %d %s", w.Code, w.Body.String())
+	}
+
+	if err := db.Create(&model.ResourceType{
+		ID: "object_type", Name: "object_type", ParentTypeID: "knowledge_network",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Operation{
+		ResourceTypeID: "object_type", ID: "view_detail", Name: "view_detail",
+		ParentOperationID: "view_detail",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "object_type", ResourceID: "kn-parent/order",
+		ParentTypeID: "knowledge_network", ParentID: "kn-parent",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantRolePermission("explain-role", "knowledge_network", "kn-parent", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.AssignRole("explain-target", "explain-role"); err != nil {
+		t.Fatal(err)
+	}
+	parentBody := map[string]any{
+		"accessor_id": "explain-target",
+		"resource":    map[string]any{"type": "object_type", "id": "kn-parent/order"},
+		"operation":   "view_detail",
+	}
+	w = adminReq(t, r, http.MethodPost, path, parentBody)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"basis":"inherited"`) ||
+		!strings.Contains(w.Body.String(), `"subject_kind":"role"`) ||
+		!strings.Contains(w.Body.String(), `"parent_operation":"view_detail"`) {
+		t.Fatalf("role/parent explanation = %d %s", w.Code, w.Body.String())
+	}
+
+	inactiveBody := map[string]any{
+		"accessor_id": "missing-user",
+		"resource":    map[string]any{"type": "catalog", "id": "c-1"},
+		"operation":   "view_detail",
+	}
+	w = adminReq(t, r, http.MethodPost, path, inactiveBody)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"scope":"effective"`) ||
+		!strings.Contains(w.Body.String(), `"resource_type":"catalog"`) ||
+		!strings.Contains(w.Body.String(), `"account_active":false`) || strings.Contains(w.Body.String(), `"resource":`) {
+		t.Fatalf("inactive explanation shape = %d %s", w.Code, w.Body.String())
+	}
+}

--- a/bkn-safe/server/internal/httpapi/managedproxy_test.go
+++ b/bkn-safe/server/internal/httpapi/managedproxy_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -217,10 +218,10 @@ func TestGenericRevokeAndRoleUnbindCannotMutateManagedProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{
-		"accessor_id": account.ProxyAccountID,
-		"resource":    gin.H{"type": "resource", "id": "r-1"},
+	grantID := oneGrantID(t, enforcer, authz.PolicyFilter{
+		AccessorID: account.ProxyAccountID, Object: "resource:r-1", Operation: "query_data",
 	})
+	w := adminReq(t, r, http.MethodDelete, objectGrantsPath, gin.H{"grant_id": grantID})
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("generic revoke = %d body=%s, want 403", w.Code, w.Body.String())
 	}

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -1039,7 +1039,11 @@ func projectDirectGrantOps(resourceType string, operations []string) []string {
 	for _, operation := range operations {
 		projected := []string{operation}
 		if operation == authz.ActFullBusinessAccess {
-			projected, _ = authz.CommunityBundleOperations(resourceType)
+		if operation == authz.ActFullBusinessAccess {
+			if bundleOps, supported := authz.CommunityBundleOperations(resourceType); supported {
+				projected = bundleOps
+			}
+		}
 		}
 		for _, item := range projected {
 			if !seen[item] {

--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -5,12 +5,16 @@
 package httpapi
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/finegrained"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
@@ -49,11 +53,9 @@ func isConcreteResourceID(id string) bool {
 
 // opAuthorize is the resource-level operation that lets someone who is NOT a
 // platform administrator hand out access to one concrete object. The domain
-// services write it to the creator at create time (bkn-backend and vega call
-// CreateResources with COMMON_OPERATIONS, which includes it), so "whoever made
-// this" is exactly who holds it. Until these handlers consulted it the operation
-// was inert: every write was gated on admin-authz alone, and the person who
-// built a knowledge network could not share it (bkn-studio#478).
+// lifecycle writes it as a separate system-derived owner grant on the resource
+// management root. BKN child resource types never expose it: their knowledge
+// network is the sole authorization root.
 const opAuthorize = "authorize"
 
 // grantableUserPageSize caps the owner-facing account picker. Deliberately not
@@ -94,7 +96,7 @@ const (
 //
 // Order matters: administrators are answered without reading any policy for the
 // object, so the admin path costs what it did before this existed.
-func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, ref resourceRef) (grantAuthority, bool) {
+func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, db *gorm.DB, adminOp string, ref resourceRef) (grantAuthority, bool) {
 	sub := c.GetString(ctxAccessorID)
 	if sub == "" {
 		replyPublicError(c, http.StatusUnauthorized)
@@ -116,10 +118,48 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 		replyPublicError(c, http.StatusForbidden)
 		return "", false
 	}
-	// Ownership first, and read as a DIRECT grant rather than through Check:
-	// Check cannot tell "granted on this object" from "granted on the whole
-	// type", and the audit trail needs them apart.
-	direct, err := e.ListObjectGrants(sub, ref.Type, ref.ID)
+	root, ok, err := grantAuthorizationRoot(c.Request.Context(), db, ref)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	if !ok {
+		replyPublicError(c, http.StatusForbidden)
+		return "", false
+	}
+	authorized, err := e.CheckContext(c.Request.Context(), sub, root.Type, root.ID, opAuthorize)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	if !authorized {
+		replyPublicError(c, http.StatusForbidden)
+		return "", false
+	}
+
+	// Holding authorize on the knowledge-network root is necessary but does not
+	// reveal a child the caller cannot otherwise see. Reading or changing that
+	// child's grant configuration therefore also requires its catalog-declared
+	// view operation through the final operation decision (including requires).
+	viewOp, err := resourceViewOperation(c.Request.Context(), db, ref.Type)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	visible, err := e.CheckContext(c.Request.Context(), sub, ref.Type, ref.ID, viewOp)
+	if err != nil {
+		serverError(c, err)
+		return "", false
+	}
+	if !visible {
+		replyPublicError(c, http.StatusForbidden)
+		return "", false
+	}
+
+	// Preserve the audit distinction between an instance owner and a holder of
+	// broader delegated authority. The security decision above is always the
+	// final operation decision; this direct read is diagnostic only.
+	direct, err := e.ListObjectGrants(sub, root.Type, root.ID)
 	if err != nil {
 		serverError(c, err)
 		return "", false
@@ -131,20 +171,75 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 			}
 		}
 	}
-	ok, err := e.CheckContext(c.Request.Context(), sub, ref.Type, ref.ID, opAuthorize)
+	return authorityTypeAuthorize, true
+}
+
+// grantAuthorizationRoot applies the BKN boundary: a knowledge-network is the
+// sole authorization-management root for its registered child resources.
+// Other resource families manage grants on the concrete resource itself.
+func grantAuthorizationRoot(ctx context.Context, db *gorm.DB, ref resourceRef) (resourceRef, bool, error) {
+	var resourceType model.ResourceType
+	if err := db.WithContext(ctx).First(&resourceType, "id = ?", ref.Type).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return resourceRef{}, false, nil
+		}
+		return resourceRef{}, false, err
+	}
+	if resourceType.ParentTypeID != "knowledge_network" {
+		return ref, true, nil
+	}
+	var parent model.ResourceParent
+	err := db.WithContext(ctx).First(&parent,
+		"resource_type_id = ? AND resource_id = ?", ref.Type, ref.ID).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return resourceRef{}, false, nil
+	}
 	if err != nil {
-		serverError(c, err)
-		return "", false
+		return resourceRef{}, false, err
 	}
-	if ok {
-		return authorityTypeAuthorize, true
+	if parent.ParentTypeID != "knowledge_network" || !isConcreteResourceID(parent.ParentID) {
+		return resourceRef{}, false, nil
 	}
-	replyPublicError(c, http.StatusForbidden)
-	return "", false
+	return resourceRef{Type: parent.ParentTypeID, ID: parent.ParentID}, true, nil
+}
+
+// resourceViewOperation resolves the view vocabulary from the registered
+// operation catalog. The authorization engine does not normalize these names:
+// BKN/Vega use view_detail, execution-factory uses view, and models use display.
+func resourceViewOperation(ctx context.Context, db *gorm.DB, resourceType string) (string, error) {
+	var ids []string
+	if err := db.WithContext(ctx).Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id IN ?", resourceType, []string{"view_detail", "view", "display"}).
+		Pluck("id", &ids).Error; err != nil {
+		return "", err
+	}
+	for _, preferred := range []string{"view_detail", "view", "display"} {
+		for _, id := range ids {
+			if id == preferred {
+				return id, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("resource type %q does not declare a view operation", resourceType)
+}
+
+func isBKNChildResourceType(ctx context.Context, db *gorm.DB, resourceType string) (bool, error) {
+	var parentTypeID string
+	result := db.WithContext(ctx).Model(&model.ResourceType{}).
+		Select("parent_type_id").Where("id = ?", resourceType).Scan(&parentTypeID)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return false, gorm.ErrRecordNotFound
+	}
+	return parentTypeID == "knowledge_network", nil
 }
 
 // restrictDelegatedOps enforces the two limits on a non-administrator writing a
-// grant. It replies and returns false when the request breaks either.
+// Professional rule. It replies and returns false when the request breaks
+// either. Community bundles are protected platform state and never reach this
+// helper.
 //
 //  1. The delegation chain is one deep: opAuthorize is administrator-conferred
 //     only. A delegate handing out opAuthorize would mint another delegate, and
@@ -156,48 +251,6 @@ func resolveGrantAuthority(c *gin.Context, e *authz.Enforcer, adminOp string, re
 //
 // Administrators skip both: admin-authz:grant is the platform-level authority
 // these two rules exist to protect.
-// protectAuthorizeHolder stops a delegate from touching the grant of another
-// `authorize` holder — the object's creator included — or the public-access row.
-//
-// It guards BOTH writes, because both erase. DELETE removes every p-line the
-// accessor holds on the object; POST is replace-semantics, so writing
-// operations:["view_detail"] onto a holder drops everything else in the same
-// motion. And restrictDelegatedOps forbids a delegate from putting `authorize`
-// back. Without this, anyone the platform trusts to share ONE object could
-// silently take that object away from the person who made it, and only a
-// platform administrator could undo it — a role carrying `authorize` type-wide
-// would be every member of that role against every object of the type.
-//
-// Same rule as the grant side, in the other direction: `authorize` is
-// administrator-conferred, so only an administrator takes it away. Grants
-// without `authorize` stay fully editable and revocable, which is what the owner
-// surface exists for.
-func protectAuthorizeHolder(c *gin.Context, e *authz.Enforcer, ref resourceRef, accessorID string) bool {
-	// The public accessor is not a person whose access a delegate may adjust: it
-	// is how the execution factory publishes a built-in toolbox to everyone. Its
-	// row carries no `authorize`, so the holder check below would wave it through,
-	// and removing it would un-publish the toolbox platform-wide — previously an
-	// admin-authz:revoke action.
-	if accessorID == authz.PublicAccessorID {
-		replyPublicError(c, http.StatusForbidden)
-		return false
-	}
-	held, err := e.ListObjectGrants(accessorID, ref.Type, ref.ID)
-	if err != nil {
-		serverError(c, err)
-		return false
-	}
-	for _, grant := range held {
-		for _, op := range grant.Operations {
-			if op == opAuthorize {
-				replyPublicError(c, http.StatusForbidden)
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func restrictDelegatedOps(c *gin.Context, e *authz.Enforcer, ref resourceRef, ops []string) bool {
 	for _, op := range ops {
 		if op == opAuthorize {
@@ -258,11 +311,25 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		}
 		entries := make([]gin.H, 0, len(policies))
 		for _, p := range policies {
+			ref := resourceRef{Type: resourceType, ID: resourceID}
+			grants, err := objectGrantRecords(e, p.AccessorID, ref)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			decisions, err := effectiveObjectGrantDecisions(c.Request.Context(), e, db, p.AccessorID, ref,
+				append(append([]string{}, p.Operations...), p.DeniedOperations...))
+			if err != nil {
+				serverError(c, err)
+				return
+			}
 			entries = append(entries, gin.H{
-				"accessor_id":       p.AccessorID,
-				"resource":          gin.H{"type": resourceType, "id": resourceID},
-				"operations":        p.Operations,
-				"denied_operations": p.DeniedOperations,
+				"accessor_id":         p.AccessorID,
+				"resource":            gin.H{"type": resourceType, "id": resourceID},
+				"operations":          p.Operations,
+				"denied_operations":   p.DeniedOperations,
+				"grants":              grants,
+				"effective_decisions": decisions,
 			})
 		}
 		c.JSON(http.StatusOK, gin.H{"entries": entries})
@@ -404,11 +471,27 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			if row.Ops != "" {
 				ops = strings.Split(row.Ops, ",")
 			}
+			ref := resourceRef{Type: row.Rtype, ID: row.Rid}
+			ops = projectDirectGrantOps(ref.Type, ops)
+			grants, err := objectGrantRecords(e, row.Accessor, ref)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			deniedOps := splitGrantOps(row.DeniedOps)
+			decisions, err := effectiveObjectGrantDecisions(c.Request.Context(), e, db, row.Accessor, ref,
+				append(append([]string{}, ops...), deniedOps...))
+			if err != nil {
+				serverError(c, err)
+				return
+			}
 			entries = append(entries, gin.H{
-				"accessor_id":       row.Accessor,
-				"resource":          gin.H{"type": row.Rtype, "id": row.Rid},
-				"operations":        ops,
-				"denied_operations": splitGrantOps(row.DeniedOps),
+				"accessor_id":         row.Accessor,
+				"resource":            gin.H{"type": ref.Type, "id": ref.ID},
+				"operations":          ops,
+				"denied_operations":   deniedOps,
+				"grants":              grants,
+				"effective_decisions": decisions,
 			})
 		}
 		resp["entries"] = entries
@@ -416,29 +499,82 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 		c.JSON(http.StatusOK, resp)
 	})
 
-	// POST /object-grants — set (replace) a user's exact allow or deny op set on
-	// one concrete resource instance. { accessor_id, resource, operations,
-	// effect?:"allow"|"deny" }. Missing effect remains allow for compatibility.
-	// Upsert semantics: that effect's ops become exactly `operations`. An empty
-	// list is rejected (use DELETE to revoke) so an accidental empty body can't
-	// silently wipe a grant.
+	// POST /object-grants accepts one of two shapes. Community stores the reviewed
+	// top-level full_business_access bundle; Professional and above may replace a
+	// source-scoped allow/deny operation set. The handler derives both provenance
+	// fields, normalizes direct requirements, and applies the same checks on the
+	// administrator and /me delegation routes.
 	g.POST("/object-grants", setObjectGrantHandler(e, db))
+	g.POST("/object-grants/preview", RequirePermission(e, "admin-authz", "view"), previewObjectGrantHandler(e))
 
-	// DELETE /object-grants — revoke one user's grant on one concrete resource
-	// instance, leaving other grantees on the same resource untouched.
-	// { accessor_id, resource{type,id} } -> 204.
+	// DELETE /object-grants revokes exactly one stable grant_id. It never deletes
+	// by the Casbin tuple, so a sibling grant with identical runtime semantics but
+	// a different source or lifecycle owner remains intact.
 	//
-	// Idempotent BY DESIGN: a request naming a grant that does not exist (already
-	// revoked, wrong accessor, wrong instance) still answers 204, so a retry or a
-	// double-click is safe. The distinction the caller cannot see is recorded in
-	// the audit trail instead — Detail carries _outcome.removed, the number of
-	// p-lines actually dropped, so 0 is auditable as "matched nothing".
-	//
-	// The resource TYPE is validated against the catalog even though revoking an
-	// unregistered type would harmlessly match nothing: a typo'd type is a silent
-	// no-op the operator would read as a successful revoke, which is the worst
-	// possible outcome for a security operation.
+	// An administrator gets idempotent 204 for an already-absent id, with
+	// _outcome.removed=false in the audit record. A delegated caller cannot prove
+	// authority over an opaque missing id and therefore receives 403.
 	g.DELETE("/object-grants", revokeObjectGrantHandler(e, db))
+}
+
+func previewObjectGrantHandler(e *authz.Enforcer) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			AccessorID string      `json:"accessor_id" binding:"required"`
+			Resource   resourceRef `json:"resource" binding:"required"`
+			Bundle     string      `json:"bundle" binding:"required"`
+		}
+		if !bind(c, &req) {
+			return
+		}
+		bundleOps, supported := authz.CommunityBundleOperations(req.Resource.Type)
+		if req.Bundle != authz.ActFullBusinessAccess || !supported || !isConcreteResourceID(req.Resource.ID) {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		records, err := e.PolicyRecords(authz.PolicyFilter{
+			AccessorID: req.AccessorID,
+			Object:     req.Resource.Type + ":" + req.Resource.ID,
+		})
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		legacy := make([]gin.H, 0)
+		legacyAllows := map[string]bool{}
+		for _, record := range records {
+			if record.PolicySource != authz.PolicySourceLegacy {
+				continue
+			}
+			legacy = append(legacy, policyRecordJSON(record))
+			if record.Active && record.Effect == authz.EffectAllow {
+				legacyAllows[record.Operation] = true
+			}
+		}
+		added := make([]string, 0, len(bundleOps))
+		for _, operation := range bundleOps {
+			if !legacyAllows[operation] {
+				added = append(added, operation)
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"accessor_id":       req.AccessorID,
+			"resource":          gin.H{"type": req.Resource.Type, "id": req.Resource.ID},
+			"bundle":            req.Bundle,
+			"bundle_operations": bundleOps,
+			"added_operations":  added,
+			"legacy_grants":     legacy,
+		})
+	}
+}
+
+func policyRecordJSON(record authz.PolicyRecord) gin.H {
+	return gin.H{
+		"grant_id": record.GrantID, "accessor_id": record.AccessorID,
+		"operation": record.Operation, "effect": record.Effect,
+		"policy_source": record.PolicySource, "authority_source": record.AuthoritySource,
+		"active": record.Active, "inherited": false,
+	}
 }
 
 // listGroupedObjectGrants serves the grouped, paginated object-grant views the
@@ -594,7 +730,7 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 		}
 		// Reading who has access is itself a privilege on the object: the same
 		// authority that lets a caller change the grants lets it see them.
-		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
+		if _, ok := resolveGrantAuthority(c, e, db, "view", ref); !ok {
 			return
 		}
 		policies, err := e.ResourcePolicies(ref.Type, ref.ID)
@@ -616,11 +752,24 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 		}
 		entries := make([]gin.H, 0, len(policies))
 		for _, policy := range policies {
+			grants, err := objectGrantRecords(e, policy.AccessorID, ref)
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			decisions, err := effectiveObjectGrantDecisions(c.Request.Context(), e, db, policy.AccessorID, ref,
+				append(append([]string{}, policy.Operations...), policy.DeniedOperations...))
+			if err != nil {
+				serverError(c, err)
+				return
+			}
 			entry := gin.H{
-				"accessor_id":       policy.AccessorID,
-				"resource":          gin.H{"type": ref.Type, "id": ref.ID},
-				"operations":        policy.Operations,
-				"denied_operations": policy.DeniedOperations,
+				"accessor_id":         policy.AccessorID,
+				"resource":            gin.H{"type": ref.Type, "id": ref.ID},
+				"operations":          policy.Operations,
+				"denied_operations":   policy.DeniedOperations,
+				"grants":              grants,
+				"effective_decisions": decisions,
 			}
 			// A row whose subject is a role, or a user since deleted, resolves to
 			// nothing. It is still shown — hiding a grant that exists would be
@@ -660,7 +809,7 @@ func registerMeObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB, 
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		if _, ok := resolveGrantAuthority(c, e, "view", ref); !ok {
+		if _, ok := resolveGrantAuthority(c, e, db, "view", ref); !ok {
 			return
 		}
 		enabled := true
@@ -710,34 +859,45 @@ func grantAccessorNames(c *gin.Context, db *gorm.DB, ids []string) (map[string]m
 
 func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var req struct {
-			AccessorID string      `json:"accessor_id" binding:"required"`
-			Resource   resourceRef `json:"resource" binding:"required"`
-			Operations []string    `json:"operations" binding:"required"`
-			Effect     string      `json:"effect"`
-		}
+		var req objectGrantWriteRequest
 		if !bind(c, &req) {
 			return
 		}
-		if !isConcreteResourceID(req.Resource.ID) {
+
+		_, bundleTarget := authz.CommunityBundleOperations(req.Resource.Type)
+		communityShape := req.Bundle == authz.ActFullBusinessAccess && req.Operations == nil &&
+			(req.Effect == "" || req.Effect == authz.EffectAllow) && bundleTarget
+		fineShape := req.Bundle == "" && req.Operations != nil
+		if !finegrained.Available() && !communityShape {
+			// This response must remain independent of whether the paid code is
+			// absent, merely unlicensed, or currently downgraded.
+			replyUnsupportedGrantShape(c)
+			return
+		}
+		if !communityShape && !fineShape {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		if len(req.Operations) == 0 {
+		if req.AccessorID == "" || req.Resource.Type == "" || !isConcreteResourceID(req.Resource.ID) {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		if req.Effect == "" {
-			req.Effect = authz.EffectAllow
+
+		effect := req.Effect
+		if effect == "" {
+			effect = authz.EffectAllow
 		}
-		if req.Effect != authz.EffectAllow && req.Effect != authz.EffectDeny {
+		if effect != authz.EffectAllow && effect != authz.EffectDeny {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if fineShape && len(*req.Operations) == 0 {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
 		// safe_admin:console:manage is exactly what CanAdmin tests, so granting it
 		// here would promote any grantee to platform administrator through the
 		// object-grant route — bypassing role binding and its escalation guards.
-		// Administrative capability is role-conferred only.
 		if req.Resource.Type == adminConsoleResourceType {
 			replyPublicError(c, http.StatusForbidden)
 			return
@@ -751,25 +911,14 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}
-		// Administrator, or the object's own owner delegating it. Resolved here
-		// rather than in middleware because the owner branch is a question about
-		// the object named in the BODY, which middleware cannot see.
-		authority, ok := resolveGrantAuthority(c, e, "grant", req.Resource)
+		authority, ok := resolveGrantAuthority(c, e, db, "grant", req.Resource)
 		if !ok {
 			return
 		}
-		// Explicit exceptions are security administration, not delegation: an
-		// object owner may share what they hold but may not install deny rules on
-		// another account.
-		if req.Effect == authz.EffectDeny && authority != authorityAdminAuthz {
+		if effect == authz.EffectDeny && authority != authorityAdminAuthz {
 			replyPublicError(c, http.StatusForbidden)
 			return
 		}
-		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
-			return
-		}
-		// Grantee must be a user (apps are user rows too). Departments/groups are
-		// rejected: their grants never match at enforce time.
 		ok, err = isUserAccessor(c, db, req.AccessorID)
 		if err != nil {
 			serverError(c, err)
@@ -779,8 +928,31 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		// Ops must be registered for the resource type — blocks typos that would
-		// create policies no /check can ever satisfy.
+
+		authoritySource := authz.AuthoritySourceAdminAuthz
+		if authority != authorityAdminAuthz {
+			authoritySource = authz.AuthoritySourceOwnerDelegate
+		}
+		outcome := map[string]any{"via": string(authority), "effect": effect}
+		if communityShape {
+			// The Community compatibility bundle is a protected source. Unlike a
+			// Professional rule it cannot be created, replaced, or revoked by an
+			// object-level delegate, even when that delegate happens to hold every
+			// operation represented by the bundle.
+			if authority != authorityAdminAuthz {
+				replyPublicError(c, http.StatusForbidden)
+				return
+			}
+			if err := e.GrantCommunityBundle(req.AccessorID, req.Resource.Type, req.Resource.ID, authoritySource); err != nil {
+				serverError(c, err)
+				return
+			}
+			outcome["bundle"] = authz.ActFullBusinessAccess
+			setAuditOutcome(c, outcome)
+			c.Status(http.StatusNoContent)
+			return
+		}
+
 		valid, err := catalogOpSet(db, req.Resource.Type)
 		if err != nil {
 			serverError(c, err)
@@ -790,55 +962,135 @@ func setObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		for _, op := range req.Operations {
+		bknChild, err := isBKNChildResourceType(c.Request.Context(), db, req.Resource.Type)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		for _, op := range *req.Operations {
 			if !valid[op] {
 				replyPublicError(c, http.StatusBadRequest)
 				return
 			}
+			// authorize is managed only through its dedicated platform/lifecycle
+			// contract; BKN child types must not expose it even if an old catalog
+			// row survives until #1432's directory migration.
+			if op == opAuthorize && (bknChild || authority != authorityAdminAuthz) {
+				replyPublicError(c, http.StatusForbidden)
+				return
+			}
 		}
-		// Add the operations directly required by the requested ones (#1121). Expanded after
-		// validation so a typo is still a 400 rather than something the expansion
-		// quietly absorbs. Upsert semantics make this self-healing: a console that
-		// clears view_detail while leaving resource_manage ticked sends a set this
-		// puts back, instead of storing a grant nothing can use.
-		ops := req.Operations
-		if req.Effect == authz.EffectAllow {
-			ops, err = e.NormalizeOperations(c.Request.Context(), req.Resource.Type, req.Operations)
+		ops := append([]string(nil), (*req.Operations)...)
+		if effect == authz.EffectAllow {
+			ops, err = e.NormalizeOperations(c.Request.Context(), req.Resource.Type, ops)
 			if err != nil {
 				serverError(c, err)
 				return
 			}
 		}
-		// Checked against the EXPANDED set, not what was asked for: normalization
-		// pass can add operations, and a delegate must not acquire one that way
-		// that it could not have named directly.
 		if authority != authorityAdminAuthz && !restrictDelegatedOps(c, e, req.Resource, ops) {
 			return
 		}
-		// The audit Detail snapshots the request body, so without this the trail
-		// would say only what was asked for and a required operation would appear
-		// on the accessor with nothing recording where it came from — the one
-		// question ("why can this account see this catalog?") the trail exists to
-		// answer. The seed's back-fill records its own repairs for the same
-		// reason; this keeps the two paths saying the same thing.
-		outcome := map[string]any{"via": string(authority)}
-		if required := addedOps(req.Operations, ops); len(required) > 0 {
+		if required := addedOps(*req.Operations, ops); len(required) > 0 {
 			outcome["required_operations"] = required
 		}
-		outcome["effect"] = req.Effect
 		setAuditOutcome(c, outcome)
-		// #1426 introduces trusted provenance and edition-aware decision APIs but
-		// does not change this route's public write contract. Keep writes in the
-		// active legacy compatibility slice until #1430 atomically adds Community
-		// bundle-only validation and the Professional capability gate. Writing a
-		// Professional row here today would return 204 in Community while storing
-		// a rule that Check and every permission read intentionally ignore.
-		if err := e.SetObjectPermissionsForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, ops, req.Effect); err != nil {
+		if err := e.SetProfessionalObjectPermissions(req.AccessorID, req.Resource.Type, req.Resource.ID,
+			ops, effect, authoritySource); err != nil {
 			serverError(c, err)
 			return
 		}
 		c.Status(http.StatusNoContent)
 	}
+}
+
+type objectGrantWriteRequest struct {
+	AccessorID string      `json:"accessor_id" binding:"required"`
+	Resource   resourceRef `json:"resource" binding:"required"`
+	// Operations is a pointer so an omitted field (Community shape) can be
+	// distinguished from an explicitly empty Professional set.
+	Operations *[]string `json:"operations"`
+	Bundle     string    `json:"bundle"`
+	Effect     string    `json:"effect"`
+}
+
+func objectGrantRecords(e *authz.Enforcer, accessorID string, ref resourceRef) ([]gin.H, error) {
+	records, err := e.PolicyRecords(authz.PolicyFilter{
+		AccessorID: accessorID,
+		Object:     ref.Type + ":" + ref.ID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gin.H, 0, len(records))
+	for _, record := range records {
+		out = append(out, policyRecordJSON(record))
+	}
+	return out, nil
+}
+
+func projectDirectGrantOps(resourceType string, operations []string) []string {
+	out := make([]string, 0, len(operations))
+	seen := map[string]bool{}
+	for _, operation := range operations {
+		projected := []string{operation}
+		if operation == authz.ActFullBusinessAccess {
+			projected, _ = authz.CommunityBundleOperations(resourceType)
+		}
+		for _, item := range projected {
+			if !seen[item] {
+				seen[item] = true
+				out = append(out, item)
+			}
+		}
+	}
+	return out
+}
+
+func effectiveObjectGrantDecisions(ctx context.Context, e *authz.Enforcer, db *gorm.DB,
+	accessorID string, ref resourceRef, operations []string) ([]gin.H, error) {
+	operations = projectDirectGrantOps(ref.Type, operations)
+	out := make([]gin.H, 0, len(operations))
+	for _, operation := range operations {
+		decision, err := e.OperationDecision(ctx, accessorID, ref.Type, ref.ID, operation)
+		if err != nil {
+			return nil, err
+		}
+		item := gin.H{"operation": operation, "decision": decision.Decision, "basis": decision.Basis}
+		if len(decision.Requirements) > 0 {
+			item["requires"] = decision.Requirements
+		}
+		if decision.DeniedRequirement != "" {
+			item["denied_requirement"] = decision.DeniedRequirement
+			item["requirement_basis"] = decision.RequirementBasis
+		}
+		if decision.Basis == authz.BasisInherited {
+			var parent model.ResourceParent
+			if err := db.WithContext(ctx).First(&parent,
+				"resource_type_id = ? AND resource_id = ?", ref.Type, ref.ID).Error; err != nil &&
+				!errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, err
+			} else if err == nil {
+				var op model.Operation
+				if err := db.WithContext(ctx).First(&op,
+					"resource_type_id = ? AND id = ?", ref.Type, operation).Error; err != nil &&
+					!errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, err
+				} else if err == nil {
+					item["inherited_from"] = gin.H{
+						"resource":  gin.H{"type": parent.ParentTypeID, "id": parent.ParentID},
+						"operation": op.ParentOperationID,
+					}
+				}
+			}
+		}
+		out = append(out, item)
+	}
+	return out, nil
 }
 
 // addedOps returns the members of normalized that were not in requested, in
@@ -860,22 +1112,52 @@ func addedOps(requested, normalized []string) []string {
 func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req struct {
-			AccessorID string      `json:"accessor_id" binding:"required"`
-			Resource   resourceRef `json:"resource" binding:"required"`
-			Effect     string      `json:"effect"`
+			GrantID string `json:"grant_id" binding:"required"`
 		}
 		if !bind(c, &req) {
 			return
 		}
-		if !isConcreteResourceID(req.Resource.ID) {
+		req.GrantID = strings.TrimSpace(req.GrantID)
+		if req.GrantID == "" || len(req.GrantID) > 64 {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		if req.Effect != "" && req.Effect != authz.EffectAllow && req.Effect != authz.EffectDeny {
+		records, err := e.PolicyRecords(authz.PolicyFilter{GrantID: req.GrantID})
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		if len(records) == 0 {
+			allowed, err := e.CheckContext(c.Request.Context(), c.GetString(ctxAccessorID),
+				"admin-authz", "*", "revoke")
+			if err != nil {
+				serverError(c, err)
+				return
+			}
+			if !allowed {
+				replyPublicError(c, http.StatusForbidden)
+				return
+			}
+			setAuditOutcome(c, map[string]any{"grant_id": req.GrantID, "removed": false})
+			c.Status(http.StatusNoContent)
+			return
+		}
+		record := records[0]
+		// Role grants have their own rbac_basic route, capability gate and
+		// admin-role:permissions check. Letting a stable ID through this
+		// user-object route would bypass all three, particularly after a downgrade
+		// where role configuration must remain active but its writer is closed.
+		if record.PolicySource == authz.PolicySourceRolePermission {
+			replyPublicError(c, http.StatusForbidden)
+			return
+		}
+		resourceType, resourceID, ok := strings.Cut(record.Object, ":")
+		if !ok || resourceType == "" || !isConcreteResourceID(resourceID) {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
-		managed, err := managedproxy.IsManaged(c.Request.Context(), db, req.AccessorID)
+		ref := resourceRef{Type: resourceType, ID: resourceID}
+		managed, err := managedproxy.IsManaged(c.Request.Context(), db, record.AccessorID)
 		if err != nil {
 			serverError(c, err)
 			return
@@ -887,46 +1169,32 @@ func revokeObjectGrantHandler(e *authz.Enforcer, db *gorm.DB) gin.HandlerFunc {
 		// Revoking on an object is the mirror of granting on it: whoever can open
 		// their own object up can close it again. No op restriction applies —
 		// taking access away can only narrow, never widen.
-		authority, ok := resolveGrantAuthority(c, e, "revoke", req.Resource)
+		authority, ok := resolveGrantAuthority(c, e, db, "revoke", ref)
 		if !ok {
 			return
 		}
-		// Deny exceptions are security-administration state. A delegated owner
-		// may revoke ordinary allows, but must not remove an administrator's deny
-		// rule. For a legacy request without effect, keep the owner-facing revoke
-		// behavior by limiting it to allow rows; administrators retain the old
-		// "remove every row" behavior.
-		if req.Effect == authz.EffectDeny && authority != authorityAdminAuthz {
-			replyPublicError(c, http.StatusForbidden)
-			return
-		}
-		if authority != authorityAdminAuthz && !protectAuthorizeHolder(c, e, req.Resource, req.AccessorID) {
-			return
-		}
-		valid, err := catalogOpSet(db, req.Resource.Type)
-		if err != nil {
-			serverError(c, err)
-			return
-		}
-		if len(valid) == 0 {
-			replyPublicError(c, http.StatusBadRequest)
-			return
-		}
-		var removed int
-		if req.Effect == "" && authority == authorityAdminAuthz {
-			removed, err = e.RemoveAccessorResourcePolicies(req.AccessorID, req.Resource.Type, req.Resource.ID)
-		} else {
-			effect := req.Effect
-			if effect == "" {
-				effect = authz.EffectAllow
+		// A delegated owner may revoke only an ordinary allow produced by the
+		// delegated Professional writer. Stable source identity makes this check
+		// sufficient: selecting that row cannot remove an administrator deny,
+		// authorize, bundle, legacy, system or role sibling.
+		if authority != authorityAdminAuthz {
+			ordinaryOwnerGrant := record.PolicySource == authz.PolicySourceProfessionalRule &&
+				record.AuthoritySource == authz.AuthoritySourceOwnerDelegate &&
+				record.Effect == authz.EffectAllow && record.Operation != opAuthorize
+			if !ordinaryOwnerGrant {
+				replyPublicError(c, http.StatusForbidden)
+				return
 			}
-			removed, err = e.RemoveAccessorResourcePoliciesForEffect(req.AccessorID, req.Resource.Type, req.Resource.ID, effect)
 		}
+		removed, err := e.RevokePolicy(req.GrantID)
 		if err != nil {
 			serverError(c, err)
 			return
 		}
-		setAuditOutcome(c, map[string]any{"removed": removed, "via": string(authority)})
+		setAuditOutcome(c, map[string]any{
+			"grant_id": req.GrantID, "policy_source": record.PolicySource,
+			"authority_source": record.AuthoritySource, "removed": removed, "via": string(authority),
+		})
 		c.Status(http.StatusNoContent)
 	}
 }

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -7,6 +7,7 @@ package httpapi
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +23,9 @@ import (
 // object-grant op-validation has a catalog to check against.
 func seedCatalogOps(t *testing.T, db *gorm.DB, resourceType string, ops ...string) {
 	t.Helper()
+	if err := db.FirstOrCreate(&model.ResourceType{ID: resourceType, Name: resourceType}).Error; err != nil {
+		t.Fatalf("seed resource type %s: %v", resourceType, err)
+	}
 	for _, op := range ops {
 		row := model.Operation{ResourceTypeID: resourceType, ID: op, Name: op}
 		if err := db.Create(&row).Error; err != nil {
@@ -38,6 +42,14 @@ type ogEntry struct {
 	} `json:"resource"`
 	Operations       []string `json:"operations"`
 	DeniedOperations []string `json:"denied_operations"`
+	Grants           []struct {
+		GrantID         string `json:"grant_id"`
+		Operation       string `json:"operation"`
+		PolicySource    string `json:"policy_source"`
+		AuthoritySource string `json:"authority_source"`
+		Active          bool   `json:"active"`
+		Inherited       bool   `json:"inherited"`
+	} `json:"grants"`
 }
 
 func listObjectGrants(t *testing.T, r *gin.Engine, query string) []ogEntry {
@@ -75,6 +87,15 @@ func listObjectGrantsBody(t *testing.T, r *gin.Engine, query string) struct {
 	return body
 }
 
+func oneGrantID(t *testing.T, e *authz.Enforcer, filter authz.PolicyFilter) string {
+	t.Helper()
+	records, err := e.PolicyRecords(filter)
+	if err != nil || len(records) != 1 {
+		t.Fatalf("grant lookup = %+v, %v; want exactly one", records, err)
+	}
+	return records[0].GrantID
+}
+
 func TestObjectGrantsSetListRevoke(t *testing.T) {
 	r, e, db, users := newAdminServer(t)
 	ctx := t.Context()
@@ -97,15 +118,14 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	if ok, _ := e.Check("u-1", "catalog", "c1", "modify"); !ok {
 		t.Fatal("grant did not take effect at enforce time")
 	}
-	// Provenance is a server-side property. Until #1430 switches this existing
-	// route to the edition-aware request contract, unknown JSON fields cannot
-	// turn its compatibility write into a bundle or Professional rule.
+	// Provenance is derived by the trusted route. Unknown client fields cannot
+	// forge either source dimension.
 	records, err := e.PolicyRecords(authz.PolicyFilter{AccessorID: "u-1", Object: "catalog:c1"})
 	if err != nil || len(records) != 2 {
 		t.Fatalf("policy provenance = %+v, %v; want two server-derived rows", records, err)
 	}
 	for _, record := range records {
-		if record.PolicySource != authz.PolicySourceLegacy || record.AuthoritySource != authz.AuthoritySourceMigration {
+		if record.PolicySource != authz.PolicySourceProfessionalRule || record.AuthoritySource != authz.AuthoritySourceAdminAuthz {
 			t.Fatalf("ordinary request forged policy provenance: %+v", record)
 		}
 	}
@@ -114,6 +134,12 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	entries := listObjectGrants(t, r, "")
 	if len(entries) != 1 || entries[0].AccessorID != "u-1" || entries[0].Resource.ID != "c1" || len(entries[0].Operations) != 2 {
 		t.Fatalf("unexpected list: %+v", entries)
+	}
+	if len(entries[0].Grants) != 2 || entries[0].Grants[0].GrantID == "" ||
+		entries[0].Grants[0].PolicySource != string(authz.PolicySourceProfessionalRule) ||
+		entries[0].Grants[0].AuthoritySource != string(authz.AuthoritySourceAdminAuthz) ||
+		!entries[0].Grants[0].Active || entries[0].Grants[0].Inherited {
+		t.Fatalf("direct grant metadata = %+v", entries[0].Grants)
 	}
 	// filtered lists
 	if got := listObjectGrants(t, r, "?accessor_id=u-1"); len(got) != 1 {
@@ -143,10 +169,11 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	}
 
 	// revoke
-	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
-		"accessor_id": "u-1",
-		"resource":    map[string]any{"type": "catalog", "id": "c1"},
+	grantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "u-1", Object: "catalog:c1", Operation: "view_detail",
+		PolicySource: authz.PolicySourceProfessionalRule, AuthoritySource: authz.AuthoritySourceAdminAuthz,
 	})
+	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{"grant_id": grantID})
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("revoke: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
@@ -155,6 +182,40 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	}
 	if got := listObjectGrants(t, r, ""); len(got) != 0 {
 		t.Fatalf("list after revoke: %+v", got)
+	}
+}
+
+func TestObjectGrantAllowAtomicallyAddsDirectRequirements(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: "required-user", Account: "required-user", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify")
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "catalog", "modify").
+		Update("implied_operation_ids", "view_detail").Error; err != nil {
+		t.Fatal(err)
+	}
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "required-user",
+		"resource":    map[string]any{"type": "catalog", "id": "c-required"},
+		"operations":  []string{"modify"},
+	}); w.Code != http.StatusNoContent {
+		t.Fatalf("normalized grant = %d %s", w.Code, w.Body.String())
+	}
+	records, err := e.PolicyRecords(authz.PolicyFilter{
+		AccessorID: "required-user", Object: "catalog:c-required",
+		PolicySource: authz.PolicySourceProfessionalRule,
+	})
+	if err != nil || len(records) != 2 {
+		t.Fatalf("normalized records = %+v, %v; want modify and view_detail", records, err)
+	}
+	for _, operation := range []string{"modify", "view_detail"} {
+		if allowed, err := e.Check("required-user", "catalog", "c-required", operation); err != nil || !allowed {
+			t.Fatalf("normalized %s decision = %v, %v", operation, allowed, err)
+		}
 	}
 }
 
@@ -170,20 +231,67 @@ func TestCommunityObjectGrantCompatibilityWriteIsImmediatelyEffective(t *testing
 	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
 		"accessor_id": "community-user",
 		"resource":    map[string]any{"type": "catalog", "id": "c-community"},
-		"operations":  []string{"view_detail", "modify"},
+		"bundle":      authz.ActFullBusinessAccess,
 	})
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("Community grant = %d %s; want 204", w.Code, w.Body.String())
 	}
-	for _, operation := range []string{"view_detail", "modify"} {
+	for _, operation := range []string{"view_detail", "modify", "query_data", "resource_manage"} {
 		allowed, err := e.Check("community-user", "catalog", "c-community", operation)
 		if err != nil || !allowed {
 			t.Fatalf("Community grant Check(%q) = %v, %v; want true", operation, allowed, err)
 		}
 	}
 	grants := listObjectGrants(t, r, "?accessor_id=community-user&resource_type=catalog&resource_id=c-community")
-	if len(grants) != 1 || len(grants[0].Operations) != 2 {
-		t.Fatalf("Community grant listing = %+v; want one visible two-operation grant", grants)
+	if len(grants) != 1 || len(grants[0].Operations) != 6 {
+		t.Fatalf("Community grant listing = %+v; want one projected bundle grant", grants)
+	}
+}
+
+func TestBundlePreviewAndLegacyRevokePreserveSiblingSource(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	if err := users.CreateLocalUser(t.Context(), &model.User{
+		ID: "legacy-user", Account: "legacy-user", Enabled: true,
+	}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "catalog", "view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage")
+	if err := e.GrantObjectPermission("legacy-user", "catalog", "c-legacy", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	legacyID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "legacy-user", Object: "catalog:c-legacy", Operation: "view_detail",
+		PolicySource: authz.PolicySourceLegacy,
+	})
+
+	preview := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants/preview", map[string]any{
+		"accessor_id": "legacy-user",
+		"resource":    map[string]any{"type": "catalog", "id": "c-legacy"},
+		"bundle":      authz.ActFullBusinessAccess,
+	})
+	if preview.Code != http.StatusOK || !strings.Contains(preview.Body.String(), legacyID) ||
+		strings.Contains(preview.Body.String(), `"added_operations":["view_detail"`) {
+		t.Fatalf("bundle preview = %d %s", preview.Code, preview.Body.String())
+	}
+
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "legacy-user",
+		"resource":    map[string]any{"type": "catalog", "id": "c-legacy"},
+		"bundle":      authz.ActFullBusinessAccess,
+	}); w.Code != http.StatusNoContent {
+		t.Fatalf("bundle grant = %d %s", w.Code, w.Body.String())
+	}
+	records, err := e.PolicyRecords(authz.PolicyFilter{AccessorID: "legacy-user", Object: "catalog:c-legacy"})
+	if err != nil || len(records) != 2 {
+		t.Fatalf("coexisting sources = %+v, %v", records, err)
+	}
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"grant_id": legacyID,
+	}); w.Code != http.StatusNoContent {
+		t.Fatalf("legacy revoke = %d %s", w.Code, w.Body.String())
+	}
+	if allowed, err := e.Check("legacy-user", "catalog", "c-legacy", "view_detail"); err != nil || !allowed {
+		t.Fatalf("bundle sibling after legacy revoke = %v, %v", allowed, err)
 	}
 }
 
@@ -239,11 +347,12 @@ func TestAdminObjectGrantDenyIsBackwardCompatible(t *testing.T) {
 		t.Fatalf("deny was not exposed separately: %+v", entries)
 	}
 
-	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
-		"accessor_id": "alice",
-		"resource":    map[string]any{"type": "catalog", "id": "c1"},
-		"effect":      "deny",
+	denyGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "alice", Object: "catalog:c1", Operation: "view_detail",
+		Effect: authz.EffectDeny, PolicySource: authz.PolicySourceProfessionalRule,
+		AuthoritySource: authz.AuthoritySourceAdminAuthz,
 	})
+	w = adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{"grant_id": denyGrantID})
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("remove deny: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
@@ -261,6 +370,9 @@ func TestObjectGrantsValidation(t *testing.T) {
 	if err := db.Create(&model.Department{ID: "dep-1", Name: "Data"}).Error; err != nil {
 		t.Fatal(err)
 	}
+	if err := db.Create(&model.Role{ID: "role-1", Name: "Readers", Source: "custom"}).Error; err != nil {
+		t.Fatal(err)
+	}
 	seedCatalogOps(t, db, "catalog", "view_detail")
 
 	cases := []struct {
@@ -268,6 +380,7 @@ func TestObjectGrantsValidation(t *testing.T) {
 		body map[string]any
 	}{
 		{"department grantee", map[string]any{"accessor_id": "dep-1", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"view_detail"}}},
+		{"role grantee", map[string]any{"accessor_id": "role-1", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"view_detail"}}},
 		{"unknown user", map[string]any{"accessor_id": "ghost", "resource": map[string]any{"type": "catalog", "id": "c1"}, "operations": []string{"view_detail"}}},
 		{"wildcard id", map[string]any{"accessor_id": "u-1", "resource": map[string]any{"type": "catalog", "id": "*"}, "operations": []string{"view_detail"}}},
 		{"unknown type", map[string]any{"accessor_id": "u-1", "resource": map[string]any{"type": "nope", "id": "c1"}, "operations": []string{"view_detail"}}},
@@ -296,6 +409,10 @@ func TestObjectGrantsExcludesRolesAndWildcards(t *testing.T) {
 	}
 	// a concrete grant to a ROLE (should be excluded)
 	_ = e.GrantRolePermission("role-x", "catalog", "c9", "view_detail")
+	roleGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "role-x", Object: "catalog:c9", Operation: "view_detail",
+		PolicySource: authz.PolicySourceRolePermission,
+	})
 	// a type-wide grant to the user (id "*", should be excluded)
 	_ = e.GrantRolePermission("u-1", "catalog", "*", "view_detail")
 	// a concrete grant to the USER (should be included)
@@ -304,6 +421,14 @@ func TestObjectGrantsExcludesRolesAndWildcards(t *testing.T) {
 	entries := listObjectGrants(t, r, "")
 	if len(entries) != 1 || entries[0].AccessorID != "u-1" || entries[0].Resource.ID != "c1" {
 		t.Fatalf("listing must contain only the user concrete grant, got %+v", entries)
+	}
+	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
+		"grant_id": roleGrantID,
+	}); w.Code != http.StatusForbidden {
+		t.Fatalf("generic role revoke = %d %s; want dedicated role API", w.Code, w.Body.String())
+	}
+	if allowed, err := e.Check("role-x", "catalog", "c9", "view_detail"); err != nil || !allowed {
+		t.Fatalf("generic object route removed a role permission: allowed=%v err=%v", allowed, err)
 	}
 }
 
@@ -445,8 +570,9 @@ func TestObjectGrantsGroupedViews(t *testing.T) {
 }
 
 // ownerGrantFixture builds the situation the owner path exists for: a builder
-// who created a knowledge network (and therefore holds the creator's object
-// grant, opAuthorize included) but holds no admin-authz permission at all.
+// who created a knowledge network (and therefore holds the Community business
+// bundle plus a separate system-derived authorize grant) but holds no
+// admin-authz permission at all.
 func ownerGrantFixture(t *testing.T) (*gin.Engine, *authz.Enforcer) {
 	r, e, _ := ownerGrantFixtureWithDB(t)
 	return r, e
@@ -473,11 +599,19 @@ func ownerGrantFixtureWithDB(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.
 	// instance, so a test can ask for an operation that is valid yet unheld.
 	seedCatalogOps(t, db, "knowledge_network",
 		"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage")
-	// Exactly what bkn-backend writes to a newly created KN instance.
-	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize", "task_manage"} {
-		if err := e.GrantObjectPermission("u-owner", "knowledge_network", "kn-mine", op); err != nil {
-			t.Fatal(err)
-		}
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "knowledge_network", "authorize").
+		Update("implied_operation_ids", "view_detail").Error; err != nil {
+		t.Fatal(err)
+	}
+	// The new-resource contract keeps business access and management authority
+	// in independently managed sources.
+	if err := e.GrantCommunityBundle("u-owner", "knowledge_network", "kn-mine",
+		authz.AuthoritySourceSystem); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantSystemObjectPermission("u-owner", "knowledge_network", "kn-mine", "authorize"); err != nil {
+		t.Fatal(err)
 	}
 	return r, e, db
 }
@@ -514,9 +648,12 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 	}
 
 	// And can take it back.
+	grantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "u-mate", Object: "knowledge_network:kn-mine", Operation: "view_detail",
+		PolicySource: authz.PolicySourceProfessionalRule, AuthoritySource: authz.AuthoritySourceOwnerDelegate,
+	})
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
-		"accessor_id": "u-mate",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": grantID,
 	}, "u-owner")
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
@@ -524,13 +661,115 @@ func TestObjectGrantsOwnerMayShareOwnObject(t *testing.T) {
 	if ok, _ := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); ok {
 		t.Error("owner revoke did not remove the grant")
 	}
-	// DELETE is idempotent when the direct grant is already absent.
+	// After the source row is gone, a delegated caller cannot prove that the
+	// opaque id belonged to an object it manages. Only platform administrators
+	// receive idempotent success for an already-absent id.
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"grant_id": grantID,
+	}, "u-owner")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("repeat owner revoke: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+}
+
+func TestObjectGrantsUseKnowledgeNetworkAsChildAuthorizationRoot(t *testing.T) {
+	r, e, db := ownerGrantFixtureWithDB(t)
+	if err := db.Create(&model.ResourceType{
+		ID: "object_type", Name: "object_type", ParentTypeID: "knowledge_network",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "object_type", "view_detail", "modify", "delete", "query_data", "authorize")
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "object_type", "view_detail").
+		Update("parent_operation_id", "view_detail").Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "object_type", ResourceID: "kn-mine/order",
+		ParentTypeID: "knowledge_network", ParentID: "kn-mine",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []string{"view_detail", "modify", "query_data"} {
+		if err := e.GrantObjectPermission("u-owner", "object_type", "kn-mine/order", operation); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
 		"accessor_id": "u-mate",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"resource":    map[string]any{"type": "object_type", "id": "kn-mine/order"},
+		"operations":  []string{"modify"},
 	}, "u-owner")
 	if w.Code != http.StatusNoContent {
-		t.Fatalf("idempotent owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+		t.Fatalf("child grant via KN authorize = %d %s", w.Code, w.Body.String())
+	}
+	if allowed, _ := e.Check("u-mate", "object_type", "kn-mine/order", "modify"); !allowed {
+		t.Fatal("child grant did not become effective")
+	}
+	if err := e.GrantProfessionalObjectPermission("u-mate", "knowledge_network", "kn-mine", "query_data",
+		authz.EffectDeny, authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "object_type", "id": "kn-mine/order"},
+		"operations":  []string{"query_data"},
+	}, "u-owner"); w.Code != http.StatusNoContent {
+		t.Fatalf("owner child allow over parent admin deny = %d %s; want 204", w.Code, w.Body.String())
+	}
+	if allowed, err := e.Check("u-mate", "object_type", "kn-mine/order", "query_data"); err != nil || !allowed {
+		t.Fatalf("specific child allow did not override parent deny: allowed=%v err=%v", allowed, err)
+	}
+
+	if err := db.Create(&model.ResourceParent{
+		ResourceTypeID: "object_type", ResourceID: "kn-mine/hidden",
+		ParentTypeID: "knowledge_network", ParentID: "kn-mine",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.DenyObjectPermission("u-owner", "object_type", "kn-mine/hidden", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "object_type", "id": "kn-mine/hidden"},
+		"operations":  []string{"query_data"},
+	}, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("grant on invisible child = %d %s; want 403", w.Code, w.Body.String())
+	}
+	if w := tokReq(t, r, http.MethodGet,
+		"/api/safe/v1/me/object-grants?resource_type=object_type&resource_id=kn-mine/hidden",
+		nil, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("read grants on invisible child = %d %s; want 403", w.Code, w.Body.String())
+	}
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "object_type", "modify").
+		Update("implied_operation_ids", "delete").Error; err != nil {
+		t.Fatal(err)
+	}
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "object_type", "id": "kn-mine/order"},
+		"operations":  []string{"modify"},
+	}, "u-owner"); w.Code != http.StatusForbidden {
+		t.Fatalf("grant with an unheld runtime requirement = %d %s; want 403", w.Code, w.Body.String())
+	}
+
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "object_type", "id": "kn-mine/order"},
+		"operations":  []string{"authorize"},
+	}); w.Code != http.StatusForbidden {
+		t.Fatalf("BKN child authorize = %d %s; want 403", w.Code, w.Body.String())
+	}
+	if w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/object-grants", map[string]any{
+		"accessor_id": "u-mate",
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"authorize"},
+	}); w.Code != http.StatusNoContent {
+		t.Fatalf("platform-managed root authorize = %d %s; want 204", w.Code, w.Body.String())
 	}
 }
 
@@ -547,23 +786,24 @@ func TestObjectGrantsOwnerCannotRemoveAdminDeny(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// A legacy owner revoke still removes only ordinary grants, never the
-	// administrator-installed deny exception.
+	denyGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "u-mate", Object: "knowledge_network:kn-mine",
+		Operation: "view_detail", Effect: authz.EffectDeny,
+	})
+	// A delegated owner cannot revoke an administrator/legacy source by naming
+	// its stable identity.
 	w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
-		"accessor_id": "u-mate",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": denyGrantID,
 	}, "u-owner")
-	if w.Code != http.StatusNoContent {
-		t.Fatalf("legacy owner revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("legacy owner revoke: want 403, got %d (%s)", w.Code, w.Body.String())
 	}
 	if ok, err := e.Check("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil || ok {
 		t.Fatalf("owner revoke removed admin deny: allowed=%v err=%v", ok, err)
 	}
 
 	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
-		"accessor_id": "u-mate",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
-		"effect":      "deny",
+		"grant_id": denyGrantID,
 	}, "u-owner")
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("owner remove deny: want 403, got %d (%s)", w.Code, w.Body.String())
@@ -627,6 +867,23 @@ func TestObjectGrantsOwnerLimits(t *testing.T) {
 				"accessor_id": "u-mate",
 				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-theirs"},
 				"operations":  []string{"view_detail"},
+			},
+		},
+		{
+			"cannot write deny",
+			map[string]any{
+				"accessor_id": "u-mate",
+				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+				"operations":  []string{"view_detail"},
+				"effect":      authz.EffectDeny,
+			},
+		},
+		{
+			"cannot change protected bundle source",
+			map[string]any{
+				"accessor_id": "u-mate",
+				"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+				"bundle":      authz.ActFullBusinessAccess,
 			},
 		},
 	}
@@ -796,11 +1053,9 @@ func TestObjectGrantsOwnerDirectoryLookups(t *testing.T) {
 	}
 }
 
-// A delegate may take back what it shared, but must not strip another holder of
-// `authorize` — the creator included. Revoking removes every op the accessor has
-// on the object, and a delegate cannot grant `authorize` back, so without this
-// rule anyone trusted with one object could take it from the person who made it.
-func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
+// Stable source slicing lets a delegate manage an ordinary owner-written row
+// for a user who also holds authorize, without touching that protected sibling.
+func TestObjectGrantsDelegateCannotMutateProtectedSources(t *testing.T) {
 	r, e := ownerGrantFixture(t)
 	// u-stranger holds type-wide authorize on the whole type, with no direct
 	// stake in this particular network.
@@ -811,9 +1066,11 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	}
 
 	// The creator holds authorize on kn-mine and must survive.
+	authorizeGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "u-owner", Object: "knowledge_network:kn-mine", Operation: "authorize",
+	})
 	w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
-		"accessor_id": "u-owner",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": authorizeGrantID,
 	}, "u-stranger")
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("stripping the creator: want 403, got %d (%s)", w.Code, w.Body.String())
@@ -823,12 +1080,19 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 	}
 
 	// A plain grantee stays revocable — undoing a share is the point.
-	if err := e.GrantObjectPermission("u-mate", "knowledge_network", "kn-mine", "view_detail"); err != nil {
-		t.Fatal(err)
-	}
-	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
 		"accessor_id": "u-mate",
 		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"operations":  []string{"view_detail"},
+	}, "u-stranger"); w.Code != http.StatusNoContent {
+		t.Fatalf("seed owner-managed grant: %d %s", w.Code, w.Body.String())
+	}
+	plaintGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: "u-mate", Object: "knowledge_network:kn-mine", Operation: "view_detail",
+		PolicySource: authz.PolicySourceProfessionalRule, AuthoritySource: authz.AuthoritySourceOwnerDelegate,
+	})
+	w = tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
+		"grant_id": plaintGrantID,
 	}, "u-stranger")
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("revoking a plain grantee: want 204, got %d (%s)", w.Code, w.Body.String())
@@ -837,23 +1101,23 @@ func TestObjectGrantsDelegateCannotStripAuthorizeHolder(t *testing.T) {
 		t.Fatal("delegate revoke left its owner-managed grant effective")
 	}
 
-	// The grant side erases just as thoroughly: POST replaces the whole op set, so
-	// writing view_detail onto the creator would drop its authorize in one move.
+	// POST replaces only the owner_delegate Professional slice. Granting an
+	// ordinary operation to the creator is safe because its protected authorize
+	// row belongs to a different source slice.
 	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/me/object-grants", map[string]any{
 		"accessor_id": "u-owner",
 		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
 		"operations":  []string{"view_detail"},
-	}, "u-stranger"); w.Code != http.StatusForbidden {
-		t.Fatalf("overwriting the creator's grant: want 403, got %d (%s)", w.Code, w.Body.String())
+	}, "u-stranger"); w.Code != http.StatusNoContent {
+		t.Fatalf("source-scoped grant to the creator: want 204, got %d (%s)", w.Code, w.Body.String())
 	}
 	if ok, _ := e.Check("u-owner", "knowledge_network", "kn-mine", "authorize"); !ok {
-		t.Fatal("the creator lost authorize through the grant path")
+		t.Fatal("the creator lost its protected authorize sibling through the grant path")
 	}
 
 	// An administrator is still able to do both.
 	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
-		"accessor_id": "u-owner",
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": authorizeGrantID,
 	}); w.Code != http.StatusNoContent {
 		t.Fatalf("administrator revoking an authorize holder: want 204, got %d", w.Code)
 	}
@@ -904,9 +1168,11 @@ func TestObjectGrantsDelegateCannotWriteWildcardOrTouchPublic(t *testing.T) {
 	if err := e.GrantObjectPermission(authz.PublicAccessorID, "knowledge_network", "kn-mine", "view_detail"); err != nil {
 		t.Fatal(err)
 	}
+	publicGrantID := oneGrantID(t, e, authz.PolicyFilter{
+		AccessorID: authz.PublicAccessorID, Object: "knowledge_network:kn-mine", Operation: "view_detail",
+	})
 	if w := tokReq(t, r, http.MethodDelete, "/api/safe/v1/me/object-grants", map[string]any{
-		"accessor_id": authz.PublicAccessorID,
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": publicGrantID,
 	}, "u-owner"); w.Code != http.StatusForbidden {
 		t.Fatalf("delegate deleting the public row: want 403, got %d (%s)", w.Code, w.Body.String())
 	}
@@ -915,8 +1181,7 @@ func TestObjectGrantsDelegateCannotWriteWildcardOrTouchPublic(t *testing.T) {
 	}
 	// An administrator may still remove it.
 	if w := adminReq(t, r, http.MethodDelete, "/api/safe/v1/admin/object-grants", map[string]any{
-		"accessor_id": authz.PublicAccessorID,
-		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-mine"},
+		"grant_id": publicGrantID,
 	}); w.Code != http.StatusNoContent {
 		t.Errorf("administrator removing the public row: want 204, got %d", w.Code)
 	}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/adminwrite"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permdata"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/extension/permobject"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/accesslog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
@@ -124,6 +125,13 @@ func New(deps Deps) *gin.Engine {
 		meVerifier = newCachingVerifier(meVerifier, verifierCacheTTL)
 	}
 	if deps.Enforcer != nil && verifier != nil && deps.Users != nil && deps.Directory != nil {
+		authzExplain := r.Group("/api/safe/v1/authz", sharedrest.PrivateNoCacheMiddleware(),
+			RequireUser(verifier), RequireActiveAccount(deps.DB))
+		if deps.Audit != nil {
+			authzExplain.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
+		}
+		registerAuthzExplain(authzExplain, deps.Enforcer, deps.DB)
+
 		admin := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), RequireAdmin(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
 		// Audit every mutating admin request. Use() must precede the route
 		// registrations below: gin snapshots the group's handler chain at
@@ -153,6 +161,14 @@ func New(deps Deps) *gin.Engine {
 		registerRoleBindings(admin, deps.Enforcer, deps.DB)
 		registerRoles(admin, deps.Enforcer, deps.DB)
 		registerObjectGrants(admin, deps.Enforcer, deps.DB)
+		if permobject.ManagementRegistered() {
+			enterpriseObjectGrants := r.Group("/api/safe/v1/admin", permobject.ManagementGate(),
+				sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier), RequireActiveAccount(deps.DB))
+			if deps.Audit != nil {
+				enterpriseObjectGrants.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
+			}
+			registerEnterpriseObjectGrants(enterpriseObjectGrants, deps.Enforcer)
+		}
 		// rbac_basic write routes (custom role create/update/delete + role
 		// permission grant/revoke) are mounted by the enterprise build through
 		// the adminwrite socket. In a community binary no mounter was registered,

--- a/bkn-safe/server/internal/httperrors/errors.go
+++ b/bkn-safe/server/internal/httperrors/errors.go
@@ -22,6 +22,11 @@ const (
 	MethodNotAllowed   = "BknSafe.MethodNotAllowed"
 	ServiceUnavailable = "BknSafe.ServiceUnavailable"
 	InternalError      = "BknSafe.InternalError"
+	// UnsupportedGrantShape is intentionally edition-neutral. The shared
+	// object-grant route returns this exact code for paid request shapes when
+	// they are not assembled or not currently licensed; it must not disclose a
+	// capability name or an upgrade hint.
+	UnsupportedGrantShape = "unsupported_grant_shape"
 
 	AdminWriteInvalid                         = "BknSafe.AdminWrite.Invalid"
 	AdminWriteImmutable                       = "BknSafe.AdminWrite.Immutable"
@@ -41,6 +46,7 @@ var (
 		MethodNotAllowed,
 		ServiceUnavailable,
 		InternalError,
+		UnsupportedGrantShape,
 		AdminWriteInvalid,
 		AdminWriteImmutable,
 		AdminWriteNoUpdatableFields,

--- a/bkn-safe/server/locale/bkn-safe.en-US.toml
+++ b/bkn-safe/server/locale/bkn-safe.en-US.toml
@@ -42,6 +42,11 @@ Description = "An internal service error occurred."
 Solution = "Try again later; contact an administrator if the problem persists."
 ErrorLink = ""
 
+[unsupported_grant_shape]
+Description = "This object grant request shape is not supported."
+Solution = "Use a top-level full business access grant."
+ErrorLink = ""
+
 [BknSafe.Auth]
 AccountPlaceholder = "Account"
 PasswordPlaceholder = "Password"

--- a/bkn-safe/server/locale/bkn-safe.zh-CN.toml
+++ b/bkn-safe/server/locale/bkn-safe.zh-CN.toml
@@ -42,6 +42,11 @@ Description = "服务内部错误。"
 Solution = "请稍后重试；如问题持续，请联系管理员。"
 ErrorLink = ""
 
+[unsupported_grant_shape]
+Description = "不支持该对象授权请求形状。"
+Solution = "请使用顶层完整业务包授权。"
+ErrorLink = ""
+
 [BknSafe.Auth]
 AccountPlaceholder = "账号"
 PasswordPlaceholder = "密码"

--- a/docs/api/bkn-safe/authorization.yaml
+++ b/docs/api/bkn-safe/authorization.yaml
@@ -10,10 +10,12 @@ info:
     Internal service-to-service authorization contract used by BKN,
     ontology-query, context-loader, and execution-factory.
 
-    This API is tokenless and belongs exclusively to the platform-internal
-    network trust boundary defined by bkn-foundry #333. Callers authenticate
-    their own public request first and pass the resulting concrete
-    `accessor_id`; clients must never expose these endpoints through an Ingress.
+    The decision and resource-directory routes are tokenless and belong
+    exclusively to the platform-internal network trust boundary defined by
+    bkn-foundry #333. Callers authenticate their own public request first and
+    pass the resulting concrete `accessor_id`; clients must never expose those
+    endpoints through an Ingress. `/explain` is the explicit exception: it is
+    a bearer-token administrator diagnostic guarded by `admin-authz:view`.
 
     Local authorization is a narrower intermediate mode for Vega's
     Resource-to-Catalog orchestration. It accepts only concrete `resource` and
@@ -411,7 +413,43 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalError'
+  /explain:
+    post:
+      operationId: explainAuthorization
+      summary: Explain one final operation decision
+      description: |
+        Authenticated administrator diagnostic endpoint. Unlike the other
+        routes in this document, this route is not tokenless: the caller must
+        hold `admin-authz:view`. It returns matching user/role/public Core
+        grants, wildcard and parent fallback, Community bundle expansion, and
+        each direct runtime requirement. The response never includes property
+        names, masking rules, or data values and does not persist a proof chain.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExplainRequest'
+      responses:
+        '200':
+          description: On-demand structured explanation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExplainResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks `admin-authz:view`}
+        '500':
+          $ref: '#/components/responses/InternalError'
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
   responses:
     BadRequest:
       description: Malformed or unsafe request.
@@ -681,6 +719,71 @@ components:
             older servers; clients that do not inspect policy administration
             details may ignore it. Runtime decision endpoints already apply
             deny precedence and keep their existing request/response shapes.
+    ExplainRequest:
+      type: object
+      required: [accessor_id, resource, operation]
+      additionalProperties: false
+      properties:
+        accessor_id: {type: string, minLength: 1}
+        resource:
+          $ref: '#/components/schemas/ResourceRef'
+        operation: {type: string, minLength: 1}
+    ExplainEvaluation:
+      type: object
+      required: [scope, decision, basis]
+      properties:
+        scope: {type: string, enum: [effective]}
+        decision: {$ref: '#/components/schemas/AuthorizationDecision'}
+        basis: {$ref: '#/components/schemas/DecisionBasis'}
+        requires: {type: array, items: {type: string}}
+        denied_requirement: {type: string}
+        requirement_basis: {$ref: '#/components/schemas/DecisionBasis'}
+    ExplainGrant:
+      type: object
+      required: [grant_id, subject_id, subject_kind, object, operation, effect, policy_source, authority_source, match]
+      properties:
+        grant_id: {type: string}
+        subject_id: {type: string}
+        subject_kind: {type: string, enum: [user, role, public]}
+        object: {type: string}
+        operation: {type: string}
+        effect: {type: string, enum: [allow, deny]}
+        policy_source: {type: string}
+        authority_source: {type: string}
+        match: {type: string, enum: [direct, wildcard, bundle]}
+    ExplainStep:
+      type: object
+      required: [resource_type, resource_id, operation, decision, basis, matched_grants]
+      properties:
+        resource_type: {type: string}
+        resource_id: {type: string}
+        operation: {type: string}
+        decision: {$ref: '#/components/schemas/AuthorizationDecision'}
+        basis: {$ref: '#/components/schemas/DecisionBasis'}
+        matched_grants: {type: array, items: {$ref: '#/components/schemas/ExplainGrant'}}
+        inherited_from: {$ref: '#/components/schemas/ResourceRef'}
+        parent_operation: {type: string}
+    ExplainRequirement:
+      type: object
+      required: [operation, evaluation, steps]
+      properties:
+        operation: {type: string}
+        evaluation: {$ref: '#/components/schemas/ExplainEvaluation'}
+        steps: {type: array, items: {$ref: '#/components/schemas/ExplainStep'}}
+    ExplainResponse:
+      type: object
+      required: [accessor_id, resource_type, resource_id, operation, evaluation, steps, requirements]
+      properties:
+        accessor_id: {type: string}
+        resource_type: {type: string}
+        resource_id: {type: string}
+        operation: {type: string}
+        evaluation: {$ref: '#/components/schemas/ExplainEvaluation'}
+        steps: {type: array, items: {$ref: '#/components/schemas/ExplainStep'}}
+        requirements: {type: array, items: {$ref: '#/components/schemas/ExplainRequirement'}}
+        account_active:
+          type: boolean
+          description: False only when the requested accessor is absent or disabled.
     ResourceParentItem:
       type: object
       required: [resource_id, parent_id]

--- a/docs/api/bkn-safe/object-grants.yaml
+++ b/docs/api/bkn-safe/object-grants.yaml
@@ -1,0 +1,428 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+info:
+  title: BKN Safe Object Grant Management API
+  version: 1.0.0
+  description: |
+    Manages source-scoped object grants. Community accepts only a logical
+    `full_business_access` bundle on reviewed top-level resource types. When
+    the assembled `perm_fine_grained` capability is licensed at Professional
+    or above, the same write route also accepts per-operation allow/deny sets
+    and BKN child resources.
+
+    Callers cannot choose `policy_source` or `authority_source`. The service
+    derives both from the authenticated management path. Revocation targets one
+    stable `grant_id`; it never deletes a Casbin tuple or a sibling source.
+servers:
+  - url: /api/safe/v1
+security:
+  - BearerAuth: []
+paths:
+  /admin/object-grants:
+    get:
+      operationId: listObjectGrants
+      summary: List direct Core object grants
+      parameters:
+        - {name: accessor_id, in: query, schema: {type: string}}
+        - {name: resource_type, in: query, schema: {type: string}}
+        - {name: resource_id, in: query, schema: {type: string}}
+        - {name: search, in: query, schema: {type: string}}
+        - {name: offset, in: query, schema: {type: integer, minimum: 0}}
+        - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 500}}
+        - {name: group_by, in: query, schema: {type: string, enum: [object, grantee]}}
+        - {name: include_summary, in: query, schema: {type: boolean, default: false}}
+      responses:
+        '200':
+          description: Direct grants grouped by accessor and resource
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: object
+                    required: [entries, total]
+                    properties:
+                      entries:
+                        type: array
+                        items: {$ref: '#/components/schemas/ObjectGrantSet'}
+                      total: {type: integer}
+                      summary:
+                        type: object
+                        required: [grants, objects, grantees]
+                        properties:
+                          grants: {type: integer}
+                          objects: {type: integer}
+                          grantees: {type: integer}
+                  - type: object
+                    required: [groups, total]
+                    properties:
+                      groups:
+                        type: array
+                        items:
+                          type: object
+                          description: Object or grantee aggregate selected by `group_by`.
+                      total: {type: integer}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks `admin-authz:view`}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: setObjectGrant
+      summary: Atomically set one trusted source slice
+      description: |
+        Community shape uses `bundle` and omits `operations` and `effect`.
+        Fine-grained shape uses `operations` and optional `effect`. A request
+        carrying a paid shape while the capability is absent or unavailable
+        returns the exact edition-neutral `unsupported_grant_shape` response.
+        Allow writes add every direct runtime requirement atomically. The
+        normalized direct set and its stable identities are available from GET.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - {$ref: '#/components/schemas/CommunityGrantRequest'}
+                - {$ref: '#/components/schemas/FineGrainedGrantRequest'}
+      responses:
+        '204':
+          description: Source-scoped grant set stored atomically
+        '400':
+          description: Invalid request or unavailable paid request shape
+          content:
+            application/json:
+              schema: {$ref: '../_shared/errors.yaml#/components/schemas/Error'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks grant authority or attempts escalation}
+        '500': {$ref: '#/components/responses/InternalError'}
+    delete:
+      operationId: revokeObjectGrant
+      summary: Revoke exactly one stable Core grant
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/GrantIDRequest'}
+      responses:
+        '204': {description: Grant was removed, or an authorized platform administrator named an already-absent ID}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller cannot manage the selected source}
+        '500': {$ref: '#/components/responses/InternalError'}
+  /admin/object-grants/preview:
+    post:
+      operationId: previewCommunityBundleGrant
+      summary: Compare a Community bundle with direct legacy rows
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              allOf:
+                - {$ref: '#/components/schemas/CommunityGrantRequest'}
+      responses:
+        '200':
+          description: Read-only bundle expansion and legacy difference
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [accessor_id, resource, bundle, bundle_operations, added_operations, legacy_grants]
+                properties:
+                  accessor_id: {type: string}
+                  resource: {$ref: '#/components/schemas/ResourceRef'}
+                  bundle: {$ref: '#/components/schemas/CommunityBundle'}
+                  bundle_operations: {type: array, items: {type: string}}
+                  added_operations: {type: array, items: {type: string}}
+                  legacy_grants: {type: array, items: {$ref: '#/components/schemas/GrantRecord'}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks `admin-authz:view`}
+        '500': {$ref: '#/components/responses/InternalError'}
+  /admin/enterprise-object-grants:
+    get:
+      operationId: inventoryEnterpriseObjectGrants
+      summary: Inventory classified historical Enterprise object rules
+      responses:
+        '200':
+          description: Active, dormant/experimental, and invalid entries
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [entries, total]
+                properties:
+                  entries:
+                    type: array
+                    items: {$ref: '#/components/schemas/EnterpriseInventoryEntry'}
+                  total: {type: integer, minimum: 0}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks `admin-authz:view`}
+        '404': {description: Enterprise management provider is absent or unavailable}
+        '500': {$ref: '#/components/responses/InternalError'}
+    delete:
+      operationId: revokeEnterpriseObjectGrant
+      summary: Revoke exactly one Enterprise Rule.ID/grant_id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [grant_id, reason]
+              properties:
+                grant_id: {type: string, minLength: 1}
+                reason: {type: string, minLength: 1, maxLength: 512}
+      responses:
+        '204': {description: Selected Enterprise rule was revoked}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks `admin-authz:revoke`}
+        '404': {description: Enterprise management provider is absent or unavailable}
+        '500': {$ref: '#/components/responses/InternalError'}
+  /me/object-grants:
+    get:
+      operationId: listDelegatedObjectGrants
+      summary: List direct grants on one resource the caller may authorize
+      parameters:
+        - name: resource_type
+          in: query
+          required: true
+          schema: {type: string, minLength: 1}
+        - name: resource_id
+          in: query
+          required: true
+          schema: {type: string, minLength: 1}
+      responses:
+        '200':
+          description: Direct grants on the selected resource
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [entries]
+                properties:
+                  entries:
+                    type: array
+                    items: {$ref: '#/components/schemas/ObjectGrantSet'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks final authorize and target-view decisions}
+        '500': {$ref: '#/components/responses/InternalError'}
+    post:
+      operationId: setDelegatedObjectGrant
+      summary: Replace one owner-delegated Professional allow set
+      description: |
+        The caller must have a final `authorize` decision on the management
+        root, a final view decision on the target resource, and every requested
+        operation including its direct runtime requirements. The target must be
+        an enabled user. Delegates cannot write deny or authorize, target a
+        role/public accessor, or change admin, system, legacy, or bundle sources.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/FineGrainedGrantRequest'}
+      responses:
+        '204': {description: Owner-delegated Professional source slice stored atomically}
+        '400': {description: Invalid target or request, including an unavailable fine-grained shape}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller lacks authority or attempts escalation}
+        '500': {$ref: '#/components/responses/InternalError'}
+    delete:
+      operationId: revokeDelegatedObjectGrant
+      summary: Revoke one owner-delegated Professional grant
+      description: |
+        Only an existing `professional_rule` allow written through
+        `owner_delegate` can establish delegated revoke authority. A missing or
+        protected stable ID returns 403 rather than revealing its lifecycle.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/GrantIDRequest'}
+      responses:
+        '204': {description: Selected owner-delegated grant removed}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller cannot manage the selected source}
+        '500': {$ref: '#/components/responses/InternalError'}
+  /me/grantable-users:
+    get:
+      operationId: searchGrantableUsers
+      summary: Search enabled user targets for one authorized resource
+      parameters:
+        - name: resource_type
+          in: query
+          required: true
+          schema: {type: string, minLength: 1}
+        - name: resource_id
+          in: query
+          required: true
+          schema: {type: string, minLength: 1}
+        - name: search
+          in: query
+          required: true
+          schema: {type: string, minLength: 1}
+      responses:
+        '200':
+          description: At most 20 matching enabled users
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [users]
+                properties:
+                  users:
+                    type: array
+                    items:
+                      type: object
+                      required: [id, account, name]
+                      properties:
+                        id: {type: string}
+                        account: {type: string}
+                        name: {type: string}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {description: Missing or invalid bearer token}
+        '403': {description: Caller cannot view or authorize the selected resource}
+        '500': {$ref: '#/components/responses/InternalError'}
+components:
+  schemas:
+    ResourceRef:
+      type: object
+      required: [type, id]
+      additionalProperties: false
+      properties:
+        type: {type: string, minLength: 1}
+        id: {type: string, minLength: 1}
+    CommunityBundle:
+      type: string
+      enum: [full_business_access]
+    CommunityGrantRequest:
+      type: object
+      required: [accessor_id, resource, bundle]
+      description: |
+        Source and authority metadata are server-derived. If an older client
+        sends such fields, the server ignores them; they cannot select the
+        stored source.
+      properties:
+        accessor_id: {type: string, minLength: 1}
+        resource: {$ref: '#/components/schemas/ResourceRef'}
+        bundle: {$ref: '#/components/schemas/CommunityBundle'}
+    FineGrainedGrantRequest:
+      type: object
+      required: [accessor_id, resource, operations]
+      description: |
+        Source and authority metadata are server-derived. If an older client
+        sends such fields, the server ignores them; they cannot select the
+        stored source.
+      properties:
+        accessor_id: {type: string, minLength: 1}
+        resource: {$ref: '#/components/schemas/ResourceRef'}
+        operations:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items: {type: string, minLength: 1}
+        effect:
+          type: string
+          enum: [allow, deny]
+          default: allow
+    GrantIDRequest:
+      type: object
+      required: [grant_id]
+      properties:
+        grant_id: {type: string, minLength: 1, maxLength: 64}
+    GrantRecord:
+      type: object
+      required: [grant_id, accessor_id, operation, effect, policy_source, authority_source, active, inherited]
+      properties:
+        grant_id: {type: string}
+        accessor_id: {type: string}
+        operation: {type: string}
+        effect: {type: string, enum: [allow, deny]}
+        policy_source:
+          type: string
+          enum: [community_bundle, professional_rule, legacy, system_derived, role_permission]
+        authority_source:
+          type: string
+          enum: [admin_authz, owner_delegate, system, migration]
+        active: {type: boolean}
+        inherited: {type: boolean}
+    ObjectGrantSet:
+      type: object
+      required: [accessor_id, resource, operations, denied_operations, grants, effective_decisions]
+      properties:
+        accessor_id: {type: string}
+        resource: {$ref: '#/components/schemas/ResourceRef'}
+        bundle: {$ref: '#/components/schemas/CommunityBundle'}
+        operations: {type: array, items: {type: string}}
+        denied_operations: {type: array, items: {type: string}}
+        grants: {type: array, items: {$ref: '#/components/schemas/GrantRecord'}}
+        effective_decisions:
+          type: array
+          items: {$ref: '#/components/schemas/EffectiveDecision'}
+    EffectiveDecision:
+      type: object
+      required: [operation, decision, basis]
+      properties:
+        operation: {type: string}
+        decision: {type: string, enum: [allow, deny]}
+        basis: {type: string, enum: [direct, inherited, bundle, wildcard, default, requires]}
+        requires: {type: array, items: {type: string}}
+        denied_requirement: {type: string}
+        requirement_basis: {type: string, enum: [direct, inherited, bundle, wildcard, default]}
+        inherited_from:
+          type: object
+          required: [resource, operation]
+          properties:
+            resource: {$ref: '#/components/schemas/ResourceRef'}
+            operation: {type: string}
+    EnterpriseInventoryEntry:
+      type: object
+      required:
+        - grant_id
+        - rule_id
+        - accessor_id
+        - subject_type
+        - resource_type
+        - resource_id
+        - operation
+        - effect
+        - classification
+        - activation_state
+        - runtime_eligible
+      properties:
+        grant_id: {type: string}
+        rule_id: {type: string}
+        accessor_id: {type: string}
+        subject_type: {type: string, enum: [user, role, department, unknown]}
+        resource_type: {type: string}
+        resource_id: {type: string}
+        operation: {type: string}
+        effect: {type: string, enum: [allow, deny]}
+        expires_at: {type: string, format: date-time}
+        classification: {type: string}
+        activation_state:
+          type: string
+          description: Persisted lifecycle state, for example inactive, active, or revoked.
+        runtime_eligible:
+          type: boolean
+          description: True only after row and authoritative subject classification checks both pass.
+        inactive_reason: {type: string}
+  responses:
+    BadRequest:
+      description: Invalid JSON, target, operation, bundle, or grant identity
+      content:
+        application/json:
+          schema: {$ref: '../_shared/errors.yaml#/components/schemas/Error'}
+    InternalError:
+      description: Object-grant operation failed without committing a partial change
+      content:
+        application/json:
+          schema: {$ref: '../_shared/errors.yaml#/components/schemas/Error'}
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Added edition-aware object-grant management, including Community bundle-only and Professional fine-grained request shapes.
- [x] Enforced stable, source-scoped grant lifecycles and final-decision one-hop delegation checks, including operation requirements and BKN child-resource rules.
- [x] Added authorization explain, Enterprise compatibility inventory/revoke extension points, auditing, localized errors, and OpenAPI documentation.

---

## Why

- Related Issue: Closes #1430
- Related Feature: Permission edition boundaries and versioned object grants
- Background: Object-grant APIs must expose only the capabilities available to the assembled and currently entitled edition while preserving source identity, anti-escalation checks, and safe Enterprise compatibility handling.

---

## How

- Key implementation points:
  - Registers the perm_fine_grained capability through a live assembly-and-entitlement check.
  - Rejects unsupported Community request shapes with the edition-neutral unsupported_grant_shape contract before target validation.
  - Stores and revokes grants by stable grant_id and source, while evaluating effective permissions using final operation decisions and requires dependencies.
  - Adds authenticated POST /api/safe/v1/authz/explain output and read/revoke-only Enterprise object-rule management extension points.
  - Documents grant, preview, explain, inventory, and revoke endpoints and extends sensitive-operation audit mapping.
- Breaking changes (API, config, database, etc.): None. The new endpoints and response fields are additive; existing protected grant sources remain non-revocable through generic routes.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- go test ./internal/httpapi -count=1
- go test ./internal/authz ./extension/finegrained ./extension/permobject -count=1
- go vet ./internal/httpapi ./internal/authz ./extension/finegrained ./extension/permobject
- git diff --check
- Parsed both changed OpenAPI YAML files and validated their local reference targets.
- make api-docs-lint could not run locally because npx is not installed in the environment; CI should run the repository documentation lint.
- Test-environment verification is not applicable to this local implementation pass.

---

## Risk & Rollback

- Potential risks: Incorrect edition gating or delegation evaluation could expose unsupported grant shapes or produce inconsistent effective permissions. Focused tests cover Community, Professional, and Enterprise gating, requirements, parent-child behavior, source-scoped revocation, explain output, and Enterprise inventory handling.
- Rollback plan: Revert commit e3475833a; the change introduces no database migration and the APIs are additive.

---

## Additional Notes

- The openbkn-ee assembly must register the Professional capability and implement and register the Enterprise compatibility manager after the Core extension points land, coordinated with openbkn-ee #65 and bkn-foundry #1431.
- Contract reference: openbkn-ai/bkn-docs PR #119, commit 0402ae6.
