### PR TITLE
feat(bkn): align operations and add action execution fallback

### DIFF
--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile.go
@@ -128,7 +128,7 @@ func ResolveOperationAuditProfile(ctx context.Context, authorization, expectedAc
 			continue
 		}
 		for _, operation := range grant.Operations {
-			if operation == "modify" || operation == "authorize" || operation == "task_manage" {
+			if operation == "modify" || operation == "authorize" {
 				networks[grant.KnowledgeNetworkID] = struct{}{}
 				break
 			}

--- a/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
+++ b/adp/bkn/bkn-backend/server/common/bkntrace/access_profile_test.go
@@ -68,7 +68,7 @@ func TestResolveOperationAuditProfileIncludesReadableIdentityAndDirectNetworkGra
 		case "/api/safe/v1/me":
 			_, _ = w.Write([]byte(`{"id":"user-1","account":"alice","name":"Alice Zhang","enabled":true,"roles":["network_builder","custom"]}`))
 		case "/api/safe/v1/me/knowledge-network-grants":
-			_, _ = w.Write([]byte(`{"grants":[{"knowledge_network_id":"kn-b","operations":["query"]},{"knowledge_network_id":"kn-a","operations":["modify"]},{"knowledge_network_id":"*","operations":["modify"]}]}`))
+			_, _ = w.Write([]byte(`{"grants":[{"knowledge_network_id":"kn-b","operations":["query"]},{"knowledge_network_id":"kn-legacy","operations":["task_manage"]},{"knowledge_network_id":"kn-a","operations":["modify"]},{"knowledge_network_id":"*","operations":["modify"]}]}`))
 		default:
 			http.NotFound(w, r)
 		}

--- a/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/permission/safe_permission_access_test.go
@@ -41,6 +41,13 @@ func newFilterStub(t *testing.T, reply map[string][]string) (*safePermissionAcce
 			return
 		}
 		body, _ := io.ReadAll(r.Body)
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(body, &raw); err != nil {
+			t.Errorf("decode raw request: %v (%s)", err, body)
+		}
+		if _, exists := raw["evaluation_scope"]; exists {
+			t.Errorf("BKN filter request selected a non-default evaluation scope: %s", body)
+		}
 		var got capturedFilter
 		if err := json.Unmarshal(body, &got); err != nil {
 			t.Errorf("decode request: %v (%s)", err, body)
@@ -59,6 +66,33 @@ func newFilterStub(t *testing.T, reply map[string][]string) (*safePermissionAcce
 	}))
 	t.Cleanup(srv.Close)
 	return &safePermissionAccess{safe: newSafeClient(srv.URL)}, calls
+}
+
+func TestSafeCheckUsesDefaultEffectiveDecision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/safe/v1/authz/check" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if _, exists := body["evaluation_scope"]; exists {
+			t.Fatalf("check request selected a non-default evaluation scope: %#v", body)
+		}
+		_, _ = w.Write([]byte(`{"allowed":true,"decision":"allow","basis":"inherited"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	access := NewPermissionAccess(srv.URL)
+	allowed, err := access.CheckPermission(context.Background(), interfaces.PermissionCheck{
+		Accessor:   interfaces.PermissionAccessor{ID: "u-1", Type: "user"},
+		Resource:   interfaces.PermissionResource{Type: "action_type", ID: "kn-1/action-1"},
+		Operations: []string{interfaces.OPERATION_TYPE_EXECUTE},
+	})
+	if err != nil || !allowed {
+		t.Fatalf("CheckPermission() = %v, %v; want final inherited allow", allowed, err)
+	}
 }
 
 func knFilter(ids []string, ops, candidates []string) interfaces.PermissionResourcesFilter {

--- a/adp/bkn/bkn-backend/server/interfaces/permission_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/permission_access.go
@@ -32,14 +32,14 @@ const (
 	RESOURCE_TYPE_RISK_TYPE     = "risk_type"
 
 	// Resource operation types.
-	OPERATION_TYPE_VIEW_DETAIL = "view_detail"
-	OPERATION_TYPE_CREATE      = "create"
-	OPERATION_TYPE_MODIFY      = "modify"
-	OPERATION_TYPE_DELETE      = "delete"
-	OPERATION_TYPE_QUERY_DATA  = "query_data"
-	OPERATION_TYPE_AUTHORIZE   = "authorize"
-	OPERATION_TYPE_TASK_MANAGE = "task_manage"
-	OPERATION_TYPE_EXECUTE     = "execute"
+	OPERATION_TYPE_VIEW_DETAIL          = "view_detail"
+	OPERATION_TYPE_CREATE               = "create"
+	OPERATION_TYPE_MODIFY               = "modify"
+	OPERATION_TYPE_DELETE               = "delete"
+	OPERATION_TYPE_QUERY_DATA           = "query_data"
+	OPERATION_TYPE_AUTHORIZE            = "authorize"
+	OPERATION_TYPE_EXECUTE              = "execute"
+	OPERATION_TYPE_FULL_BUSINESS_ACCESS = "full_business_access"
 
 	// Topic used to update a resource name.
 	AUTHORIZATION_RESOURCE_NAME_MODIFY = "authorization.resource.name.modify"
@@ -53,17 +53,14 @@ var (
 		OPERATION_TYPE_DELETE,
 		OPERATION_TYPE_QUERY_DATA,
 		OPERATION_TYPE_AUTHORIZE,
-		OPERATION_TYPE_TASK_MANAGE,
+		OPERATION_TYPE_EXECUTE,
 	}
-	// KN_CREATOR_OPERATIONS is the fixed instance-level grant installed for a
-	// newly created knowledge network. Create remains a type-level capability.
+	// KN_CREATOR_OPERATIONS asks bkn-safe to atomically install the Community
+	// business bundle and the system-derived authorize permission. Create remains
+	// a type-level capability.
 	KN_CREATOR_OPERATIONS = []string{
-		OPERATION_TYPE_VIEW_DETAIL,
-		OPERATION_TYPE_MODIFY,
-		OPERATION_TYPE_DELETE,
-		OPERATION_TYPE_QUERY_DATA,
+		OPERATION_TYPE_FULL_BUSINESS_ACCESS,
 		OPERATION_TYPE_AUTHORIZE,
-		OPERATION_TYPE_TASK_MANAGE,
 	}
 )
 

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -31,10 +31,9 @@ func allowAllActionPermissionResources(_ context.Context, _ string, ids, _ []str
 	for _, id := range ids {
 		matched[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{
 			interfaces.OPERATION_TYPE_VIEW_DETAIL,
-			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
+			interfaces.OPERATION_TYPE_EXECUTE,
 		}}
 	}
 	return matched, nil

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -303,7 +303,7 @@ func Test_conceptGroupService_ListConceptGroups(t *testing.T) {
 			DoAndReturn(func(_ context.Context, _ string, ids, _ []string, _ bool, _ []string) (map[string]interfaces.PermissionResourceOps, error) {
 				matched := make(map[string]interfaces.PermissionResourceOps, len(ids))
 				for _, id := range ids {
-					matched[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE, interfaces.OPERATION_TYPE_AUTHORIZE}}
+					matched[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE}}
 				}
 				return matched, nil
 			}).AnyTimes()
@@ -522,7 +522,7 @@ func Test_conceptGroupService_GetConceptGroupByID(t *testing.T) {
 			DoAndReturn(func(_ context.Context, _ string, ids, _ []string, _ bool, _ []string) (map[string]interfaces.PermissionResourceOps, error) {
 				matched := make(map[string]interfaces.PermissionResourceOps, len(ids))
 				for _, id := range ids {
-					matched[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE, interfaces.OPERATION_TYPE_AUTHORIZE}}
+					matched[id] = interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_MODIFY, interfaces.OPERATION_TYPE_DELETE}}
 				}
 				return matched, nil
 			}).AnyTimes()

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -1975,7 +1975,8 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			vbs.EXPECT().WriteDatasetDocument(gomock.Any(), interfaces.BKN_DATASET_ID, gomock.Any(), gomock.Any()).Return(nil)
 			ps.EXPECT().CreateResources(gomock.Any(), []interfaces.PermissionResource{{
 				ID: "kn1", Type: interfaces.RESOURCE_TYPE_KN, Name: "kn1",
-			}}, interfaces.KN_CREATOR_OPERATIONS).Return(nil)
+			}}, []string{interfaces.OPERATION_TYPE_FULL_BUSINESS_ACCESS,
+				interfaces.OPERATION_TYPE_AUTHORIZE}).Return(nil)
 			smock.ExpectCommit()
 
 			knID, err := service.CreateKN(ctx, kn, mode, true)

--- a/adp/bkn/bkn-backend/server/logics/metric/authorization_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/authorization_test.go
@@ -96,7 +96,6 @@ func TestMetricListAuthorizationFiltersBeforeTotalAndPagination(t *testing.T) {
 			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
 		}).Return(map[string]interfaces.PermissionResourceOps{
 		"kn-1/metric-1": {ResourceID: "kn-1/metric-1"},
 		"kn-1/metric-3": {ResourceID: "kn-1/metric-3"},

--- a/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/metric/metric_service_test.go
@@ -33,7 +33,6 @@ func allowAllMetricPermissionResources(_ context.Context, _ string, ids, _ []str
 			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
 		}}
 	}
 	return matched, nil

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -34,7 +34,6 @@ func allowAllPermissionResources(_ context.Context, _ string, ids, _ []string, _
 				interfaces.OPERATION_TYPE_QUERY_DATA,
 				interfaces.OPERATION_TYPE_MODIFY,
 				interfaces.OPERATION_TYPE_DELETE,
-				interfaces.OPERATION_TYPE_AUTHORIZE,
 			},
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization.go
@@ -18,16 +18,20 @@ import (
 
 const knChildResourceFilterChunkSizeEnv = "KN_CHILD_RESOURCE_FILTER_CHUNK_SIZE"
 
-var knChildOperations = []string{
+var schemaChildOperations = []string{
 	interfaces.OPERATION_TYPE_VIEW_DETAIL,
 	interfaces.OPERATION_TYPE_QUERY_DATA,
 	interfaces.OPERATION_TYPE_MODIFY,
 	interfaces.OPERATION_TYPE_DELETE,
-	interfaces.OPERATION_TYPE_AUTHORIZE,
 }
 
-var actionTypeOperations = append(append([]string{}, knChildOperations...),
-	interfaces.OPERATION_TYPE_TASK_MANAGE,
+var structuralChildOperations = []string{
+	interfaces.OPERATION_TYPE_VIEW_DETAIL,
+	interfaces.OPERATION_TYPE_MODIFY,
+	interfaces.OPERATION_TYPE_DELETE,
+}
+
+var actionTypeOperations = append(append([]string{}, structuralChildOperations...),
 	interfaces.OPERATION_TYPE_EXECUTE,
 )
 
@@ -49,10 +53,17 @@ func KNImportPermissionPrechecked(ctx context.Context) bool {
 // KNChildOperationCandidates returns the instance-level operations exposed to
 // the current accessor for one knowledge-network child resource type.
 func KNChildOperationCandidates(resourceType string) []string {
-	if resourceType == interfaces.RESOURCE_TYPE_ACTION_TYPE {
+	switch resourceType {
+	case interfaces.RESOURCE_TYPE_ACTION_TYPE:
 		return append([]string{}, actionTypeOperations...)
+	case interfaces.RESOURCE_TYPE_OBJECT_TYPE, interfaces.RESOURCE_TYPE_RELATION_TYPE,
+		interfaces.RESOURCE_TYPE_METRIC:
+		return append([]string{}, schemaChildOperations...)
+	case interfaces.RESOURCE_TYPE_CONCEPT_GROUP, interfaces.RESOURCE_TYPE_RISK_TYPE:
+		return append([]string{}, structuralChildOperations...)
+	default:
+		return []string{}
 	}
-	return append([]string{}, knChildOperations...)
 }
 
 // CheckKNChildBatchPermission authorizes every requested child with

--- a/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization_test.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/kn_child_authorization_test.go
@@ -44,19 +44,29 @@ type childCandidate struct {
 }
 
 func TestKNChildOperationCandidatesMatchResourceContract(t *testing.T) {
-	wantChild := []string{
+	wantSchemaChild := []string{
 		interfaces.OPERATION_TYPE_VIEW_DETAIL,
 		interfaces.OPERATION_TYPE_QUERY_DATA,
 		interfaces.OPERATION_TYPE_MODIFY,
 		interfaces.OPERATION_TYPE_DELETE,
-		interfaces.OPERATION_TYPE_AUTHORIZE,
 	}
-	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_RELATION_TYPE); !reflect.DeepEqual(got, wantChild) {
-		t.Fatalf("relation type operations = %#v, want %#v", got, wantChild)
+	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_RELATION_TYPE); !reflect.DeepEqual(got, wantSchemaChild) {
+		t.Fatalf("relation type operations = %#v, want %#v", got, wantSchemaChild)
 	}
-	wantAction := append(append([]string{}, wantChild...), interfaces.OPERATION_TYPE_TASK_MANAGE, interfaces.OPERATION_TYPE_EXECUTE)
+	wantStructuralChild := []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_MODIFY,
+		interfaces.OPERATION_TYPE_DELETE,
+	}
+	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_RISK_TYPE); !reflect.DeepEqual(got, wantStructuralChild) {
+		t.Fatalf("risk type operations = %#v, want %#v", got, wantStructuralChild)
+	}
+	wantAction := append(append([]string{}, wantStructuralChild...), interfaces.OPERATION_TYPE_EXECUTE)
 	if got := KNChildOperationCandidates(interfaces.RESOURCE_TYPE_ACTION_TYPE); !reflect.DeepEqual(got, wantAction) {
 		t.Fatalf("action type operations = %#v, want %#v", got, wantAction)
+	}
+	if got := KNChildOperationCandidates("unknown"); len(got) != 0 {
+		t.Fatalf("unknown resource operations = %#v, want none", got)
 	}
 }
 
@@ -67,16 +77,12 @@ func TestFilterAndPaginateKNChildrenWithOperationsProjectsCanonicalOperations(t 
 		[]string{"kn-1/action-1"}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
 		[]string{
 			interfaces.OPERATION_TYPE_VIEW_DETAIL,
-			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
-			interfaces.OPERATION_TYPE_TASK_MANAGE,
 			interfaces.OPERATION_TYPE_EXECUTE,
 		}).Return(map[string]interfaces.PermissionResourceOps{
 		"kn-1/action-1": {ResourceID: "kn-1/action-1", Operations: []string{
 			interfaces.OPERATION_TYPE_VIEW_DETAIL,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
 			interfaces.OPERATION_TYPE_EXECUTE,
 		}},
 	}, nil)
@@ -92,7 +98,6 @@ func TestFilterAndPaginateKNChildrenWithOperationsProjectsCanonicalOperations(t 
 	}
 	if got := operations["kn-1/action-1"].Operations; !reflect.DeepEqual(got, []string{
 		interfaces.OPERATION_TYPE_VIEW_DETAIL,
-		interfaces.OPERATION_TYPE_AUTHORIZE,
 		interfaces.OPERATION_TYPE_EXECUTE,
 	}) {
 		t.Fatalf("operations = %#v", got)
@@ -109,7 +114,6 @@ func TestGetKNChildOperationsUsesCanonicalDetailResource(t *testing.T) {
 			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
 		}).Return(map[string]interfaces.PermissionResourceOps{
 		"kn-1/metric-1": {ResourceID: "kn-1/metric-1", Operations: []string{
 			interfaces.OPERATION_TYPE_VIEW_DETAIL,

--- a/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/bkn/bkn-backend/server/logics/permission/permission_service_impl.go
@@ -108,7 +108,6 @@ func (ps *PermissionServiceImpl) CreateResources(ctx context.Context, resources 
 		return httpErr
 	}
 
-	// Permission resource creation is temporarily disabled.
 	allowOps := []interfaces.PermissionOperation{}
 	for _, op := range ops {
 		allowOps = append(allowOps, interfaces.PermissionOperation{

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -33,7 +33,6 @@ func allowAllRelationPermissionResources(_ context.Context, _ string, ids, _ []s
 			interfaces.OPERATION_TYPE_QUERY_DATA,
 			interfaces.OPERATION_TYPE_MODIFY,
 			interfaces.OPERATION_TYPE_DELETE,
-			interfaces.OPERATION_TYPE_AUTHORIZE,
 		}}
 	}
 	return matched, nil

--- a/adp/bkn/ontology-query/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/bkn/ontology-query/server/drivenadapters/permission/permission_access_test.go
@@ -6,6 +6,7 @@ package permission
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,6 +21,13 @@ func TestPermissionAccessFilterResources(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != "/api/safe/v1/authz/resource-filter" {
 				t.Fatalf("path = %s", r.URL.Path)
+			}
+			var request map[string]json.RawMessage
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			if _, exists := request["evaluation_scope"]; exists {
+				t.Fatalf("ontology-query selected a non-default evaluation scope: %#v", request)
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"metric","resource_id":"kn-a/m-1","operations":["query_data"]}]}`))

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization.go
@@ -71,11 +71,6 @@ func (s *actionSchedulerService) resolveActionPermissionRequirements(ctx context
 
 	requirements := []interfaces.PermissionRequirement{
 		{
-			ResourceType: interfaces.PermissionResourceTypeKnowledgeNetwork,
-			ResourceID:   knID,
-			Operation:    interfaces.PermissionOperationExecute,
-		},
-		{
 			ResourceType: interfaces.PermissionResourceTypeActionType,
 			ResourceID:   knID + "/" + actionType.ATID,
 			Operation:    interfaces.PermissionOperationExecute,

--- a/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization_test.go
+++ b/adp/bkn/ontology-query/server/logics/action_scheduler/action_execution_authorization_test.go
@@ -96,7 +96,6 @@ func TestAuthorizeActionTypeResolvesTrustedRequirements(t *testing.T) {
 	}
 	want := []interfaces.PermissionRequirement{
 		{ResourceType: "action_type", ResourceID: "kn-1/at-1", Operation: "execute"},
-		{ResourceType: "knowledge_network", ResourceID: "kn-1", Operation: "execute"},
 		{ResourceType: "object_type", ResourceID: "kn-1/ot-input", Operation: "query_data"},
 		{ResourceType: "object_type", ResourceID: "kn-1/ot-output", Operation: "query_data"},
 	}
@@ -127,7 +126,6 @@ func TestExecuteActionChecksPermissionsBeforeInstanceData(t *testing.T) {
 	}
 	want := []interfaces.PermissionRequirement{
 		{ResourceType: "action_type", ResourceID: "kn-1/at-1", Operation: "execute"},
-		{ResourceType: "knowledge_network", ResourceID: "kn-1", Operation: "execute"},
 	}
 	if !reflect.DeepEqual(permissions.requirements, want) {
 		t.Fatalf("checked requirements = %#v, want %#v", permissions.requirements, want)

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -548,6 +548,37 @@ func (en *Enforcer) GrantCommunityBundle(accessorID, resourceType, resourceID st
 		EffectAllow, PolicySourceCommunityBundle, authority)
 }
 
+// GrantKnowledgeNetworkCreatorPermissions atomically installs the two grants
+// owned by the knowledge-network creation lifecycle. The business permissions
+// remain one logical Community bundle, while authorize is system-derived and
+// therefore cannot be revoked through ordinary owner delegation.
+func (en *Enforcer) GrantKnowledgeNetworkCreatorPermissions(ctx context.Context, accessorID, resourceID string) error {
+	if err := validateCommunityBundleTarget("knowledge_network", resourceID); err != nil {
+		return err
+	}
+	return en.Transaction(ctx, func(tx *PolicyTransaction) error {
+		if err := tx.enforcer.addPolicy(accessorID, obj("knowledge_network", resourceID), ActFullBusinessAccess,
+			EffectAllow, PolicySourceCommunityBundle, AuthoritySourceSystem); err != nil {
+			return err
+		}
+		return tx.enforcer.addPolicy(accessorID, obj("knowledge_network", resourceID), "authorize",
+			EffectAllow, PolicySourceSystemDerived, AuthoritySourceSystem)
+	})
+}
+
+// GrantActionTypeCreatorPermission records the creator's historical direct
+// execute authority with trusted lifecycle provenance. Parent fallback is only
+// consulted when no direct action rule exists.
+func (en *Enforcer) GrantActionTypeCreatorPermission(ctx context.Context, accessorID, resourceID string) error {
+	if resourceID == "" || hasWildcard(resourceID) {
+		return fmt.Errorf("action type creator permission requires a concrete resource id")
+	}
+	return en.Transaction(ctx, func(tx *PolicyTransaction) error {
+		return tx.enforcer.addPolicy(accessorID, obj("action_type", resourceID), "execute",
+			EffectAllow, PolicySourceSystemDerived, AuthoritySourceSystem)
+	})
+}
+
 // RemoveCommunityBundle removes only the logical bundle owned by one trusted
 // authority. Legacy, system-derived and Professional rows on the same resource
 // remain untouched.

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -331,11 +331,8 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			c.Status(http.StatusNoContent)
 			return
 		}
-		if req.Resource.Type == "action_type" && slices.Contains(req.Operations, "execute") {
-			if !isConcreteResourceID(req.Resource.ID) || !sameOperationSet(req.Operations, []string{"execute"}) {
-				replyPublicError(c, http.StatusBadRequest)
-				return
-			}
+		if req.Resource.Type == "action_type" && isConcreteResourceID(req.Resource.ID) &&
+			sameOperationSet(req.Operations, []string{"execute"}) {
 			if err := e.GrantActionTypeCreatorPermission(c.Request.Context(), req.AccessorID, req.Resource.ID); err != nil {
 				serverError(c, err)
 				return

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -315,6 +315,35 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			replyPublicError(c, http.StatusBadRequest)
 			return
 		}
+		// BKN creation requests use server-owned provenance. The caller selects
+		// only the lifecycle shape; policy_source and authority_source never come
+		// from the request body.
+		if req.Resource.Type == "knowledge_network" && slices.Contains(req.Operations, authz.ActFullBusinessAccess) {
+			if !isConcreteResourceID(req.Resource.ID) ||
+				!sameOperationSet(req.Operations, []string{authz.ActFullBusinessAccess, "authorize"}) {
+				replyPublicError(c, http.StatusBadRequest)
+				return
+			}
+			if err := e.GrantKnowledgeNetworkCreatorPermissions(c.Request.Context(), req.AccessorID, req.Resource.ID); err != nil {
+				serverError(c, err)
+				return
+			}
+			c.Status(http.StatusNoContent)
+			return
+		}
+		if req.Resource.Type == "action_type" && slices.Contains(req.Operations, "execute") {
+			if !isConcreteResourceID(req.Resource.ID) || !sameOperationSet(req.Operations, []string{"execute"}) {
+				replyPublicError(c, http.StatusBadRequest)
+				return
+			}
+			if err := e.GrantActionTypeCreatorPermission(c.Request.Context(), req.AccessorID, req.Resource.ID); err != nil {
+				serverError(c, err)
+				return
+			}
+			c.Status(http.StatusNoContent)
+			return
+		}
+
 		auditPolicyWriteShape(c, db, "POST", req.AccessorID, req.Resource, req.Operations)
 		// Normalize direct requirements here too (#1121). This route is the one a service
 		// calls directly, so leaving it out would keep the very bypass the rule
@@ -325,10 +354,9 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			serverError(c, err)
 			return
 		}
-		// Keep the existing generic create-resource route on its compatibility
-		// source until #1430 replaces the request contract with explicit
-		// edition-aware bundle and Professional writers. The normalized set is one
-		// transaction, so target and requirements cannot become partially visible.
+		// Keep non-BKN lifecycle callers on the compatibility source. The
+		// normalized set is one transaction, so target and requirements cannot
+		// become partially visible.
 		if err := e.GrantNormalizedObjectPermissions(c.Request.Context(), req.AccessorID,
 			req.Resource.Type, req.Resource.ID, ops); err != nil {
 			serverError(c, err)
@@ -707,10 +735,21 @@ func rejectWildcardGrant(resourceType string, operations []string) error {
 	return nil
 }
 
-// rejectTypeWideActionExecute keeps execution authority instance-scoped. A KN
-// grant deliberately does not inherit to action_type/execute, and accepting an
-// action_type wildcard here would bypass that boundary for every Action Type,
-// including instances created later.
+func sameOperationSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for _, operation := range want {
+		if !slices.Contains(got, operation) {
+			return false
+		}
+	}
+	return true
+}
+
+// rejectTypeWideActionExecute keeps direct execution authority instance-scoped.
+// Parent fallback is bounded by a concrete KN; an action_type wildcard would
+// instead bypass that boundary for every Action Type, including future ones.
 func rejectTypeWideActionExecute(resourceType, resourceID string, operations []string) error {
 	if resourceType != "action_type" || !strings.Contains(resourceID, "*") {
 		return nil

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -408,6 +408,30 @@ func TestBKNCreationPoliciesUseTrustedLifecycleSources(t *testing.T) {
 		t.Fatalf("action execute records = %#v, want one system-derived grant", actionRecords)
 	}
 
+	// Existing callers may combine execute with other concrete action-type
+	// operations. Keep those requests on the legacy compatibility path rather
+	// than rejecting a shape accepted before lifecycle provenance was added.
+	legacyActionBody := map[string]any{
+		"accessor_id": "legacy-creator",
+		"resource":    map[string]string{"type": "action_type", "id": "kn-1/action-2"},
+		"operations":  []string{"view_detail", "execute"},
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", legacyActionBody); w.Code != http.StatusNoContent {
+		t.Fatalf("create legacy mixed action-type policies: want 204, got %d: %s", w.Code, w.Body.String())
+	}
+	for _, operation := range []string{"view_detail", "execute"} {
+		records, recordsErr := e.PolicyRecords(authz.PolicyFilter{
+			AccessorID: "legacy-creator", Object: "action_type:kn-1/action-2", Operation: operation,
+		})
+		if recordsErr != nil {
+			t.Fatal(recordsErr)
+		}
+		if len(records) != 1 || records[0].PolicySource != authz.PolicySourceLegacy ||
+			records[0].AuthoritySource != authz.AuthoritySourceMigration {
+			t.Fatalf("legacy action %s records = %#v, want one legacy/migration grant", operation, records)
+		}
+	}
+
 	knBody["operations"] = []string{authz.ActFullBusinessAccess}
 	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", knBody); w.Code != http.StatusBadRequest {
 		t.Fatalf("partial lifecycle shape: want 400, got %d: %s", w.Code, w.Body.String())

--- a/bkn-safe/server/internal/httpapi/router_test.go
+++ b/bkn-safe/server/internal/httpapi/router_test.go
@@ -347,3 +347,69 @@ func TestPolicyWriteWildcardGuard(t *testing.T) {
 		t.Error("public-accessor grant should reach every requester")
 	}
 }
+
+func TestBKNCreationPoliciesUseTrustedLifecycleSources(t *testing.T) {
+	r, e, _ := newTestServer(t)
+
+	knBody := map[string]any{
+		"accessor_id":      "creator-1",
+		"resource":         map[string]string{"type": "knowledge_network", "id": "kn-1"},
+		"operations":       []string{authz.ActFullBusinessAccess, "authorize"},
+		"policy_source":    authz.PolicySourceProfessionalRule,
+		"authority_source": authz.AuthoritySourceOwnerDelegate,
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", knBody); w.Code != http.StatusNoContent {
+		t.Fatalf("create knowledge-network policies: want 204, got %d: %s", w.Code, w.Body.String())
+	}
+	records, err := e.PolicyRecords(authz.PolicyFilter{AccessorID: "creator-1", Object: "knowledge_network:kn-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("knowledge-network records = %#v, want bundle and authorize", records)
+	}
+	byOperation := make(map[string]authz.PolicyRecord, len(records))
+	for _, record := range records {
+		byOperation[record.Operation] = record
+	}
+	bundle := byOperation[authz.ActFullBusinessAccess]
+	if bundle.PolicySource != authz.PolicySourceCommunityBundle || bundle.AuthoritySource != authz.AuthoritySourceSystem {
+		t.Fatalf("bundle provenance = (%q, %q)", bundle.PolicySource, bundle.AuthoritySource)
+	}
+	authorize := byOperation["authorize"]
+	if authorize.PolicySource != authz.PolicySourceSystemDerived || authorize.AuthoritySource != authz.AuthoritySourceSystem {
+		t.Fatalf("authorize provenance = (%q, %q)", authorize.PolicySource, authorize.AuthoritySource)
+	}
+	for _, operation := range []string{"view_detail", "modify", "delete", "query_data", "execute", "authorize"} {
+		if allowed, checkErr := e.Check("creator-1", "knowledge_network", "kn-1", operation); checkErr != nil || !allowed {
+			t.Fatalf("creator %s = %v, %v; want allowed", operation, allowed, checkErr)
+		}
+	}
+	if allowed, checkErr := e.Check("creator-1", "knowledge_network", "kn-1", "task_manage"); checkErr != nil || allowed {
+		t.Fatalf("creator task_manage = %v, %v; want denied", allowed, checkErr)
+	}
+
+	actionBody := map[string]any{
+		"accessor_id": "creator-1",
+		"resource":    map[string]string{"type": "action_type", "id": "kn-1/action-1"},
+		"operations":  []string{"execute"},
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", actionBody); w.Code != http.StatusNoContent {
+		t.Fatalf("create action-type policy: want 204, got %d: %s", w.Code, w.Body.String())
+	}
+	actionRecords, err := e.PolicyRecords(authz.PolicyFilter{
+		AccessorID: "creator-1", Object: "action_type:kn-1/action-1", Operation: "execute",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actionRecords) != 1 || actionRecords[0].PolicySource != authz.PolicySourceSystemDerived ||
+		actionRecords[0].AuthoritySource != authz.AuthoritySourceSystem {
+		t.Fatalf("action execute records = %#v, want one system-derived grant", actionRecords)
+	}
+
+	knBody["operations"] = []string{authz.ActFullBusinessAccess}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/policies", knBody); w.Code != http.StatusBadRequest {
+		t.Fatalf("partial lifecycle shape: want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -45,15 +45,14 @@
       "id": "knowledge_network",
       "name": "知识网络",
       "_source": "bkn",
-      "_note": "The knowledge network is the authorization root for its domain resources; child instances inherit through ResourceParent.",
+      "_note": "The knowledge network is the authorization root for its domain resources; child instances inherit through ResourceParent. authorize is only defined at this root.",
       "operations": [
         {"id": "view_detail", "name": "查看详情"},
         {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
+        {"id": "modify", "name": "修改", "requires": ["view_detail"]},
+        {"id": "delete", "name": "删除", "requires": ["view_detail"]},
         {"id": "query_data", "name": "数据查询"},
-        {"id": "authorize", "name": "授权"},
-        {"id": "task_manage", "name": "任务管理"},
+        {"id": "authorize", "name": "授权", "requires": ["view_detail"]},
         {"id": "execute", "name": "执行"}
       ]
     },
@@ -64,10 +63,8 @@
       "parent_type": "knowledge_network",
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]}
       ]
     },
     {
@@ -78,10 +75,8 @@
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
         {"id": "query_data", "name": "Query Data", "parent_operation": "query_data"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]}
       ]
     },
     {
@@ -92,25 +87,21 @@
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
         {"id": "query_data", "name": "Query Data", "parent_operation": "query_data"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]}
       ]
     },
     {
       "id": "action_type",
       "name": "Action Type",
       "_source": "bkn",
-      "_note": "execute deliberately has no parent_operation and must be granted on a concrete Action Type instance",
+      "_note": "execute first evaluates the concrete Action Type and falls back to execute on its owning knowledge network when no direct rule exists",
       "parent_type": "knowledge_network",
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"},
-        {"id": "execute", "name": "Execute"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "execute", "name": "Execute", "parent_operation": "execute"}
       ]
     },
     {
@@ -121,10 +112,8 @@
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
         {"id": "query_data", "name": "Query Data", "parent_operation": "query_data"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]}
       ]
     },
     {
@@ -134,10 +123,8 @@
       "parent_type": "knowledge_network",
       "operations": [
         {"id": "view_detail", "name": "View Details", "parent_operation": "view_detail"},
-        {"id": "modify", "name": "Modify", "parent_operation": "modify"},
-        {"id": "delete", "name": "Delete", "parent_operation": "modify"},
-        {"id": "authorize", "name": "Authorize", "parent_operation": "authorize"},
-        {"id": "task_manage", "name": "Manage Tasks", "parent_operation": "task_manage"}
+        {"id": "modify", "name": "Modify", "parent_operation": "modify", "requires": ["view_detail"]},
+        {"id": "delete", "name": "Delete", "parent_operation": "modify", "requires": ["view_detail"]}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/data/grants.json
+++ b/bkn-safe/server/internal/seed/data/grants.json
@@ -137,7 +137,7 @@
       "role_name": "network_builder",
       "resource_type": "knowledge_network",
       "id_pattern": "*",
-      "operations": ["view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"]
+      "operations": ["view_detail", "create", "modify", "delete", "query_data", "authorize", "execute"]
     },
     {
       "role_id": "1572fb82-526f-11f0-bde6-e674ec8dde71",

--- a/bkn-safe/server/internal/seed/hierarchy_test.go
+++ b/bkn-safe/server/internal/seed/hierarchy_test.go
@@ -6,6 +6,7 @@ package seed
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -13,10 +14,8 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
 
-// TestSeedDeclaresKnowledgeNetworkHierarchy pins the KN authorization contract:
-// six domain resource types inherit selected operations from their owning KN,
-// while action_type/execute remains instance-only and Vega's resource type is
-// deliberately unaffected.
+// TestSeedDeclaresKnowledgeNetworkHierarchy pins the final BKN operation table
+// and the direct-first action execution fallback.
 func TestSeedDeclaresKnowledgeNetworkHierarchy(t *testing.T) {
 	db := newDB(t)
 	e, err := authz.New(db)
@@ -38,40 +37,71 @@ func TestSeedDeclaresKnowledgeNetworkHierarchy(t *testing.T) {
 		}
 	}
 
-	wantMappings := map[string]string{
-		"view_detail": "view_detail",
-		"modify":      "modify",
-		"delete":      "modify",
-		"authorize":   "authorize",
-		"task_manage": "task_manage",
+	type operationSpec struct {
+		parent   string
+		requires string
 	}
-	for _, child := range children {
-		for operation, parentOperation := range wantMappings {
-			var op model.Operation
-			if err := db.First(&op, "resource_type_id = ? AND id = ?", child, operation).Error; err != nil {
-				t.Fatalf("load operation %s/%s: %v", child, operation, err)
+	want := map[string]map[string]operationSpec{
+		"knowledge_network": {
+			"view_detail": {}, "create": {}, "modify": {requires: "view_detail"},
+			"delete": {requires: "view_detail"}, "query_data": {},
+			"authorize": {requires: "view_detail"}, "execute": {},
+		},
+		"concept_group": {
+			"view_detail": {parent: "view_detail"}, "modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"},
+		},
+		"object_type": {
+			"view_detail": {parent: "view_detail"}, "query_data": {parent: "query_data"},
+			"modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"},
+		},
+		"relation_type": {
+			"view_detail": {parent: "view_detail"}, "query_data": {parent: "query_data"},
+			"modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"},
+		},
+		"action_type": {
+			"view_detail": {parent: "view_detail"}, "modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"}, "execute": {parent: "execute"},
+		},
+		"metric": {
+			"view_detail": {parent: "view_detail"}, "query_data": {parent: "query_data"},
+			"modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"},
+		},
+		"risk_type": {
+			"view_detail": {parent: "view_detail"}, "modify": {parent: "modify", requires: "view_detail"},
+			"delete": {parent: "modify", requires: "view_detail"},
+		},
+	}
+	for resourceType, expected := range want {
+		var operations []model.Operation
+		if err := db.Where("resource_type_id = ?", resourceType).Find(&operations).Error; err != nil {
+			t.Fatalf("load operations for %s: %v", resourceType, err)
+		}
+		if len(operations) != len(expected) {
+			t.Errorf("%s operations = %+v, want exactly %d", resourceType, operations, len(expected))
+		}
+		for _, operation := range operations {
+			spec, ok := expected[operation.ID]
+			if !ok {
+				t.Errorf("%s unexpectedly declares %s", resourceType, operation.ID)
+				continue
 			}
-			if op.ParentOperationID != parentOperation {
-				t.Errorf("%s/%s parent operation = %q, want %q", child, operation, op.ParentOperationID, parentOperation)
+			if operation.ParentOperationID != spec.parent || operation.RequiredOperationIDs != spec.requires {
+				t.Errorf("%s/%s = parent %q requires %q, want parent %q requires %q",
+					resourceType, operation.ID, operation.ParentOperationID, operation.RequiredOperationIDs,
+					spec.parent, spec.requires)
 			}
 		}
 	}
-	for _, child := range []string{"object_type", "relation_type", "metric"} {
-		var op model.Operation
-		if err := db.First(&op, "resource_type_id = ? AND id = ?", child, "query_data").Error; err != nil {
-			t.Fatalf("load operation %s/query_data: %v", child, err)
-		}
-		if op.ParentOperationID != "query_data" {
-			t.Errorf("%s/query_data parent operation = %q, want query_data", child, op.ParentOperationID)
-		}
+	var executeActionCount int64
+	if err := db.Model(&model.Operation{}).Where("id = ?", "execute_action").Count(&executeActionCount).Error; err != nil {
+		t.Fatal(err)
 	}
-
-	var execute model.Operation
-	if err := db.First(&execute, "resource_type_id = ? AND id = ?", "action_type", "execute").Error; err != nil {
-		t.Fatalf("load action_type/execute: %v", err)
-	}
-	if execute.ParentOperationID != "" {
-		t.Errorf("action_type/execute must be instance-only, got parent operation %q", execute.ParentOperationID)
+	if executeActionCount != 0 {
+		t.Fatalf("catalog declares %d execute_action operations, want none", executeActionCount)
 	}
 
 	var vegaResource model.ResourceType
@@ -90,37 +120,70 @@ func TestSeedDeclaresKnowledgeNetworkHierarchy(t *testing.T) {
 	if err := db.Create(&parents).Error; err != nil {
 		t.Fatalf("create resource parents: %v", err)
 	}
-	const user = "u-1"
-	for _, op := range []string{"view_detail", "modify", "query_data", "authorize", "task_manage"} {
-		if err := e.GrantObjectPermission(user, "knowledge_network", "kn-1", op); err != nil {
-			t.Fatalf("grant KN operation %s: %v", op, err)
+	mustNoErrSeed(t, e.GrantCommunityBundle("bundle-parent", "knowledge_network", "kn-1", authz.AuthoritySourceSystem))
+	for _, operation := range []string{"view_detail", "query_data", "modify", "delete"} {
+		if allowed, checkErr := e.Check("bundle-parent", "object_type", "kn-1/shared", operation); checkErr != nil || !allowed {
+			t.Fatalf("Community KN bundle did not inherit object_type/%s: %v, %v", operation, allowed, checkErr)
 		}
 	}
-	for _, op := range []string{"view_detail", "modify", "delete", "query_data", "authorize", "task_manage"} {
-		if ok, err := e.Check(user, "object_type", "kn-1/shared", op); err != nil {
-			t.Fatal(err)
-		} else if !ok {
-			t.Errorf("KN grant did not inherit to object_type/%s", op)
+	for _, operation := range []string{"authorize", "task_manage"} {
+		if allowed, checkErr := e.Check("bundle-parent", "object_type", "kn-1/shared", operation); checkErr != nil || allowed {
+			t.Fatalf("removed child operation %s = %v, %v; want denied", operation, allowed, checkErr)
 		}
 	}
-	if ok, err := e.Check(user, "object_type", "kn-2/shared", "view_detail"); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Error("same child id in another KN inherited across the KN boundary")
+	if allowed, checkErr := e.Check("bundle-parent", "object_type", "kn-2/shared", "view_detail"); checkErr != nil || allowed {
+		t.Fatalf("parent inheritance crossed the KN boundary: %v, %v", allowed, checkErr)
 	}
-	if ok, err := e.Check(user, "action_type", "kn-1/run", "execute"); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Error("KN grants must not imply action_type/execute")
+	mustNoErrSeed(t, e.GrantObjectPermission("requires-view", "object_type", "kn-1/shared", "modify"))
+	if allowed, _ := e.Check("requires-view", "object_type", "kn-1/shared", "modify"); allowed {
+		t.Fatal("object_type/modify bypassed its view_detail requirement")
 	}
-	if err := e.GrantObjectPermission(user, "action_type", "kn-1/run", "execute"); err != nil {
-		t.Fatal(err)
+	mustNoErrSeed(t, e.GrantObjectPermission("requires-view", "object_type", "kn-1/shared", "view_detail"))
+	if allowed, _ := e.Check("requires-view", "object_type", "kn-1/shared", "modify"); !allowed {
+		t.Fatal("object_type/modify stayed denied after its view_detail requirement was granted")
 	}
-	if ok, err := e.Check(user, "action_type", "kn-1/run", "execute"); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Error("concrete action_type/execute grant must be effective")
+
+	assertFinal := func(user string, allowed bool, basis authz.DecisionBasis) {
+		t.Helper()
+		decision, err := e.OperationDecision(t.Context(), user, "action_type", "kn-1/run", "execute")
+		if err != nil || decision.Allowed() != allowed || decision.Basis != basis {
+			t.Fatalf("OperationDecision(%s) = %+v, %v; want allowed=%v basis=%s", user, decision, err, allowed, basis)
+		}
+		checked, err := e.Check(user, "action_type", "kn-1/run", "execute")
+		if err != nil || checked != allowed {
+			t.Fatalf("Check(%s) = %v, %v; want %v", user, checked, err, allowed)
+		}
+		operations, err := e.AllowedOps(user, "action_type", "kn-1/run", []string{"execute"})
+		if err != nil || (len(operations) == 1) != allowed {
+			t.Fatalf("AllowedOps(%s) = %v, %v; want allowed=%v", user, operations, err, allowed)
+		}
+		filtered, err := e.FilterResourceOps(user,
+			[]authz.ResourceRef{{Type: "action_type", ID: "kn-1/run"}}, nil, []string{"execute"})
+		if err != nil || len(filtered) != 1 || (len(filtered[0].Operations) == 1) != allowed {
+			t.Fatalf("FilterResourceOps(%s) = %+v, %v; want allowed=%v", user, filtered, err, allowed)
+		}
+		accessible, err := e.AccessibleResources(user, "action_type", "execute")
+		if err != nil || slices.Contains(accessible, "kn-1/run") != allowed {
+			t.Fatalf("AccessibleResources(%s) = %v, %v; want allowed=%v", user, accessible, err, allowed)
+		}
 	}
+
+	mustNoErrSeed(t, e.GrantObjectPermission("parent-allow", "knowledge_network", "kn-1", "execute"))
+	assertFinal("parent-allow", true, authz.BasisInherited)
+	mustNoErrSeed(t, e.DenyObjectPermission("parent-deny", "knowledge_network", "kn-1", "execute"))
+	assertFinal("parent-deny", false, authz.BasisInherited)
+	mustNoErrSeed(t, e.DenyObjectPermission("child-allow", "knowledge_network", "kn-1", "execute"))
+	mustNoErrSeed(t, e.GrantObjectPermission("child-allow", "action_type", "kn-1/run", "execute"))
+	assertFinal("child-allow", true, authz.BasisDirect)
+	mustNoErrSeed(t, e.GrantObjectPermission("child-deny", "knowledge_network", "kn-1", "execute"))
+	mustNoErrSeed(t, e.DenyObjectPermission("child-deny", "action_type", "kn-1/run", "execute"))
+	assertFinal("child-deny", false, authz.BasisDirect)
+	mustNoErrSeed(t, e.GrantObjectPermission("same-deny", "action_type", "kn-1/run", "execute"))
+	mustNoErrSeed(t, e.DenyObjectPermission("same-deny", "action_type", "kn-1/run", "execute"))
+	assertFinal("same-deny", false, authz.BasisDirect)
+	mustNoErrSeed(t, e.GrantObjectPermission("historical-direct", "action_type", "kn-1/run", "execute"))
+	assertFinal("historical-direct", true, authz.BasisDirect)
+	assertFinal("default-deny", false, authz.BasisDefault)
 }
 
 // TestValidateHierarchyRejectsAuthoringMistakes: every case here would compile,

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -589,7 +589,7 @@ func TestNetworkBuilderManagesKnowledgeNetworksTypeWide(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, op := range []string{"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"} {
+	for _, op := range []string{"view_detail", "create", "modify", "delete", "query_data", "authorize", "execute"} {
 		ok, err := e.Check(builder, "knowledge_network", network, op)
 		if err != nil {
 			t.Fatal(err)
@@ -648,7 +648,7 @@ func TestNetworkBuilderPermissionMatrixMatchesBusinessBuilderRole(t *testing.T) 
 	}
 	want := map[string][]string{
 		"catalog:*":           {"view_detail", "create", "modify", "delete", "authorize", "task_manage", "resource_manage", "query_data"},
-		"knowledge_network:*": {"view_detail", "create", "modify", "delete", "query_data", "authorize", "task_manage", "execute"},
+		"knowledge_network:*": {"view_detail", "create", "modify", "delete", "query_data", "authorize", "execute"},
 		"operator:*":          {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
 		"tool_box:*":          {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},
 		"skill:*":             {"create", "modify", "delete", "view", "publish", "unpublish", "authorize", "public_access", "execute"},

--- a/docs/api/bkn-safe/authorization.yaml
+++ b/docs/api/bkn-safe/authorization.yaml
@@ -255,6 +255,15 @@ paths:
         Wildcard resource types and wildcard operations are rejected.
         `action_type:*:execute` is also rejected; Action Type execute grants
         must target a concrete `{kn_id}/{action_type_id}`.
+
+        BKN creation uses two server-recognized lifecycle shapes. A newly
+        created knowledge network sends `[full_business_access, authorize]`;
+        bkn-safe atomically stores the logical Community bundle and a
+        system-derived `authorize` grant. A newly created Action Type sends
+        `[execute]`, stored as system-derived direct execution authority.
+        Policy and authority sources are selected by bkn-safe and are never
+        accepted from the request body. Other shapes retain the compatibility
+        policy writer.
       requestBody:
         required: true
         content:

--- a/docs/api/bkn-safe/authorization.yaml
+++ b/docs/api/bkn-safe/authorization.yaml
@@ -262,8 +262,10 @@ paths:
         system-derived `authorize` grant. A newly created Action Type sends
         `[execute]`, stored as system-derived direct execution authority.
         Policy and authority sources are selected by bkn-safe and are never
-        accepted from the request body. Other shapes retain the compatibility
-        policy writer.
+        accepted from the request body. Other requests that pass the wildcard
+        guards retain the compatibility policy writer, except that a knowledge
+        network request containing `full_business_access` must match the exact
+        lifecycle shape above or it is rejected with `400`.
       requestBody:
         required: true
         content:

--- a/docs/api/bkn/action-type.yaml
+++ b/docs/api/bkn/action-type.yaml
@@ -6,8 +6,10 @@ info:
   description: |
     Action types use `action_type:{kn_id}/{action_type_id}`. Reads and lists
     require `view_detail`; updates and deletes use `modify` and `delete`.
-    `execute` requires a direct concrete Action Type grant and never inherits
-    from the knowledge network. See `../knowledge-network-authorization.md`.
+    `execute` first evaluates the concrete Action Type rule; when no direct
+    rule exists it falls back to `execute` on the owning knowledge network.
+    A direct child allow or deny takes precedence, and a deny wins when both
+    effects exist on the same resource. See `../knowledge-network-authorization.md`.
 security:
   - OAuth2: []
 paths:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Align the BKN authorization catalog and operation prerequisites with the approved operation matrix.
- [x] Add direct-first Action Type execute fallback to the owning Knowledge Network and remove the duplicate runtime KN check.
- [x] Store Knowledge Network and Action Type creator grants with trusted lifecycle provenance.
- [x] Preserve compatibility for concrete Action Type requests that combine `execute` with other operations.
- [x] Update BKN authorization documentation and focused regression coverage.

---

## Why

- Related Issue: Closes #1432
- Related Feature: BKN operation model and Action execution authorization
- Background: Action execution previously required independent Action Type and Knowledge Network checks, which prevented child rules from overriding parent rules and diverged from the final authorization decision model.

---

## How

- Key implementation points:
  - Remove authorize and task_manage from BKN child resource types, and remove task_manage from Knowledge Networks.
  - Map action_type execute to knowledge_network execute through the catalog hierarchy while preserving direct child allow and deny precedence.
  - Submit only the Action Type execute requirement from ontology-query; object data and tool or MCP checks remain independent.
  - Atomically create the Community business bundle plus system-derived authorize for new Knowledge Networks, and system-derived direct execute for new Action Types.
  - Keep concrete mixed Action Type operation sets on the legacy compatibility writer.
  - Keep BKN clients on the default effective decision scope.
- Breaking changes (API, config, database, etc.):
  - The public execute_action method name is unchanged. The BKN permission catalog no longer exposes the obsolete child authorize or task_manage operations or Knowledge Network task_manage. Historical policy cleanup remains owned by #1431.
  - The new bkn-backend must not run against an old bkn-safe. An old bkn-safe stores the new `[full_business_access, authorize]` creator request as legacy rows and does not expand `full_business_access`, leaving newly created Knowledge Networks without their intended creator permissions. Existing installations must use the coordinated maintenance-window transition in #1431 / PR #1466 before reopening traffic.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- go test -p 1 ./internal/seed ./internal/authz ./internal/httpapi in bkn-safe/server
- go test ./internal/httpapi -count=1 in bkn-safe/server after the compatibility fix
- I18N_MODE_UT=true go test -p 1 ./drivenadapters/permission ./logics/permission ./logics/action_scheduler in adp/bkn/ontology-query/server
- I18N_MODE_UT=true go test -p 1 ./drivenadapters/permission ./logics/permission ./logics/knowledge_network ./logics/action_type ./logics/object_type ./logics/relation_type ./logics/metric ./logics/concept_group ./logics/risk_type in adp/bkn/bkn-backend/server
- I18N_MODE_UT=true go test -p 1 ./common/bkntrace in adp/bkn/bkn-backend/server
- npx @redocly/cli lint --config .redocly.yaml docs/api/bkn-safe/authorization.yaml
- make api-docs-lint passed in PR CI against the current base.

---

## Risk & Rollback

- Potential risks:
  - Catalog reconciliation removes obsolete BKN operations from the newly exposed authorization vocabulary. Action fallback depends on the existing concrete Action Type-to-Knowledge Network parent records. Historical stale policy rows are intentionally left for #1431.
  - Deploying the new bkn-backend with an old bkn-safe creates incomplete creator authorization. These versions must not receive traffic together; upgrades must use the #1431 / PR #1466 maintenance-window workflow and coordinated service transition.
- Rollback plan: Revert PR #1465 in full, restore the previous service versions, and follow the coordinated database rollback in #1431 / PR #1466 if the permission transition has already been applied.

---

## Additional Notes

- The updated documentation is covered by the PR's aggregate API documentation lint.
- PR #1466 is the release prerequisite for upgrading an existing installation; merging this PR does not authorize deploying its bkn-backend changes against an old bkn-safe.
