### PR TITLE
fix(bkn): restore indirect relation type

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/models.go
@@ -11,6 +11,7 @@ import "bkn-backend/common/maskrule"
 // RelationType mapping types.
 const (
 	RELATION_MAPPING_TYPE_DIRECT              = "direct"
+	RELATION_MAPPING_TYPE_INDIRECT            = "indirect"
 	RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN = "filtered_cross_join"
 )
 
@@ -297,7 +298,7 @@ type BknRelationType struct {
 type Endpoint struct {
 	Source string
 	Target string
-	Type   string // direct | filtered_cross_join
+	Type   string // direct | indirect | filtered_cross_join
 }
 
 // MappingRule represents a property mapping between source and target.

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
@@ -30,7 +30,7 @@ var knownObjectTypeSections = map[string]bool{
 var knownRelationTypeSections = map[string]bool{
 	"Endpoint":         true,
 	"Mapping Rules":    true,
-	"Mapping View":     true,
+	"Backing Resource": true,
 	"Source Mapping":   true,
 	"Target Mapping":   true,
 	"Source Condition": true,
@@ -585,6 +585,36 @@ func ParseRelationTypeFile(text string, sourcePath string) (*BknRelationType, er
 			}
 			rel.MappingRules = DirectMappingRule(rules)
 		}
+	case RELATION_MAPPING_TYPE_INDIRECT:
+		indirect := &InDirectMappingRule{}
+		if s, ok := sections["Backing Resource"]; ok {
+			rows := parseTable(strings.Split(s, "\n"))
+			if len(rows) > 0 {
+				indirect.BackingDataSource = &ResourceInfo{
+					Type: rows[0]["Type"],
+					ID:   rows[0]["ID"],
+				}
+			}
+		}
+		if s, ok := sections["Source Mapping"]; ok {
+			rows := parseTable(strings.Split(s, "\n"))
+			for _, row := range rows {
+				sp, rp := row["Source Property"], row["Resource Property"]
+				if sp != "" || rp != "" {
+					indirect.SourceMappingRules = append(indirect.SourceMappingRules, MappingRule{SourceProperty: sp, TargetProperty: rp})
+				}
+			}
+		}
+		if s, ok := sections["Target Mapping"]; ok {
+			rows := parseTable(strings.Split(s, "\n"))
+			for _, row := range rows {
+				rp, tp := row["Resource Property"], row["Target Property"]
+				if rp != "" || tp != "" {
+					indirect.TargetMappingRules = append(indirect.TargetMappingRules, MappingRule{SourceProperty: rp, TargetProperty: tp})
+				}
+			}
+		}
+		rel.MappingRules = indirect
 	case RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN:
 		mapping := &FilteredCrossJoinMapping{}
 		if s, ok := sections["Source Condition"]; ok {

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser_test.go
@@ -52,6 +52,59 @@ Content`
 	assert.Empty(t, fm)
 }
 
+func TestParseAndSerializeRelationType_DataView(t *testing.T) {
+	text := `---
+type: relation_type
+id: pod_node
+name: Pod Node
+---
+
+## RelationType: Pod Node
+
+### Endpoint
+
+| Source | Target | Type |
+|--------|--------|------|
+| pod | node | indirect |
+
+### Backing Resource
+
+| Type | ID |
+|------|-----|
+| resource | res_pod_node |
+
+### Source Mapping
+
+| Source Property | Resource Property |
+|-----------------|-------------------|
+| node_name | view_node_name |
+
+### Target Mapping
+
+| Resource Property | Target Property |
+|-------------------|-----------------|
+| view_node_name | name |
+`
+
+	rt, err := ParseRelationTypeFile(text, "/test/pod_node.bkn")
+	require.NoError(t, err)
+	assert.Equal(t, RELATION_MAPPING_TYPE_INDIRECT, rt.Endpoint.Type)
+	rules, ok := rt.MappingRules.(*InDirectMappingRule)
+	require.True(t, ok)
+	require.NotNil(t, rules.BackingDataSource)
+	assert.Equal(t, DATA_SOURCE_TYPE_RESOURCE, rules.BackingDataSource.Type)
+	assert.Equal(t, "res_pod_node", rules.BackingDataSource.ID)
+	assert.Len(t, rules.SourceMappingRules, 1)
+	assert.Len(t, rules.TargetMappingRules, 1)
+
+	serialized := SerializeRelationType(rt)
+	assert.Contains(t, serialized, "| pod | node | indirect |")
+	assert.Contains(t, serialized, "### Backing Resource")
+	assert.Contains(t, serialized, "| Source Property | Resource Property |")
+	assert.Contains(t, serialized, "| Resource Property | Target Property |")
+	assert.Contains(t, serialized, "| resource | res_pod_node |")
+}
+
 // === Parse Network File Tests ===
 
 func TestParseNetworkFile_Success(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
@@ -411,6 +411,31 @@ func SerializeRelationType(rt *BknRelationType) string {
 		}
 		_, _ = fmt.Fprintf(&sb, "\n")
 
+	case RELATION_MAPPING_TYPE_INDIRECT:
+		_, _ = fmt.Fprintf(&sb, "### Backing Resource\n\n")
+		_, _ = fmt.Fprintf(&sb, "| Type | ID |\n")
+		_, _ = fmt.Fprintf(&sb, "|------|----|\n")
+		if rules, ok := rt.MappingRules.(*InDirectMappingRule); ok {
+			if rules.BackingDataSource != nil {
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", rules.BackingDataSource.Type, rules.BackingDataSource.ID)
+			}
+			_, _ = fmt.Fprintf(&sb, "\n")
+			_, _ = fmt.Fprintf(&sb, "### Source Mapping\n\n")
+			_, _ = fmt.Fprintf(&sb, "| Source Property | Resource Property |\n")
+			_, _ = fmt.Fprintf(&sb, "|-----------------|-------------------|\n")
+			for _, r := range rules.SourceMappingRules {
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
+			}
+			_, _ = fmt.Fprintf(&sb, "\n")
+			_, _ = fmt.Fprintf(&sb, "### Target Mapping\n\n")
+			_, _ = fmt.Fprintf(&sb, "| Resource Property | Target Property |\n")
+			_, _ = fmt.Fprintf(&sb, "|-------------------|-----------------|\n")
+			for _, r := range rules.TargetMappingRules {
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
+			}
+			_, _ = fmt.Fprintf(&sb, "\n")
+		}
+
 	case RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN:
 		if fcj, ok := rt.MappingRules.(*FilteredCrossJoinMapping); ok {
 			_, _ = fmt.Fprintf(&sb, "### Source Condition\n\n")

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator.go
@@ -36,6 +36,7 @@ var validDataSourceTypes = map[string]bool{
 
 var validRelationMappingTypes = map[string]bool{
 	RELATION_MAPPING_TYPE_DIRECT:              true,
+	RELATION_MAPPING_TYPE_INDIRECT:            true,
 	RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN: true,
 }
 
@@ -728,7 +729,7 @@ func validateRelationTypeDeep(result *ValidationResult, table string, rt *BknRel
 	epType := strings.TrimSpace(rt.Endpoint.Type)
 	if epType != "" && !validRelationMappingTypes[epType] {
 		appendError(result, table, "endpoint.type", "invalid_relation_type",
-			fmt.Sprintf("relation type must be %q or %q, got %q", RELATION_MAPPING_TYPE_DIRECT, RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN, epType))
+			fmt.Sprintf("relation type must be %q, %q, or %q, got %q", RELATION_MAPPING_TYPE_DIRECT, RELATION_MAPPING_TYPE_INDIRECT, RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN, epType))
 	}
 	if strings.TrimSpace(rt.Endpoint.Source) == "" {
 		appendError(result, table, "Source", "invalid_relation_type", "endpoint source_object_type_id must not be empty")
@@ -768,6 +769,52 @@ func validateRelationTypeDeep(result *ValidationResult, table string, rt *BknRel
 				appendError(result, table, "mapping_rules", "invalid_relation_type", fmt.Sprintf("duplicate mapping rule %q", key))
 			}
 			seen[key] = true
+		}
+	case RELATION_MAPPING_TYPE_INDIRECT:
+		ind, ok := rt.MappingRules.(*InDirectMappingRule)
+		if !ok {
+			appendError(result, table, "mapping_rules", "invalid_relation_type", "indirect relation requires InDirectMappingRule")
+			return
+		}
+		if ind.BackingDataSource == nil {
+			appendError(result, table, "mapping_rules", "invalid_relation_type", "backing_data_source must not be empty")
+			return
+		}
+		if strings.TrimSpace(ind.BackingDataSource.Type) == "" {
+			appendError(result, table, "backing_data_source", "invalid_relation_type", "backing_data_source.type must not be empty")
+		} else if normType(ind.BackingDataSource.Type) != DATA_SOURCE_TYPE_RESOURCE {
+			appendError(result, table, "backing_data_source", "invalid_relation_type", fmt.Sprintf("backing_data_source.type must be %q", DATA_SOURCE_TYPE_RESOURCE))
+		}
+		if strings.TrimSpace(ind.BackingDataSource.ID) == "" {
+			appendError(result, table, "backing_data_source", "invalid_relation_type", "backing_data_source.id must not be empty")
+		}
+		if len(ind.SourceMappingRules) == 0 {
+			appendError(result, table, "source_mapping_rules", "invalid_relation_type", "source_mapping_rules must not be empty")
+		}
+		seenS := make(map[string]bool)
+		for i, r := range ind.SourceMappingRules {
+			if strings.TrimSpace(r.SourceProperty) == "" || strings.TrimSpace(r.TargetProperty) == "" {
+				appendError(result, table, "source_mapping_rules", "invalid_relation_type", fmt.Sprintf("source_mapping_rules[%d] properties must not be empty", i))
+			}
+			key := r.SourceProperty + ":" + r.TargetProperty
+			if seenS[key] {
+				appendError(result, table, "source_mapping_rules", "invalid_relation_type", fmt.Sprintf("duplicate mapping %q", key))
+			}
+			seenS[key] = true
+		}
+		if len(ind.TargetMappingRules) == 0 {
+			appendError(result, table, "target_mapping_rules", "invalid_relation_type", "target_mapping_rules must not be empty")
+		}
+		seenT := make(map[string]bool)
+		for i, r := range ind.TargetMappingRules {
+			if strings.TrimSpace(r.SourceProperty) == "" || strings.TrimSpace(r.TargetProperty) == "" {
+				appendError(result, table, "target_mapping_rules", "invalid_relation_type", fmt.Sprintf("target_mapping_rules[%d] properties must not be empty", i))
+			}
+			key := r.SourceProperty + ":" + r.TargetProperty
+			if seenT[key] {
+				appendError(result, table, "target_mapping_rules", "invalid_relation_type", fmt.Sprintf("duplicate mapping %q", key))
+			}
+			seenT[key] = true
 		}
 	case RELATION_MAPPING_TYPE_FILTERED_CROSS_JOIN:
 		fcj, ok := rt.MappingRules.(*FilteredCrossJoinMapping)

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
@@ -141,6 +141,26 @@ func TestValidateNetwork_InvalidEndpointRef(t *testing.T) {
 	assert.True(t, found, "expected invalid_endpoint_ref, got %+v", res.Errors)
 }
 
+func TestValidateRelationTypeDeep_DataViewRequiresResourceBacking(t *testing.T) {
+	valid := &BknRelationType{
+		Endpoint: Endpoint{Source: "source", Target: "target", Type: RELATION_MAPPING_TYPE_INDIRECT},
+		MappingRules: &InDirectMappingRule{
+			BackingDataSource:  &ResourceInfo{Type: DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1"},
+			SourceMappingRules: []MappingRule{{SourceProperty: "source_id", TargetProperty: "resource_source_id"}},
+			TargetMappingRules: []MappingRule{{SourceProperty: "resource_target_id", TargetProperty: "target_id"}},
+		},
+	}
+	result := &ValidationResult{}
+	validateRelationTypeDeep(result, "relations/indirect.bkn", valid)
+	assert.Empty(t, result.Errors)
+
+	valid.MappingRules.(*InDirectMappingRule).BackingDataSource.Type = "data_view"
+	result = &ValidationResult{}
+	validateRelationTypeDeep(result, "relations/indirect.bkn", valid)
+	assert.NotEmpty(t, result.Errors)
+	assert.Equal(t, "invalid_relation_type", result.Errors[0].Code)
+}
+
 func TestValidateNetwork_InvalidBoundObjectRef(t *testing.T) {
 	net := &BknNetwork{
 		BknNetworkFrontmatter: BknNetworkFrontmatter{

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/validator_test.go
@@ -158,7 +158,8 @@ func TestValidateRelationTypeDeep_DataViewRequiresResourceBacking(t *testing.T) 
 	result = &ValidationResult{}
 	validateRelationTypeDeep(result, "relations/indirect.bkn", valid)
 	assert.NotEmpty(t, result.Errors)
-	assert.Equal(t, "invalid_relation_type", result.Errors[0].Code)
+	assert.Equal(t, "backing_data_source", result.Errors[0].Column)
+	assert.Contains(t, result.Errors[0].Message, `must be "resource"`)
 }
 
 func TestValidateNetwork_InvalidBoundObjectRef(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/exchange-recovery/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/exchange-recovery/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-08-04T17:17:22+08:00
+# generated: 2026-09-11T14:08:37+08:00
 SKILL.md  sha256:84b912d3c20e2382
 action_type:browse_backup_emails  sha256:bb76433333b3059b
 action_type:execute_recovery_task  sha256:5fff7459e3f3c6a9

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/k8s-network/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/k8s-network/CHECKSUM
@@ -1,11 +1,11 @@
 # BKN Directory Checksum
-# generated: 2026-08-04T17:17:22+08:00
+# generated: 2026-09-11T14:08:37+08:00
 SKILL.md  sha256:dc8001908e7adf8c
 action_type:cordon_node  sha256:ce7b6d4945a47aa8
 action_type:restart_pod  sha256:12f3a3bea480d2e1
 concept_group:k8s  sha256:97c4d2aa63493fc4
 metric:node_ready_count  sha256:d8bbba94fbffb546
-metric:pod_count_by_namespace  sha256:0b59736fd32a6c99
+metric:pod_count_by_namespace  sha256:7d83fe1f488a7dd2
 metric:pod_pending_count  sha256:0f4ff660ec2e0000
 metric:pod_running_count  sha256:9e6eb6382b21a221
 metric:service_count_by_type  sha256:73414731ad91b119

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/k8s-network/metrics/pod_count_by_namespace.bkn
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/k8s-network/metrics/pod_count_by_namespace.bkn
@@ -48,3 +48,4 @@ atomic:
 | Name | Display Name |
 |------|--------------|
 | pod_namespace | 命名空间 |
+

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-08-04T17:17:22+08:00
+# generated: 2026-09-11T13:16:56+08:00
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:ddcfd628ac7fb792
 action_type:delete_department  sha256:e96c729c1b099924
@@ -17,6 +17,7 @@ object_type:employee  sha256:0bf1f14b0274b8ea
 object_type:employee_resource  sha256:7084404af040425e
 object_type:relation  sha256:b87a52fad3d3bbf9
 object_type:skill  sha256:ae627aad3deb6b8c
+relation_type:emp_dept_indirect  sha256:a65451bb38f768ef
 relation_type:emp_dept_resource  sha256:1c9a2007e3f32d8b
 relation_type:emp_skill  sha256:41187a1389b20af5
 relation_type:source_object_type_id  sha256:3517043fa1a34614

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-09-11T13:16:56+08:00
+# generated: 2026-09-11T14:08:37+08:00
 SKILL.md  sha256:08301dfb5f554f2a
 action_type:assess_department  sha256:ddcfd628ac7fb792
 action_type:delete_department  sha256:e96c729c1b099924

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/network.bkn
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/network.bkn
@@ -26,6 +26,7 @@ branch: main
 
 | ID | Name | File Path | Description |
 |----|------|-----------|-------------|
+| emp_dept_indirect | 员工-部门（间接关联） | `relation_types/emp_dept_indirect.bkn` | 员工通过中间 Resource 的员工和部门字段关联部门。 |
 | emp_dept_resource | 员工-部门（Resource版） | `relation_types/emp_dept_resource.bkn` |  |
 | emp_skill | 员工-skill | `relation_types/emp_skill.bkn` |  |
 | source_object_type_id | 员工-部门 | `relation_types/source_object_type_id.bkn` |  |
@@ -75,6 +76,7 @@ branch: main
 │   ├── relation.bkn
 │   └── skill.bkn
 ├── relation_types/
+│   ├── emp_dept_indirect.bkn
 │   ├── emp_dept_resource.bkn
 │   ├── emp_skill.bkn
 │   └── source_object_type_id.bkn

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/relation_types/emp_dept_indirect.bkn
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/relation_types/emp_dept_indirect.bkn
@@ -32,3 +32,4 @@ tags: [example]
 | Resource Property | Target Property |
 |-------------------|-----------------|
 | department_id | department_id |
+

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/relation_types/emp_dept_indirect.bkn
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/mock_system/relation_types/emp_dept_indirect.bkn
@@ -1,0 +1,34 @@
+---
+type: relation_type
+id: emp_dept_indirect
+name: 员工-部门（间接关联）
+tags: [example]
+---
+
+## RelationType: 员工-部门（间接关联）
+
+员工通过中间 Resource 的员工和部门字段关联部门。
+
+### Endpoint
+
+| Source | Target | Type |
+|--------|--------|------|
+| employee_resource | department_resource | indirect |
+
+### Backing Resource
+
+| Type | ID |
+|------|----|
+| resource | employee_department_mapping_resource |
+
+### Source Mapping
+
+| Source Property | Resource Property |
+|-----------------|-------------------|
+| employee_id | employee_id |
+
+### Target Mapping
+
+| Resource Property | Target Property |
+|-------------------|-----------------|
+| department_id | department_id |

--- a/adp/bkn/bkn-backend/server/bkn-specification/examples/supplychain-hd/CHECKSUM
+++ b/adp/bkn/bkn-backend/server/bkn-specification/examples/supplychain-hd/CHECKSUM
@@ -1,5 +1,5 @@
 # BKN Directory Checksum
-# generated: 2026-08-04T17:17:22+08:00
+# generated: 2026-09-11T14:08:37+08:00
 SKILL.md  sha256:d88bd5ba972bca41
 metric:hd_forecast_consensus_by_product  sha256:e73c7a7840428dec
 metric:hd_inventory_available_qty_by_org  sha256:3484ca0e822dbac2

--- a/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/relation_type/relation_type_access.go
@@ -280,6 +280,15 @@ func (rta *relationTypeAccess) ListRelationTypes(ctx context.Context, query inte
 			}
 			relationType.MappingRules = mappings
 		}
+		if relationType.Type == interfaces.RELATION_TYPE_INDIRECT {
+			var mappings interfaces.InDirectMapping
+			err = sonic.Unmarshal(mappingRulesBytes, &mappings)
+			if err != nil {
+				common.LogSafeError(ctx, "Failed to unmarshal mappingRules after getting relation type, err", err)
+				return []*interfaces.RelationType{}, err
+			}
+			relationType.MappingRules = &mappings
+		}
 		if relationType.Type == interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN {
 			var fcj interfaces.FilteredCrossJoinMapping
 			err = sonic.Unmarshal(mappingRulesBytes, &fcj)
@@ -417,6 +426,15 @@ func (rta *relationTypeAccess) GetRelationTypeByID(ctx context.Context, knID str
 		}
 		relationType.MappingRules = mappings
 	}
+	if relationType.Type == interfaces.RELATION_TYPE_INDIRECT {
+		var mappings interfaces.InDirectMapping
+		err = sonic.Unmarshal(mappingRulesBytes, &mappings)
+		if err != nil {
+			common.LogSafeError(ctx, "Failed to unmarshal mappingRules after getting relation type, err", err)
+			return nil, err
+		}
+		relationType.MappingRules = &mappings
+	}
 	if relationType.Type == interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN {
 		var fcj interfaces.FilteredCrossJoinMapping
 		err = sonic.Unmarshal(mappingRulesBytes, &fcj)
@@ -527,6 +545,15 @@ func (rta *relationTypeAccess) GetRelationTypesByIDs(ctx context.Context, knID s
 				return []*interfaces.RelationType{}, err
 			}
 			relationType.MappingRules = mappings
+		}
+		if relationType.Type == interfaces.RELATION_TYPE_INDIRECT {
+			var mappings interfaces.InDirectMapping
+			err = sonic.Unmarshal(mappingRulesBytes, &mappings)
+			if err != nil {
+				common.LogSafeError(ctx, "Failed to unmarshal mappingRules after getting relation type, err", err)
+				return []*interfaces.RelationType{}, err
+			}
+			relationType.MappingRules = &mappings
 		}
 		if relationType.Type == interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN {
 			var fcj interfaces.FilteredCrossJoinMapping
@@ -888,6 +915,15 @@ func (rta *relationTypeAccess) GetAllRelationTypesByKnID(ctx context.Context, kn
 				return map[string]*interfaces.RelationType{}, err
 			}
 			relationType.MappingRules = mappings
+		}
+		if relationType.Type == interfaces.RELATION_TYPE_INDIRECT {
+			var mappings interfaces.InDirectMapping
+			err = sonic.Unmarshal(mappingRulesBytes, &mappings)
+			if err != nil {
+				common.LogSafeError(ctx, "Failed to unmarshal mappingRules after getting relation type, err", err)
+				return map[string]*interfaces.RelationType{}, err
+			}
+			relationType.MappingRules = &mappings
 		}
 		if relationType.Type == interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN {
 			var fcj interfaces.FilteredCrossJoinMapping

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type.go
@@ -83,10 +83,12 @@ func ValidateRelationType(ctx context.Context, relationType *interfaces.Relation
 	// Validate the type field.
 	if relationType.Type != "" {
 		if relationType.Type != interfaces.RELATION_TYPE_DIRECT &&
+			relationType.Type != interfaces.RELATION_TYPE_INDIRECT &&
 			relationType.Type != interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
 				WithErrorDetails(relationTypeInvalidDetail(ctx, "TypeNotSupported", map[string]any{
 					"directType":    interfaces.RELATION_TYPE_DIRECT,
+					"indirectType":  interfaces.RELATION_TYPE_INDIRECT,
 					"crossJoinType": interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN,
 					"type":          relationType.Type,
 				}))
@@ -135,6 +137,8 @@ func validateMappingRules(ctx context.Context, relationType string, mappingRules
 	switch relationType {
 	case interfaces.RELATION_TYPE_DIRECT:
 		return validateDirectMappingRules(ctx, mappingRules, strictMode)
+	case interfaces.RELATION_TYPE_INDIRECT:
+		return validateInDirectMappingRules(ctx, mappingRules, strictMode)
 	case interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN:
 		return validateFilteredCrossJoinMappingRules(ctx, mappingRules, strictMode)
 	default:

--- a/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validate_relation_type_test.go
@@ -137,6 +137,53 @@ func Test_ValidateRelationType(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("Success with indirect relation backed by a resource\n", func() {
+			rt := &interfaces.RelationType{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID:               "rt-data-view",
+					RTName:             "data view relation",
+					SourceObjectTypeID: "ot1",
+					TargetObjectTypeID: "ot2",
+					Type:               interfaces.RELATION_TYPE_INDIRECT,
+					MappingRules: map[string]any{
+						"backing_data_source":  map[string]any{"id": "resource-1", "type": "resource"},
+						"source_mapping_rules": []map[string]any{{"source_property": map[string]any{"name": "source_id"}, "target_property": map[string]any{"name": "resource_source_id"}}},
+						"target_mapping_rules": []map[string]any{{"source_property": map[string]any{"name": "resource_target_id"}, "target_property": map[string]any{"name": "target_id"}}},
+					},
+				},
+			}
+			err := ValidateRelationType(ctx, rt, true)
+			So(err, ShouldBeNil)
+			_, ok := rt.MappingRules.(*interfaces.InDirectMapping)
+			So(ok, ShouldBeTrue)
+		})
+
+		Convey("Rejects legacy data_view relation type\n", func() {
+			rt := &interfaces.RelationType{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID: "rt-legacy-type", RTName: "legacy type", Type: "data_view",
+					MappingRules: map[string]any{
+						"backing_data_source":  map[string]any{"id": "resource-1", "type": "resource"},
+						"source_mapping_rules": []map[string]any{},
+						"target_mapping_rules": []map[string]any{},
+					},
+				},
+			}
+			err := ValidateRelationType(ctx, rt, false)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Rejects legacy data_view backing data source\n", func() {
+			rt := &interfaces.RelationType{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID: "rt-legacy-backing", RTName: "legacy backing", Type: interfaces.RELATION_TYPE_INDIRECT,
+					MappingRules: map[string]any{"backing_data_source": map[string]any{"id": "view-1", "type": "data_view"}},
+				},
+			}
+			err := ValidateRelationType(ctx, rt, false)
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("Failed with direct mapping rules empty source prop\n", func() {
 			rt := &interfaces.RelationType{
 				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
@@ -267,12 +314,12 @@ func TestValidateRelationTypeLocalizesInvalidParameterDetails(t *testing.T) {
 		{
 			name:     "English",
 			language: rest.AmericanEnglish,
-			want:     "Relation type must be direct or filtered_cross_join; received unsupported.",
+			want:     "Relation type must be direct, indirect, or filtered_cross_join; received unsupported.",
 		},
 		{
 			name:     "SimplifiedChinese",
 			language: rest.SimplifiedChinese,
-			want:     "关系类型仅支持 direct 和 filtered_cross_join，当前为 unsupported。",
+			want:     "关系类型仅支持 direct、indirect 和 filtered_cross_join，当前为 unsupported。",
 		},
 	}
 

--- a/adp/bkn/bkn-backend/server/interfaces/relation_type.go
+++ b/adp/bkn/bkn-backend/server/interfaces/relation_type.go
@@ -10,6 +10,7 @@ import cond "bkn-backend/common/condition"
 
 const (
 	RELATION_TYPE_DIRECT              = "direct"
+	RELATION_TYPE_INDIRECT            = "indirect"
 	RELATION_TYPE_FILTERED_CROSS_JOIN = "filtered_cross_join"
 )
 

--- a/adp/bkn/bkn-backend/server/locale/relation_type.en-US.toml
+++ b/adp/bkn/bkn-backend/server/locale/relation_type.en-US.toml
@@ -70,7 +70,7 @@ Solution = "Please try again. If the error occurs again, please submit the work 
 ErrorLink = ""
 
 [BknBackend.RelationType.InvalidParameter.Detail]
-TypeNotSupported = "Relation type must be {{.directType}} or {{.crossJoinType}}; received {{.type}}."
+TypeNotSupported = "Relation type must be {{.directType}}, {{.indirectType}}, or {{.crossJoinType}}; received {{.type}}."
 SourceObjectTypeIDRequired = "source_object_type_id is required for a relation type."
 TargetObjectTypeIDRequired = "target_object_type_id is required for a relation type."
 MappingRulesRequired = "mapping_rules is required for a relation type."
@@ -86,6 +86,8 @@ BackingDataSourceRequired = "backing_data_source is required for an indirect rel
 BackingDataSourceTypeRequired = "backing_data_source.type is required."
 BackingDataSourceTypeInvalid = "backing_data_source.type must be {{.expected}}; received {{.actual}}."
 BackingDataSourceIDRequired = "backing_data_source.id is required."
+BackingDataSourceNotFound = "The backing resource {{.resource}} does not exist."
+BackingPropertyNotFound = "The property {{.property}} does not exist on backing resource {{.resource}}."
 SourceMappingRulesRequired = "source_mapping_rules is required for an indirect relation type."
 SourceMappingSourcePropertyRequired = "source_mapping_rules[{{.index}}].source_property.name is required."
 SourceMappingBridgePropertyRequired = "source_mapping_rules[{{.index}}].target_property.name is required."

--- a/adp/bkn/bkn-backend/server/locale/relation_type.zh-CN.toml
+++ b/adp/bkn/bkn-backend/server/locale/relation_type.zh-CN.toml
@@ -70,7 +70,7 @@ Solution = "请重试该操作，若再次出现该错误请提交工单或联�
 ErrorLink = ""
 
 [BknBackend.RelationType.InvalidParameter.Detail]
-TypeNotSupported = "关系类型仅支持 {{.directType}} 和 {{.crossJoinType}}，当前为 {{.type}}。"
+TypeNotSupported = "关系类型仅支持 {{.directType}}、{{.indirectType}} 和 {{.crossJoinType}}，当前为 {{.type}}。"
 SourceObjectTypeIDRequired = "关系类的 source_object_type_id 不能为空。"
 TargetObjectTypeIDRequired = "关系类的 target_object_type_id 不能为空。"
 MappingRulesRequired = "关系类的 mapping_rules 不能为空。"
@@ -86,6 +86,8 @@ BackingDataSourceRequired = "间接关联的 backing_data_source 不能为空。
 BackingDataSourceTypeRequired = "backing_data_source.type 不能为空。"
 BackingDataSourceTypeInvalid = "backing_data_source.type 必须为 {{.expected}}，当前为 {{.actual}}。"
 BackingDataSourceIDRequired = "backing_data_source.id 不能为空。"
+BackingDataSourceNotFound = "backing 资源 {{.resource}} 不存在。"
+BackingPropertyNotFound = "backing 资源 {{.resource}} 中不存在字段 {{.property}}。"
 SourceMappingRulesRequired = "间接关联的 source_mapping_rules 不能为空。"
 SourceMappingSourcePropertyRequired = "source_mapping_rules[{{.index}}].source_property.name 不能为空。"
 SourceMappingBridgePropertyRequired = "source_mapping_rules[{{.index}}].target_property.name 不能为空。"

--- a/adp/bkn/bkn-backend/server/logics/common.go
+++ b/adp/bkn/bkn-backend/server/logics/common.go
@@ -94,19 +94,14 @@ func VegaResourceIndexCaps(res *interfaces.VegaResource) map[string]PropertyInde
 	return caps
 }
 
-// VegaResourceSchemaToFieldsMap maps vega Resource schema to view-like fields for display and validation.
-func VegaResourceSchemaToFieldsMap(res *interfaces.VegaResource) map[string]*interfaces.ViewField {
-	fields := make(map[string]*interfaces.ViewField)
+// VegaResourceSchemaToPropertiesMap maps a Vega Resource schema by property name.
+func VegaResourceSchemaToPropertiesMap(res *interfaces.VegaResource) map[string]*interfaces.Property {
+	properties := make(map[string]*interfaces.Property)
 	for _, p := range res.SchemaDefinition {
 		if p == nil {
 			continue
 		}
-		fields[p.Name] = &interfaces.ViewField{
-			Name:         p.Name,
-			Type:         p.Type,
-			DisplayName:  p.DisplayName,
-			OriginalName: p.OriginalName,
-		}
+		properties[p.Name] = p
 	}
-	return fields
+	return properties
 }

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -1643,14 +1643,14 @@ func (ots *objectTypeService) processObjectTypeDetails(ctx context.Context, obje
 					objectType.OTID, objectType.DataSource.ID, err))
 			} else {
 				objectType.DataSource.Name = res.Name
-				fieldsMap := logics.VegaResourceSchemaToFieldsMap(res)
+				propertiesMap := logics.VegaResourceSchemaToPropertiesMap(res)
 				indexCaps := logics.VegaResourceIndexCaps(res)
 				dslView := &interfaces.DataView{QueryType: interfaces.VIEW_QueryType_DSL}
 				for j, prop := range objectType.DataProperties {
 					if prop.MappedField != nil {
-						if field, exists := fieldsMap[prop.MappedField.Name]; exists {
-							objectType.DataProperties[j].MappedField.DisplayName = field.DisplayName
-							objectType.DataProperties[j].MappedField.Type = field.Type
+						if property, exists := propertiesMap[prop.MappedField.Name]; exists {
+							objectType.DataProperties[j].MappedField.DisplayName = property.DisplayName
+							objectType.DataProperties[j].MappedField.Type = property.Type
 						}
 					}
 					ops := ots.processConditionOperations(objectType, prop, dslView)

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -448,6 +448,53 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 				}
 			}
 
+		case interfaces.RELATION_TYPE_INDIRECT:
+			mappingRules := relationType.MappingRules.(*interfaces.InDirectMapping)
+			var propertiesMap map[string]*interfaces.Property
+			if mappingRules.BackingDataSource != nil && mappingRules.BackingDataSource.ID != "" {
+				if mappingRules.BackingDataSource.Type != interfaces.DATA_SOURCE_TYPE_RESOURCE {
+					return []*interfaces.RelationType{}, logics.UnsupportedRelationBackingDataSourceError(ctx, relationType.RTID, mappingRules.BackingDataSource.Type)
+				}
+				res, err := rts.vbs.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
+				if err != nil {
+					return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
+						berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
+						WithErrorDetails(err.Error())
+				}
+				if res == nil {
+					otellog.LogWarn(ctx, fmt.Sprintf("Relation type [%s]'s backing vega Resource %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
+					if sourceObj == nil && targetObj == nil {
+						continue
+					}
+				} else {
+					mappingRules.BackingDataSource.Name = res.Name
+					propertiesMap = logics.VegaResourceSchemaToPropertiesMap(res)
+				}
+			}
+
+			for k, m := range mappingRules.SourceMappingRules {
+				if sourceObj != nil {
+					relationType.SourceObjectType = interfaces.SimpleObjectType{OTID: relationType.SourceObjectTypeID, OTName: sourceObj.OTName, Icon: sourceObj.Icon, Color: sourceObj.Color}
+					mappingRules.SourceMappingRules[k].SourceProp.DisplayName = sourceObj.PropertyMap[m.SourceProp.Name]
+				}
+				if propertiesMap != nil {
+					if property, ok := propertiesMap[m.TargetProp.Name]; ok && property != nil {
+						mappingRules.SourceMappingRules[k].TargetProp.DisplayName = property.DisplayName
+					}
+				}
+			}
+			for k, m := range mappingRules.TargetMappingRules {
+				if propertiesMap != nil {
+					if property, ok := propertiesMap[m.SourceProp.Name]; ok && property != nil {
+						mappingRules.TargetMappingRules[k].SourceProp.DisplayName = property.DisplayName
+					}
+				}
+				if targetObj != nil {
+					relationType.TargetObjectType = interfaces.SimpleObjectType{OTID: relationType.TargetObjectTypeID, OTName: targetObj.OTName, Icon: targetObj.Icon, Color: targetObj.Color}
+					mappingRules.TargetMappingRules[k].TargetProp.DisplayName = targetObj.PropertyMap[m.TargetProp.Name]
+				}
+			}
+
 		case interfaces.RELATION_TYPE_FILTERED_CROSS_JOIN:
 			if sourceObj != nil {
 				relationType.SourceObjectType = interfaces.SimpleObjectType{
@@ -1256,6 +1303,48 @@ func (rts *relationTypeService) validateDependency(ctx context.Context, tx *sql.
 				if targetObjectType != nil {
 					// Check that target properties exist in target object type data properties.
 					if _, exist := targetObjectType.PropertyMap[mapping.TargetProp.Name]; !exist {
+						return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+							WithErrorDetails(invalidParameterDetail(ctx, "TargetPropertyNotFound", map[string]any{"property": mapping.TargetProp.Name, "objectType": targetObjectType.OTName}))
+					}
+				}
+			}
+		case interfaces.RELATION_TYPE_INDIRECT:
+			mappingRules := relationType.MappingRules.(*interfaces.InDirectMapping)
+			if mappingRules.BackingDataSource == nil {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+					WithErrorDetails(invalidParameterDetail(ctx, "BackingDataSourceRequired", nil))
+			}
+			if mappingRules.BackingDataSource.Type != interfaces.DATA_SOURCE_TYPE_RESOURCE {
+				return logics.UnsupportedRelationBackingDataSourceError(ctx, relationType.RTID, mappingRules.BackingDataSource.Type)
+			}
+			res, err := rts.vbs.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
+			if err != nil {
+				return err
+			}
+			if res == nil {
+				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+					WithErrorDetails(invalidParameterDetail(ctx, "BackingDataSourceNotFound", map[string]any{"resource": mappingRules.BackingDataSource.ID}))
+			}
+			propertiesMap := logics.VegaResourceSchemaToPropertiesMap(res)
+			for _, mapping := range mappingRules.SourceMappingRules {
+				if sourceObjectType != nil {
+					if _, exists := sourceObjectType.PropertyMap[mapping.SourceProp.Name]; !exists {
+						return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+							WithErrorDetails(invalidParameterDetail(ctx, "SourcePropertyNotFound", map[string]any{"property": mapping.SourceProp.Name, "objectType": sourceObjectType.OTName}))
+					}
+				}
+				if _, exists := propertiesMap[mapping.TargetProp.Name]; !exists {
+					return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+						WithErrorDetails(invalidParameterDetail(ctx, "BackingPropertyNotFound", map[string]any{"property": mapping.TargetProp.Name, "resource": res.Name}))
+				}
+			}
+			for _, mapping := range mappingRules.TargetMappingRules {
+				if _, exists := propertiesMap[mapping.SourceProp.Name]; !exists {
+					return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+						WithErrorDetails(invalidParameterDetail(ctx, "BackingPropertyNotFound", map[string]any{"property": mapping.SourceProp.Name, "resource": res.Name}))
+				}
+				if targetObjectType != nil {
+					if _, exists := targetObjectType.PropertyMap[mapping.TargetProp.Name]; !exists {
 						return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
 							WithErrorDetails(invalidParameterDetail(ctx, "TargetPropertyNotFound", map[string]any{"property": mapping.TargetProp.Name, "objectType": targetObjectType.OTName}))
 					}

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -456,13 +456,8 @@ func (rts *relationTypeService) GetRelationTypesByIDs(ctx context.Context, knID 
 					return []*interfaces.RelationType{}, logics.UnsupportedRelationBackingDataSourceError(ctx, relationType.RTID, mappingRules.BackingDataSource.Type)
 				}
 				res, err := rts.vbs.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
-				if err != nil {
-					return []*interfaces.RelationType{}, rest.NewHTTPError(ctx, http.StatusInternalServerError,
-						berrors.BknBackend_RelationType_InternalError_GetDataViewByIDFailed).
-						WithErrorDetails(err.Error())
-				}
-				if res == nil {
-					otellog.LogWarn(ctx, fmt.Sprintf("Relation type [%s]'s backing vega Resource %s not found", relationType.RTID, mappingRules.BackingDataSource.ID))
+				if err != nil || res == nil {
+					otellog.LogWarn(ctx, fmt.Sprintf("Relation type [%s]'s backing vega Resource %s not found, error: %v", relationType.RTID, mappingRules.BackingDataSource.ID, err))
 					if sourceObj == nil && targetObj == nil {
 						continue
 					}

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -329,18 +329,40 @@ func Test_relationTypeService_GetRelationTypesByIDs(t *testing.T) {
 					TargetObjectTypeID: "ot2",
 					MappingRules: &interfaces.InDirectMapping{
 						BackingDataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource1"},
+						SourceMappingRules: []interfaces.Mapping{{
+							SourceProp: interfaces.SimpleProperty{Name: "source_prop"},
+							TargetProp: interfaces.SimpleProperty{Name: "resource_source_prop"},
+						}},
+						TargetMappingRules: []interfaces.Mapping{{
+							SourceProp: interfaces.SimpleProperty{Name: "resource_target_prop"},
+							TargetProp: interfaces.SimpleProperty{Name: "target_prop"},
+						}},
 					},
 				},
 			}}
 
 			rta.EXPECT().GetRelationTypesByIDs(gomock.Any(), knID, branch, rtIDs).Return(rtArr, nil)
-			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), knID, branch, []string{"ot1", "ot2"}, true).Return(map[string]*interfaces.ObjectType{}, nil)
+			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), knID, branch, []string{"ot1", "ot2"}, true).Return(map[string]*interfaces.ObjectType{
+				"ot1": {
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot1", OTName: "Source"},
+					PropertyMap:            map[string]string{"source_prop": "Source Property"},
+				},
+				"ot2": {
+					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{OTID: "ot2", OTName: "Target"},
+					PropertyMap:            map[string]string{"target_prop": "Target Property"},
+				},
+			}, nil)
 			vbs.EXPECT().GetResourceByID(gomock.Any(), "resource1").Return(nil, errors.New("vega unavailable"))
 			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
 
 			result, err := service.GetRelationTypesByIDs(ctx, knID, branch, rtIDs)
 			So(err, ShouldBeNil)
 			So(result, ShouldHaveLength, 1)
+			So(result[0].SourceObjectType.OTName, ShouldEqual, "Source")
+			So(result[0].TargetObjectType.OTName, ShouldEqual, "Target")
+			mappingRules := result[0].MappingRules.(*interfaces.InDirectMapping)
+			So(mappingRules.SourceMappingRules[0].SourceProp.DisplayName, ShouldEqual, "Source Property")
+			So(mappingRules.TargetMappingRules[0].TargetProp.DisplayName, ShouldEqual, "Target Property")
 		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -9,6 +9,7 @@ package relation_type
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -162,6 +163,7 @@ func Test_relationTypeService_GetRelationTypesByIDs(t *testing.T) {
 			DoAndReturn(allowAllRelationPermissionResources).AnyTimes()
 		ots := bmock.NewMockObjectTypeService(mockCtrl)
 		ums := bmock.NewMockUserMgmtService(mockCtrl)
+		vbs := bmock.NewMockVegaBackendService(mockCtrl)
 
 		service := &relationTypeService{
 			appSetting: appSetting,
@@ -169,6 +171,7 @@ func Test_relationTypeService_GetRelationTypesByIDs(t *testing.T) {
 			ps:         ps,
 			ots:        ots,
 			ums:        ums,
+			vbs:        vbs,
 		}
 
 		Convey("Success getting relation types by IDs\n", func() {
@@ -311,6 +314,33 @@ func Test_relationTypeService_GetRelationTypesByIDs(t *testing.T) {
 			So(len(result), ShouldEqual, 1)
 			So(result[0].SourceObjectType.OTID, ShouldEqual, "ot1")
 			So(result[0].TargetObjectType.OTID, ShouldEqual, "ot2")
+		})
+
+		Convey("Degrades when backing resource lookup fails for INDIRECT type\n", func() {
+			knID := "kn1"
+			branch := interfaces.MAIN_BRANCH
+			rtIDs := []string{"rt1"}
+			rtArr := []*interfaces.RelationType{{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID:               "rt1",
+					RTName:             "rt1",
+					Type:               interfaces.RELATION_TYPE_INDIRECT,
+					SourceObjectTypeID: "ot1",
+					TargetObjectTypeID: "ot2",
+					MappingRules: &interfaces.InDirectMapping{
+						BackingDataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource1"},
+					},
+				},
+			}}
+
+			rta.EXPECT().GetRelationTypesByIDs(gomock.Any(), knID, branch, rtIDs).Return(rtArr, nil)
+			ots.EXPECT().GetObjectTypesMapByIDs(gomock.Any(), knID, branch, []string{"ot1", "ot2"}, true).Return(map[string]*interfaces.ObjectType{}, nil)
+			vbs.EXPECT().GetResourceByID(gomock.Any(), "resource1").Return(nil, errors.New("vega unavailable"))
+			ums.EXPECT().GetAccountNames(gomock.Any(), gomock.Any()).Return(nil)
+
+			result, err := service.GetRelationTypesByIDs(ctx, knID, branch, rtIDs)
+			So(err, ShouldBeNil)
+			So(result, ShouldHaveLength, 1)
 		})
 	})
 }

--- a/adp/bkn/ontology-query/server/interfaces/relation_type.go
+++ b/adp/bkn/ontology-query/server/interfaces/relation_type.go
@@ -10,6 +10,7 @@ import cond "ontology-query/common/condition"
 
 const (
 	RELATION_TYPE_DIRECT              = "direct"
+	RELATION_TYPE_INDIRECT            = "indirect"
 	RELATION_TYPE_FILTERED_CROSS_JOIN = "filtered_cross_join"
 )
 

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -1035,6 +1035,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Mapping"
+    IndirectMappingRule:
+      description: 关系类型为 indirect 时的匹配规则
+      required:
+        - backing_data_source
+        - source_mapping_rules
+        - target_mapping_rules
+      type: object
+      properties:
+        backing_data_source:
+          $ref: "#/components/schemas/DataSource"
+          description: 数据来源资源
+        source_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
+        target_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
     ReqObjectType:
       description: Object type creation information
       required:
@@ -1256,14 +1275,16 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/m"
               type: array
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
-          description: "Matching rules for the relation. direct uses key mapping; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule with side-specific conditions. A direct mapping maps source object property 1 to target object property 1."
+          description: "Matching rules for the relation. direct uses key mapping; indirect uses IndirectMappingRule backed by a resource; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule with side-specific conditions."
     UpdateRelationType:
       description: Relation type update information
       required:
@@ -1309,13 +1330,15 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/Object"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
-          description: "Matching rules for the relation. direct uses key mapping; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule. A direct mapping maps source object property 1 to target object property 1."
+          description: "Matching rules for the relation. direct uses key mapping; indirect uses IndirectMappingRule backed by a resource; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule."
     ReqActionType:
       description: Action type creation information
       required:
@@ -1737,13 +1760,15 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/Object"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
-          description: "Matching rules for the relation. direct uses key mapping; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule. A direct mapping maps source object property 1 to target object property 1."
+          description: "Matching rules for the relation. direct uses key mapping; indirect uses IndirectMappingRule backed by a resource; filtered_cross_join (FCJ) uses FilteredCrossJoinMappingRule."
         creator:
           $ref: '../_shared/common.yaml#/components/schemas/AccountInfo'
         create_time:

--- a/docs/api/bkn/concept-group.yaml
+++ b/docs/api/bkn/concept-group.yaml
@@ -1123,11 +1123,13 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
           description: Matching rules for the relation. direct uses a Mapping array; filtered_cross_join uses FilteredCrossJoinMappingRule.
         creator:
@@ -1147,6 +1149,24 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/Mapping"
+    IndirectMappingRule:
+      description: Mapping rules for an indirect relation type backed by a Vega resource.
+      required:
+        - backing_data_source
+        - source_mapping_rules
+        - target_mapping_rules
+      type: object
+      properties:
+        backing_data_source:
+          $ref: "#/components/schemas/DataSource"
+        source_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
+        target_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
     FilteredCrossJoinMappingRule:
       description: |
         Matching rules for filtered_cross_join (FCJ). It does not use data views or key mappings.

--- a/docs/api/bkn/relation-type.yaml
+++ b/docs/api/bkn/relation-type.yaml
@@ -597,6 +597,7 @@ paths:
                             name: comment_replyof_comment
                             source_object_type_id: comment
                             target_object_type_id: comment
+                            type: indirect
                             mapping_rules:
                               backing_data_source:
                                 type: resource
@@ -793,6 +794,7 @@ paths:
                             name: person_likes_comment
                             source_object_type_id: person
                             target_object_type_id: comment
+                            type: indirect
                             mapping_rules:
                               source_mapping_rules:
                                 - target_property:
@@ -979,6 +981,24 @@ components:
         name:
           description: Data view name. Returned when retrieving details.
           type: string
+    IndirectMappingRule:
+      description: Mapping rules for an indirect relation type backed by a Vega resource.
+      required:
+        - backing_data_source
+        - source_mapping_rules
+        - target_mapping_rules
+      type: object
+      properties:
+        backing_data_source:
+          $ref: "#/components/schemas/DataSource"
+        source_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
+        target_mapping_rules:
+          type: array
+          items:
+            $ref: "#/components/schemas/Mapping"
     FilteredCrossJoinMappingRule:
       description: |
         Matching rules for the filtered_cross_join relation type (FCJ).
@@ -1404,11 +1424,13 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
           description: Mapping rule. For direct, this is a Mapping array; for filtered_cross_join (FCJ), this is a FilteredCrossJoinMappingRule with per-side conditions and no key mapping.
     UpdateRelationType:
@@ -1451,11 +1473,13 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
           description: Associated matching rule. For direct, this is a Mapping array; for filtered_cross_join, this is a FilteredCrossJoinMappingRule.
     RelationTypeDetail:
@@ -1521,11 +1545,13 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
           description: Associated matching rule. For direct, this is a Mapping array; for filtered_cross_join, this is a FilteredCrossJoinMappingRule.
         creator:
@@ -1605,11 +1631,13 @@ components:
           description: Relation type
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
           description: Associated matching rule. For direct, this is a Mapping array; for filtered_cross_join, this is a FilteredCrossJoinMappingRule.
         creator:
@@ -1760,14 +1788,16 @@ components:
           description: Target object type ID
           type: string
         type:
-          description: Relation type. direct uses direct key mapping; filtered_cross_join uses per-side filtered cross join (FCJ) without array-form key mapping.
+          description: Relation type. direct uses direct key mapping; indirect uses a Vega resource backing source; filtered_cross_join uses per-side filtered cross join (FCJ) without array-form key mapping.
           enum:
             - direct
+            - indirect
             - filtered_cross_join
           type: string
         mapping_rules:
           oneOf:
             - $ref: "#/components/schemas/DirectMappingRules"
+            - $ref: "#/components/schemas/IndirectMappingRule"
             - $ref: "#/components/schemas/FilteredCrossJoinMappingRule"
     TypeEdge:
       description: Path edge

--- a/help/en/manual/bkn.md
+++ b/help/en/manual/bkn.md
@@ -64,7 +64,7 @@ Display Key: pod_name
 
 | Type | ID | Name |
 |------|-----|------|
-| data_view | pod_info_view | pod_info_view |
+| resource | pod_info_resource | pod_info_resource |
 ```
 
 Heading levels are fixed: `#` for network title, `##` for type definitions (`ObjectType:` / `RelationType:` / `ActionType:`), `###` for sections within a type (Data Properties, Keys, Endpoint, etc.).

--- a/help/zh/manual/bkn.md
+++ b/help/zh/manual/bkn.md
@@ -64,7 +64,7 @@ Display Key: pod_name
 
 | Type | ID | Name |
 |------|-----|------|
-| data_view | pod_info_view | pod_info_view |
+| resource | pod_info_resource | pod_info_resource |
 ```
 
 标题层级固定：`#` 网络标题、`##` 类型定义（`ObjectType:` / `RelationType:` / `ActionType:`）、`###` 类型内 section（Data Properties、Keys、Endpoint 等）。


### PR DESCRIPTION
## What Changed

- [x] Restore the relation type as `indirect` with a resource backing source.
- [x] Update BKN parser, serializer, validator, API contracts, examples, and regression tests.

---

## Why

- Related Issue: Closes #1474
- Background: PR #797 removed an indirect relation capability while removing legacy bindings.

---

## How

- Uses resource native properties for object and indirect-relation mappings.
- Breaking changes: legacy `data_view` relation types are rejected; no compatibility path is retained.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally (not run)
- [ ] Verified in test environment (not run)

Test notes: BKN specification, driver adapter, relation logic, and object logic Go tests passed.

---

## Risk & Rollback

- Potential risks: consumers still emitting legacy relation types will be rejected.
- Rollback plan: revert this PR.

---

## Additional Notes

- Studio, SDK, and engineering updates are submitted separately.