### PR TITLE
feat(bkn-safe): integrate Agent resource authorization

### DIFF
--- a/bkn-safe/server/internal/authz/community_bundle.go
+++ b/bkn-safe/server/internal/authz/community_bundle.go
@@ -23,6 +23,12 @@ var communityBundleOperations = map[string][]string{
 	"skill":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
 	"small_model":       {"display", "modify", "delete", "execute"},
 	"large_model":       {"display", "modify", "delete", "execute"},
+	"agent": {
+		"use", "publish", "unpublish", "publish_to_be_skill_agent",
+		"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+		"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+	},
+	"agent_tpl": {"publish", "unpublish"},
 }
 
 // CommunityBundleOperations returns a copy of the reviewed operation whitelist

--- a/bkn-safe/server/internal/authz/community_bundle_test.go
+++ b/bkn-safe/server/internal/authz/community_bundle_test.go
@@ -25,6 +25,12 @@ func TestCommunityBundleWhitelistIsExplicitAndDefensive(t *testing.T) {
 		"skill":             {"view", "modify", "delete", "publish", "unpublish", "execute"},
 		"small_model":       {"display", "modify", "delete", "execute"},
 		"large_model":       {"display", "modify", "delete", "execute"},
+		"agent": {
+			"use", "publish", "unpublish", "publish_to_be_skill_agent",
+			"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+			"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+		},
+		"agent_tpl": {"publish", "unpublish"},
 	}
 	for resourceType, expected := range want {
 		got, ok := CommunityBundleOperations(resourceType)
@@ -119,6 +125,98 @@ func TestConnectorTypeBundleAndProfessionalDecisions(t *testing.T) {
 	))
 	if allowed, err := e.Check(directHolder, "connector_type", resourceID, "modify"); err != nil || allowed {
 		t.Fatalf("same-resource direct deny did not override allow: allowed=%v err=%v", allowed, err)
+	}
+}
+
+func TestAgentFamilyBundlesKeepPrivilegedOperationsExplicit(t *testing.T) {
+	edition := useEdition(t, licverify.EditionProfessional)
+	e := newTestEnforcer(t)
+
+	approved := map[string][]string{
+		"agent": {
+			"use", "publish", "unpublish", "publish_to_be_skill_agent",
+			"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+			"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+		},
+		"agent_tpl": {"publish", "unpublish"},
+	}
+	excluded := map[string][]string{
+		"agent": {
+			"create", "authorize", "public_access", "create_system_agent",
+			"mgnt_built_in_agent", "unpublish_other_user_agent", ActFullBusinessAccess,
+		},
+		"agent_tpl": {"create", "authorize", "public_access", "unpublish_other_user_agent_tpl", ActFullBusinessAccess},
+	}
+	for resourceType, operations := range approved {
+		resourceID := resourceType + "-1"
+		mustNoErr(t, e.GrantCommunityBundle("ordinary-user", resourceType, resourceID, AuthoritySourceAdminAuthz))
+		for _, operation := range operations {
+			if ok, err := e.Check("ordinary-user", resourceType, resourceID, operation); err != nil || !ok {
+				t.Errorf("%s bundle operation %q: allowed=%v err=%v; want true", resourceType, operation, ok, err)
+			}
+		}
+		for _, operation := range excluded[resourceType] {
+			if ok, err := e.Check("ordinary-user", resourceType, resourceID, operation); err != nil || ok {
+				t.Errorf("%s privileged operation %q leaked from bundle: allowed=%v err=%v", resourceType, operation, ok, err)
+			}
+		}
+	}
+
+	// Owner authorization is a separate lifecycle-derived rule. It neither
+	// comes from nor broadens the ordinary business bundle.
+	mustNoErr(t, e.GrantCommunityBundle("agent-owner", "agent", "owned-1", AuthoritySourceSystem))
+	mustNoErr(t, e.GrantSystemObjectPermission("agent-owner", "agent", "owned-1", "authorize"))
+	if ok, err := e.Check("agent-owner", "agent", "owned-1", "authorize"); err != nil || !ok {
+		t.Fatalf("owner authorize = %v, %v; want explicit system-derived allow", ok, err)
+	}
+	if ok, err := e.Check("ordinary-user", "agent", "agent-1", "authorize"); err != nil || ok {
+		t.Fatalf("ordinary bundle acquired owner authority: allowed=%v err=%v", ok, err)
+	}
+
+	// System/built-in and cross-owner operations only become effective through
+	// an explicit trusted rule or role; naming them in the directory is not a
+	// grant. A same-object Professional deny still overrides a role wildcard.
+	mustNoErr(t, e.GrantSystemObjectPermission("system-agent-manager", "agent", "built-in-1", "mgnt_built_in_agent"))
+	if ok, err := e.Check("system-agent-manager", "agent", "built-in-1", "mgnt_built_in_agent"); err != nil || !ok {
+		t.Fatalf("explicit built-in management = %v, %v; want true", ok, err)
+	}
+	const adminRole = "agent-admin-role"
+	mustNoErr(t, e.GrantRolePermission(adminRole, "agent", "*", "unpublish_other_user_agent"))
+	mustNoErr(t, e.AssignRole("agent-admin", adminRole))
+	if ok, err := e.Check("agent-admin", "agent", "other-1", "unpublish_other_user_agent"); err != nil || !ok {
+		t.Fatalf("explicit cross-owner role = %v, %v; want true", ok, err)
+	}
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		"agent-admin", "agent", "other-1", "unpublish_other_user_agent", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+	if ok, err := e.Check("agent-admin", "agent", "other-1", "unpublish_other_user_agent"); err != nil || ok {
+		t.Fatalf("direct deny did not override cross-owner wildcard: allowed=%v err=%v", ok, err)
+	}
+
+	// A Professional rule can grant and deny one real Agent operation without
+	// affecting its siblings. On downgrade it is retained but inactive, while
+	// the Community bundle remains effective and recovers from its deny.
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		"professional-user", "agent", "agent-2", "use", EffectAllow, AuthoritySourceAdminAuthz,
+	))
+	if ok, err := e.Check("professional-user", "agent", "agent-2", "use"); err != nil || !ok {
+		t.Fatalf("Professional use allow = %v, %v; want true", ok, err)
+	}
+	if ok, err := e.Check("professional-user", "agent", "agent-2", "publish"); err != nil || ok {
+		t.Fatalf("Professional use leaked to publish: allowed=%v err=%v", ok, err)
+	}
+	mustNoErr(t, e.GrantProfessionalObjectPermission(
+		"ordinary-user", "agent", "agent-1", "publish", EffectDeny, AuthoritySourceAdminAuthz,
+	))
+	if ok, err := e.Check("ordinary-user", "agent", "agent-1", "publish"); err != nil || ok {
+		t.Fatalf("Professional deny did not override Agent bundle: allowed=%v err=%v", ok, err)
+	}
+	*edition = licverify.EditionCommunity
+	if ok, err := e.Check("professional-user", "agent", "agent-2", "use"); err != nil || ok {
+		t.Fatalf("Professional rule remained active after downgrade: allowed=%v err=%v", ok, err)
+	}
+	if ok, err := e.Check("ordinary-user", "agent", "agent-1", "publish"); err != nil || !ok {
+		t.Fatalf("Community bundle did not recover after Professional deny became inactive: allowed=%v err=%v", ok, err)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/community_bundle_test.go
+++ b/bkn-safe/server/internal/httpapi/community_bundle_test.go
@@ -121,6 +121,97 @@ func TestCommunityBundleHTTPReadPathsAgree(t *testing.T) {
 	assertSameOperations(t, grantResponse.Grants[0].Operations, approved)
 }
 
+func TestAgentBundleHTTPReadPathsAgree(t *testing.T) {
+	r, e, db, _ := newAdminServer(t)
+	const user = "agent-bundle-http-user"
+	if err := db.Create(&model.User{ID: user, Account: user, Enabled: true}).Error; err != nil {
+		t.Fatal(err)
+	}
+	approved := []string{
+		"use", "publish", "unpublish", "publish_to_be_skill_agent",
+		"publish_to_be_web_sdk_agent", "publish_to_be_api_agent",
+		"publish_to_be_data_flow_agent", "see_trajectory_analysis",
+	}
+	allCatalogOperations := append(append([]string(nil), approved...),
+		"unpublish_other_user_agent", "create_system_agent", "mgnt_built_in_agent")
+	seedCatalogOps(t, db, "agent", allCatalogOperations...)
+	if err := e.GrantCommunityBundle(user, "agent", "agent-1", authz.AuthoritySourceAdminAuthz); err != nil {
+		t.Fatal(err)
+	}
+
+	check := do(t, r, http.MethodPost, "/api/safe/v1/authz/check", map[string]any{
+		"accessor_id": user,
+		"resource":    map[string]string{"type": "agent", "id": "agent-1"},
+		"operation":   "use",
+	})
+	if check.Code != http.StatusOK || !jsonBool(t, check.Body.Bytes(), "allowed") {
+		t.Fatalf("check = %d %s; want allowed", check.Code, check.Body.String())
+	}
+
+	operations := do(t, r, http.MethodPost, "/api/safe/v1/authz/operations", map[string]any{
+		"accessor_id": user,
+		"resource":    map[string]string{"type": "agent", "id": "agent-1"},
+	})
+	assertJSONOperations(t, operations.Code, operations.Body.Bytes(), approved)
+
+	filtered := postFilter(t, r, map[string]any{
+		"accessor_id":           user,
+		"resource_type":         "agent",
+		"resource_ids":          []string{"agent-1", "agent-2"},
+		"visibility_operations": []string{"use"},
+		"candidate_operations":  allCatalogOperations,
+	})
+	if len(filtered) != 1 || filtered[0].ResourceID != "agent-1" {
+		t.Fatalf("resource-filter = %+v; want only agent-1", filtered)
+	}
+	assertSameOperations(t, filtered[0].Operations, approved)
+
+	resources := do(t, r, http.MethodGet,
+		"/api/safe/v1/authz/resources?accessor_id="+user+"&resource_type=agent&operation=use", nil)
+	if resources.Code != http.StatusOK {
+		t.Fatalf("resources = %d %s", resources.Code, resources.Body.String())
+	}
+	var resourceResponse struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.Unmarshal(resources.Body.Bytes(), &resourceResponse); err != nil ||
+		!reflect.DeepEqual(resourceResponse.IDs, []string{"agent-1"}) {
+		t.Fatalf("resources = %v, %v; want [agent-1]", resourceResponse.IDs, err)
+	}
+
+	policies := do(t, r, http.MethodGet,
+		"/api/safe/v1/authz/policies?resource_type=agent&resource_id=agent-1", nil)
+	if policies.Code != http.StatusOK {
+		t.Fatalf("policies = %d %s", policies.Code, policies.Body.String())
+	}
+	var policyResponse struct {
+		Entries []struct {
+			AccessorID string   `json:"accessor_id"`
+			Operations []string `json:"operations"`
+		} `json:"entries"`
+	}
+	if err := json.Unmarshal(policies.Body.Bytes(), &policyResponse); err != nil ||
+		len(policyResponse.Entries) != 1 || policyResponse.Entries[0].AccessorID != user {
+		t.Fatalf("policies = %+v, %v", policyResponse, err)
+	}
+	assertSameOperations(t, policyResponse.Entries[0].Operations, approved)
+
+	mePermissions := tokReq(t, r, http.MethodGet,
+		"/api/safe/v1/me/permissions?resource_type=agent&resource_id=agent-1", nil, user)
+	if mePermissions.Code != http.StatusOK {
+		t.Fatalf("me permissions = %d %s", mePermissions.Code, mePermissions.Body.String())
+	}
+	var meResponse struct {
+		Permissions []struct {
+			Operations []string `json:"operations"`
+		} `json:"permissions"`
+	}
+	if err := json.Unmarshal(mePermissions.Body.Bytes(), &meResponse); err != nil || len(meResponse.Permissions) != 1 {
+		t.Fatalf("me permissions = %+v, %v", meResponse, err)
+	}
+	assertSameOperations(t, meResponse.Permissions[0].Operations, approved)
+}
+
 func assertJSONOperations(t *testing.T, status int, body []byte, want []string) {
 	t.Helper()
 	if status != http.StatusOK {

--- a/bkn-safe/server/internal/seed/community_bundle_test.go
+++ b/bkn-safe/server/internal/seed/community_bundle_test.go
@@ -6,6 +6,7 @@ package seed
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
@@ -29,6 +30,7 @@ func TestCommunityBundleWhitelistOperationsExistInCatalog(t *testing.T) {
 	}
 	for _, resourceType := range []string{
 		"catalog", "knowledge_network", "connector_type", "tool_box", "mcp", "operator", "skill", "small_model", "large_model",
+		"agent", "agent_tpl",
 	} {
 		operations, ok := authz.CommunityBundleOperations(resourceType)
 		if !ok {
@@ -39,6 +41,53 @@ func TestCommunityBundleWhitelistOperationsExistInCatalog(t *testing.T) {
 			if !registered[resourceType][operation] {
 				t.Errorf("Community whitelist contains unregistered operation %s:%s", resourceType, operation)
 			}
+		}
+	}
+}
+
+// TestAgentCatalogMatchesReviewedContract pins the resource-owner review from
+// openbkn-ai/bkn-docs#117 at 8e28e43b. Agent execution is named "use" in the
+// compatibility vocabulary; neither root has a natural parent or an operation
+// prerequisite, and no generic view/modify/delete verbs are invented here.
+func TestAgentCatalogMatchesReviewedContract(t *testing.T) {
+	var c catalog
+	if err := json.Unmarshal(catalogJSON, &c); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string][]string{
+		"agent": {
+			"use", "publish", "unpublish", "unpublish_other_user_agent",
+			"publish_to_be_skill_agent", "publish_to_be_web_sdk_agent",
+			"publish_to_be_api_agent", "publish_to_be_data_flow_agent",
+			"create_system_agent", "mgnt_built_in_agent", "see_trajectory_analysis",
+		},
+		"agent_tpl": {"publish", "unpublish", "unpublish_other_user_agent_tpl"},
+	}
+	seen := map[string]bool{}
+	for _, resourceType := range c.ResourceTypes {
+		expected, ok := want[resourceType.ID]
+		if !ok {
+			continue
+		}
+		seen[resourceType.ID] = true
+		if resourceType.ParentType != "" {
+			t.Errorf("%s parent_type = %q, want standalone root", resourceType.ID, resourceType.ParentType)
+		}
+		got := make([]string, 0, len(resourceType.Operations))
+		for _, operation := range resourceType.Operations {
+			got = append(got, operation.ID)
+			if operation.ParentOperation != "" || len(operation.Requires) != 0 {
+				t.Errorf("%s/%s unexpectedly declares parent=%q requires=%v",
+					resourceType.ID, operation.ID, operation.ParentOperation, operation.Requires)
+			}
+		}
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("%s operations = %v, want %v", resourceType.ID, got, expected)
+		}
+	}
+	for resourceType := range want {
+		if !seen[resourceType] {
+			t.Errorf("reviewed Agent resource type %q is missing", resourceType)
 		}
 	}
 }

--- a/bkn-safe/server/internal/seed/data/catalog.json
+++ b/bkn-safe/server/internal/seed/data/catalog.json
@@ -2,6 +2,34 @@
   "_comment": "Resource-type + operation catalog, extracted from each service's enums/consts (2026-06-03). Exact op id strings are the seed source of truth. NOTE: 'view' (exec-factory, flow-automation) and 'view_detail' (vega/bkn/pipeline) are DIFFERENT op strings and are not normalized. Role-to-permission grants are maintained in grants.json for the Studio 0.1.0 role model.",
   "resource_types": [
     {
+      "id": "agent",
+      "name": "数据智能体",
+      "_note": "Standalone authorization root. The operation vocabulary is compatibility-sensitive: use is the execution permission; system, built-in, and cross-owner operations remain explicit and are not part of the Community business bundle.",
+      "operations": [
+        {"id": "use", "name": "使用Agent"},
+        {"id": "publish", "name": "发布Agent"},
+        {"id": "unpublish", "name": "取消发布Agent"},
+        {"id": "unpublish_other_user_agent", "name": "取消发布其他用户的Agent"},
+        {"id": "publish_to_be_skill_agent", "name": "发布为技能Agent"},
+        {"id": "publish_to_be_web_sdk_agent", "name": "发布为Web SDK Agent"},
+        {"id": "publish_to_be_api_agent", "name": "发布为API Agent"},
+        {"id": "publish_to_be_data_flow_agent", "name": "发布为数据流Agent"},
+        {"id": "create_system_agent", "name": "创建系统Agent"},
+        {"id": "mgnt_built_in_agent", "name": "内置Agent管理"},
+        {"id": "see_trajectory_analysis", "name": "查看轨迹分析"}
+      ]
+    },
+    {
+      "id": "agent_tpl",
+      "name": "数据智能体模板",
+      "_note": "Standalone authorization root. Cross-owner template operations are explicit system/admin permissions and are excluded from the Community business bundle.",
+      "operations": [
+        {"id": "publish", "name": "发布Agent模板"},
+        {"id": "unpublish", "name": "取消发布Agent模板"},
+        {"id": "unpublish_other_user_agent_tpl", "name": "取消发布其他用户Agent模板"}
+      ]
+    },
+    {
       "id": "catalog",
       "name": "数据目录",
       "_source": "vega",

--- a/bkn-safe/server/internal/seed/matrix_test.go
+++ b/bkn-safe/server/internal/seed/matrix_test.go
@@ -39,7 +39,7 @@ func TestRoleResourceMatrix(t *testing.T) {
 		"concept_group": "view_detail", "object_type": "query_data", "relation_type": "query_data",
 		"action_type": "execute", "metric": "query_data", "risk_type": "view_detail",
 		"tool_box": "execute", "mcp": "execute", "operator": "execute", "skill": "execute",
-		"small_model": "execute", "large_model": "execute",
+		"small_model": "execute", "large_model": "execute", "agent": "use", "agent_tpl": "publish",
 	}
 	roleAllowed := map[string]map[string]string{
 		networkBuilder: {

--- a/bkn-safe/server/internal/seed/seed.go
+++ b/bkn-safe/server/internal/seed/seed.go
@@ -55,8 +55,6 @@ var deprecatedSeedRoleIDs = []string{
 }
 
 var withdrawnResourceTypes = []string{
-	"agent",
-	"agent_tpl",
 	"stream_data_pipeline",
 }
 

--- a/bkn-safe/server/internal/seed/seed_test.go
+++ b/bkn-safe/server/internal/seed/seed_test.go
@@ -70,8 +70,16 @@ func TestApplySeedsRolesCatalogGrants(t *testing.T) {
 		t.Errorf("network_builder description = %q", networkBuilder.Description)
 	}
 
-	// Retained Studio admin resource types and their operations are seeded.
+	// Retained Studio admin and Agent resource types are seeded.
 	var opCount int64
+	db.Model(&model.Operation{}).Where("resource_type_id = ?", "agent").Count(&opCount)
+	if opCount != 11 {
+		t.Errorf("agent operation count = %d, want 11", opCount)
+	}
+	db.Model(&model.Operation{}).Where("resource_type_id = ?", "agent_tpl").Count(&opCount)
+	if opCount != 3 {
+		t.Errorf("agent_tpl operation count = %d, want 3", opCount)
+	}
 	db.Model(&model.Operation{}).Where("resource_type_id = ?", "admin-user").Count(&opCount)
 	if opCount == 0 {
 		t.Error("expected admin-user operations seeded")
@@ -99,9 +107,7 @@ func TestApplyRemovesWithdrawnResourceTypes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	legacy := map[string]string{
-		"agent": "use", "agent_tpl": "publish", "stream_data_pipeline": "view_detail",
-	}
+	legacy := map[string]string{"stream_data_pipeline": "view_detail"}
 	for resourceType, operation := range legacy {
 		if err := db.Create(&model.ResourceType{ID: resourceType, Name: resourceType}).Error; err != nil {
 			t.Fatal(err)
@@ -138,15 +144,61 @@ func TestApplyRemovesWithdrawnResourceTypes(t *testing.T) {
 			t.Errorf("direct %s permission remains: allow=%v err=%v", resourceType, ok, err)
 		}
 	}
-	if err := e.AssignRole("legacy-role-user", "legacy-role"); err != nil {
+	if err := Apply(db, e); err != nil {
+		t.Fatalf("second apply must remain idempotent: %v", err)
+	}
+}
+
+// TestApplyRestoresAgentTypesWithoutDeletingExistingGrants guards the upgrade
+// path from #1458: Agent types are active again, so startup must preserve any
+// compatible grant that predates the restored directory and fill in the full
+// reviewed operation vocabulary around it.
+func TestApplyRestoresAgentTypesWithoutDeletingExistingGrants(t *testing.T) {
+	db := newDB(t)
+	e, err := authz.New(db)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if ok, err := e.Check("legacy-role-user", "agent", "old-1", "use"); err != nil || ok {
-		t.Errorf("role permission for withdrawn type remains: allow=%v err=%v", ok, err)
+	for resourceType, operation := range map[string]string{
+		"agent": "use", "agent_tpl": "publish",
+	} {
+		if err := db.Create(&model.ResourceType{ID: resourceType, Name: "legacy " + resourceType}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Create(&model.Operation{ResourceTypeID: resourceType, ID: operation, Name: operation}).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := e.GrantObjectPermission("legacy-user", resourceType, "old-1", operation); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	if err := Apply(db, e); err != nil {
-		t.Fatalf("second apply must remain idempotent: %v", err)
+		t.Fatalf("apply upgrade seed: %v", err)
+	}
+
+	wantCounts := map[string]int64{"agent": 11, "agent_tpl": 3}
+	for resourceType, operation := range map[string]string{
+		"agent": "use", "agent_tpl": "publish",
+	} {
+		var resourceTypeRow model.ResourceType
+		if err := db.First(&resourceTypeRow, "id = ?", resourceType).Error; err != nil {
+			t.Fatalf("load restored type %s: %v", resourceType, err)
+		}
+		if resourceTypeRow.ParentTypeID != "" {
+			t.Errorf("%s parent = %q, want standalone root", resourceType, resourceTypeRow.ParentTypeID)
+		}
+		var operationCount int64
+		if err := db.Model(&model.Operation{}).Where("resource_type_id = ?", resourceType).
+			Count(&operationCount).Error; err != nil {
+			t.Fatal(err)
+		}
+		if operationCount != wantCounts[resourceType] {
+			t.Errorf("%s operation count = %d, want %d", resourceType, operationCount, wantCounts[resourceType])
+		}
+		if ok, err := e.Check("legacy-user", resourceType, "old-1", operation); err != nil || !ok {
+			t.Errorf("compatible %s grant was not preserved: allow=%v err=%v", resourceType, ok, err)
+		}
 	}
 }
 
@@ -189,7 +241,7 @@ func TestSeededRoleGrants(t *testing.T) {
 		{"network-builder manages catalog", networkBuilder, "catalog", "x", "create", true},
 		{"network-builder manages skill", networkBuilder, "skill", "s1", "publish", true},
 		{"network-builder not system users", networkBuilder, "admin-user", "x", "create", false},
-		{"super-admin does anything (withdrawn type)", superAdmin, "agent", "x", "use", true},
+		{"super-admin manages agents", superAdmin, "agent", "x", "use", true},
 		{"super-admin does anything (any type/op)", superAdmin, "whatever", "z", "some_random_op", true},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Restore the `agent` and `agent_tpl` resource types with the reviewed, compatibility-sensitive operation catalog.
- [x] Add explicit Community `full_business_access` whitelists for Agent instances and Agent templates.
- [x] Keep system, built-in, cross-owner, creation, authorization, and public-access operations outside the Community bundle.
- [x] Preserve existing Agent grants during startup while continuing to reconcile the retired `stream_data_pipeline` type.
- [x] Add focused coverage for Community, Professional allow/deny, owners, administrators, built-in resources, cross-owner operations, upgrades, and HTTP read-path consistency.
- [ ] Docs/doc 1 (N/A: the implementation follows the approved contract in openbkn-ai/bkn-docs#117 and does not change a public API shape.)

---

## Why

- Related Issue: Closes #1437
- Related Feature: Agent resource-family authorization
- Background:
  - The approved four-edition authorization contract requires Agent resources to use an explicit Community business-operation bundle and Professional fine-grained rules.
  - Implementation follows openbkn-ai/bkn-docs#117 at commit `8e28e43b49eaf8962261150d6d1af12ea2e83700`.
  - Agent operations contain privileged system and cross-owner semantics, so the bundle must be reviewed operation by operation instead of derived from the catalog.

---

## How

- Key implementation points:
  - Reintroduce `agent` and `agent_tpl` as standalone authorization roots with no parent-resource or operation-requirement mapping.
  - Preserve the established vocabulary: Agent execution remains `use`; no generic `view`, `modify`, or `delete` operations are invented.
  - Store Community access as one logical `full_business_access` grant and expand only the reviewed whitelist through the shared decision engine.
  - Exclude `create_system_agent`, `mgnt_built_in_agent`, `unpublish_other_user_agent`, `unpublish_other_user_agent_tpl`, `authorize`, creation operations, and `public_access` from Community bundles.
  - Exercise Professional per-operation allow/deny, same-object deny precedence, wildcard fallback, edition downgrade behavior, and independent system-derived owner rules.
  - Verify consistent results through check, operation projection, resource filtering, accessible-resource listing, policy projection, and self-service permission reads.
- Breaking changes (API, config, database, etc.):
  - No API or schema changes.
  - Startup seeding no longer removes Agent resource types or surviving Agent grants.
  - Agent resource types and operations become available in the authorization catalog again.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally (in-memory database and HTTP router integration coverage)
- [ ] Verified in test environment (not performed locally)

Test notes:

```text
cd bkn-safe/server
go test ./internal/authz -count=1
go test ./internal/seed -count=1
go test ./internal/httpapi -count=1

git diff --check
```

All commands passed.

---

## Risk & Rollback

- Potential risks:
  - Restoring a compatibility-sensitive operation catalog can expose stale callers or configuration assumptions that still treat Agent resources as retired.
  - Deployments that already ran the destructive cleanup introduced by #1458 have lost those historical Agent grants; this change cannot reconstruct deleted authorization intent.
  - Reverting to the old startup cleanup after new Agent grants are created would delete those grants on the next seed run.
- Rollback plan:
  - Before deployment/startup: revert this commit and do not start the reverted seed against a database containing newly restored Agent grants.
  - After deployment: back up the authorization database first, then use a follow-up that disables Agent catalog exposure without re-enabling destructive grant cleanup. Restore from backup if any cleanup has already run.

---

## Additional Notes

- The operation whitelist and hierarchy are pinned by focused tests to prevent catalog scanning or inferred privilege expansion.
- The current `infra/bkn-agent` service is outside this Issue's `bkn-safe` module scope; this PR changes the shared authorization resource family and its API decision surfaces only.
