### PR TITLE
feat(authz): 接入 Connector 资源族权限

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/permission/filter_resources_bulk_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/filter_resources_bulk_test.go
@@ -20,27 +20,51 @@ import (
 	"vega-backend/interfaces"
 )
 
-// bknSafeStub mocks the two bkn-safe authz endpoints the adapter uses and counts
-// the round-trips, so tests can assert they do NOT scale with the resource count.
+// bknSafeStub mocks bkn-safe's effective resource filter and counts the
+// round-trips, so tests can assert they do NOT scale with the resource count.
 type bknSafeStub struct {
-	wildcard   bool     // obj="*" check result
-	accessible []string // ids returned by /authz/resources
-	checkCalls atomic.Int32
-	listCalls  atomic.Int32
+	allowAll    bool
+	allowedIDs  []string
+	filterCalls atomic.Int32
 }
 
 func (b *bknSafeStub) server() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/api/safe/v1/authz/check":
-			b.checkCalls.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string]bool{"allowed": b.wildcard})
-		case r.Method == http.MethodGet && r.URL.Path == "/api/safe/v1/authz/resources":
-			b.listCalls.Add(1)
-			_ = json.NewEncoder(w).Encode(map[string][]string{"ids": b.accessible})
-		default:
+		if r.Method != http.MethodPost || r.URL.Path != "/api/safe/v1/authz/resource-filter" {
 			w.WriteHeader(http.StatusNotFound)
+			return
 		}
+		b.filterCalls.Add(1)
+		var req struct {
+			Resources            []interfaces.PermissionResource `json:"resources"`
+			VisibilityOperations []string                        `json:"visibility_operations"`
+			CandidateOperations  []string                        `json:"candidate_operations"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		allowedIDs := make(map[string]bool, len(b.allowedIDs))
+		for _, id := range b.allowedIDs {
+			allowedIDs[id] = true
+		}
+		resources := make([]map[string]any, 0, len(req.Resources))
+		for _, resource := range req.Resources {
+			allowed := b.allowAll || allowedIDs[resource.ID]
+			if len(req.VisibilityOperations) > 0 && !allowed {
+				continue
+			}
+			operations := []string{}
+			if allowed {
+				operations = append(operations, req.CandidateOperations...)
+			}
+			resources = append(resources, map[string]any{
+				"resource_type": resource.Type,
+				"resource_id":   resource.ID,
+				"operations":    operations,
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"resources": resources})
 	}))
 }
 
@@ -59,8 +83,8 @@ func TestSafeFilterResourcesIsBulk(t *testing.T) {
 	const op = interfaces.OPERATION_TYPE_VIEW_DETAIL
 	ctx := context.Background()
 
-	t.Run("concrete grants: one check + one id-set fetch for any resource count", func(t *testing.T) {
-		stub := &bknSafeStub{wildcard: false, accessible: []string{"r1", "r5"}}
+	t.Run("concrete grants: one effective filter for any resource count", func(t *testing.T) {
+		stub := &bknSafeStub{allowedIDs: []string{"r1", "r5"}}
 		srv := stub.server()
 		defer srv.Close()
 
@@ -77,15 +101,13 @@ func TestSafeFilterResourcesIsBulk(t *testing.T) {
 		if len(got) != 2 || got["r1"].Operations[0] != op || got["r5"].Operations[0] != op {
 			t.Fatalf("want only r1,r5 with [%s]; got %+v", op, got)
 		}
-		// One op, one resource type -> one wildcard probe + one id-set fetch,
-		// independent of the 100 resources filtered.
-		if c, l := stub.checkCalls.Load(), stub.listCalls.Load(); c != 1 || l != 1 {
-			t.Fatalf("round-trips must not scale with resource count: checks=%d lists=%d", c, l)
+		if calls := stub.filterCalls.Load(); calls != 1 {
+			t.Fatalf("round-trips must not scale with resource count: filters=%d", calls)
 		}
 	})
 
-	t.Run("wildcard grant: everything passes without fetching the id set", func(t *testing.T) {
-		stub := &bknSafeStub{wildcard: true, accessible: []string{"unused"}}
+	t.Run("wildcard grant: everything passes in one effective filter", func(t *testing.T) {
+		stub := &bknSafeStub{allowAll: true}
 		srv := stub.server()
 		defer srv.Close()
 
@@ -101,15 +123,15 @@ func TestSafeFilterResourcesIsBulk(t *testing.T) {
 		if len(got) != 100 {
 			t.Fatalf("wildcard grant must pass every resource, got %d", len(got))
 		}
-		if c, l := stub.checkCalls.Load(), stub.listCalls.Load(); c != 1 || l != 0 {
-			t.Fatalf("wildcard: want 1 check and no id-set fetch, got checks=%d lists=%d", c, l)
+		if calls := stub.filterCalls.Load(); calls != 1 {
+			t.Fatalf("wildcard: want 1 effective filter, got %d", calls)
 		}
 	})
 
 	// GetResourcesOperations keeps every requested resource (even with no ops),
 	// unlike FilterResources which drops the unauthorized ones.
 	t.Run("GetResourcesOperations keeps unauthorized resources with empty ops", func(t *testing.T) {
-		stub := &bknSafeStub{wildcard: false, accessible: []string{"r1"}}
+		stub := &bknSafeStub{allowedIDs: []string{"r1"}}
 		srv := stub.server()
 		defer srv.Close()
 
@@ -136,22 +158,13 @@ func TestSafeFilterResourcesIsBulk(t *testing.T) {
 // 那些。只解析可见性动词的话,operations 恒等于 view_detail,界面上除了「查看」
 // 之外每个按钮都是暗的——持有取数权与目录管理权的账号也一样。
 func TestFilterResourcesReportsCandidateOperations(t *testing.T) {
-	held := map[string]bool{
-		interfaces.OPERATION_TYPE_VIEW_DETAIL: true,
-		interfaces.OPERATION_TYPE_QUERY_DATA:  true,
-	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body struct {
-			Resource  struct{ ID string } `json:"resource"`
-			Operation string              `json:"operation"`
-		}
-		_ = json.NewDecoder(r.Body).Decode(&body)
 		w.Header().Set("Content-Type", "application/json")
-		if strings.HasSuffix(r.URL.Path, "/check") {
-			_, _ = fmt.Fprintf(w, `{"allowed":%t}`, held[body.Operation])
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/resource-filter") {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		_, _ = w.Write([]byte(`{"resources":[]}`))
+		_, _ = w.Write([]byte(`{"resources":[{"resource_type":"resource","resource_id":"r-1","operations":["view_detail","query_data"]}]}`))
 	}))
 	defer srv.Close()
 
@@ -176,5 +189,86 @@ func TestFilterResourcesReportsCandidateOperations(t *testing.T) {
 	want := []string{interfaces.OPERATION_TYPE_VIEW_DETAIL, interfaces.OPERATION_TYPE_QUERY_DATA}
 	if !reflect.DeepEqual(entry.Operations, want) {
 		t.Fatalf("operations = %v, want %v(候选集里持有的那些,不含没授的 delete)", entry.Operations, want)
+	}
+}
+
+// A type-wide operation grant can depend on a prerequisite held only on one
+// concrete resource. The final answer therefore cannot be inferred by checking
+// type:* and enumerating concrete grants independently; bkn-safe must evaluate
+// the supplied resource as one effective decision.
+func TestFilterResourcesCombinesWildcardOperationWithConcreteRequirement(t *testing.T) {
+	var filterCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/safe/v1/authz/check":
+			// modify on connector_type:* is denied because view_detail exists only
+			// on remote-api, not on the wildcard pseudo-resource.
+			_, _ = w.Write([]byte(`{"allowed":false}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/safe/v1/authz/resources":
+			if r.URL.Query().Get("operation") == interfaces.OPERATION_TYPE_VIEW_DETAIL {
+				_, _ = w.Write([]byte(`{"ids":["remote-api"]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"ids":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/safe/v1/authz/resource-filter":
+			filterCalls.Add(1)
+			var body struct {
+				AccessorID           string                          `json:"accessor_id"`
+				Resources            []interfaces.PermissionResource `json:"resources"`
+				VisibilityOperations []string                        `json:"visibility_operations"`
+				CandidateOperations  []string                        `json:"candidate_operations"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode resource-filter request: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if body.AccessorID != "legacy-user" ||
+				!reflect.DeepEqual(body.Resources, []interfaces.PermissionResource{{Type: "connector_type", ID: "remote-api"}}) ||
+				!reflect.DeepEqual(body.VisibilityOperations, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}) ||
+				!reflect.DeepEqual(body.CandidateOperations, []string{
+					interfaces.OPERATION_TYPE_VIEW_DETAIL,
+					interfaces.OPERATION_TYPE_MODIFY,
+					interfaces.OPERATION_TYPE_DELETE,
+					interfaces.OPERATION_TYPE_AUTHORIZE,
+				}) {
+				t.Errorf("resource-filter request = %+v", body)
+			}
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"connector_type","resource_id":"remote-api","operations":["view_detail","modify","delete","authorize"]}]}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	pa := &safePermissionAccess{safe: newSafeClient(srv.URL)}
+	got, err := pa.FilterResources(context.Background(), interfaces.PermissionResourcesFilter{
+		Accessor:  interfaces.PermissionAccessor{ID: "legacy-user", Type: interfaces.ACCESSOR_TYPE_USER},
+		Resources: []interfaces.PermissionResource{{Type: "connector_type", ID: "remote-api"}},
+		Operations: []string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		},
+		CandidateOperations: []string{
+			interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			interfaces.OPERATION_TYPE_MODIFY,
+			interfaces.OPERATION_TYPE_DELETE,
+			interfaces.OPERATION_TYPE_AUTHORIZE,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		interfaces.OPERATION_TYPE_MODIFY,
+		interfaces.OPERATION_TYPE_DELETE,
+		interfaces.OPERATION_TYPE_AUTHORIZE,
+	}
+	if !reflect.DeepEqual(got["remote-api"].Operations, want) {
+		t.Fatalf("operations = %v, want %v", got["remote-api"].Operations, want)
+	}
+	if calls := filterCalls.Load(); calls != 1 {
+		t.Fatalf("resource-filter calls = %d, want 1", calls)
 	}
 }

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -668,20 +668,10 @@ func TestSafePermissionAccessCheckPermission(t *testing.T) {
 
 func TestSafePermissionAccessFilterResources(t *testing.T) {
 	t.Run("returns resources with allowed operations", func(t *testing.T) {
-		// 鉴权按 op 批量解析：先探类型级通配（此处无），再取该 op 的可访问 id 集
 		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			switch r.URL.Path {
-			case "/api/safe/v1/authz/check":
-				_, _ = w.Write([]byte(`{"allowed":false}`)) // 无类型级通配授权
-			case "/api/safe/v1/authz/resources":
-				if r.URL.Query().Get("operation") == interfaces.OPERATION_TYPE_VIEW_DETAIL {
-					_, _ = w.Write([]byte(`{"ids":["resource-1"]}`))
-					return
-				}
-				_, _ = w.Write([]byte(`{"ids":[]}`))
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/safe/v1/authz/resource-filter", r.URL.Path)
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"resource","resource_id":"resource-1","operations":["view_detail"]}]}`))
 		})
 		access := &safePermissionAccess{safe: client}
 
@@ -709,7 +699,9 @@ func TestSafePermissionAccessFilterResources(t *testing.T) {
 func TestSafePermissionAccessGetResourcesOperations(t *testing.T) {
 	t.Run("returns all resources with operation slices", func(t *testing.T) {
 		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"allowed":false}`))
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/api/safe/v1/authz/resource-filter", r.URL.Path)
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"resource","resource_id":"resource-1","operations":[]}]}`))
 		})
 		access := &safePermissionAccess{safe: client}
 

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -694,6 +694,24 @@ func TestSafePermissionAccessFilterResources(t *testing.T) {
 			},
 		}, got)
 	})
+
+	t.Run("accepts an explicit empty resource list", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[]}`))
+		})
+		access := &safePermissionAccess{safe: client}
+
+		got, err := access.FilterResources(context.Background(), samplePermissionResourcesFilter())
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("rejects invalid resource filter responses", func(t *testing.T) {
+		assertRejectsInvalidResourceFilterResponses(t, func(access *safePermissionAccess) (map[string]interfaces.PermissionResourceOps, error) {
+			return access.FilterResources(context.Background(), samplePermissionResourcesFilter())
+		})
+	})
 }
 
 func TestSafePermissionAccessGetResourcesOperations(t *testing.T) {
@@ -715,6 +733,26 @@ func TestSafePermissionAccessGetResourcesOperations(t *testing.T) {
 		assert.Equal(t, map[string]interfaces.PermissionResourceOps{
 			"resource-1": {ResourceID: "resource-1", Operations: []string{}},
 		}, got)
+	})
+
+	t.Run("accepts an explicit empty resource list", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[]}`))
+		})
+		access := &safePermissionAccess{safe: client}
+
+		got, err := access.GetResourcesOperations(context.Background(), samplePermissionResourcesFilter())
+
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interfaces.PermissionResourceOps{
+			"resource-1": {ResourceID: "resource-1", Operations: []string{}},
+		}, got)
+	})
+
+	t.Run("rejects invalid resource filter responses", func(t *testing.T) {
+		assertRejectsInvalidResourceFilterResponses(t, func(access *safePermissionAccess) (map[string]interfaces.PermissionResourceOps, error) {
+			return access.GetResourcesOperations(context.Background(), samplePermissionResourcesFilter())
+		})
 	})
 }
 
@@ -941,6 +979,42 @@ func newSafeReadErrorClient() *safeClient {
 			}),
 		},
 	}
+}
+
+func assertRejectsInvalidResourceFilterResponses(t *testing.T,
+	call func(*safePermissionAccess) (map[string]interfaces.PermissionResourceOps, error)) {
+	t.Helper()
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "empty body", body: ""},
+		{name: "missing resources field", body: `{}`},
+		{name: "null response", body: `null`},
+		{name: "null resources field", body: `{"resources":null}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			})
+
+			got, err := call(&safePermissionAccess{safe: client})
+
+			require.Error(t, err)
+			assert.Nil(t, got)
+		})
+	}
+
+	t.Run("response body read failure", func(t *testing.T) {
+		client := newSafeReadErrorClient()
+
+		got, err := call(&safePermissionAccess{safe: client})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		assert.Nil(t, got)
+	})
 }
 
 func boolJSON(value bool) string {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -252,21 +251,27 @@ func (c *safeClient) allowedOps(ctx context.Context, accessorID, rtype, rid stri
 	return out, nil
 }
 
-// accessibleIDs returns the concrete resource ids of rtype the accessor may
-// perform op on (type-wide "*" grants are excluded by bkn-safe; the caller
-// detects those via a separate obj="*" check). One bulk round-trip.
-func (c *safeClient) accessibleIDs(ctx context.Context, accessorID, rtype, op string) ([]string, error) {
-	q := url.Values{}
-	q.Set("accessor_id", accessorID)
-	q.Set("resource_type", rtype)
-	q.Set("operation", op)
+type safeFilteredResource struct {
+	ResourceID string   `json:"resource_id"`
+	Operations []string `json:"operations"`
+}
+
+// filterResources delegates the complete effective decision to bkn-safe. A
+// result cannot be reconstructed from an independent wildcard probe and a list
+// of concrete grants when an operation has same-resource prerequisites: the
+// operation may be type-wide while its prerequisite is instance-specific.
+func (c *safeClient) filterResources(ctx context.Context, accessorID string,
+	resources []interfaces.PermissionResource, visibility, candidates []string) ([]safeFilteredResource, error) {
 	var out struct {
-		IDs []string `json:"ids"`
+		Resources []safeFilteredResource `json:"resources"`
 	}
-	if err := c.do(ctx, http.MethodGet, "/api/safe/v1/authz/resources?"+q.Encode(), nil, &out); err != nil {
-		return nil, err
-	}
-	return out.IDs, nil
+	err := c.do(ctx, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+		"accessor_id":           accessorID,
+		"resources":             resources,
+		"visibility_operations": visibility,
+		"candidate_operations":  candidates,
+	}, &out)
+	return out.Resources, err
 }
 
 func (c *safeClient) allowedAll(ctx context.Context, accessorID, rtype, rid string, ops []string) (bool, error) {
@@ -363,82 +368,6 @@ func (s *safePermissionAccess) LocalResourceDecisions(ctx context.Context,
 	return s.safe.localResourceDecisions(ctx, filter)
 }
 
-// opAccess is the authorization resolution result of a single operation under a certain resource type: either it holds type-level wildcard authorization
-// (Covering all instances of this type), or a specific collection of accessible ids.
-type opAccess struct {
-	all bool
-	ids map[string]bool
-}
-
-// resolveOps batch resolves the authorization of each candidate operation under a certain resource type: first, use a check with obj="*"
-// Determine type-level/over-pipe matching (if hit, this op covers all instances and no further collection is required); otherwise, proceed to bkn-safe
-// Take the set of accessible ids of this (accessor, type, operation).
-//
-// The number of round trips is only related to the "operand" and has nothing to do with the number of resources to be filtered - this is precisely why large directories no longer time out
-// (#357: In the original implementation of resource-by-resource authentication, accounts with full authorization had approximately 5.6k resources, which led to a timeout of over 40 seconds.)
-func (s *safePermissionAccess) resolveOps(ctx context.Context, accessorID, rtype string, ops []string) (map[string]opAccess, error) {
-	out := make(map[string]opAccess, len(ops))
-	for _, op := range ops {
-		wild, err := s.safe.checkOne(ctx, accessorID, rtype, "*", op)
-		if err != nil {
-			return nil, err
-		}
-		if wild {
-			out[op] = opAccess{all: true}
-			continue
-		}
-		ids, err := s.safe.accessibleIDs(ctx, accessorID, rtype, op)
-		if err != nil {
-			return nil, err
-		}
-		set := make(map[string]bool, len(ids))
-		for _, id := range ids {
-			set[id] = true
-		}
-		out[op] = opAccess{ids: set}
-	}
-	return out, nil
-}
-
-// resolveFilter parses each op authorization of each resource type that appears in the filter for the caller to store in memory
-// Determine each resource one by one to avoid initiating authentication requests resource by resource.
-func (s *safePermissionAccess) resolveFilter(ctx context.Context,
-	filter interfaces.PermissionResourcesFilter) (map[string]map[string]opAccess, error) {
-
-	byType := make(map[string]map[string]opAccess)
-	for _, r := range filter.Resources {
-		if _, done := byType[r.Type]; done {
-			continue
-		}
-		access, err := s.resolveOps(ctx, filter.Accessor.ID, r.Type, filterOps(filter))
-		if err != nil {
-			return nil, err
-		}
-		byType[r.Type] = access
-	}
-	return byType, nil
-}
-
-// filterOps is every operation the answer has to know about: the ones that
-// decide visibility, plus the ones the answer reports on. They are separate
-// axes — a resource is listed because the caller may view it, while the
-// operations travelling back with it are what the caller may then do — so
-// resolving only the first leaves the second empty and every button dark.
-func filterOps(filter interfaces.PermissionResourcesFilter) []string {
-	out := make([]string, 0, len(filter.Operations)+len(filter.CandidateOperations))
-	seen := make(map[string]bool, cap(out))
-	for _, group := range [][]string{filter.Operations, filter.CandidateOperations} {
-		for _, op := range group {
-			if seen[op] {
-				continue
-			}
-			seen[op] = true
-			out = append(out, op)
-		}
-	}
-	return out
-}
-
 // reportOps is the set the answer names back. Callers that state no candidates
 // get the visibility operations, which is what they asked about.
 func reportOps(filter interfaces.PermissionResourcesFilter) []string {
@@ -448,47 +377,39 @@ func reportOps(filter interfaces.PermissionResourcesFilter) []string {
 	return filter.Operations
 }
 
-// allowedFrom selects the actual operations held on the resource from each op authorization that has been parsed.
-func allowedFrom(access map[string]opAccess, ops []string, id string) []string {
-	out := make([]string, 0, len(ops))
-	for _, op := range ops {
-		if a := access[op]; a.all || a.ids[id] {
-			out = append(out, op)
-		}
-	}
-	return out
-}
-
 func (s *safePermissionAccess) FilterResources(ctx context.Context, filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
-	byType, err := s.resolveFilter(ctx, filter)
+	resources, err := s.safe.filterResources(ctx, filter.Accessor.ID, filter.Resources,
+		filter.Operations, reportOps(filter))
 	if err != nil {
 		return nil, err
 	}
 	out := map[string]interfaces.PermissionResourceOps{}
-	for _, r := range filter.Resources {
-		// Visibility and reporting are decided separately: the first says whether
-		// the resource belongs in the answer at all, the second says what comes
-		// back with it.
-		if visible := allowedFrom(byType[r.Type], filter.Operations, r.ID); len(visible) > 0 {
-			out[r.ID] = interfaces.PermissionResourceOps{
-				ResourceID: r.ID,
-				Operations: allowedFrom(byType[r.Type], reportOps(filter), r.ID),
-			}
+	for _, r := range resources {
+		out[r.ResourceID] = interfaces.PermissionResourceOps{
+			ResourceID: r.ResourceID,
+			Operations: r.Operations,
 		}
 	}
 	return out, nil
 }
 
 func (s *safePermissionAccess) GetResourcesOperations(ctx context.Context, filter interfaces.PermissionResourcesFilter) (map[string]interfaces.PermissionResourceOps, error) {
-	byType, err := s.resolveFilter(ctx, filter)
+	resources, err := s.safe.filterResources(ctx, filter.Accessor.ID, filter.Resources,
+		nil, reportOps(filter))
 	if err != nil {
 		return nil, err
 	}
-	out := map[string]interfaces.PermissionResourceOps{}
+	out := make(map[string]interfaces.PermissionResourceOps, len(filter.Resources))
 	for _, r := range filter.Resources {
 		out[r.ID] = interfaces.PermissionResourceOps{
 			ResourceID: r.ID,
-			Operations: allowedFrom(byType[r.Type], reportOps(filter), r.ID),
+			Operations: []string{},
+		}
+	}
+	for _, r := range resources {
+		out[r.ResourceID] = interfaces.PermissionResourceOps{
+			ResourceID: r.ResourceID,
+			Operations: r.Operations,
 		}
 	}
 	return out, nil

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -263,15 +263,20 @@ type safeFilteredResource struct {
 func (c *safeClient) filterResources(ctx context.Context, accessorID string,
 	resources []interfaces.PermissionResource, visibility, candidates []string) ([]safeFilteredResource, error) {
 	var out struct {
-		Resources []safeFilteredResource `json:"resources"`
+		Resources *[]safeFilteredResource `json:"resources"`
 	}
-	err := c.do(ctx, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+	if err := c.do(ctx, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
 		"accessor_id":           accessorID,
 		"resources":             resources,
 		"visibility_operations": visibility,
 		"candidate_operations":  candidates,
-	}, &out)
-	return out.Resources, err
+	}, &out); err != nil {
+		return nil, err
+	}
+	if out.Resources == nil {
+		return nil, fmt.Errorf("bkn-safe resource-filter response is missing a non-null resources field")
+	}
+	return *out.Resources, nil
 }
 
 func (c *safeClient) allowedAll(ctx context.Context, accessorID, rtype, rid string, ops []string) (bool, error) {

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
@@ -409,11 +409,13 @@ func (cts *connectorTypeService) SetEnabled(ctx context.Context, tp string, enab
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Set enabled connector type")
 	defer span.End()
 
-	// Determine whether the userid has the permission to be modified
+	// Enabling or disabling a connector changes its runtime availability, so it
+	// belongs to the connector task-management surface rather than definition
+	// editing. The catalog requires view_detail for this operation as well.
 	err := cts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
 		ID:   tp,
-	}, []string{interfaces.OPERATION_TYPE_MODIFY})
+	}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE})
 	if err != nil {
 		return err
 	}

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service.go
@@ -409,13 +409,12 @@ func (cts *connectorTypeService) SetEnabled(ctx context.Context, tp string, enab
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Set enabled connector type")
 	defer span.End()
 
-	// Enabling or disabling a connector changes its runtime availability, so it
-	// belongs to the connector task-management surface rather than definition
-	// editing. The catalog requires view_detail for this operation as well.
+	// Enabled is part of the connector definition, so changing it uses modify.
+	// The permission catalog also requires view_detail for this operation.
 	err := cts.ps.CheckPermission(ctx, interfaces.PermissionResource{
 		Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
 		ID:   tp,
-	}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE})
+	}, []string{interfaces.OPERATION_TYPE_MODIFY})
 	if err != nil {
 		return err
 	}

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service_test.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service_test.go
@@ -118,6 +118,19 @@ func TestConnectorTypeServiceRegister(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "database unavailable")
 	})
+
+	t.Run("checks type-level create permission before side effects", func(t *testing.T) {
+		service, _, ps := newTestConnectorTypeService(t)
+		denied := errors.New("create denied")
+		ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
+			ID:   interfaces.RESOURCE_ID_ALL,
+		}, []string{interfaces.OPERATION_TYPE_CREATE}).Return(denied)
+
+		err := service.Register(context.Background(), &interfaces.ConnectorTypeReq{Type: "remote-api"})
+
+		require.ErrorIs(t, err, denied)
+	})
 }
 
 func TestConnectorTypeServiceGetByType(t *testing.T) {
@@ -490,7 +503,7 @@ func TestConnectorTypeServiceDeleteByType(t *testing.T) {
 }
 
 func TestConnectorTypeServiceSetEnabled(t *testing.T) {
-	t.Run("set enabled checks permission and updates access", func(t *testing.T) {
+	t.Run("set enabled checks task management permission and updates access", func(t *testing.T) {
 		service, cta, ps := newTestConnectorTypeService(t)
 		connectorFactory := vmock.NewMockConnectorFactory(gomock.NewController(t))
 		service.cf = connectorFactory
@@ -498,12 +511,25 @@ func TestConnectorTypeServiceSetEnabled(t *testing.T) {
 			CheckPermission(gomock.Any(), interfaces.PermissionResource{
 				Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
 				ID:   "remote-api",
-			}, []string{interfaces.OPERATION_TYPE_MODIFY}).
+			}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE}).
 			Return(nil)
 		cta.EXPECT().SetEnabled(gomock.Any(), "remote-api", true).Return(nil)
 		connectorFactory.EXPECT().SetConnectorEnabled("remote-api", true)
 
 		require.NoError(t, service.SetEnabled(context.Background(), "remote-api", true))
+	})
+
+	t.Run("permission denial prevents enabled-state changes", func(t *testing.T) {
+		service, _, ps := newTestConnectorTypeService(t)
+		denied := errors.New("task management denied")
+		ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
+			Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
+			ID:   "remote-api",
+		}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE}).Return(denied)
+
+		err := service.SetEnabled(context.Background(), "remote-api", true)
+
+		require.ErrorIs(t, err, denied)
 	})
 
 	t.Run("set enabled wraps access error", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/connector_type/connector_type_service_test.go
+++ b/adp/vega/vega-backend/server/logics/connector_type/connector_type_service_test.go
@@ -503,7 +503,7 @@ func TestConnectorTypeServiceDeleteByType(t *testing.T) {
 }
 
 func TestConnectorTypeServiceSetEnabled(t *testing.T) {
-	t.Run("set enabled checks task management permission and updates access", func(t *testing.T) {
+	t.Run("set enabled checks modify permission and updates access", func(t *testing.T) {
 		service, cta, ps := newTestConnectorTypeService(t)
 		connectorFactory := vmock.NewMockConnectorFactory(gomock.NewController(t))
 		service.cf = connectorFactory
@@ -511,7 +511,7 @@ func TestConnectorTypeServiceSetEnabled(t *testing.T) {
 			CheckPermission(gomock.Any(), interfaces.PermissionResource{
 				Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
 				ID:   "remote-api",
-			}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE}).
+			}, []string{interfaces.OPERATION_TYPE_MODIFY}).
 			Return(nil)
 		cta.EXPECT().SetEnabled(gomock.Any(), "remote-api", true).Return(nil)
 		connectorFactory.EXPECT().SetConnectorEnabled("remote-api", true)
@@ -521,11 +521,11 @@ func TestConnectorTypeServiceSetEnabled(t *testing.T) {
 
 	t.Run("permission denial prevents enabled-state changes", func(t *testing.T) {
 		service, _, ps := newTestConnectorTypeService(t)
-		denied := errors.New("task management denied")
+		denied := errors.New("modify denied")
 		ps.EXPECT().CheckPermission(gomock.Any(), interfaces.PermissionResource{
 			Type: interfaces.AUTH_RESOURCE_TYPE_CONNECTOR_TYPE,
 			ID:   "remote-api",
-		}, []string{interfaces.OPERATION_TYPE_TASK_MANAGE}).Return(denied)
+		}, []string{interfaces.OPERATION_TYPE_MODIFY}).Return(denied)
 
 		err := service.SetEnabled(context.Background(), "remote-api", true)
 

--- a/bkn-safe/server/internal/authz/community_bundle.go
+++ b/bkn-safe/server/internal/authz/community_bundle.go
@@ -16,7 +16,7 @@ import "fmt"
 var communityBundleOperations = map[string][]string{
 	"catalog":           {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
 	"knowledge_network": {"view_detail", "modify", "delete", "query_data", "execute"},
-	"connector_type":    {"view_detail", "modify", "delete", "task_manage"},
+	"connector_type":    {"view_detail", "modify", "delete"},
 	"tool_box":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
 	"mcp":               {"view", "modify", "delete", "publish", "unpublish", "execute"},
 	"operator":          {"view", "modify", "delete", "publish", "unpublish", "execute"},

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -18,7 +18,7 @@ func TestCommunityBundleWhitelistIsExplicitAndDefensive(t *testing.T) {
 	want := map[string][]string{
 		"catalog":           {"view_detail", "modify", "delete", "query_data", "resource_manage", "task_manage"},
 		"knowledge_network": {"view_detail", "modify", "delete", "query_data", "execute"},
-		"connector_type":    {"view_detail", "modify", "delete", "task_manage"},
+		"connector_type":    {"view_detail", "modify", "delete"},
 		"tool_box":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
 		"mcp":               {"view", "modify", "delete", "publish", "unpublish", "execute"},
 		"operator":          {"view", "modify", "delete", "publish", "unpublish", "execute"},
@@ -52,7 +52,7 @@ func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
 	if err := db.Create(&model.ResourceType{ID: "connector_type"}).Error; err != nil {
 		t.Fatal(err)
 	}
-	for _, operation := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage"} {
+	for _, operation := range []string{"view_detail", "create", "modify", "delete", "authorize"} {
 		requires := ""
 		if operation != "view_detail" && operation != "create" {
 			requires = "view_detail"
@@ -68,7 +68,7 @@ func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
 		directHolder = "connector-direct-holder"
 		resourceID   = "remote-api"
 	)
-	bundleOperations := []string{"view_detail", "modify", "delete", "task_manage"}
+	bundleOperations := []string{"view_detail", "modify", "delete"}
 
 	mustNoErr(t, e.GrantCommunityBundle(
 		bundleHolder, "connector_type", resourceID, AuthoritySourceAdminAuthz,
@@ -79,7 +79,7 @@ func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
 			t.Errorf("bundle Check(%s) = %v, %v; want true", operation, allowed, err)
 		}
 	}
-	for _, operation := range []string{"create", "authorize", "public_access", ActFullBusinessAccess} {
+	for _, operation := range []string{"create", "authorize", "task_manage", "public_access", ActFullBusinessAccess} {
 		allowed, err := e.Check(bundleHolder, "connector_type", resourceID, operation)
 		if err != nil || allowed {
 			t.Errorf("bundle Check(excluded %s) = %v, %v; want false", operation, allowed, err)
@@ -95,29 +95,29 @@ func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
 
 	*edition = licverify.EditionProfessional
 	mustNoErr(t, e.GrantProfessionalObjectPermission(
-		bundleHolder, "connector_type", resourceID, "task_manage", EffectDeny, AuthoritySourceAdminAuthz,
+		bundleHolder, "connector_type", resourceID, "modify", EffectDeny, AuthoritySourceAdminAuthz,
 	))
-	if allowed, err := e.Check(bundleHolder, "connector_type", resourceID, "task_manage"); err != nil || allowed {
+	if allowed, err := e.Check(bundleHolder, "connector_type", resourceID, "modify"); err != nil || allowed {
 		t.Fatalf("Professional deny did not override bundle: allowed=%v err=%v", allowed, err)
 	}
 	mustNoErr(t, e.GrantProfessionalObjectPermission(
-		directHolder, "connector_type", resourceID, "task_manage", EffectAllow, AuthoritySourceAdminAuthz,
+		directHolder, "connector_type", resourceID, "modify", EffectAllow, AuthoritySourceAdminAuthz,
 	))
-	decision, err := e.OperationDecision(t.Context(), directHolder, "connector_type", resourceID, "task_manage")
+	decision, err := e.OperationDecision(t.Context(), directHolder, "connector_type", resourceID, "modify")
 	if err != nil || decision.Decision != DecisionDeny || decision.Basis != BasisRequires ||
 		decision.DeniedRequirement != "view_detail" {
-		t.Fatalf("task_manage without view_detail = %+v, %v; want requires deny", decision, err)
+		t.Fatalf("modify without view_detail = %+v, %v; want requires deny", decision, err)
 	}
 	mustNoErr(t, e.GrantProfessionalObjectPermission(
 		directHolder, "connector_type", resourceID, "view_detail", EffectAllow, AuthoritySourceAdminAuthz,
 	))
-	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "task_manage"); err != nil || !allowed {
+	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "modify"); err != nil || !allowed {
 		t.Fatalf("direct allow with view_detail = %v, %v; want true", allowed, err)
 	}
 	mustNoErr(t, e.GrantProfessionalObjectPermission(
-		directHolder, "connector_type", resourceID, "task_manage", EffectDeny, AuthoritySourceAdminAuthz,
+		directHolder, "connector_type", resourceID, "modify", EffectDeny, AuthoritySourceAdminAuthz,
 	))
-	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "task_manage"); err != nil || allowed {
+	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "modify"); err != nil || allowed {
 		t.Fatalf("same-resource direct deny did not override allow: allowed=%v err=%v", allowed, err)
 	}
 }

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -46,6 +46,82 @@ func TestCommunityBundleWhitelistIsExplicitAndDefensive(t *testing.T) {
 	}
 }
 
+func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
+	edition := useEdition(t, licverify.EditionCommunity)
+	e, db := newTestEnforcerDB(t)
+	if err := db.Create(&model.ResourceType{ID: "connector_type"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range []string{"view_detail", "create", "modify", "delete", "authorize", "task_manage"} {
+		requires := ""
+		if operation != "view_detail" && operation != "create" {
+			requires = "view_detail"
+		}
+		if err := db.Create(&model.Operation{
+			ResourceTypeID: "connector_type", ID: operation, RequiredOperationIDs: requires,
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	const (
+		bundleHolder = "connector-bundle-holder"
+		directHolder = "connector-direct-holder"
+		resourceID   = "remote-api"
+	)
+	bundleOperations := []string{"view_detail", "modify", "delete", "task_manage"}
+
+	mustNoErr(t, e.GrantCommunityBundle(
+		bundleHolder, "connector_type", resourceID, AuthoritySourceAdminAuthz,
+	))
+	for _, operation := range bundleOperations {
+		allowed, err := e.Check(bundleHolder, "connector_type", resourceID, operation)
+		if err != nil || !allowed {
+			t.Errorf("bundle Check(%s) = %v, %v; want true", operation, allowed, err)
+		}
+	}
+	for _, operation := range []string{"create", "authorize", "public_access", ActFullBusinessAccess} {
+		allowed, err := e.Check(bundleHolder, "connector_type", resourceID, operation)
+		if err != nil || allowed {
+			t.Errorf("bundle Check(excluded %s) = %v, %v; want false", operation, allowed, err)
+		}
+	}
+	filtered, err := e.FilterResourceOps(bundleHolder,
+		[]ResourceRef{{Type: "connector_type", ID: resourceID}, {Type: "connector_type", ID: "local-db"}},
+		[]string{"view_detail"}, bundleOperations)
+	if err != nil || len(filtered) != 1 || filtered[0].ID != resourceID ||
+		!reflect.DeepEqual(filtered[0].Operations, bundleOperations) {
+		t.Fatalf("FilterResourceOps = %+v, %v; want only complete bundle resource", filtered, err)
+	}
+
+	*edition = licverify.EditionProfessional
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		bundleHolder, "connector_type", resourceID, "task_manage", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+	if allowed, err := e.Check(bundleHolder, "connector_type", resourceID, "task_manage"); err != nil || allowed {
+		t.Fatalf("Professional deny did not override bundle: allowed=%v err=%v", allowed, err)
+	}
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		directHolder, "connector_type", resourceID, "task_manage", EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	decision, err := e.OperationDecision(t.Context(), directHolder, "connector_type", resourceID, "task_manage")
+	if err != nil || decision.Decision != DecisionDeny || decision.Basis != BasisRequires ||
+		decision.DeniedRequirement != "view_detail" {
+		t.Fatalf("task_manage without view_detail = %+v, %v; want requires deny", decision, err)
+	}
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		directHolder, "connector_type", resourceID, "view_detail", EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "task_manage"); err != nil || !allowed {
+		t.Fatalf("direct allow with view_detail = %v, %v; want true", allowed, err)
+	}
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		directHolder, "connector_type", resourceID, "task_manage", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "task_manage"); err != nil || allowed {
+		t.Fatalf("same-resource direct deny did not override allow: allowed=%v err=%v", allowed, err)
+	}
+}
+
 func TestCommunityBundlePersistsOneLogicalPolicyAndExpandsOnlyApprovedOps(t *testing.T) {
 	edition := useEdition(t, licverify.EditionCommunity)
 	e := newTestEnforcer(t)

--- a/bkn-safe/server/internal/authz/policy_source.go
+++ b/bkn-safe/server/internal/authz/policy_source.go
@@ -398,10 +398,17 @@ func (en *Enforcer) removePolicyGrants(filter PolicyFilter) (int, error) {
 }
 
 func (en *Enforcer) removePolicyGrantsByObjectPrefix(prefix string) (int, error) {
+	return en.removePolicyGrantsByObjectPrefixAndOperation(prefix, "")
+}
+
+func (en *Enforcer) removePolicyGrantsByObjectPrefixAndOperation(prefix, operation string) (int, error) {
 	var rows []safemodel.AuthorizationGrant
-	if err := en.db.Model(&safemodel.AuthorizationGrant{}).
-		Where("object LIKE ?", prefix+"%").
-		Order("grant_id").Find(&rows).Error; err != nil {
+	q := en.db.Model(&safemodel.AuthorizationGrant{}).
+		Where("substr(object, 1, ?) = ?", len(prefix), prefix)
+	if operation != "" {
+		q = q.Where("operation = ?", operation)
+	}
+	if err := q.Order("grant_id").Find(&rows).Error; err != nil {
 		return 0, err
 	}
 	removedProjections := 0

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/casbin/casbin/v2"
 	casbinmodel "github.com/casbin/casbin/v2/model"
@@ -86,6 +87,14 @@ func (tx *PolicyTransaction) RemovePoliciesForResourceTypes(resourceTypes ...str
 // for one withdrawn operation while preserving the resource type's other
 // grants. It is reserved for startup vocabulary migrations.
 func (tx *PolicyTransaction) RemovePoliciesForOperation(resourceType, operation string) (int, error) {
+	resourceType = strings.TrimSpace(resourceType)
+	operation = strings.TrimSpace(operation)
+	if resourceType == "" {
+		return 0, errors.New("resource type is required")
+	}
+	if operation == "" {
+		return 0, errors.New("operation is required")
+	}
 	return tx.enforcer.removePolicyGrantsByObjectPrefixAndOperation(resourceType+":", operation)
 }
 

--- a/bkn-safe/server/internal/authz/transaction.go
+++ b/bkn-safe/server/internal/authz/transaction.go
@@ -82,6 +82,13 @@ func (tx *PolicyTransaction) RemovePoliciesForResourceTypes(resourceTypes ...str
 	return removed, nil
 }
 
+// RemovePoliciesForOperation removes every durable grant and Casbin projection
+// for one withdrawn operation while preserving the resource type's other
+// grants. It is reserved for startup vocabulary migrations.
+func (tx *PolicyTransaction) RemovePoliciesForOperation(resourceType, operation string) (int, error) {
+	return tx.enforcer.removePolicyGrantsByObjectPrefixAndOperation(resourceType+":", operation)
+}
+
 func (tx *PolicyTransaction) GrantObjectPermission(accessorID, resourceType, resourceID, operation string) error {
 	return tx.enforcer.addPolicy(accessorID, obj(resourceType, resourceID), operation, EffectAllow,
 		PolicySourceSystemDerived, AuthoritySourceSystem)

--- a/bkn-safe/server/internal/authz/transaction_test.go
+++ b/bkn-safe/server/internal/authz/transaction_test.go
@@ -100,6 +100,47 @@ func TestPolicyTransactionRollsBackGrantIdentityAndProjectionTogether(t *testing
 	}
 }
 
+func TestRemovePoliciesForOperationRejectsEmptyTargetsWithoutDeleting(t *testing.T) {
+	e := newTestEnforcer(t)
+	const (
+		accessorID   = "connector-operator"
+		resourceID   = "remote-api"
+		resourceType = "connector_type"
+	)
+	for _, operation := range []string{"modify", "task_manage"} {
+		if err := e.GrantObjectPermission(accessorID, resourceType, resourceID, operation); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, tc := range []struct {
+		name         string
+		resourceType string
+		operation    string
+	}{
+		{name: "empty resource type", operation: "task_manage"},
+		{name: "blank resource type", resourceType: " \t", operation: "task_manage"},
+		{name: "empty operation", resourceType: resourceType},
+		{name: "blank operation", resourceType: resourceType, operation: " \t"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := e.Transaction(t.Context(), func(tx *PolicyTransaction) error {
+				_, err := tx.RemovePoliciesForOperation(tc.resourceType, tc.operation)
+				return err
+			})
+			if err == nil {
+				t.Fatal("RemovePoliciesForOperation() error = nil; want validation error")
+			}
+			for _, operation := range []string{"modify", "task_manage"} {
+				allowed, checkErr := e.Check(accessorID, resourceType, resourceID, operation)
+				if checkErr != nil || !allowed {
+					t.Fatalf("grant %s was removed after rejected migration: allowed=%v err=%v", operation, allowed, checkErr)
+				}
+			}
+		})
+	}
+}
+
 func waitForTestResult(t *testing.T, result <-chan error) error {
 	t.Helper()
 	select {

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -37,8 +37,7 @@
         {"id": "create", "name": "创建"},
         {"id": "modify", "name": "修改", "requires": ["view_detail"]},
         {"id": "delete", "name": "删除", "requires": ["view_detail"]},
-        {"id": "authorize", "name": "授权", "requires": ["view_detail"]},
-        {"id": "task_manage", "name": "任务管理", "requires": ["view_detail"]}
+        {"id": "authorize", "name": "授权", "requires": ["view_detail"]}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -35,10 +35,10 @@
       "operations": [
         {"id": "view_detail", "name": "查看详情"},
         {"id": "create", "name": "创建"},
-        {"id": "modify", "name": "修改"},
-        {"id": "delete", "name": "删除"},
-        {"id": "authorize", "name": "授权"},
-        {"id": "task_manage", "name": "任务管理"}
+        {"id": "modify", "name": "修改", "requires": ["view_detail"]},
+        {"id": "delete", "name": "删除", "requires": ["view_detail"]},
+        {"id": "authorize", "name": "授权", "requires": ["view_detail"]},
+        {"id": "task_manage", "name": "任务管理", "requires": ["view_detail"]}
       ]
     },
     {

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -6,6 +6,7 @@ package seed
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -209,6 +210,27 @@ func TestConnectorTypeRequirementsApplyToChecksAndLists(t *testing.T) {
 	if err != nil || len(filtered) != 1 || len(filtered[0].Operations) != 0 ||
 		len(filtered[0].Decisions) != 1 || filtered[0].Decisions[0].Basis != authz.BasisRequires {
 		t.Fatalf("FilterResourceOps(modify) = %+v, %v", filtered, err)
+	}
+
+	// Legacy grants are immutable snapshots, so startup deliberately does not
+	// add view_detail beside a type-wide modify grant. Effective evaluation must
+	// still combine that grant with view_detail held on a concrete connector.
+	const legacyUser = "legacy-connector-operator"
+	if err := e.GrantObjectPermission(legacyUser, "connector_type", "*", "modify"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission(legacyUser, "connector_type", "remote-api", "view_detail"); err != nil {
+		t.Fatal(err)
+	}
+	if allowed, err := e.Check(legacyUser, "connector_type", "remote-api", "modify"); err != nil || !allowed {
+		t.Fatalf("legacy Check(remote-api, modify) = %v, %v; want true", allowed, err)
+	}
+	filtered, err = e.FilterResourceOps(legacyUser,
+		[]authz.ResourceRef{{Type: "connector_type", ID: "remote-api"}},
+		[]string{"view_detail"}, []string{"view_detail", "modify"})
+	if err != nil || len(filtered) != 1 ||
+		!reflect.DeepEqual(filtered[0].Operations, []string{"view_detail", "modify"}) {
+		t.Fatalf("legacy FilterResourceOps(remote-api) = %+v, %v; want view_detail and modify", filtered, err)
 	}
 }
 

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -110,6 +110,36 @@ func TestShippedCatalogBindsResourceManageToViewDetail(t *testing.T) {
 	t.Fatal("catalog type missing from catalog.json")
 }
 
+func TestShippedConnectorTypeDeclaresViewRequirements(t *testing.T) {
+	var c catalog
+	if err := json.Unmarshal(catalogJSON, &c); err != nil {
+		t.Fatalf("parse catalog.json: %v", err)
+	}
+	if err := validateRequirements(c); err != nil {
+		t.Fatalf("shipped catalog.json declares an invalid requirement: %v", err)
+	}
+
+	operations := map[string][]string{}
+	for _, resourceType := range c.ResourceTypes {
+		if resourceType.ID != "connector_type" {
+			continue
+		}
+		for _, operation := range resourceType.Operations {
+			operations[operation.ID] = operation.Requires
+		}
+	}
+	for _, operation := range []string{"modify", "delete", "authorize", "task_manage"} {
+		if got := operations[operation]; len(got) != 1 || got[0] != "view_detail" {
+			t.Errorf("connector_type/%s requires %v, want [view_detail]", operation, got)
+		}
+	}
+	for _, operation := range []string{"create", "view_detail"} {
+		if got := operations[operation]; len(got) != 0 {
+			t.Errorf("connector_type/%s unexpectedly requires %v", operation, got)
+		}
+	}
+}
+
 // TestSeedPersistsImplications proves the declaration survives the seed, since
 // the grant paths read it from the operations table rather than from the file.
 func TestSeedPersistsImplications(t *testing.T) {
@@ -127,6 +157,55 @@ func TestSeedPersistsImplications(t *testing.T) {
 	}
 	if row.RequiredOperationIDs != "view_detail" {
 		t.Fatalf("required operation ids = %q, want %q", row.RequiredOperationIDs, "view_detail")
+	}
+}
+
+func TestConnectorTypeRequirementsApplyToChecksAndLists(t *testing.T) {
+	entitlement.SetGateForTest(entitlement.FixedGate(licverify.EditionProfessional))
+	t.Cleanup(entitlement.ResetForTest)
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	const user = "connector-operator"
+	if err := e.GrantProfessionalObjectPermission(
+		user, "connector_type", "remote-api", "task_manage", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantProfessionalObjectPermission(
+		user, "connector_type", "remote-api", "view_detail", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantProfessionalObjectPermission(
+		user, "connector_type", "remote-api", "view_detail", authz.EffectDeny, authz.AuthoritySourceAdminAuthz,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	decision, err := e.OperationDecision(t.Context(), user, "connector_type", "remote-api", "task_manage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Decision != authz.DecisionDeny || decision.Basis != authz.BasisRequires ||
+		decision.DeniedRequirement != "view_detail" {
+		t.Fatalf("task_manage decision = %+v; want requires deny on view_detail", decision)
+	}
+	ids, err := e.AccessibleResources(user, "connector_type", "task_manage")
+	if err != nil || len(ids) != 0 {
+		t.Fatalf("AccessibleResources(task_manage) = %v, %v; want none", ids, err)
+	}
+	filtered, err := e.FilterResourceOps(user,
+		[]authz.ResourceRef{{Type: "connector_type", ID: "remote-api"}}, nil, []string{"task_manage"})
+	if err != nil || len(filtered) != 1 || len(filtered[0].Operations) != 0 ||
+		len(filtered[0].Decisions) != 1 || filtered[0].Decisions[0].Basis != authz.BasisRequires {
+		t.Fatalf("FilterResourceOps(task_manage) = %+v, %v", filtered, err)
 	}
 }
 

--- a/bkn-safe/server/internal/seed/implications_test.go
+++ b/bkn-safe/server/internal/seed/implications_test.go
@@ -128,7 +128,7 @@ func TestShippedConnectorTypeDeclaresViewRequirements(t *testing.T) {
 			operations[operation.ID] = operation.Requires
 		}
 	}
-	for _, operation := range []string{"modify", "delete", "authorize", "task_manage"} {
+	for _, operation := range []string{"modify", "delete", "authorize"} {
 		if got := operations[operation]; len(got) != 1 || got[0] != "view_detail" {
 			t.Errorf("connector_type/%s requires %v, want [view_detail]", operation, got)
 		}
@@ -137,6 +137,9 @@ func TestShippedConnectorTypeDeclaresViewRequirements(t *testing.T) {
 		if got := operations[operation]; len(got) != 0 {
 			t.Errorf("connector_type/%s unexpectedly requires %v", operation, got)
 		}
+	}
+	if _, ok := operations["task_manage"]; ok {
+		t.Error("connector_type unexpectedly declares task_manage without a task lifecycle entry")
 	}
 }
 
@@ -174,7 +177,7 @@ func TestConnectorTypeRequirementsApplyToChecksAndLists(t *testing.T) {
 
 	const user = "connector-operator"
 	if err := e.GrantProfessionalObjectPermission(
-		user, "connector_type", "remote-api", "task_manage", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
+		user, "connector_type", "remote-api", "modify", authz.EffectAllow, authz.AuthoritySourceAdminAuthz,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -189,23 +192,78 @@ func TestConnectorTypeRequirementsApplyToChecksAndLists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	decision, err := e.OperationDecision(t.Context(), user, "connector_type", "remote-api", "task_manage")
+	decision, err := e.OperationDecision(t.Context(), user, "connector_type", "remote-api", "modify")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if decision.Decision != authz.DecisionDeny || decision.Basis != authz.BasisRequires ||
 		decision.DeniedRequirement != "view_detail" {
-		t.Fatalf("task_manage decision = %+v; want requires deny on view_detail", decision)
+		t.Fatalf("modify decision = %+v; want requires deny on view_detail", decision)
 	}
-	ids, err := e.AccessibleResources(user, "connector_type", "task_manage")
+	ids, err := e.AccessibleResources(user, "connector_type", "modify")
 	if err != nil || len(ids) != 0 {
-		t.Fatalf("AccessibleResources(task_manage) = %v, %v; want none", ids, err)
+		t.Fatalf("AccessibleResources(modify) = %v, %v; want none", ids, err)
 	}
 	filtered, err := e.FilterResourceOps(user,
-		[]authz.ResourceRef{{Type: "connector_type", ID: "remote-api"}}, nil, []string{"task_manage"})
+		[]authz.ResourceRef{{Type: "connector_type", ID: "remote-api"}}, nil, []string{"modify"})
 	if err != nil || len(filtered) != 1 || len(filtered[0].Operations) != 0 ||
 		len(filtered[0].Decisions) != 1 || filtered[0].Decisions[0].Basis != authz.BasisRequires {
-		t.Fatalf("FilterResourceOps(task_manage) = %+v, %v", filtered, err)
+		t.Fatalf("FilterResourceOps(modify) = %+v, %v", filtered, err)
+	}
+}
+
+func TestSeedPrunesWithdrawnConnectorTaskManageGrants(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Create(&model.Operation{
+		ResourceTypeID: "connector_type", ID: "task_manage", Name: "任务管理",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("legacy-connector-operator", "connector_type", "remote-api", "task_manage"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission("decoy-operator", "connectorXtype", "remote-api", "task_manage"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Apply(db, e); err != nil {
+		t.Fatal(err)
+	}
+
+	var operationCount int64
+	if err := db.Model(&model.Operation{}).
+		Where("resource_type_id = ? AND id = ?", "connector_type", "task_manage").
+		Count(&operationCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if operationCount != 0 {
+		t.Fatalf("connector_type/task_manage operation count = %d; want 0", operationCount)
+	}
+	records, err := e.PolicyRecords(authz.PolicyFilter{
+		AccessorID: "legacy-connector-operator",
+		Operation:  "task_manage",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 0 {
+		t.Fatalf("withdrawn connector task_manage grants survived: %+v", records)
+	}
+	allowed, err := e.Check("legacy-connector-operator", "connector_type", "remote-api", "task_manage")
+	if err != nil || allowed {
+		t.Fatalf("withdrawn connector task_manage check = %v, %v; want false", allowed, err)
+	}
+	allowed, err = e.Check("decoy-operator", "connectorXtype", "remote-api", "task_manage")
+	if err != nil || !allowed {
+		t.Fatalf("neighbor resource type grant was removed: allowed=%v err=%v", allowed, err)
 	}
 }
 

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -60,6 +60,13 @@ var withdrawnResourceTypes = []string{
 	"stream_data_pipeline",
 }
 
+var withdrawnOperations = []struct {
+	resourceType string
+	operation    string
+}{
+	{"connector_type", "task_manage"},
+}
+
 const normalUserRoleID = "b5f9ac3e-992c-4bbd-8126-95e87e51c46e"
 
 // AdminUserID is the built-in admin user's id, exported so callers can protect
@@ -136,6 +143,9 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 	if err := reconcileWithdrawnResourceTypes(enforcer); err != nil {
 		return fmt.Errorf("reconcile withdrawn resource types: %w", err)
 	}
+	if err := reconcileWithdrawnOperations(enforcer); err != nil {
+		return fmt.Errorf("reconcile withdrawn operations: %w", err)
+	}
 	if err := seedCatalog(db); err != nil {
 		return fmt.Errorf("seed catalog: %w", err)
 	}
@@ -167,6 +177,28 @@ func Apply(db *gorm.DB, enforcer *authz.Enforcer) error {
 		return fmt.Errorf("seed business provenance owner: %w", err)
 	}
 	return nil
+}
+
+// reconcileWithdrawnOperations removes stale grants before pruning their
+// catalog rows. Leaving those grants behind would keep an invisible permission
+// active in the policy engine on upgraded deployments.
+func reconcileWithdrawnOperations(enforcer *authz.Enforcer) error {
+	return enforcer.Transaction(context.Background(), func(tx *authz.PolicyTransaction) error {
+		for _, withdrawn := range withdrawnOperations {
+			removed, err := tx.RemovePoliciesForOperation(withdrawn.resourceType, withdrawn.operation)
+			if err != nil {
+				return err
+			}
+			if removed > 0 {
+				slog.Info("removed policies for withdrawn operation",
+					"resource_type", withdrawn.resourceType,
+					"operation", withdrawn.operation,
+					"projections", removed,
+				)
+			}
+		}
+		return nil
+	})
 }
 
 // reconcileWithdrawnResourceTypes removes resource types that are no longer


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] 为 connector_type 的 modify、delete、authorize 声明 view_detail 前置权限
- [x] 保持 Connector 启用/停用属于 modify，不归入任务管理
- [x] 从 Connector 权限目录和 Community 完整包中删除没有业务入口的 task_manage
- [x] 启动时清理升级环境遗留的 connector_type/task_manage operation 和授权策略
- [x] RemovePoliciesForOperation 对空或纯空格资源类型/operation 执行 fail-closed 校验，防止误删整类授权
- [x] Vega 列表/详情改用 bkn-safe effective `/authz/resource-filter`，避免漏报通配操作授权与实例级前置权限组合后的实际能力
- [x] Vega 批量权限响应执行 fail-closed 校验：拒绝空 body、缺失或为 null 的 `resources`，并传播响应体读取错误；显式 `[]` 保持合法
- [x] 补充 Community、Professional、列表过滤、创建、业务执行入口、破坏性迁移参数及跨组件权限投影回归测试

---

## Why

- Related Issue: Closes #1435
- Related Feature: Connector 资源族权限接入
- Background: Connector 的 enabled 是 Connector 定义属性；当前不存在 Connector 任务生命周期入口，因此 task_manage 不应暴露或用于启停。stream_data_pipeline 已由 #1458 从主线退役，本 PR 不重新引入。Connector 列表/详情返回的操作集合必须与具体业务入口的最终判权一致。

---

## How

- Key implementation points: Community 完整包使用显式白名单 view_detail、modify、delete；Professional 使用统一直接 allow/deny、requires 和资源过滤算法；创建继续在 connector_type:* 上判定；启动迁移按资源类型和 operation 精确删除历史 task_manage 授权，不影响相邻资源类型；破坏性 operation 清理入口拒绝空目标；Vega 将候选 Connector 实例批量提交给 bkn-safe 的 effective resource-filter，由同一最终判权同时计算可见性和可执行操作，不再分别推断通配授权与具体授权。批量响应缺失必需字段或读取失败时返回错误，避免把鉴权服务异常伪装成无权限。
- Breaking changes (API, config, database, etc.): 从 Connector 可配置 operation 中删除 task_manage；升级启动会删除已有 connector_type/task_manage 持久化授权。无 API 结构和数据库 schema 变更。

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- bkn-safe: `go test ./internal/authz ./internal/seed ./internal/httpapi -count=1`
- Vega: `make ci`（lint 0 issues，单元测试与覆盖率门禁通过，coverage 37.6%）
- 新增回归覆盖空 resourceType、空 operation、纯空格参数，以及校验失败后现有授权完整保留
- 新增回归覆盖 legacy `connector_type:*` 操作授权与具体 Connector `view_detail` 前置权限组合；列表/详情正确返回最终有效操作
- 批量过滤 100 个候选资源仍只调用一次 bkn-safe resource-filter，不退化为逐资源判权
- 新增 10 个异常响应回归用例，覆盖两个适配器方法下的空 body、`{}`、`null`、`{"resources":null}` 和响应体读取失败；另覆盖 2 个显式空数组合法用例
- Integration/test environment verification: N/A，本次完成本地代码与单元测试验证，等待测试环境验证。

---

## Risk & Rollback

- Potential risks: 升级后历史 connector_type/task_manage 授权会被永久清理；原有启停能力继续由 modify 控制。删除范围使用精确资源类型前缀和 operation，并有相邻资源类型不受影响及空参数拒绝的回归测试。Vega 权限批量查询切换到 bkn-safe 已有 effective resource-filter，调用次数由按 operation 的多次请求收敛为每批一次。鉴权服务返回结构异常时列表/详情会显式失败，不再静默显示为空或错误返回 403。
- Rollback plan: 部署前备份 authorization_grants 与 casbin_rule。代码回滚可以恢复旧目录和旧的 Vega 权限查询路径，但不能自动恢复已经删除的授权；如需恢复，应从备份还原或按原授权主体重新授予相应权限。

---

## Additional Notes

- 已 rebase 到 `main@02512dc1d`，解决与 #1470 Resource-to-Catalog authorization 在共享 Vega `safeClient` 上的冲突；保留主线 LocalPermissionAccess 和协议校验，并复用主线统一的响应读取错误处理。
- 当前 PR HEAD 为 `3998178cb`；本地 bkn-safe 相关测试及 Vega `make ci` 已通过，GitHub 检查已重新触发。
- Connector 为独立顶层资源，没有可用父资源，因此父级回退在本资源类型上为 N/A。
- Issue 仍包含已退役的数据管道范围，建议合入前同步修订 Issue 验收描述。
