### PR TITLE
fix(vega): reject invalid OutputFields in MariaDB aggregate queries

### DIFF
--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -318,6 +318,44 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})
 
+	for _, tt := range []struct {
+		name      string
+		fieldType string
+		wantError string
+	}{
+		{
+			name:      "binary",
+			fieldType: interfaces.DataType_Binary,
+			wantError: "Binary field \\\"result\\\" cannot be requested by an aggregation query",
+		},
+		{
+			name:      "other",
+			fieldType: interfaces.DataType_Other,
+			wantError: "Other field \\\"result\\\" cannot be requested by an aggregation query",
+		},
+	} {
+		t.Run("rejects aggregate aliases shadowing "+tt.name+" fields", func(t *testing.T) {
+			engine, rs, _, _ := setupResourceDataHandlerTest(t)
+			resource := sampleDatasetResource()
+			resource.SchemaDefinition = []*interfaces.Property{
+				{Name: "score", Type: interfaces.DataType_Integer},
+				{Name: "result", Type: tt.fieldType},
+			}
+			rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+				strings.NewReader(`{"aggregation":{"property":"score","aggr":"count","alias":"result"},"output_fields":["result"]}`))
+			req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+			assert.Contains(t, w.Body.String(), tt.wantError)
+		})
+	}
+
 	t.Run("rejects non-grouped plain output fields in aggregation queries", func(t *testing.T) {
 		engine, rs, _, _ := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()

--- a/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/resource_data_handler_test.go
@@ -293,6 +293,53 @@ func Test_ResourceDataRestHandler_QueryResourceData(t *testing.T) {
 		assert.Contains(t, w.Body.String(), "Other field \\\"metadata\\\" cannot be requested by an aggregation query")
 	})
 
+	t.Run("accepts group fields and the aggregate alias as output fields", func(t *testing.T) {
+		engine, rs, _, rds := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{
+			{Name: "department", Type: interfaces.DataType_String},
+			{Name: "amount", Type: interfaces.DataType_Integer},
+		}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+		rds.EXPECT().QueryWithPaging(gomock.Any(), resource, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *interfaces.Resource, params *interfaces.ResourceDataQueryParams) (*interfaces.ResourceDataQueryResult, error) {
+				assert.Equal(t, []string{"department", "total"}, params.OutputFields)
+				return &interfaces.ResourceDataQueryResult{Entries: []map[string]any{}}, nil
+			})
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"department"}],"aggregation":{"property":"amount","aggr":"sum","alias":"total"},"output_fields":["department","total"]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+
+	t.Run("rejects non-grouped plain output fields in aggregation queries", func(t *testing.T) {
+		engine, rs, _, _ := setupResourceDataHandlerTest(t)
+		resource := sampleDatasetResource()
+		resource.SchemaDefinition = []*interfaces.Property{
+			{Name: "department", Type: interfaces.DataType_String},
+			{Name: "region", Type: interfaces.DataType_String},
+			{Name: "amount", Type: interfaces.DataType_Integer},
+		}
+		rs.EXPECT().GetByID(gomock.Any(), "res-1").Return(resource, nil)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/vega-backend/in/v1/resources/res-1/data",
+			strings.NewReader(`{"group_by":[{"property":"department"}],"aggregation":{"property":"amount","aggr":"sum","alias":"total"},"output_fields":["region"]}`))
+		req.Header.Set(interfaces.HTTP_HEADER_METHOD_OVERRIDE, http.MethodGet)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		engine.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+		assert.Contains(t, w.Body.String(), "must be a group_by field or aggregate alias")
+	})
+
 	t.Run("preserves total count requested by cursor session", func(t *testing.T) {
 		engine, rs, _, rds := setupResourceDataHandlerTest(t)
 		resource := sampleDatasetResource()

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -382,11 +382,26 @@ func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfa
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_Aggregation).
 			WithErrorDetails(fmt.Sprintf("Binary field %q cannot be used in aggregation", params.Aggregation.Property))
 	}
-	groupByFields := make(map[string]struct{}, len(params.GroupBy))
+	// Aggregate results always contain the grouping dimensions and the aggregate
+	// value. output_fields may name those outputs, but cannot introduce another
+	// plain resource field into the projection.
+	validOutputFields := make(map[string]struct{}, len(params.GroupBy)+1)
 	for _, groupByItem := range params.GroupBy {
-		groupByFields[groupByItem.Property] = struct{}{}
+		validOutputFields[groupByItem.Property] = struct{}{}
+	}
+	if params.Aggregation != nil {
+		aggregateAlias := params.Aggregation.Alias
+		if aggregateAlias == "" {
+			aggregateAlias = "__value"
+		}
+		validOutputFields[aggregateAlias] = struct{}{}
+	} else if params.Having != nil && params.Having.Field == "count(*)" {
+		validOutputFields["__value"] = struct{}{}
 	}
 	for _, outputField := range params.OutputFields {
+		if _, valid := validOutputFields[outputField]; valid {
+			continue
+		}
 		fieldType := fields[outputField]
 		if fieldType == interfaces.DataType_Binary {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
@@ -396,10 +411,8 @@ func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfa
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 				WithErrorDetails(fmt.Sprintf("Other field %q cannot be requested by an aggregation query", outputField))
 		}
-		if _, grouped := groupByFields[outputField]; !grouped {
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
-				WithErrorDetails(fmt.Sprintf("Output field %q must be included in group_by for an aggregation query", outputField))
-		}
+		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
+			WithErrorDetails(fmt.Sprintf("Output field %q must be a group_by field or aggregate alias for an aggregation query", outputField))
 	}
 
 	return nil

--- a/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
+++ b/adp/vega/vega-backend/server/driveradapters/validate_resource_data.go
@@ -399,9 +399,6 @@ func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfa
 		validOutputFields["__value"] = struct{}{}
 	}
 	for _, outputField := range params.OutputFields {
-		if _, valid := validOutputFields[outputField]; valid {
-			continue
-		}
 		fieldType := fields[outputField]
 		if fieldType == interfaces.DataType_Binary {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
@@ -410,6 +407,9 @@ func validateResourceDataQueryGroupByFields(ctx context.Context, params *interfa
 		if fieldType == interfaces.DataType_Other {
 			return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 				WithErrorDetails(fmt.Sprintf("Other field %q cannot be requested by an aggregation query", outputField))
+		}
+		if _, valid := validOutputFields[outputField]; valid {
+			continue
 		}
 		return rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_Query_InvalidParameter).
 			WithErrorDetails(fmt.Sprintf("Output field %q must be a group_by field or aggregate alias for an aggregation query", outputField))

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query.go
@@ -130,8 +130,6 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 
 	// Construct the SELECT clause
 	selectFields := []string{}
-	// Output names already selected (column or alias), used to de-duplicate output_fields
-	selected := map[string]struct{}{}
 
 	// Add the GROUP BY field (when aggregating queries)
 	for _, groupByItem := range params.GroupBy {
@@ -140,11 +138,9 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 		if groupByItem.CalendarInterval != "" {
 			dateFmt := c.buildDateFormat(groupByItem.Property, quoteColumnName(column), groupByItem.CalendarInterval)
 			selectFields = append(selectFields, dateFmt+" AS "+quoteColumnName(groupByItem.Property))
-			selected[groupByItem.Property] = struct{}{}
 		} else {
 			selectFields = append(selectFields,
 				quoteColumnName(column)+" AS "+quoteColumnName(groupByItem.Property))
-			selected[groupByItem.Property] = struct{}{}
 		}
 	}
 
@@ -170,12 +166,10 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 		}
 
 		selectFields = append(selectFields, aggFunc+" AS "+quoteColumnName(aggAlias))
-		selected[aggAlias] = struct{}{}
 	} else if params.Having != nil && params.Having.Field == "count(*)" {
 		// When HAVING uses count(*), add the COUNT(*) aggregate automatically
 		aggAlias = "__value"
 		selectFields = append(selectFields, "COUNT(*) AS "+quoteColumnName(aggAlias))
-		selected[aggAlias] = struct{}{}
 	}
 
 	// Select every field when the query is neither aggregated nor grouped
@@ -196,7 +190,10 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 		}
 		return column + " AS " + quoteColumnName(name)
 	}
-	if len(params.GroupBy) == 0 && params.Aggregation == nil {
+	// output_fields controls detail-query projection only. Aggregate projection is
+	// defined by group_by, aggregation, or count(*) having; appending any other
+	// plain field would violate aggregate semantics and differs from PostgreSQL.
+	if len(params.GroupBy) == 0 && params.Aggregation == nil && params.Having == nil {
 		if len(params.OutputFields) > 0 {
 			for _, outName := range params.OutputFields {
 				selectFields = append(selectFields, selectField(outName))
@@ -208,15 +205,6 @@ func (c *MariaDBConnector) buildSelectBuilder(resource *interfaces.Resource,
 			for _, prop := range resource.SchemaDefinition {
 				selectFields = append(selectFields, selectField(prop.Name))
 			}
-		}
-	} else if len(params.OutputFields) > 0 {
-		// For aggregate or GROUP BY queries, make sure output_fields end up in selectFields
-		for _, outName := range params.OutputFields {
-			if _, found := selected[outName]; found {
-				continue
-			}
-			selectFields = append(selectFields, selectField(outName))
-			selected[outName] = struct{}{}
 		}
 	}
 

--- a/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
+++ b/adp/vega/vega-backend/server/logics/connector/local/table/mariadb/mariadb_query_test.go
@@ -271,11 +271,11 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 			sql)
 	})
 
-	t.Run("output_fields already selected as an alias are not duplicated", func(t *testing.T) {
+	t.Run("aggregate output_fields do not alter the grouped and aggregate projection", func(t *testing.T) {
 		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
 			GroupBy:      []*interfaces.GroupByItem{{Property: "key"}},
 			Aggregation:  &interfaces.Aggregation{Property: "id", Aggr: "count", Alias: "cnt"},
-			OutputFields: []string{"key", "cnt"},
+			OutputFields: []string{"key", "cnt", "created"},
 			Paging:       interfaces.PagingRequest{Limit: 20},
 		}, fieldMap, nil)
 		require.NoError(t, err)
@@ -284,6 +284,21 @@ func TestBuildSelectBuilderQuotesIdentifiers(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t,
 			"SELECT `key` AS `key`, COUNT(`id`) AS `cnt` FROM `yanfeng_kb`.`fact` GROUP BY `key` LIMIT 20 OFFSET 0",
+			sql)
+	})
+
+	t.Run("count star having output_fields do not alter the aggregate projection", func(t *testing.T) {
+		builder, err := connector.buildSelectBuilder(resource, &interfaces.ResourceDataQueryParams{
+			Having:       &interfaces.HavingClause{Field: "count(*)", Operation: ">=", Value: 3},
+			OutputFields: []string{"created"},
+			Paging:       interfaces.PagingRequest{Limit: 20},
+		}, fieldMap, nil)
+		require.NoError(t, err)
+
+		sql, _, err := builder.ToSql()
+		require.NoError(t, err)
+		assert.Equal(t,
+			"SELECT COUNT(*) AS `__value` FROM `yanfeng_kb`.`fact` HAVING COUNT(*) >= 3 LIMIT 20 OFFSET 0",
 			sql)
 	})
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Prevent MariaDB aggregate queries from appending plain `output_fields` to the aggregate projection.
- [x] Validate that aggregate `output_fields` contain only grouping fields or the aggregate alias.
- [x] Add regression coverage for grouped aggregation, aliases, invalid plain fields, and `HAVING count(*)`.

---

## Why

- Related Issue: Closes #1480
- Related Feature: N/A — bug fix
- Background: MariaDB generated invalid SQL under `ONLY_FULL_GROUP_BY`, or nondeterministic grouped values in permissive SQL modes, when a plain output field was appended to an aggregate query.

---

## How

- Key implementation points:
  - Treat `output_fields` as detail-query projection controls only in the MariaDB query builder.
  - Preserve aggregate projections defined by `group_by`, `aggregation`, and `HAVING count(*)`.
  - Reject non-grouped, non-aggregate output fields during schema-aware request validation.
- Breaking changes (API, config, database, etc.): No schema, configuration, or database changes. Requests relying on permissive invalid aggregate projections now receive a validation error.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally
- [ ] Verified in test environment

Test notes:

- `make ci` passed from `adp/vega/vega-backend` (lint: 0 issues; unit coverage: 37.8%).
- Focused MariaDB, PostgreSQL, and resource-data handler tests passed.
- `git diff --check` passed.
- A live MariaDB integration environment was not used.

---

## Risk & Rollback

- Potential risks: Callers that relied on MariaDB returning an arbitrary non-grouped value will now receive a clear validation error. `HAVING count(*)` remains supported.
- Rollback plan: Revert this PR; no data or schema rollback is required.

---

## Additional Notes

- The behavior now matches the existing PostgreSQL aggregate projection semantics.
- No documentation artifact is required because the selected contract is captured in validation errors, code comments, and regression tests.