### PR TITLE
feat(vega): compose Resource-to-Catalog authorization

### DIFF
--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -294,11 +294,24 @@ func TestSafeClientLocalDecision(t *testing.T) {
 		}, got)
 	})
 
+	t.Run("maps the inactive account compatibility response to a refusal", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"allowed":false}`))
+		})
+
+		_, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+			Accessor:  interfaces.PermissionAccessor{ID: "disabled-user"},
+			Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		})
+
+		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+	})
+
 	for name, response := range map[string]string{
-		"missing structured decision": `{"allowed":false}`,
-		"wrong evaluation scope":      `{"allowed":false,"evaluation_scope":"effective","decision":"deny","basis":"direct"}`,
-		"inconsistent allowed flag":   `{"allowed":true,"evaluation_scope":"local","decision":"deny","basis":"direct"}`,
-		"locally enforced requires":   `{"allowed":false,"evaluation_scope":"local","decision":"deny","basis":"direct","denied_requirement":"view_detail"}`,
+		"wrong evaluation scope":    `{"allowed":false,"evaluation_scope":"effective","decision":"deny","basis":"direct"}`,
+		"inconsistent allowed flag": `{"allowed":true,"evaluation_scope":"local","decision":"deny","basis":"direct"}`,
+		"locally enforced requires": `{"allowed":false,"evaluation_scope":"local","decision":"deny","basis":"direct","denied_requirement":"view_detail"}`,
 	} {
 		t.Run(name+" is an infrastructure error", func(t *testing.T) {
 			client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -345,7 +358,7 @@ func TestSafeClientLocalResourceDecisions(t *testing.T) {
 		assert.Equal(t, interfaces.PermissionDecisionNone, got["resource-2"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
 	})
 
-	t.Run("rejects an omitted resource instead of treating it as none", func(t *testing.T) {
+	t.Run("maps an empty inactive account response to a refusal", func(t *testing.T) {
 		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write([]byte(`{"resources":[]}`))
 		})
@@ -357,8 +370,24 @@ func TestSafeClientLocalResourceDecisions(t *testing.T) {
 			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
 		})
 
+		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+	})
+
+	t.Run("rejects a partially omitted resource instead of treating it as none", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"resource","resource_id":"resource-1",` +
+				`"decisions":[{"operation":"view_detail","decision":"none","basis":"none"}]}]}`))
+		})
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1", "resource-2"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "omitted requested resource")
+		assert.Contains(t, err.Error(), "omitted requested resource resource:resource-2")
 	})
 
 	t.Run("rejects an omitted operation instead of treating it as none", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -339,6 +339,28 @@ func TestSafeClientLocalDecision(t *testing.T) {
 	})
 
 	for name, response := range map[string]string{
+		"empty object":  `{}`,
+		"null document": `null`,
+		"null allowed":  `{"allowed":null}`,
+	} {
+		t.Run("rejects "+name+" as a protocol error", func(t *testing.T) {
+			client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(response))
+			})
+
+			_, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+				Accessor:  interfaces.PermissionAccessor{ID: "u1"},
+				Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+				Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			})
+
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+			assert.Contains(t, err.Error(), "required allowed field")
+		})
+	}
+
+	for name, response := range map[string]string{
 		"wrong evaluation scope":    `{"allowed":false,"evaluation_scope":"effective","decision":"deny","basis":"direct"}`,
 		"inconsistent allowed flag": `{"allowed":true,"evaluation_scope":"local","decision":"deny","basis":"direct"}`,
 		"locally enforced requires": `{"allowed":false,"evaluation_scope":"local","decision":"deny","basis":"direct","denied_requirement":"view_detail"}`,
@@ -434,6 +456,29 @@ func TestSafeClientLocalResourceDecisions(t *testing.T) {
 		assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
 		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
+
+	for name, response := range map[string]string{
+		"empty object":   `{}`,
+		"null document":  `null`,
+		"null resources": `{"resources":null}`,
+	} {
+		t.Run("rejects "+name+" as a protocol error", func(t *testing.T) {
+			client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(response))
+			})
+
+			_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+				Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+				ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+				ResourceIDs:  []string{"resource-1"},
+				Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+			})
+
+			require.Error(t, err)
+			assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+			assert.Contains(t, err.Error(), "required resources field")
+		})
+	}
 
 	t.Run("rejects a partially omitted resource instead of treating it as none", func(t *testing.T) {
 		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -308,6 +308,36 @@ func TestSafeClientLocalDecision(t *testing.T) {
 		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
 	})
 
+	t.Run("rejects an empty success response as a protocol error", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		_, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+			Accessor:  interfaces.PermissionAccessor{ID: "u1"},
+			Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		})
+
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+		assert.Contains(t, err.Error(), "empty response body")
+	})
+
+	t.Run("returns a response body read error", func(t *testing.T) {
+		client := newSafeReadErrorClient()
+
+		_, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+			Accessor:  interfaces.PermissionAccessor{ID: "u1"},
+			Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		})
+
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
 	for name, response := range map[string]string{
 		"wrong evaluation scope":    `{"allowed":false,"evaluation_scope":"effective","decision":"deny","basis":"direct"}`,
 		"inconsistent allowed flag": `{"allowed":true,"evaluation_scope":"local","decision":"deny","basis":"direct"}`,
@@ -371,6 +401,38 @@ func TestSafeClientLocalResourceDecisions(t *testing.T) {
 		})
 
 		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+	})
+
+	t.Run("rejects an empty success response as a protocol error", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+		assert.Contains(t, err.Error(), "empty response body")
+	})
+
+	t.Run("returns a response body read error", func(t *testing.T) {
+		client := newSafeReadErrorClient()
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+		assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 	})
 
 	t.Run("rejects a partially omitted resource instead of treating it as none", func(t *testing.T) {
@@ -828,6 +890,22 @@ func newSafeTestClient(t *testing.T, handler http.HandlerFunc) *safeClient {
 	}
 }
 
+func newSafeReadErrorClient() *safeClient {
+	return &safeClient{
+		baseURL: "http://safe.test",
+		http: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       readErrorBody{},
+					Request:    req,
+				}, nil
+			}),
+		},
+	}
+}
+
 func boolJSON(value bool) string {
 	if value {
 		return "true"
@@ -847,4 +925,14 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+type readErrorBody struct{}
+
+func (readErrorBody) Read([]byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func (readErrorBody) Close() error {
+	return nil
 }

--- a/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/permission_access_test.go
@@ -264,6 +264,137 @@ func TestSafeClientCheckOne(t *testing.T) {
 	})
 }
 
+func TestSafeClientLocalDecision(t *testing.T) {
+	t.Run("sends a typed local request and returns structured decision", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/safe/v1/authz/check", r.URL.Path)
+			assert.Equal(t, "vega", r.Header.Get("x-caller-service"))
+			var body localCheckRequest
+			decodeRequestJSON(t, r, &body)
+			assert.Equal(t, "local", body.EvaluationScope)
+			assert.Equal(t, "u1", body.AccessorID)
+			assert.Equal(t, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, body.Resource.Type)
+			assert.Equal(t, "resource-1", body.Resource.ID)
+			assert.Equal(t, interfaces.OPERATION_TYPE_VIEW_DETAIL, body.Operation)
+			_, _ = w.Write([]byte(`{"allowed":true,"evaluation_scope":"local","decision":"allow","basis":"direct","requires":["query_data"]}`))
+		})
+
+		got, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+			Accessor:  interfaces.PermissionAccessor{Type: interfaces.ACCESSOR_TYPE_USER, ID: "u1"},
+			Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, interfaces.PermissionOperationDecision{
+			Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			Decision:  interfaces.PermissionDecisionAllow,
+			Basis:     interfaces.PermissionBasisDirect,
+			Requires:  []string{interfaces.OPERATION_TYPE_QUERY_DATA},
+		}, got)
+	})
+
+	for name, response := range map[string]string{
+		"missing structured decision": `{"allowed":false}`,
+		"wrong evaluation scope":      `{"allowed":false,"evaluation_scope":"effective","decision":"deny","basis":"direct"}`,
+		"inconsistent allowed flag":   `{"allowed":true,"evaluation_scope":"local","decision":"deny","basis":"direct"}`,
+		"locally enforced requires":   `{"allowed":false,"evaluation_scope":"local","decision":"deny","basis":"direct","denied_requirement":"view_detail"}`,
+	} {
+		t.Run(name+" is an infrastructure error", func(t *testing.T) {
+			client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(response))
+			})
+
+			_, err := client.localDecision(context.Background(), interfaces.LocalPermissionCheck{
+				Accessor:  interfaces.PermissionAccessor{ID: "u1"},
+				Resource:  interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+				Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			})
+
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestSafeClientLocalResourceDecisions(t *testing.T) {
+	t.Run("returns every requested decision including none", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/safe/v1/authz/resource-filter", r.URL.Path)
+			assert.Equal(t, "vega", r.Header.Get("x-caller-service"))
+			var body localFilterRequest
+			decodeRequestJSON(t, r, &body)
+			assert.Equal(t, "local", body.EvaluationScope)
+			assert.Empty(t, body.VisibilityOperations)
+			assert.ElementsMatch(t, []string{"resource-1", "resource-2"}, body.ResourceIDs)
+			assert.Equal(t, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, body.CandidateOperations)
+			_, _ = w.Write([]byte(`{"resources":[` +
+				`{"resource_type":"resource","resource_id":"resource-1","decisions":[{"operation":"view_detail","decision":"deny","basis":"direct"}]},` +
+				`{"resource_type":"resource","resource_id":"resource-2","decisions":[{"operation":"view_detail","decision":"none","basis":"none"}]}` +
+				`]}`))
+		})
+
+		got, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1", "resource-2", "resource-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, interfaces.PermissionDecisionDeny, got["resource-1"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
+		assert.Equal(t, interfaces.PermissionDecisionNone, got["resource-2"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
+	})
+
+	t.Run("rejects an omitted resource instead of treating it as none", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[]}`))
+		})
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "omitted requested resource")
+	})
+
+	t.Run("rejects an omitted operation instead of treating it as none", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"resource","resource_id":"resource-1","decisions":[]}]}`))
+		})
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_RESOURCE,
+			ResourceIDs:  []string{"resource-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_VIEW_DETAIL},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "omitted resource:resource-1 operation view_detail")
+	})
+
+	t.Run("rejects an omitted required operation", func(t *testing.T) {
+		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{"resources":[{"resource_type":"catalog","resource_id":"catalog-1",` +
+				`"decisions":[{"operation":"resource_manage","decision":"allow","basis":"direct","requires":["view_detail"]}]}]}`))
+		})
+
+		_, err := client.localResourceDecisions(context.Background(), interfaces.LocalPermissionFilter{
+			Accessor:     interfaces.PermissionAccessor{ID: "u1"},
+			ResourceType: interfaces.AUTH_RESOURCE_TYPE_CATALOG,
+			ResourceIDs:  []string{"catalog-1"},
+			Operations:   []string{interfaces.OPERATION_TYPE_RESOURCE_MANAGE},
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "omitted catalog:catalog-1 required operation view_detail")
+	})
+}
+
 func TestSafeClientAllowedOps(t *testing.T) {
 	t.Run("returns allowed subset", func(t *testing.T) {
 		client := newSafeTestClient(t, func(w http.ResponseWriter, r *http.Request) {
@@ -572,6 +703,8 @@ func TestMaybeShadow(t *testing.T) {
 		require.NoError(t, err)
 		require.IsType(t, &shadowPermissionAccess{}, got)
 		assert.Same(t, inner, got.(*shadowPermissionAccess).PermissionAccess)
+		_, exposesLocal := got.(interfaces.LocalPermissionAccess)
+		assert.False(t, exposesLocal, "shadow mode must keep ISF authoritative")
 	})
 
 	t.Run("returns safe access in bkn safe mode", func(t *testing.T) {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -89,6 +89,12 @@ func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPe
 		Requires: out.Requires, DeniedRequirement: out.DeniedRequirement,
 		RequirementBasis: out.RequirementBasis,
 	}
+	// bkn-safe keeps its effective compatibility response for an unknown or
+	// disabled account: {"allowed":false}. Preserve that as an account-level
+	// refusal rather than fabricating a local none decision or reporting 500.
+	if !out.Allowed && out.EvaluationScope == "" && out.Decision == "" && out.Basis == "" {
+		return interfaces.PermissionOperationDecision{}, interfaces.ErrPermissionAccountNotActive
+	}
 	if out.EvaluationScope != "local" {
 		return interfaces.PermissionOperationDecision{}, fmt.Errorf("bkn-safe local check returned evaluation_scope %q", out.EvaluationScope)
 	}
@@ -116,6 +122,12 @@ func (c *safeClient) localResourceDecisions(ctx context.Context,
 	}, &out)
 	if err != nil {
 		return nil, err
+	}
+	// With non-empty input, an empty result is bkn-safe's compatibility response
+	// for an unknown or disabled account. A partial result remains a protocol
+	// error below so omitted resources cannot be confused with deny or none.
+	if len(out.Resources) == 0 {
+		return nil, interfaces.ErrPermissionAccountNotActive
 	}
 	expectedIDs := make(map[string]bool, len(ids))
 	for _, id := range ids {

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -41,6 +41,168 @@ func newSafeClient(baseURL string) *safeClient {
 	return &safeClient{baseURL: baseURL, http: &http.Client{Timeout: 5 * time.Second}}
 }
 
+type localCheckRequest struct {
+	AccessorID      string                        `json:"accessor_id"`
+	Resource        interfaces.PermissionResource `json:"resource"`
+	Operation       string                        `json:"operation"`
+	EvaluationScope string                        `json:"evaluation_scope"`
+}
+
+type localCheckResponse struct {
+	Allowed           bool                               `json:"allowed"`
+	EvaluationScope   string                             `json:"evaluation_scope"`
+	Decision          interfaces.PermissionDecision      `json:"decision"`
+	Basis             interfaces.PermissionDecisionBasis `json:"basis"`
+	Requires          []string                           `json:"requires"`
+	DeniedRequirement string                             `json:"denied_requirement"`
+	RequirementBasis  interfaces.PermissionDecisionBasis `json:"requirement_basis"`
+}
+
+type localFilterRequest struct {
+	AccessorID           string   `json:"accessor_id"`
+	ResourceType         string   `json:"resource_type"`
+	ResourceIDs          []string `json:"resource_ids"`
+	VisibilityOperations []string `json:"visibility_operations"`
+	CandidateOperations  []string `json:"candidate_operations"`
+	EvaluationScope      string   `json:"evaluation_scope"`
+}
+
+type localFilterResponse struct {
+	Resources []struct {
+		ResourceType string                                   `json:"resource_type"`
+		ResourceID   string                                   `json:"resource_id"`
+		Decisions    []interfaces.PermissionOperationDecision `json:"decisions"`
+	} `json:"resources"`
+}
+
+func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+	var out localCheckResponse
+	err := c.doLocal(ctx, http.MethodPost, "/api/safe/v1/authz/check", localCheckRequest{
+		AccessorID: check.Accessor.ID, Resource: check.Resource, Operation: check.Operation,
+		EvaluationScope: "local",
+	}, &out)
+	if err != nil {
+		return interfaces.PermissionOperationDecision{}, err
+	}
+	decision := interfaces.PermissionOperationDecision{
+		Operation: check.Operation, Decision: out.Decision, Basis: out.Basis,
+		Requires: out.Requires, DeniedRequirement: out.DeniedRequirement,
+		RequirementBasis: out.RequirementBasis,
+	}
+	if out.EvaluationScope != "local" {
+		return interfaces.PermissionOperationDecision{}, fmt.Errorf("bkn-safe local check returned evaluation_scope %q", out.EvaluationScope)
+	}
+	if err := validateLocalDecision(decision); err != nil {
+		return interfaces.PermissionOperationDecision{}, err
+	}
+	if out.Allowed != decision.Allowed() {
+		return interfaces.PermissionOperationDecision{}, fmt.Errorf("bkn-safe local check returned inconsistent allowed and decision values")
+	}
+	return decision, nil
+}
+
+func (c *safeClient) localResourceDecisions(ctx context.Context,
+	filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+
+	ids := uniqueStrings(filter.ResourceIDs)
+	operations := uniqueStrings(filter.Operations)
+	if len(ids) == 0 || len(operations) == 0 {
+		return map[string]map[string]interfaces.PermissionOperationDecision{}, nil
+	}
+	var out localFilterResponse
+	err := c.doLocal(ctx, http.MethodPost, "/api/safe/v1/authz/resource-filter", localFilterRequest{
+		AccessorID: filter.Accessor.ID, ResourceType: filter.ResourceType, ResourceIDs: ids,
+		VisibilityOperations: []string{}, CandidateOperations: operations, EvaluationScope: "local",
+	}, &out)
+	if err != nil {
+		return nil, err
+	}
+	expectedIDs := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		expectedIDs[id] = true
+	}
+	result := make(map[string]map[string]interfaces.PermissionOperationDecision, len(ids))
+	for _, resource := range out.Resources {
+		if resource.ResourceType != filter.ResourceType || !expectedIDs[resource.ResourceID] {
+			return nil, fmt.Errorf("bkn-safe local filter returned unexpected resource %s:%s", resource.ResourceType, resource.ResourceID)
+		}
+		if _, duplicate := result[resource.ResourceID]; duplicate {
+			return nil, fmt.Errorf("bkn-safe local filter returned duplicate resource %s:%s", resource.ResourceType, resource.ResourceID)
+		}
+		decisions := make(map[string]interfaces.PermissionOperationDecision, len(resource.Decisions))
+		for _, decision := range resource.Decisions {
+			if _, duplicate := decisions[decision.Operation]; duplicate {
+				return nil, fmt.Errorf("bkn-safe local filter returned duplicate decision for %s:%s operation %s",
+					resource.ResourceType, resource.ResourceID, decision.Operation)
+			}
+			if err := validateLocalDecision(decision); err != nil {
+				return nil, err
+			}
+			decisions[decision.Operation] = decision
+		}
+		for _, operation := range operations {
+			decision, ok := decisions[operation]
+			if !ok {
+				return nil, fmt.Errorf("bkn-safe local filter omitted %s:%s operation %s",
+					resource.ResourceType, resource.ResourceID, operation)
+			}
+			for _, requirement := range decision.Requires {
+				if _, ok := decisions[requirement]; !ok {
+					return nil, fmt.Errorf("bkn-safe local filter omitted %s:%s required operation %s",
+						resource.ResourceType, resource.ResourceID, requirement)
+				}
+			}
+		}
+		result[resource.ResourceID] = decisions
+	}
+	for _, id := range ids {
+		if _, ok := result[id]; !ok {
+			return nil, fmt.Errorf("bkn-safe local filter omitted requested resource %s:%s", filter.ResourceType, id)
+		}
+	}
+	return result, nil
+}
+
+func validateLocalDecision(decision interfaces.PermissionOperationDecision) error {
+	if decision.Operation == "" {
+		return fmt.Errorf("bkn-safe local decision omitted operation")
+	}
+	switch decision.Decision {
+	case interfaces.PermissionDecisionAllow, interfaces.PermissionDecisionDeny:
+		if decision.Basis != interfaces.PermissionBasisDirect &&
+			decision.Basis != interfaces.PermissionBasisBundle &&
+			decision.Basis != interfaces.PermissionBasisWildcard {
+			return fmt.Errorf("bkn-safe local decision for operation %s returned invalid basis %q",
+				decision.Operation, decision.Basis)
+		}
+	case interfaces.PermissionDecisionNone:
+		if decision.Basis != interfaces.PermissionBasisNone {
+			return fmt.Errorf("bkn-safe local none decision for operation %s returned basis %q",
+				decision.Operation, decision.Basis)
+		}
+	default:
+		return fmt.Errorf("bkn-safe local decision for operation %s returned invalid decision %q",
+			decision.Operation, decision.Decision)
+	}
+	if decision.DeniedRequirement != "" || decision.RequirementBasis != "" {
+		return fmt.Errorf("bkn-safe local decision for operation %s unexpectedly enforced requirements", decision.Operation)
+	}
+	return nil
+}
+
+func uniqueStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
 func (c *safeClient) checkOne(ctx context.Context, accessorID, rtype, rid, op string) (bool, error) {
 	var out struct {
 		Allowed bool `json:"allowed"`
@@ -99,6 +261,14 @@ func (c *safeClient) allowedAll(ctx context.Context, accessorID, rtype, rid stri
 }
 
 func (c *safeClient) do(ctx context.Context, method, path string, body, out any) error {
+	return c.doWithHeaders(ctx, method, path, body, out, nil)
+}
+
+func (c *safeClient) doLocal(ctx context.Context, method, path string, body, out any) error {
+	return c.doWithHeaders(ctx, method, path, body, out, map[string]string{"x-caller-service": "vega"})
+}
+
+func (c *safeClient) doWithHeaders(ctx context.Context, method, path string, body, out any, extraHeaders map[string]string) error {
 	b, _ := sonic.Marshal(body)
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(b))
 	if err != nil {
@@ -106,6 +276,9 @@ func (c *safeClient) do(ctx context.Context, method, path string, body, out any)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range common.BuildTraceHeadersForChildOperation(ctx, "permission.shadow", 1) {
+		req.Header.Set(key, value)
+	}
+	for key, value := range extraHeaders {
 		req.Header.Set(key, value)
 	}
 	resp, err := c.http.Do(req)
@@ -150,6 +323,15 @@ type safePermissionAccess struct {
 
 func (s *safePermissionAccess) CheckPermission(ctx context.Context, check interfaces.PermissionCheck) (bool, error) {
 	return s.safe.allowedAll(ctx, check.Accessor.ID, check.Resource.Type, check.Resource.ID, check.Operations)
+}
+
+func (s *safePermissionAccess) LocalDecision(ctx context.Context, check interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+	return s.safe.localDecision(ctx, check)
+}
+
+func (s *safePermissionAccess) LocalResourceDecisions(ctx context.Context,
+	filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+	return s.safe.localResourceDecisions(ctx, filter)
 }
 
 // opAccess is the authorization resolution result of a single operation under a certain resource type: either it holds type-level wildcard authorization

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -49,7 +49,7 @@ type localCheckRequest struct {
 }
 
 type localCheckResponse struct {
-	Allowed           bool                               `json:"allowed"`
+	Allowed           *bool                              `json:"allowed"`
 	EvaluationScope   string                             `json:"evaluation_scope"`
 	Decision          interfaces.PermissionDecision      `json:"decision"`
 	Basis             interfaces.PermissionDecisionBasis `json:"basis"`
@@ -68,11 +68,13 @@ type localFilterRequest struct {
 }
 
 type localFilterResponse struct {
-	Resources []struct {
-		ResourceType string                                   `json:"resource_type"`
-		ResourceID   string                                   `json:"resource_id"`
-		Decisions    []interfaces.PermissionOperationDecision `json:"decisions"`
-	} `json:"resources"`
+	Resources *[]localFilterResource `json:"resources"`
+}
+
+type localFilterResource struct {
+	ResourceType string                                   `json:"resource_type"`
+	ResourceID   string                                   `json:"resource_id"`
+	Decisions    []interfaces.PermissionOperationDecision `json:"decisions"`
 }
 
 func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
@@ -84,6 +86,10 @@ func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPe
 	if err != nil {
 		return interfaces.PermissionOperationDecision{}, err
 	}
+	if out.Allowed == nil {
+		return interfaces.PermissionOperationDecision{}, fmt.Errorf("bkn-safe local check omitted the required allowed field")
+	}
+	allowed := *out.Allowed
 	decision := interfaces.PermissionOperationDecision{
 		Operation: check.Operation, Decision: out.Decision, Basis: out.Basis,
 		Requires: out.Requires, DeniedRequirement: out.DeniedRequirement,
@@ -92,7 +98,7 @@ func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPe
 	// bkn-safe keeps its effective compatibility response for an unknown or
 	// disabled account: {"allowed":false}. Preserve that as an account-level
 	// refusal rather than fabricating a local none decision or reporting 500.
-	if !out.Allowed && out.EvaluationScope == "" && out.Decision == "" && out.Basis == "" {
+	if !allowed && out.EvaluationScope == "" && out.Decision == "" && out.Basis == "" {
 		return interfaces.PermissionOperationDecision{}, interfaces.ErrPermissionAccountNotActive
 	}
 	if out.EvaluationScope != "local" {
@@ -101,7 +107,7 @@ func (c *safeClient) localDecision(ctx context.Context, check interfaces.LocalPe
 	if err := validateLocalDecision(decision); err != nil {
 		return interfaces.PermissionOperationDecision{}, err
 	}
-	if out.Allowed != decision.Allowed() {
+	if allowed != decision.Allowed() {
 		return interfaces.PermissionOperationDecision{}, fmt.Errorf("bkn-safe local check returned inconsistent allowed and decision values")
 	}
 	return decision, nil
@@ -123,10 +129,14 @@ func (c *safeClient) localResourceDecisions(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if out.Resources == nil {
+		return nil, fmt.Errorf("bkn-safe local filter omitted the required resources field")
+	}
+	resources := *out.Resources
 	// With non-empty input, an empty result is bkn-safe's compatibility response
 	// for an unknown or disabled account. A partial result remains a protocol
 	// error below so omitted resources cannot be confused with deny or none.
-	if len(out.Resources) == 0 {
+	if len(resources) == 0 {
 		return nil, interfaces.ErrPermissionAccountNotActive
 	}
 	expectedIDs := make(map[string]bool, len(ids))
@@ -134,7 +144,7 @@ func (c *safeClient) localResourceDecisions(ctx context.Context,
 		expectedIDs[id] = true
 	}
 	result := make(map[string]map[string]interfaces.PermissionOperationDecision, len(ids))
-	for _, resource := range out.Resources {
+	for _, resource := range resources {
 		if resource.ResourceType != filter.ResourceType || !expectedIDs[resource.ResourceID] {
 			return nil, fmt.Errorf("bkn-safe local filter returned unexpected resource %s:%s", resource.ResourceType, resource.ResourceID)
 		}

--- a/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
+++ b/adp/vega/vega-backend/server/drivenadapters/permission/shadow.go
@@ -273,14 +273,15 @@ func (c *safeClient) allowedAll(ctx context.Context, accessorID, rtype, rid stri
 }
 
 func (c *safeClient) do(ctx context.Context, method, path string, body, out any) error {
-	return c.doWithHeaders(ctx, method, path, body, out, nil)
+	return c.doWithHeaders(ctx, method, path, body, out, nil, false)
 }
 
 func (c *safeClient) doLocal(ctx context.Context, method, path string, body, out any) error {
-	return c.doWithHeaders(ctx, method, path, body, out, map[string]string{"x-caller-service": "vega"})
+	return c.doWithHeaders(ctx, method, path, body, out, map[string]string{"x-caller-service": "vega"}, true)
 }
 
-func (c *safeClient) doWithHeaders(ctx context.Context, method, path string, body, out any, extraHeaders map[string]string) error {
+func (c *safeClient) doWithHeaders(ctx context.Context, method, path string, body, out any,
+	extraHeaders map[string]string, requireResponseBody bool) error {
 	b, _ := sonic.Marshal(body)
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(b))
 	if err != nil {
@@ -298,9 +299,15 @@ func (c *safeClient) doWithHeaders(ctx context.Context, method, path string, bod
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	data, _ := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read bkn-safe %s %s response: %w", method, path, err)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("bkn-safe %s %s: %d: %s", method, path, resp.StatusCode, data)
+	}
+	if requireResponseBody && out != nil && len(data) == 0 {
+		return fmt.Errorf("bkn-safe %s %s returned an empty response body", method, path)
 	}
 	if out != nil && len(data) > 0 {
 		return sonic.Unmarshal(data, out)

--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -52,6 +52,7 @@ const (
 
 var (
 	ErrLocalPermissionUnsupported = errors.New("local permission decisions are unavailable for the configured authorization provider")
+	ErrPermissionAccountNotActive = errors.New("permission account is missing or disabled")
 
 	// COMMON_OPERATIONS is the set every authorization answer is asked to report
 	// on. It grants nothing by itself — a verb missing here is simply never

--- a/adp/vega/vega-backend/server/interfaces/permission_access.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_access.go
@@ -51,6 +51,8 @@ const (
 )
 
 var (
+	ErrLocalPermissionUnsupported = errors.New("local permission decisions are unavailable for the configured authorization provider")
+
 	// COMMON_OPERATIONS is the set every authorization answer is asked to report
 	// on. It grants nothing by itself — a verb missing here is simply never
 	// mentioned back, which is how query_data and resource_manage stayed
@@ -67,6 +69,55 @@ var (
 		OPERATION_TYPE_RESOURCE_MANAGE,
 	}
 )
+
+type PermissionDecision string
+
+const (
+	PermissionDecisionAllow PermissionDecision = "allow"
+	PermissionDecisionDeny  PermissionDecision = "deny"
+	PermissionDecisionNone  PermissionDecision = "none"
+)
+
+type PermissionDecisionBasis string
+
+const (
+	PermissionBasisDirect    PermissionDecisionBasis = "direct"
+	PermissionBasisInherited PermissionDecisionBasis = "inherited"
+	PermissionBasisBundle    PermissionDecisionBasis = "bundle"
+	PermissionBasisWildcard  PermissionDecisionBasis = "wildcard"
+	PermissionBasisDefault   PermissionDecisionBasis = "default"
+	PermissionBasisRequires  PermissionDecisionBasis = "requires"
+	PermissionBasisNone      PermissionDecisionBasis = "none"
+)
+
+// PermissionOperationDecision is one structured authorization result. Local
+// decisions may return none; decisions returned to a business operation must
+// first be composed into allow or deny.
+type PermissionOperationDecision struct {
+	Operation         string                  `json:"operation"`
+	Decision          PermissionDecision      `json:"decision"`
+	Basis             PermissionDecisionBasis `json:"basis"`
+	Requires          []string                `json:"requires,omitempty"`
+	DeniedRequirement string                  `json:"denied_requirement,omitempty"`
+	RequirementBasis  PermissionDecisionBasis `json:"requirement_basis,omitempty"`
+}
+
+func (d PermissionOperationDecision) Allowed() bool {
+	return d.Decision == PermissionDecisionAllow
+}
+
+type LocalPermissionCheck struct {
+	Accessor  PermissionAccessor
+	Resource  PermissionResource
+	Operation string
+}
+
+type LocalPermissionFilter struct {
+	Accessor     PermissionAccessor
+	ResourceType string
+	ResourceIDs  []string
+	Operations   []string
+}
 
 // IsPermissionRefusal reports whether an authorization error is the service
 // saying no, as opposed to the service failing to answer.
@@ -150,4 +201,12 @@ type PermissionAccess interface {
 
 	CreateResources(ctx context.Context, policies []PermissionPolicy) error
 	DeleteResources(ctx context.Context, resources []PermissionResource) error
+}
+
+// LocalPermissionAccess is the narrow, typed port used only by Vega's trusted
+// Resource-to-Catalog composition. Implementations must not turn an unavailable
+// account or authorization backend into PermissionDecisionNone.
+type LocalPermissionAccess interface {
+	LocalDecision(ctx context.Context, check LocalPermissionCheck) (PermissionOperationDecision, error)
+	LocalResourceDecisions(ctx context.Context, filter LocalPermissionFilter) (map[string]map[string]PermissionOperationDecision, error)
 }

--- a/adp/vega/vega-backend/server/interfaces/permission_service.go
+++ b/adp/vega/vega-backend/server/interfaces/permission_service.go
@@ -18,3 +18,11 @@ type PermissionService interface {
 	DeleteResources(ctx context.Context, resourceType string, ids []string) error
 	UpdateResource(ctx context.Context, resource PermissionResource) error
 }
+
+// LocalPermissionService exposes bkn-safe's non-final local decision only to
+// the Resource service, which owns the trusted Resource-to-Catalog relation.
+// Other business services continue to use PermissionService's effective APIs.
+type LocalPermissionService interface {
+	LocalDecision(ctx context.Context, resource PermissionResource, op string) (PermissionOperationDecision, error)
+	LocalResourceDecisions(ctx context.Context, resourceType string, ids, ops []string) (map[string]map[string]PermissionOperationDecision, error)
+}

--- a/adp/vega/vega-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/vega/vega-backend/server/logics/permission/permission_service_impl.go
@@ -68,6 +68,61 @@ func (ps *PermissionServiceImpl) CheckPermission(ctx context.Context, resource i
 	return nil
 }
 
+func (ps *PermissionServiceImpl) LocalDecision(ctx context.Context, resource interfaces.PermissionResource,
+	op string) (interfaces.PermissionOperationDecision, error) {
+
+	accountInfo := interfaces.AccountInfo{}
+	if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {
+		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	}
+	if accountInfo.ID == "" || accountInfo.Type == "" {
+		return interfaces.PermissionOperationDecision{}, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+			WithErrorDetails("Access denied: missing account ID or type")
+	}
+	local, ok := ps.pa.(interfaces.LocalPermissionAccess)
+	if !ok {
+		return interfaces.PermissionOperationDecision{}, interfaces.ErrLocalPermissionUnsupported
+	}
+	decision, err := local.LocalDecision(ctx, interfaces.LocalPermissionCheck{
+		Accessor: interfaces.PermissionAccessor{ID: accountInfo.ID, Type: accountInfo.Type},
+		Resource: resource, Operation: op,
+	})
+	if err != nil {
+		return interfaces.PermissionOperationDecision{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_InternalError_CheckPermissionFailed).WithErrorDetails(err)
+	}
+	return decision, nil
+}
+
+func (ps *PermissionServiceImpl) LocalResourceDecisions(ctx context.Context, resourceType string,
+	ids, ops []string) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+
+	accountInfo := interfaces.AccountInfo{}
+	if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {
+		accountInfo = ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+	}
+	if accountInfo.ID == "" || accountInfo.Type == "" {
+		return nil, rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+			WithErrorDetails("Access denied: missing account ID or type")
+	}
+	if len(ids) == 0 || len(ops) == 0 {
+		return map[string]map[string]interfaces.PermissionOperationDecision{}, nil
+	}
+	local, ok := ps.pa.(interfaces.LocalPermissionAccess)
+	if !ok {
+		return nil, interfaces.ErrLocalPermissionUnsupported
+	}
+	decisions, err := local.LocalResourceDecisions(ctx, interfaces.LocalPermissionFilter{
+		Accessor:     interfaces.PermissionAccessor{ID: accountInfo.ID, Type: accountInfo.Type},
+		ResourceType: resourceType, ResourceIDs: ids, Operations: ops,
+	})
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_InternalError_FilterResourcesFailed).WithErrorDetails(err)
+	}
+	return decisions, nil
+}
+
 func (ps *PermissionServiceImpl) CreateResources(ctx context.Context, resources []interfaces.PermissionResource, ops []string) error {
 	accountInfo := interfaces.AccountInfo{}
 	if ctx.Value(interfaces.ACCOUNT_INFO_KEY) != nil {

--- a/adp/vega/vega-backend/server/logics/permission/permission_service_impl.go
+++ b/adp/vega/vega-backend/server/logics/permission/permission_service_impl.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -88,6 +89,9 @@ func (ps *PermissionServiceImpl) LocalDecision(ctx context.Context, resource int
 		Resource: resource, Operation: op,
 	})
 	if err != nil {
+		if errors.Is(err, interfaces.ErrPermissionAccountNotActive) {
+			return interfaces.PermissionOperationDecision{}, err
+		}
 		return interfaces.PermissionOperationDecision{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			verrors.VegaBackend_InternalError_CheckPermissionFailed).WithErrorDetails(err)
 	}
@@ -117,6 +121,9 @@ func (ps *PermissionServiceImpl) LocalResourceDecisions(ctx context.Context, res
 		ResourceType: resourceType, ResourceIDs: ids, Operations: ops,
 	})
 	if err != nil {
+		if errors.Is(err, interfaces.ErrPermissionAccountNotActive) {
+			return nil, err
+		}
 		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
 			verrors.VegaBackend_InternalError_FilterResourcesFailed).WithErrorDetails(err)
 	}

--- a/adp/vega/vega-backend/server/logics/permission/permission_service_impl_test.go
+++ b/adp/vega/vega-backend/server/logics/permission/permission_service_impl_test.go
@@ -167,6 +167,20 @@ func TestPermissionServiceImplLocalDecision(t *testing.T) {
 		assertHTTPStatus(t, err, http.StatusInternalServerError)
 	})
 
+	t.Run("preserves the inactive account refusal", func(t *testing.T) {
+		access := &fakeLocalPermissionAccess{checkFn: func(context.Context,
+			interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+			return interfaces.PermissionOperationDecision{}, interfaces.ErrPermissionAccountNotActive
+		}}
+		svc := &PermissionServiceImpl{pa: access}
+
+		_, err := svc.LocalDecision(contextWithAccount("disabled-user", interfaces.ACCESSOR_TYPE_USER),
+			interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+	})
+
 	t.Run("rejects a missing account before local evaluation", func(t *testing.T) {
 		access := &fakeLocalPermissionAccess{checkFn: func(context.Context,
 			interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
@@ -184,32 +198,49 @@ func TestPermissionServiceImplLocalDecision(t *testing.T) {
 }
 
 func TestPermissionServiceImplLocalResourceDecisions(t *testing.T) {
-	var got interfaces.LocalPermissionFilter
-	access := &fakeLocalPermissionAccess{filterFn: func(_ context.Context,
-		filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
-		got = filter
-		return map[string]map[string]interfaces.PermissionOperationDecision{
-			"resource-1": {
-				interfaces.OPERATION_TYPE_VIEW_DETAIL: {
-					Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
-					Decision:  interfaces.PermissionDecisionDeny,
-					Basis:     interfaces.PermissionBasisDirect,
+	t.Run("delegates the typed batch request", func(t *testing.T) {
+		var got interfaces.LocalPermissionFilter
+		access := &fakeLocalPermissionAccess{filterFn: func(_ context.Context,
+			filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+			got = filter
+			return map[string]map[string]interfaces.PermissionOperationDecision{
+				"resource-1": {
+					interfaces.OPERATION_TYPE_VIEW_DETAIL: {
+						Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+						Decision:  interfaces.PermissionDecisionDeny,
+						Basis:     interfaces.PermissionBasisDirect,
+					},
 				},
-			},
-		}, nil
-	}}
-	svc := &PermissionServiceImpl{pa: access}
+			}, nil
+		}}
+		svc := &PermissionServiceImpl{pa: access}
 
-	decisions, err := svc.LocalResourceDecisions(
-		contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
-		interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"resource-1"},
-		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+		decisions, err := svc.LocalResourceDecisions(
+			contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
+			interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"resource-1"},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
 
-	require.NoError(t, err)
-	assert.Equal(t, interfaces.PermissionDecisionDeny,
-		decisions["resource-1"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
-	assert.Equal(t, interfaces.PermissionAccessor{ID: "user-1", Type: interfaces.ACCESSOR_TYPE_USER}, got.Accessor)
-	assert.Equal(t, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, got.ResourceType)
+		require.NoError(t, err)
+		assert.Equal(t, interfaces.PermissionDecisionDeny,
+			decisions["resource-1"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
+		assert.Equal(t, interfaces.PermissionAccessor{ID: "user-1", Type: interfaces.ACCESSOR_TYPE_USER}, got.Accessor)
+		assert.Equal(t, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, got.ResourceType)
+	})
+
+	t.Run("preserves the inactive account refusal", func(t *testing.T) {
+		access := &fakeLocalPermissionAccess{filterFn: func(context.Context,
+			interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+			return nil, interfaces.ErrPermissionAccountNotActive
+		}}
+		svc := &PermissionServiceImpl{pa: access}
+
+		_, err := svc.LocalResourceDecisions(
+			contextWithAccount("disabled-user", interfaces.ACCESSOR_TYPE_USER),
+			interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"resource-1"},
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+
+		require.ErrorIs(t, err, interfaces.ErrPermissionAccountNotActive)
+	})
 }
 
 func TestPermissionServiceImplCreateResources(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/permission/permission_service_impl_test.go
+++ b/adp/vega/vega-backend/server/logics/permission/permission_service_impl_test.go
@@ -35,6 +35,22 @@ func (f *fakeMQClient) Sub(topic string, channel string, handler mqclient.Messag
 
 func (f *fakeMQClient) Close() {}
 
+type fakeLocalPermissionAccess struct {
+	interfaces.PermissionAccess
+	checkFn  func(context.Context, interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error)
+	filterFn func(context.Context, interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error)
+}
+
+func (f *fakeLocalPermissionAccess) LocalDecision(ctx context.Context,
+	check interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+	return f.checkFn(ctx, check)
+}
+
+func (f *fakeLocalPermissionAccess) LocalResourceDecisions(ctx context.Context,
+	filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+	return f.filterFn(ctx, filter)
+}
+
 func TestPermissionServiceImplCheckPermission(t *testing.T) {
 	t.Run("rejects missing account", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -100,6 +116,100 @@ func TestPermissionServiceImplCheckPermission(t *testing.T) {
 		assertHTTPStatus(t, err, http.StatusForbidden)
 		assert.ErrorContains(t, err, "insufficient permissions")
 	})
+}
+
+func TestPermissionServiceImplLocalDecision(t *testing.T) {
+	t.Run("delegates account through the local access contract", func(t *testing.T) {
+		var got interfaces.LocalPermissionCheck
+		access := &fakeLocalPermissionAccess{checkFn: func(_ context.Context,
+			check interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+			got = check
+			return interfaces.PermissionOperationDecision{
+				Operation: check.Operation, Decision: interfaces.PermissionDecisionNone,
+				Basis: interfaces.PermissionBasisNone,
+			}, nil
+		}}
+		svc := &PermissionServiceImpl{pa: access}
+		resource := interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"}
+
+		decision, err := svc.LocalDecision(contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
+			resource, interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+		require.NoError(t, err)
+		assert.Equal(t, interfaces.PermissionDecisionNone, decision.Decision)
+		assert.Equal(t, interfaces.PermissionAccessor{ID: "user-1", Type: interfaces.ACCESSOR_TYPE_USER}, got.Accessor)
+		assert.Equal(t, resource, got.Resource)
+	})
+
+	t.Run("reports unsupported for the retired access provider", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		t.Cleanup(ctrl.Finish)
+		svc := &PermissionServiceImpl{pa: vmock.NewMockPermissionAccess(ctrl)}
+
+		_, err := svc.LocalDecision(contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
+			interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+		require.ErrorIs(t, err, interfaces.ErrLocalPermissionUnsupported)
+	})
+
+	t.Run("does not turn a safe failure into none", func(t *testing.T) {
+		access := &fakeLocalPermissionAccess{checkFn: func(context.Context,
+			interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+			return interfaces.PermissionOperationDecision{}, errors.New("safe unavailable")
+		}}
+		svc := &PermissionServiceImpl{pa: access}
+
+		_, err := svc.LocalDecision(contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
+			interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+		assertHTTPStatus(t, err, http.StatusInternalServerError)
+	})
+
+	t.Run("rejects a missing account before local evaluation", func(t *testing.T) {
+		access := &fakeLocalPermissionAccess{checkFn: func(context.Context,
+			interfaces.LocalPermissionCheck) (interfaces.PermissionOperationDecision, error) {
+			t.Fatal("local access must not be called")
+			return interfaces.PermissionOperationDecision{}, nil
+		}}
+		svc := &PermissionServiceImpl{pa: access}
+
+		_, err := svc.LocalDecision(context.Background(),
+			interfaces.PermissionResource{Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+		assertHTTPStatus(t, err, http.StatusForbidden)
+	})
+}
+
+func TestPermissionServiceImplLocalResourceDecisions(t *testing.T) {
+	var got interfaces.LocalPermissionFilter
+	access := &fakeLocalPermissionAccess{filterFn: func(_ context.Context,
+		filter interfaces.LocalPermissionFilter) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+		got = filter
+		return map[string]map[string]interfaces.PermissionOperationDecision{
+			"resource-1": {
+				interfaces.OPERATION_TYPE_VIEW_DETAIL: {
+					Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+					Decision:  interfaces.PermissionDecisionDeny,
+					Basis:     interfaces.PermissionBasisDirect,
+				},
+			},
+		}, nil
+	}}
+	svc := &PermissionServiceImpl{pa: access}
+
+	decisions, err := svc.LocalResourceDecisions(
+		contextWithAccount("user-1", interfaces.ACCESSOR_TYPE_USER),
+		interfaces.AUTH_RESOURCE_TYPE_RESOURCE, []string{"resource-1"},
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL})
+
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.PermissionDecisionDeny,
+		decisions["resource-1"][interfaces.OPERATION_TYPE_VIEW_DETAIL].Decision)
+	assert.Equal(t, interfaces.PermissionAccessor{ID: "user-1", Type: interfaces.ACCESSOR_TYPE_USER}, got.Accessor)
+	assert.Equal(t, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, got.ResourceType)
 }
 
 func TestPermissionServiceImplCreateResources(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/resource/local_authorization.go
+++ b/adp/vega/vega-backend/server/logics/resource/local_authorization.go
@@ -1,0 +1,273 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+func composeVegaBaseDecision(operation string, resourceDecision, catalogDecision *interfaces.PermissionOperationDecision) interfaces.PermissionOperationDecision {
+	if resourceDecision != nil && resourceDecision.Decision == interfaces.PermissionDecisionDeny {
+		return copyDecisionForOperation(*resourceDecision, operation)
+	}
+	if resourceDecision != nil && resourceDecision.Decision == interfaces.PermissionDecisionAllow &&
+		resourceDecision.Basis != interfaces.PermissionBasisWildcard {
+		return copyDecisionForOperation(*resourceDecision, operation)
+	}
+	if catalogDecision != nil {
+		switch catalogDecision.Decision {
+		case interfaces.PermissionDecisionDeny, interfaces.PermissionDecisionAllow:
+			decision := copyDecisionForOperation(*catalogDecision, operation)
+			decision.Basis = interfaces.PermissionBasisInherited
+			return decision
+		}
+	}
+	if resourceDecision != nil && resourceDecision.Decision == interfaces.PermissionDecisionAllow &&
+		resourceDecision.Basis == interfaces.PermissionBasisWildcard {
+		return copyDecisionForOperation(*resourceDecision, operation)
+	}
+	return interfaces.PermissionOperationDecision{
+		Operation: operation, Decision: interfaces.PermissionDecisionDeny, Basis: interfaces.PermissionBasisDefault,
+	}
+}
+
+func copyDecisionForOperation(decision interfaces.PermissionOperationDecision, operation string) interfaces.PermissionOperationDecision {
+	decision.Operation = operation
+	decision.Requires = append([]string(nil), decision.Requires...)
+	return decision
+}
+
+func applyVegaRequirements(operation string, base interfaces.PermissionOperationDecision,
+	resolve func(string) interfaces.PermissionOperationDecision) interfaces.PermissionOperationDecision {
+	if !base.Allowed() {
+		return base
+	}
+	for _, requirement := range uniqueOperations(base.Requires) {
+		required := resolve(requirement)
+		if required.Allowed() {
+			continue
+		}
+		return interfaces.PermissionOperationDecision{
+			Operation: operation, Decision: interfaces.PermissionDecisionDeny,
+			Basis: interfaces.PermissionBasisRequires, Requires: append([]string(nil), base.Requires...),
+			DeniedRequirement: requirement, RequirementBasis: required.Basis,
+		}
+	}
+	return base
+}
+
+func (rs *resourceService) localOperationDecision(ctx context.Context, resourceID, catalogID,
+	operation string) (interfaces.PermissionOperationDecision, error) {
+	local, ok := rs.ps.(interfaces.LocalPermissionService)
+	if !ok {
+		return interfaces.PermissionOperationDecision{}, interfaces.ErrLocalPermissionUnsupported
+	}
+	resourceCache := map[string]interfaces.PermissionOperationDecision{}
+	catalogCache := map[string]interfaces.PermissionOperationDecision{}
+	resolveBase := func(op string) (interfaces.PermissionOperationDecision, error) {
+		var resourceDecision *interfaces.PermissionOperationDecision
+		if resourceOwnOperations[op] {
+			decision, exists := resourceCache[op]
+			if !exists {
+				var err error
+				decision, err = local.LocalDecision(ctx, interfaces.PermissionResource{
+					Type: interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ID: resourceID,
+				}, op)
+				if err != nil {
+					return interfaces.PermissionOperationDecision{}, err
+				}
+				resourceCache[op] = decision
+			}
+			resourceDecision = &decision
+			if decision.Decision == interfaces.PermissionDecisionDeny ||
+				(decision.Decision == interfaces.PermissionDecisionAllow &&
+					decision.Basis != interfaces.PermissionBasisWildcard) {
+				return copyDecisionForOperation(decision, op), nil
+			}
+		}
+		var catalogDecision *interfaces.PermissionOperationDecision
+		if catalogOp, mapped := resourceOpOnCatalog[op]; mapped && catalogID != "" {
+			decision, exists := catalogCache[catalogOp]
+			if !exists {
+				var err error
+				decision, err = local.LocalDecision(ctx, interfaces.PermissionResource{
+					Type: interfaces.AUTH_RESOURCE_TYPE_CATALOG, ID: catalogID,
+				}, catalogOp)
+				if err != nil {
+					return interfaces.PermissionOperationDecision{}, err
+				}
+				catalogCache[catalogOp] = decision
+			}
+			catalogDecision = &decision
+		}
+		return composeVegaBaseDecision(op, resourceDecision, catalogDecision), nil
+	}
+
+	base, err := resolveBase(operation)
+	if err != nil || !base.Allowed() {
+		return base, err
+	}
+	var requirementErr error
+	final := applyVegaRequirements(operation, base, func(requirement string) interfaces.PermissionOperationDecision {
+		decision, err := resolveBase(requirement)
+		if err != nil {
+			requirementErr = err
+			return interfaces.PermissionOperationDecision{}
+		}
+		return decision
+	})
+	if requirementErr != nil {
+		return interfaces.PermissionOperationDecision{}, requirementErr
+	}
+	return final, nil
+}
+
+func (rs *resourceService) localFilterResourcePermissions(ctx context.Context, ids, visibilityOperations []string,
+	allowOperation bool) (map[string]interfaces.PermissionResourceOps, error) {
+	local, ok := rs.ps.(interfaces.LocalPermissionService)
+	if !ok {
+		return nil, interfaces.ErrLocalPermissionUnsupported
+	}
+	ids = uniqueOperations(ids)
+	if len(ids) == 0 {
+		return map[string]interfaces.PermissionResourceOps{}, nil
+	}
+	refs, err := rs.ra.GetPermissionRefsByIDs(ctx, ids)
+	if err != nil {
+		return nil, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+			verrors.VegaBackend_Resource_InternalError_GetFailed).WithErrorDetails(err.Error())
+	}
+	catalogOf := make(map[string]string, len(refs))
+	catalogIDs := make([]string, 0, len(refs))
+	seenCatalog := map[string]bool{}
+	for _, ref := range refs {
+		catalogOf[ref.ResourceID] = ref.CatalogID
+		if ref.CatalogID != "" && !seenCatalog[ref.CatalogID] {
+			seenCatalog[ref.CatalogID] = true
+			catalogIDs = append(catalogIDs, ref.CatalogID)
+		}
+	}
+
+	candidateOperations := uniqueOperations(append(append([]string(nil), visibilityOperations...), interfaces.COMMON_OPERATIONS...))
+	resourceOperations, catalogOperations := splitVegaOperations(candidateOperations)
+	resourceDecisions, err := local.LocalResourceDecisions(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ids, resourceOperations)
+	if err != nil {
+		return nil, err
+	}
+	catalogDecisions, err := local.LocalResourceDecisions(ctx, interfaces.AUTH_RESOURCE_TYPE_CATALOG, catalogIDs, catalogOperations)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]interfaces.PermissionResourceOps, len(ids))
+	for _, id := range ids {
+		catalogID := catalogOf[id]
+		final := make(map[string]interfaces.PermissionOperationDecision, len(candidateOperations))
+		resolve := func(operation string) interfaces.PermissionOperationDecision {
+			resourceDecision := decisionPointer(resourceDecisions[id], operation, resourceOwnOperations[operation])
+			catalogOp, mapped := resourceOpOnCatalog[operation]
+			catalogDecision := decisionPointer(catalogDecisions[catalogID], catalogOp, mapped && catalogID != "")
+			return composeVegaBaseDecision(operation, resourceDecision, catalogDecision)
+		}
+		for _, operation := range candidateOperations {
+			base := resolve(operation)
+			final[operation] = applyVegaRequirements(operation, base, resolve)
+		}
+		if !resourceVisible(final, visibilityOperations, allowOperation) {
+			continue
+		}
+		entry := interfaces.PermissionResourceOps{ResourceID: id, Operations: []string{}}
+		for _, operation := range interfaces.COMMON_OPERATIONS {
+			if final[operation].Allowed() {
+				entry.Operations = append(entry.Operations, operation)
+			}
+		}
+		result[id] = entry
+	}
+	return result, nil
+}
+
+func splitVegaOperations(operations []string) (resourceOperations, catalogOperations []string) {
+	seenResource, seenCatalog := map[string]bool{}, map[string]bool{}
+	for _, operation := range operations {
+		if resourceOwnOperations[operation] && !seenResource[operation] {
+			seenResource[operation] = true
+			resourceOperations = append(resourceOperations, operation)
+		}
+		if catalogOperation, ok := resourceOpOnCatalog[operation]; ok && !seenCatalog[catalogOperation] {
+			seenCatalog[catalogOperation] = true
+			catalogOperations = append(catalogOperations, catalogOperation)
+		}
+	}
+	return resourceOperations, catalogOperations
+}
+
+func decisionPointer(decisions map[string]interfaces.PermissionOperationDecision, operation string,
+	wanted bool) *interfaces.PermissionOperationDecision {
+	if !wanted {
+		return nil
+	}
+	decision, ok := decisions[operation]
+	if !ok {
+		return nil
+	}
+	return &decision
+}
+
+func resourceVisible(decisions map[string]interfaces.PermissionOperationDecision, operations []string,
+	allowOperation bool) bool {
+	operations = uniqueOperations(operations)
+	if len(operations) == 0 {
+		return true
+	}
+	if allowOperation {
+		for _, operation := range operations {
+			if decisions[operation].Allowed() {
+				return true
+			}
+		}
+		return false
+	}
+	for _, operation := range operations {
+		if !decisions[operation].Allowed() {
+			return false
+		}
+	}
+	return true
+}
+
+func uniqueOperations(operations []string) []string {
+	result := make([]string, 0, len(operations))
+	seen := make(map[string]bool, len(operations))
+	for _, operation := range operations {
+		if operation == "" || seen[operation] {
+			continue
+		}
+		seen[operation] = true
+		result = append(result, operation)
+	}
+	return result
+}
+
+func permissionDeniedForDecision(ctx context.Context, operation string,
+	decision interfaces.PermissionOperationDecision) error {
+	details := fmt.Sprintf("Access denied: insufficient permissions for[%v]", operation)
+	if decision.Basis == interfaces.PermissionBasisRequires {
+		return rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).WithErrorDetails(map[string]any{
+			"message":            details,
+			"basis":              decision.Basis,
+			"denied_requirement": decision.DeniedRequirement,
+			"requirement_basis":  decision.RequirementBasis,
+		})
+	}
+	return rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).WithErrorDetails(details)
+}

--- a/adp/vega/vega-backend/server/logics/resource/local_authorization_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/local_authorization_test.go
@@ -1,0 +1,265 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+type localDecisionKey struct {
+	resourceType string
+	resourceID   string
+	operation    string
+}
+
+type localPermissionServiceStub struct {
+	interfaces.PermissionService
+	decisions  map[localDecisionKey]interfaces.PermissionOperationDecision
+	errors     map[localDecisionKey]error
+	calls      []localDecisionKey
+	batchCalls []interfaces.LocalPermissionFilter
+}
+
+func (s *localPermissionServiceStub) LocalDecision(_ context.Context, resource interfaces.PermissionResource,
+	operation string) (interfaces.PermissionOperationDecision, error) {
+	key := localDecisionKey{resourceType: resource.Type, resourceID: resource.ID, operation: operation}
+	s.calls = append(s.calls, key)
+	if err := s.errors[key]; err != nil {
+		return interfaces.PermissionOperationDecision{}, err
+	}
+	if decision, ok := s.decisions[key]; ok {
+		return copyDecisionForOperation(decision, operation), nil
+	}
+	return noneDecision(operation), nil
+}
+
+func (s *localPermissionServiceStub) LocalResourceDecisions(_ context.Context, resourceType string,
+	ids, operations []string) (map[string]map[string]interfaces.PermissionOperationDecision, error) {
+	s.batchCalls = append(s.batchCalls, interfaces.LocalPermissionFilter{
+		ResourceType: resourceType, ResourceIDs: append([]string(nil), ids...), Operations: append([]string(nil), operations...),
+	})
+	result := make(map[string]map[string]interfaces.PermissionOperationDecision, len(ids))
+	for _, id := range ids {
+		result[id] = make(map[string]interfaces.PermissionOperationDecision, len(operations))
+		for _, operation := range operations {
+			key := localDecisionKey{resourceType: resourceType, resourceID: id, operation: operation}
+			if err := s.errors[key]; err != nil {
+				return nil, err
+			}
+			decision, ok := s.decisions[key]
+			if !ok {
+				decision = noneDecision(operation)
+			}
+			result[id][operation] = copyDecisionForOperation(decision, operation)
+		}
+	}
+	return result, nil
+}
+
+func noneDecision(operation string) interfaces.PermissionOperationDecision {
+	return interfaces.PermissionOperationDecision{
+		Operation: operation, Decision: interfaces.PermissionDecisionNone, Basis: interfaces.PermissionBasisNone,
+	}
+}
+
+func localDecision(decision interfaces.PermissionDecision,
+	basis interfaces.PermissionDecisionBasis, requires ...string) interfaces.PermissionOperationDecision {
+	return interfaces.PermissionOperationDecision{Decision: decision, Basis: basis, Requires: requires}
+}
+
+func TestLocalOperationDecisionPriority(t *testing.T) {
+	resourceKey := func(operation string) localDecisionKey {
+		return localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", operation}
+	}
+	catalogKey := func(operation string) localDecisionKey {
+		return localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", operation}
+	}
+	tests := []struct {
+		name          string
+		resource      interfaces.PermissionOperationDecision
+		catalog       interfaces.PermissionOperationDecision
+		wantDecision  interfaces.PermissionDecision
+		wantBasis     interfaces.PermissionDecisionBasis
+		wantCallCount int
+	}{
+		{
+			name:         "resource deny is terminal over catalog allow",
+			resource:     localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+			catalog:      localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+			wantDecision: interfaces.PermissionDecisionDeny, wantBasis: interfaces.PermissionBasisDirect,
+			wantCallCount: 1,
+		},
+		{
+			name:         "resource direct allow is terminal over catalog deny",
+			resource:     localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+			catalog:      localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+			wantDecision: interfaces.PermissionDecisionAllow, wantBasis: interfaces.PermissionBasisDirect,
+			wantCallCount: 1,
+		},
+		{
+			name:         "catalog allow fills resource none",
+			resource:     noneDecision(interfaces.OPERATION_TYPE_VIEW_DETAIL),
+			catalog:      localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+			wantDecision: interfaces.PermissionDecisionAllow, wantBasis: interfaces.PermissionBasisInherited,
+			wantCallCount: 2,
+		},
+		{
+			name:         "catalog deny beats resource wildcard allow",
+			resource:     localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisWildcard),
+			catalog:      localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+			wantDecision: interfaces.PermissionDecisionDeny, wantBasis: interfaces.PermissionBasisInherited,
+			wantCallCount: 2,
+		},
+		{
+			name:         "resource wildcard allow is the final fallback",
+			resource:     localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisWildcard),
+			catalog:      noneDecision(interfaces.OPERATION_TYPE_VIEW_DETAIL),
+			wantDecision: interfaces.PermissionDecisionAllow, wantBasis: interfaces.PermissionBasisWildcard,
+			wantCallCount: 2,
+		},
+		{
+			name:         "two none decisions become default deny",
+			resource:     noneDecision(interfaces.OPERATION_TYPE_VIEW_DETAIL),
+			catalog:      noneDecision(interfaces.OPERATION_TYPE_VIEW_DETAIL),
+			wantDecision: interfaces.PermissionDecisionDeny, wantBasis: interfaces.PermissionBasisDefault,
+			wantCallCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &localPermissionServiceStub{decisions: map[localDecisionKey]interfaces.PermissionOperationDecision{
+				resourceKey(interfaces.OPERATION_TYPE_VIEW_DETAIL): tt.resource,
+				catalogKey(interfaces.OPERATION_TYPE_VIEW_DETAIL):  tt.catalog,
+			}}
+			rs := &resourceService{ps: stub}
+
+			got, err := rs.localOperationDecision(context.Background(), "resource-1", "catalog-1",
+				interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantDecision, got.Decision)
+			assert.Equal(t, tt.wantBasis, got.Basis)
+			assert.Len(t, stub.calls, tt.wantCallCount)
+		})
+	}
+}
+
+func TestLocalOperationDecisionRequiresUsesTheSameComposition(t *testing.T) {
+	stub := &localPermissionServiceStub{decisions: map[localDecisionKey]interfaces.PermissionOperationDecision{
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_RESOURCE_MANAGE}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL),
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}: localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}:   localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+	}}
+	rs := &resourceService{ps: stub}
+
+	got, err := rs.localOperationDecision(context.Background(), "resource-1", "catalog-1",
+		interfaces.OPERATION_TYPE_MODIFY)
+
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.PermissionDecisionDeny, got.Decision)
+	assert.Equal(t, interfaces.PermissionBasisRequires, got.Basis)
+	assert.Equal(t, interfaces.OPERATION_TYPE_VIEW_DETAIL, got.DeniedRequirement)
+	assert.Equal(t, interfaces.PermissionBasisDirect, got.RequirementBasis)
+	assert.Len(t, stub.calls, 2, "the direct requirement deny must also short-circuit Catalog")
+
+	stub.calls = nil
+	err = rs.checkResourceOrCatalog(context.Background(), "resource-1", "catalog-1", false,
+		interfaces.OPERATION_TYPE_MODIFY)
+	var httpErr *rest.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.HTTPCode)
+	assert.Equal(t, map[string]any{
+		"message":            "Access denied: insufficient permissions for[modify]",
+		"basis":              interfaces.PermissionBasisRequires,
+		"denied_requirement": interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		"requirement_basis":  interfaces.PermissionBasisDirect,
+	}, httpErr.BaseError.ErrorDetails)
+}
+
+func TestLocalOperationDecisionDoesNotTreatFailuresAsNone(t *testing.T) {
+	want := errors.New("bkn-safe unavailable")
+	key := localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}
+	stub := &localPermissionServiceStub{errors: map[localDecisionKey]error{key: want}}
+	rs := &resourceService{ps: stub}
+
+	_, err := rs.localOperationDecision(context.Background(), "resource-1", "catalog-1",
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+	require.ErrorIs(t, err, want)
+	assert.Len(t, stub.calls, 1)
+}
+
+func TestLocalFilterResourcePermissionsUsesFinalDecisions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	access := vmock.NewMockResourceAccess(ctrl)
+	ids := []string{"resource-deny", "resource-allow", "resource-wild-deny", "resource-wild-none"}
+	access.EXPECT().GetPermissionRefsByIDs(gomock.Any(), ids).Return([]interfaces.ResourcePermissionRef{
+		{ResourceID: "resource-deny", CatalogID: "catalog-allow"},
+		{ResourceID: "resource-allow", CatalogID: "catalog-deny"},
+		{ResourceID: "resource-wild-deny", CatalogID: "catalog-deny"},
+		{ResourceID: "resource-wild-none", CatalogID: "catalog-none"},
+	}, nil)
+	view := interfaces.OPERATION_TYPE_VIEW_DETAIL
+	stub := &localPermissionServiceStub{decisions: map[localDecisionKey]interfaces.PermissionOperationDecision{
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-deny", view}:      localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-allow", view}:     localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-wild-deny", view}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisWildcard),
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-wild-none", view}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisWildcard),
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-allow", view}:       localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-deny", view}:        localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+	}}
+	rs := &resourceService{ps: stub, ra: access}
+
+	got, err := rs.localFilterResourcePermissions(context.Background(), ids, []string{view}, true)
+
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"resource-allow", "resource-wild-none"}, mapKeysOfResourceOps(got))
+	assert.Equal(t, []string{view}, got["resource-allow"].Operations)
+	assert.Equal(t, []string{view}, got["resource-wild-none"].Operations)
+	assert.Len(t, stub.batchCalls, 2, "batch calls must scale by resource type, not by resource count")
+}
+
+func TestLocalFilterResourcePermissionsEnforcesRequirements(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	access := vmock.NewMockResourceAccess(ctrl)
+	access.EXPECT().GetPermissionRefsByIDs(gomock.Any(), []string{"resource-1"}).Return([]interfaces.ResourcePermissionRef{
+		{ResourceID: "resource-1", CatalogID: "catalog-1"},
+	}, nil)
+	stub := &localPermissionServiceStub{decisions: map[localDecisionKey]interfaces.PermissionOperationDecision{
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_RESOURCE_MANAGE}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect,
+			interfaces.OPERATION_TYPE_VIEW_DETAIL),
+		{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}: localDecision(interfaces.PermissionDecisionDeny, interfaces.PermissionBasisDirect),
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}:   localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+	}}
+	rs := &resourceService{ps: stub, ra: access}
+
+	got, err := rs.localFilterResourcePermissions(context.Background(), []string{"resource-1"}, nil, true)
+
+	require.NoError(t, err)
+	entry := got["resource-1"]
+	assert.NotContains(t, entry.Operations, interfaces.OPERATION_TYPE_MODIFY)
+	assert.NotContains(t, entry.Operations, interfaces.OPERATION_TYPE_DELETE)
+}
+
+func mapKeysOfResourceOps(values map[string]interfaces.PermissionResourceOps) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+	return result
+}

--- a/adp/vega/vega-backend/server/logics/resource/local_authorization_test.go
+++ b/adp/vega/vega-backend/server/logics/resource/local_authorization_test.go
@@ -191,6 +191,25 @@ func TestLocalOperationDecisionRequiresUsesTheSameComposition(t *testing.T) {
 	}, httpErr.BaseError.ErrorDetails)
 }
 
+func TestLocalOperationDecisionCatalogRequiresStillUsesResourceComposition(t *testing.T) {
+	stub := &localPermissionServiceStub{decisions: map[localDecisionKey]interfaces.PermissionOperationDecision{
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_RESOURCE_MANAGE}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect,
+			interfaces.OPERATION_TYPE_AUTHORIZE),
+		{interfaces.AUTH_RESOURCE_TYPE_CATALOG, "catalog-1", interfaces.OPERATION_TYPE_AUTHORIZE}: localDecision(interfaces.PermissionDecisionAllow, interfaces.PermissionBasisDirect),
+	}}
+	rs := &resourceService{ps: stub}
+
+	got, err := rs.localOperationDecision(context.Background(), "resource-1", "catalog-1",
+		interfaces.OPERATION_TYPE_MODIFY)
+
+	require.NoError(t, err)
+	assert.Equal(t, interfaces.PermissionDecisionDeny, got.Decision)
+	assert.Equal(t, interfaces.PermissionBasisRequires, got.Basis)
+	assert.Equal(t, interfaces.OPERATION_TYPE_AUTHORIZE, got.DeniedRequirement)
+	assert.Equal(t, interfaces.PermissionBasisDefault, got.RequirementBasis)
+	assert.Len(t, stub.calls, 1, "an intentionally unmapped Resource operation must not become a Catalog grant")
+}
+
 func TestLocalOperationDecisionDoesNotTreatFailuresAsNone(t *testing.T) {
 	want := errors.New("bkn-safe unavailable")
 	key := localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}
@@ -202,6 +221,41 @@ func TestLocalOperationDecisionDoesNotTreatFailuresAsNone(t *testing.T) {
 
 	require.ErrorIs(t, err, want)
 	assert.Len(t, stub.calls, 1)
+}
+
+func TestCheckResourceOrCatalogMapsInactiveAccountToForbidden(t *testing.T) {
+	key := localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}
+	stub := &localPermissionServiceStub{errors: map[localDecisionKey]error{
+		key: interfaces.ErrPermissionAccountNotActive,
+	}}
+	rs := &resourceService{ps: stub}
+
+	err := rs.checkResourceOrCatalog(context.Background(), "resource-1", "catalog-1", false,
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+	var httpErr *rest.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusForbidden, httpErr.HTTPCode)
+	assert.Len(t, stub.calls, 1)
+}
+
+func TestFilterResourcePermissionsMapsInactiveAccountToEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	access := vmock.NewMockResourceAccess(ctrl)
+	access.EXPECT().GetPermissionRefsByIDs(gomock.Any(), []string{"resource-1"}).Return([]interfaces.ResourcePermissionRef{
+		{ResourceID: "resource-1", CatalogID: "catalog-1"},
+	}, nil)
+	key := localDecisionKey{interfaces.AUTH_RESOURCE_TYPE_RESOURCE, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL}
+	stub := &localPermissionServiceStub{errors: map[localDecisionKey]error{
+		key: interfaces.ErrPermissionAccountNotActive,
+	}}
+	rs := &resourceService{ps: stub, ra: access}
+
+	got, err := rs.filterResourcePermissions(context.Background(), []string{"resource-1"}, nil,
+		[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
+
+	require.NoError(t, err)
+	assert.Empty(t, got)
 }
 
 func TestLocalFilterResourcePermissionsUsesFinalDecisions(t *testing.T) {

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -123,15 +123,34 @@ func catalogAuthResourceType(internal bool) string {
 	return interfaces.AUTH_RESOURCE_TYPE_CATALOG
 }
 
-// checkResourceOrCatalog determines an operation on a resource: First, ask the resource itself; if rejected, then ask the directory to which it belongs
-// (The operation should be translated according to the above table.)
-//
-// This is pure relaxation: the first question that can be asked today will pass, and under normal circumstances, only one authentication request will still be sent. Only the first question was rejected
-// Only then will there be a second question. When both questions are rejected, the error of the first question is returned, and the error code and prompt seen by the caller remain unchanged.
-//
-// The attribution relationship does not require any synchronization :catalog_id is in the row of resource records that vega is judging.
+// checkResourceOrCatalog applies Vega's Resource -> Catalog authorization
+// composition. Structured local decisions preserve explicit deny, distinguish
+// none from deny, and keep wildcard allow behind the Catalog decision. The
+// attribution relationship does not require synchronization: catalog_id is in
+// the Resource row that Vega is already judging.
 func (rs *resourceService) checkResourceOrCatalog(ctx context.Context,
 	resourceID, catalogID string, parentInternal bool, op string) error {
+	if !parentInternal {
+		decision, err := rs.localOperationDecision(ctx, resourceID, catalogID, op)
+		switch {
+		case errors.Is(err, interfaces.ErrLocalPermissionUnsupported):
+			// The retired ISF provider has no structured local decision. Preserve
+			// its compatibility behavior until that escape hatch is removed.
+		case err != nil:
+			return err
+		case decision.Allowed():
+			return nil
+		default:
+			return permissionDeniedForDecision(ctx, op, decision)
+		}
+	}
+	return rs.checkResourceOrCatalogLegacy(ctx, resourceID, catalogID, parentInternal, op)
+}
+
+func (rs *resourceService) checkResourceOrCatalogLegacy(ctx context.Context,
+	resourceID, catalogID string, parentInternal bool, op string) error {
+	// The retired provider exposes only effective allow/error results. Preserve
+	// its historical relaxation behavior while that compatibility path exists.
 
 	// err stays nil when the resource is never asked, which is how the code below
 	// tells "the resource refused" from "the resource was not entitled to answer".
@@ -329,6 +348,32 @@ func partitionResourceIDs(ids []string, internalSet map[string]struct{}) (normal
 // Permissions filterResourcePermissions grouped by internal/common resources do filtering: according to the internal directory of resources
 // The internal_resource type is verified, and the rest are verified by the resource type. The results are merged and returned
 func (rs *resourceService) filterResourcePermissions(ctx context.Context, ids []string,
+	internalSet map[string]struct{}, ops []string, allowOperation bool) (map[string]interfaces.PermissionResourceOps, error) {
+
+	normalIDs, internalIDs := partitionResourceIDs(ids, internalSet)
+	if len(normalIDs) > 0 {
+		result, err := rs.localFilterResourcePermissions(ctx, normalIDs, ops, allowOperation)
+		if err == nil {
+			if len(internalIDs) > 0 {
+				internalResult, internalErr := rs.filterResourcePermissionsLegacy(ctx, internalIDs,
+					internalSet, ops, allowOperation)
+				if internalErr != nil {
+					return nil, internalErr
+				}
+				for id, entry := range internalResult {
+					result[id] = entry
+				}
+			}
+			return result, nil
+		}
+		if !errors.Is(err, interfaces.ErrLocalPermissionUnsupported) {
+			return nil, err
+		}
+	}
+	return rs.filterResourcePermissionsLegacy(ctx, ids, internalSet, ops, allowOperation)
+}
+
+func (rs *resourceService) filterResourcePermissionsLegacy(ctx context.Context, ids []string,
 	internalSet map[string]struct{}, ops []string, allowOperation bool) (map[string]interfaces.PermissionResourceOps, error) {
 
 	normalIDs, internalIDs := partitionResourceIDs(ids, internalSet)
@@ -579,16 +624,14 @@ func (rs *resourceService) GetByID(ctx context.Context, id string) (*interfaces.
 		// When internal services access on behalf of users, checking per account will only result in false rejection. The external network endpoint will not carry this tag.
 		resource.Operations = interfaces.COMMON_OPERATIONS
 	} else {
-		matchResoucesMap, err := rs.ps.FilterResources(ctx, resourceAuthResourceType(parentInternal), []string{resource.ID},
-			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS)
+		internalResources := map[string]struct{}{}
+		if parentInternal {
+			internalResources[resource.ID] = struct{}{}
+		}
+		matchResoucesMap, err := rs.filterResourcePermissions(ctx, []string{resource.ID}, internalResources,
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true)
 		if err != nil {
 			span.SetStatus(codes.Error, "Filter resources error")
-			return nil, err
-		}
-		// The resource side has not approved it. Check the affiliated directory (#817) again.
-		if err := rs.mergeCatalogPermissions(ctx, []string{resource.ID},
-			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, matchResoucesMap); err != nil {
-			span.SetStatus(codes.Error, "Merge catalog permissions error")
 			return nil, err
 		}
 
@@ -1997,8 +2040,8 @@ func (rs *resourceService) filterAuthorizedResourceAuthResources(ctx context.Con
 			end = len(ids)
 		}
 
-		batchMatchResources, err := rs.ps.FilterResources(ctx, interfaces.AUTH_RESOURCE_TYPE_RESOURCE, ids[i:end],
-			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, false, interfaces.COMMON_OPERATIONS)
+		batchMatchResources, err := rs.filterResourcePermissions(ctx, ids[i:end], internalResources,
+			[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, false)
 		if err != nil {
 			return nil, err
 		}

--- a/adp/vega/vega-backend/server/logics/resource/resource_service.go
+++ b/adp/vega/vega-backend/server/logics/resource/resource_service.go
@@ -136,6 +136,9 @@ func (rs *resourceService) checkResourceOrCatalog(ctx context.Context,
 		case errors.Is(err, interfaces.ErrLocalPermissionUnsupported):
 			// The retired ISF provider has no structured local decision. Preserve
 			// its compatibility behavior until that escape hatch is removed.
+		case errors.Is(err, interfaces.ErrPermissionAccountNotActive):
+			return rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden).
+				WithErrorDetails(fmt.Sprintf("Access denied: insufficient permissions for[%v]", op))
 		case err != nil:
 			return err
 		case decision.Allowed():
@@ -365,6 +368,9 @@ func (rs *resourceService) filterResourcePermissions(ctx context.Context, ids []
 				}
 			}
 			return result, nil
+		}
+		if errors.Is(err, interfaces.ErrPermissionAccountNotActive) {
+			return map[string]interfaces.PermissionResourceOps{}, nil
 		}
 		if !errors.Is(err, interfaces.ErrLocalPermissionUnsupported) {
 			return nil, err


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Add typed single and batch local-decision clients for the trusted Vega-to-bkn-safe path.
- [x] Compose Resource and Catalog decisions with explicit deny, direct allow, Catalog fallback, wildcard fallback, and default deny precedence.
- [x] Apply direct requirements through the same composition path across checks, filters, lists, and business operations.
- [ ] Docs/doc 1 — N/A; this implements the approved design contract from openbkn-ai/bkn-docs#119.

---

## Why

- Related Issue: Closes #1433
- Related Feature: Edition-aware permission boundaries
- Background: Effective-only authorization could not distinguish a direct deny from no Resource rule, so Vega could not safely own the Resource-to-Catalog relation or keep list and execution decisions consistent.

---

## How

- Key implementation points:
  - Request evaluation_scope=local only through a narrow typed client and validate every structured decision.
  - Treat missing resources, operations, requirements, inactive-account responses, and dependency failures as errors rather than none.
  - Keep Resource deny and non-wildcard allow terminal; consult Catalog only for none or Resource wildcard allow.
  - Return structured requires denial details with basis, denied_requirement, and requirement_basis.
  - Preserve ISF shadow authority and the authorization-disabled compatibility path.
- Breaking changes (API, config, database, etc.): None. Existing effective bkn-safe APIs, public Vega APIs, configuration, and database schemas are unchanged.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A; no live dependencies are required for this change.
- [ ] Verified in test environment — N/A; deployment is not part of this PR.

Test notes:

- make ci
- make test
- Focused Vega permission/resource package tests
- Focused bkn-safe local-scope HTTP tests
- git diff --check
- Local coverage: 37.6% (required: 10%)

---

## Risk & Rollback

- Potential risks: Authorization precedence changes only for non-internal Resource operations when bkn-safe is authoritative. Malformed or incomplete local responses fail closed as dependency errors. Cluster NetworkPolicy enforcement remains the separate #1289 production release gate.
- Rollback plan: Revert commit 7b28bcb48. Existing effective APIs and the ISF/shadow compatibility paths remain available and require no data rollback.

---

## Additional Notes

- Resource run_sql remains mapped to view_detail.
- The existing chart does not expose internal authz routes through Ingress.
- #1289 must still be completed before production rollout to block sandbox and customer workloads at the network boundary.