### PR TITLE
fix(bkn-backend): preserve dependency validation semantics

### DIFF
--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access.go
@@ -39,14 +39,6 @@ type agentOperatorAccess struct {
 	httpClient       rest.HTTPClient
 }
 
-type OperatorError struct {
-	Code        string      `json:"code"`        // Error code
-	Description string      `json:"description"` // Error description
-	Detail      interface{} `json:"detail"`      // Error details
-	Solution    interface{} `json:"solution"`    // Suggested resolution
-	Link        interface{} `json:"link"`        // Error link
-}
-
 // NewAgentOperatorAccess returns a singleton ToolBox and MCP access client.
 func NewAgentOperatorAccess(appSetting *common.AppSetting) interfaces.AgentOperatorAccess {
 	aoAccessOnce.Do(func() {
@@ -65,7 +57,8 @@ func (aoa *agentOperatorAccess) GetToolByID(ctx context.Context, boxID, toolID s
 	defer span.End()
 
 	if boxID == "" || toolID == "" {
-		err := fmt.Errorf("box_id and tool_id are required for tool binding check")
+		err := interfaces.NewDependencyError("execution-factory", "get_tool",
+			interfaces.DependencyInvalidBinding, 0)
 		common.LogSafeError(ctx, "Invalid tool binding parameter", err)
 		return err
 	}
@@ -95,43 +88,36 @@ func (aoa *agentOperatorAccess) GetToolByID(ctx context.Context, boxID, toolID s
 	if err != nil {
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http get tool failed")
 		common.LogSafeError(ctx, "Tool binding check request failed", err)
-		return fmt.Errorf("tool binding check failed: %w", err)
+		return executionDependencyTransportError("get_tool", respCode, err)
 	}
 	if respCode == http.StatusOK {
+		var payload struct {
+			ToolID string `json:"tool_id"`
+		}
+		if err := json.Unmarshal(result, &payload); err != nil || strings.TrimSpace(payload.ToolID) != toolID {
+			invalidErr := interfaces.NewDependencyError("execution-factory", "get_tool",
+				interfaces.DependencyInvalidResponse, respCode)
+			if err != nil {
+				common.LogSafeError(ctx, "Tool binding response was invalid", err)
+			} else {
+				common.LogSafeError(ctx, "Tool binding response was invalid", invalidErr)
+			}
+			return invalidErr
+		}
 		oteltrace.AddHttpAttrs4Ok(span, respCode)
 		return nil
 	}
-	if respCode == http.StatusNotFound {
-		err := fmt.Errorf("tool not found: box_id=%s tool_id=%s", boxID, toolID)
-		oteltrace.AddHttpAttrs4Error(span, respCode, "NotFound", "Tool not found")
-		common.LogSafeError(ctx, "Tool not found", err)
-		return err
-	}
-	if respCode != http.StatusOK {
-		var opError OperatorError
-		if err = json.Unmarshal(result, &opError); err != nil {
-			oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Unmarshal OperatorError failed")
-			common.LogSafeError(ctx, "Unmarshal OperatorError failed", err)
-			return fmt.Errorf("tool binding check failed: %w", err)
-		}
-		httpErr := &rest.HTTPError{HTTPCode: respCode,
-			BaseError: rest.BaseError{
-				ErrorCode:    opError.Code,
-				Description:  opError.Description,
-				ErrorDetails: opError.Detail,
-			}}
-		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
-		common.LogSafeError(ctx, "Tool binding check failed", httpErr)
-		return fmt.Errorf("tool binding check returned HTTP %d", respCode)
-	}
-	oteltrace.AddHttpAttrs4Ok(span, respCode)
-	return nil
+	kind := executionDependencyKindForStatus(respCode)
+	oteltrace.AddHttpAttrs4Error(span, respCode, "DependencyError", "Tool binding check failed")
+	logger.Debugf("Tool binding check response: %s", common.SafeTextSummary("response", string(result)))
+	return interfaces.NewDependencyError("execution-factory", "get_tool", kind, respCode)
 }
 
 // CheckMCPToolBinding verifies MCP exposes a tool with toolName (GET .../mcp/proxy/{mcp_id}/tools).
 func (aoa *agentOperatorAccess) GetMcpToolByName(ctx context.Context, mcpID, toolName string) error {
 	if mcpID == "" || toolName == "" {
-		err := fmt.Errorf("mcp_id and tool_name are required for MCP tool binding check")
+		err := interfaces.NewDependencyError("execution-factory", "get_mcp_tool",
+			interfaces.DependencyInvalidBinding, 0)
 		common.LogSafeError(ctx, "Invalid MCP tool binding parameter", err)
 		return err
 	}
@@ -144,7 +130,8 @@ func (aoa *agentOperatorAccess) GetMcpToolByName(ctx context.Context, mcpID, too
 		return err
 	}
 	if tools == nil {
-		return fmt.Errorf("MCP server not found: mcp_id=%s", mcpID)
+		return interfaces.NewDependencyError("execution-factory", "get_mcp_tool",
+			interfaces.DependencyNotFound, http.StatusNotFound)
 	}
 	want := strings.TrimSpace(toolName)
 	for _, tool := range tools {
@@ -152,7 +139,8 @@ func (aoa *agentOperatorAccess) GetMcpToolByName(ctx context.Context, mcpID, too
 			return nil
 		}
 	}
-	return fmt.Errorf("MCP tool not found: mcp_id=%s tool_name=%s", mcpID, want)
+	return interfaces.NewDependencyError("execution-factory", "get_mcp_tool",
+		interfaces.DependencyNotFound, http.StatusNotFound)
 }
 
 // execFactoryHeaders carries the caller's account to the execution factory. The internal face
@@ -448,7 +436,8 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 	defer span.End()
 
 	if mcpID == "" {
-		return nil, fmt.Errorf("mcp_id is required for MCP server lookup")
+		return nil, interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			interfaces.DependencyInvalidBinding, 0)
 	}
 
 	detailURL := fmt.Sprintf("%s/mcp/%s", aoa.agentOperatorURL, mcpID)
@@ -462,7 +451,7 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 	if err != nil {
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Http get MCP server failed")
 		common.LogSafeError(ctx, "MCP server lookup request failed", err)
-		return nil, fmt.Errorf("MCP server lookup failed: %w", err)
+		return nil, executionDependencyTransportError("list_mcp_tools", respCode, err)
 	}
 	if respCode == http.StatusNotFound {
 		oteltrace.AddHttpAttrs4Ok(span, respCode)
@@ -472,7 +461,8 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 		common.LogSafeError(ctx, "MCP server lookup failed",
 			fmt.Errorf("MCP server lookup returned HTTP %d", respCode))
 		oteltrace.AddHttpAttrs4Error(span, respCode, "InternalError", "Get MCP server failed")
-		return nil, fmt.Errorf("MCP server lookup returned HTTP %d", respCode)
+		return nil, interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			executionDependencyKindForStatus(respCode), respCode)
 	}
 
 	var detail struct {
@@ -484,14 +474,21 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 	}
 	if err = json.Unmarshal(result, &detail); err != nil {
 		common.LogSafeError(ctx, "Unmarshal MCP server detail failed", err)
-		return nil, fmt.Errorf("MCP server lookup failed: %w", err)
+		return nil, interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			interfaces.DependencyInvalidResponse, respCode)
+	}
+	if strings.TrimSpace(detail.BaseInfo.MCPID) != mcpID || strings.TrimSpace(detail.BaseInfo.Status) == "" {
+		invalidErr := interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			interfaces.DependencyInvalidResponse, respCode)
+		common.LogSafeError(ctx, "MCP server detail response was invalid", invalidErr)
+		return nil, invalidErr
 	}
 
 	toolsURL := fmt.Sprintf("%s/mcp/proxy/%s/tools", aoa.agentOperatorURL, mcpID)
 	respCode, result, err = aoa.httpClient.GetNoUnmarshal(ctx, toolsURL, nil, aoa.execFactoryHeaders(ctx))
 	if err != nil {
 		common.LogSafeError(ctx, "MCP tool listing request failed", err)
-		return nil, fmt.Errorf("MCP tool listing failed: %w", err)
+		return nil, executionDependencyTransportError("list_mcp_tools", respCode, err)
 	}
 	if respCode == http.StatusNotFound {
 		return nil, nil
@@ -499,22 +496,35 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 	if respCode != http.StatusOK {
 		common.LogSafeError(ctx, "MCP tool listing failed",
 			fmt.Errorf("MCP tool listing returned HTTP %d", respCode))
-		return nil, fmt.Errorf("MCP tool listing returned HTTP %d", respCode)
+		return nil, interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			executionDependencyKindForStatus(respCode), respCode)
 	}
 
 	var payload struct {
-		Tools []struct {
+		Tools *[]struct {
 			Name        string `json:"name"`
 			Description string `json:"description"`
 		} `json:"tools"`
 	}
-	if err = json.Unmarshal(result, &payload); err != nil {
-		common.LogSafeError(ctx, "Unmarshal MCP tool listing failed", err)
-		return nil, fmt.Errorf("MCP tool listing failed: %w", err)
+	if err = json.Unmarshal(result, &payload); err != nil || payload.Tools == nil {
+		invalidErr := interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+			interfaces.DependencyInvalidResponse, respCode)
+		if err != nil {
+			common.LogSafeError(ctx, "Unmarshal MCP tool listing failed", err)
+		} else {
+			common.LogSafeError(ctx, "MCP tool listing response was invalid", invalidErr)
+		}
+		return nil, invalidErr
 	}
 
-	tools := make([]*interfaces.MCPToolBrief, 0, len(payload.Tools))
-	for _, tool := range payload.Tools {
+	tools := make([]*interfaces.MCPToolBrief, 0, len(*payload.Tools))
+	for _, tool := range *payload.Tools {
+		if strings.TrimSpace(tool.Name) == "" {
+			invalidErr := interfaces.NewDependencyError("execution-factory", "list_mcp_tools",
+				interfaces.DependencyInvalidResponse, respCode)
+			common.LogSafeError(ctx, "MCP tool listing entry was invalid", invalidErr)
+			return nil, invalidErr
+		}
 		tools = append(tools, &interfaces.MCPToolBrief{
 			MCPID:       mcpID,
 			MCPName:     detail.BaseInfo.Name,
@@ -524,6 +534,28 @@ func (aoa *agentOperatorAccess) ListMCPTools(ctx context.Context, mcpID string) 
 		})
 	}
 	return tools, nil
+}
+
+func executionDependencyTransportError(operation string, status int, err error) error {
+	kind := interfaces.DependencyTransportKind(err)
+	return interfaces.NewDependencyError("execution-factory", operation, kind, status)
+}
+
+func executionDependencyKindForStatus(status int) interfaces.DependencyErrorKind {
+	switch status {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return interfaces.DependencyForbidden
+	case http.StatusNotFound:
+		return interfaces.DependencyNotFound
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return interfaces.DependencyInvalidBinding
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return interfaces.DependencyTimeout
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable:
+		return interfaces.DependencyUnavailable
+	default:
+		return interfaces.DependencyDownstreamError
+	}
 }
 
 // FindMCPServersByName resolves an MCP Server name to the ids that carry it exactly.

--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access_test.go
@@ -1,5 +1,4 @@
 // Copyright openbkn.ai
-// Copyright The kweaver.ai Authors.
 //
 // Licensed under the Apache License, Version 2.0.
 

--- a/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/agent_operator/agent_operator_access_test.go
@@ -1,0 +1,156 @@
+// Copyright openbkn.ai
+// Copyright The kweaver.ai Authors.
+//
+// Licensed under the Apache License, Version 2.0.
+
+package agent_operator
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	rmock "github.com/openbkn-ai/bkn-foundry/comm-go/rest/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"bkn-backend/interfaces"
+)
+
+func TestGetToolByIDClassifiesSafeDependencyErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       []byte
+		requestErr error
+		kind       interfaces.DependencyErrorKind
+	}{
+		{name: "forbidden", status: http.StatusForbidden, body: []byte(`{"secret":"policy"}`), kind: interfaces.DependencyForbidden},
+		{name: "not found", status: http.StatusNotFound, kind: interfaces.DependencyNotFound},
+		{name: "timeout", requestErr: context.DeadlineExceeded, kind: interfaces.DependencyTimeout},
+		{name: "unavailable", requestErr: errors.New("dial tcp 10.0.0.1: refused"), kind: interfaces.DependencyUnavailable},
+		{name: "downstream 5xx", status: http.StatusInternalServerError, body: []byte(`{"secret":"stack"}`), kind: interfaces.DependencyDownstreamError},
+		{name: "invalid response", status: http.StatusOK, body: []byte(`not-json-secret`), kind: interfaces.DependencyInvalidResponse},
+		{name: "missing tools field", status: http.StatusOK, body: []byte(`{}`), kind: interfaces.DependencyInvalidResponse},
+		{name: "null tools field", status: http.StatusOK, body: []byte(`{"tools":null}`), kind: interfaces.DependencyInvalidResponse},
+		{name: "invalid tool entry", status: http.StatusOK, body: []byte(`{"tools":[{"name":""}]}`), kind: interfaces.DependencyInvalidResponse},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			httpClient := rmock.NewMockHTTPClient(ctrl)
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(tc.status, tc.body, tc.requestErr)
+			access := &agentOperatorAccess{agentOperatorURL: "http://execution", httpClient: httpClient}
+
+			err := access.GetToolByID(t.Context(), "box-1", "tool-1")
+
+			var dependencyErr *interfaces.DependencyError
+			require.ErrorAs(t, err, &dependencyErr)
+			assert.Equal(t, tc.kind, dependencyErr.Kind)
+			assert.NotContains(t, err.Error(), "secret")
+			assert.NotContains(t, err.Error(), "10.0.0.1")
+		})
+	}
+}
+
+func TestGetMcpToolByNameTreatsExplicitEmptyToolListAsNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	httpClient := rmock.NewMockHTTPClient(ctrl)
+	gomock.InOrder(
+		httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://execution/mcp/mcp-1", nil, gomock.Any()).
+			Return(http.StatusOK, []byte(`{"base_info":{"mcp_id":"mcp-1","name":"orders","status":"published"}}`), nil),
+		httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://execution/mcp/proxy/mcp-1/tools", nil, gomock.Any()).
+			Return(http.StatusOK, []byte(`{"tools":[]}`), nil),
+	)
+	access := &agentOperatorAccess{agentOperatorURL: "http://execution", httpClient: httpClient}
+
+	err := access.GetMcpToolByName(t.Context(), "mcp-1", "create_order")
+
+	var dependencyErr *interfaces.DependencyError
+	require.ErrorAs(t, err, &dependencyErr)
+	assert.Equal(t, interfaces.DependencyNotFound, dependencyErr.Kind)
+}
+
+func TestGetToolByIDAcceptsMatchingToolResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	httpClient := rmock.NewMockHTTPClient(ctrl)
+	httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(http.StatusOK, []byte(`{"tool_id":"tool-1"}`), nil)
+	access := &agentOperatorAccess{agentOperatorURL: "http://execution", httpClient: httpClient}
+
+	require.NoError(t, access.GetToolByID(t.Context(), "box-1", "tool-1"))
+}
+
+func TestGetMcpToolByNameClassifiesServerLookupErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       []byte
+		requestErr error
+		kind       interfaces.DependencyErrorKind
+	}{
+		{name: "not found", status: http.StatusNotFound, kind: interfaces.DependencyNotFound},
+		{name: "forbidden", status: http.StatusForbidden, body: []byte(`{"secret":"policy"}`), kind: interfaces.DependencyForbidden},
+		{name: "timeout", requestErr: context.DeadlineExceeded, kind: interfaces.DependencyTimeout},
+		{name: "downstream 5xx", status: http.StatusInternalServerError, body: []byte(`{"secret":"stack"}`), kind: interfaces.DependencyDownstreamError},
+		{name: "invalid response", status: http.StatusOK, body: []byte(`not-json-secret`), kind: interfaces.DependencyInvalidResponse},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			httpClient := rmock.NewMockHTTPClient(ctrl)
+			httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://execution/mcp/mcp-1", nil, gomock.Any()).
+				Return(tc.status, tc.body, tc.requestErr)
+			access := &agentOperatorAccess{agentOperatorURL: "http://execution", httpClient: httpClient}
+
+			err := access.GetMcpToolByName(t.Context(), "mcp-1", "create_order")
+
+			var dependencyErr *interfaces.DependencyError
+			require.ErrorAs(t, err, &dependencyErr)
+			assert.Equal(t, tc.kind, dependencyErr.Kind)
+			assert.NotContains(t, err.Error(), "secret")
+		})
+	}
+}
+
+func TestGetMcpToolByNameClassifiesToolListingErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       []byte
+		requestErr error
+		kind       interfaces.DependencyErrorKind
+	}{
+		{name: "not found", status: http.StatusNotFound, kind: interfaces.DependencyNotFound},
+		{name: "unavailable", requestErr: errors.New("dial tcp 10.0.0.1: refused"), kind: interfaces.DependencyUnavailable},
+		{name: "downstream 5xx", status: http.StatusInternalServerError, body: []byte(`{"secret":"stack"}`), kind: interfaces.DependencyDownstreamError},
+		{name: "invalid response", status: http.StatusOK, body: []byte(`not-json-secret`), kind: interfaces.DependencyInvalidResponse},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			httpClient := rmock.NewMockHTTPClient(ctrl)
+			gomock.InOrder(
+				httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://execution/mcp/mcp-1", nil, gomock.Any()).
+					Return(http.StatusOK, []byte(`{"base_info":{"mcp_id":"mcp-1","name":"orders","status":"published"}}`), nil),
+				httpClient.EXPECT().GetNoUnmarshal(gomock.Any(), "http://execution/mcp/proxy/mcp-1/tools", nil, gomock.Any()).
+					Return(tc.status, tc.body, tc.requestErr),
+			)
+			access := &agentOperatorAccess{agentOperatorURL: "http://execution", httpClient: httpClient}
+
+			err := access.GetMcpToolByName(t.Context(), "mcp-1", "create_order")
+
+			var dependencyErr *interfaces.DependencyError
+			require.ErrorAs(t, err, &dependencyErr)
+			assert.Equal(t, tc.kind, dependencyErr.Kind)
+			assert.NotContains(t, err.Error(), "secret")
+			assert.NotContains(t, err.Error(), "10.0.0.1")
+		})
+	}
+}

--- a/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/kn_proxy/safe_client_test.go
@@ -59,6 +59,9 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(interfaces.ProxyGrantBatchCheckResult{
 			DeniedSources: body.Sources,
+			ResolvedSources: []interfaces.ProxyGrantResolvedSource{{
+				ProxyGrantSourceSpec: body.Sources[0], GrantedBy: "historical-grantor",
+			}},
 		})
 	})
 	mux.HandleFunc("/api/safe/in/v1/proxy-grant-sources/sync", func(w http.ResponseWriter, r *http.Request) {
@@ -117,7 +120,8 @@ func TestSafeClientUsesManagedInternalContracts(t *testing.T) {
 		SourceType: interfaces.ProxyGrantSourceTypeKNBinding, SourceID: "source-1", KNID: "kn-1",
 		BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
 	}})
-	if err != nil || len(batchResult.DeniedSources) != 1 || batchResult.DeniedSources[0].BindingID != "ot-1" {
+	if err != nil || len(batchResult.DeniedSources) != 1 || batchResult.DeniedSources[0].BindingID != "ot-1" ||
+		len(batchResult.ResolvedSources) != 1 || batchResult.ResolvedSources[0].GrantedBy != "historical-grantor" {
 		t.Fatalf("CheckGrants() = %#v, %v", batchResult, err)
 	}
 	syncResult, err := client.SyncGrants(t.Context(), "proxy-1", "grantor-1", nil)

--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access.go
@@ -210,6 +210,92 @@ func (vba *vegaBackendAccess) GetResourceByID(ctx context.Context, id string) (*
 	return resourceData.Entries[0], nil
 }
 
+// GetResourceSchema reads only the schema required by strict model validation.
+// A resolved historical delegator from bkn-safe takes precedence over the
+// current editor, and Vega rechecks the exact declared operation.
+func (vba *vegaBackendAccess) GetResourceSchema(ctx context.Context, id, operation string) (*interfaces.VegaResource, error) {
+	ctx, span := oteltrace.StartNamedClientSpan(ctx, "driven layer: Get resource schema")
+	defer span.End()
+
+	if id == "" || (operation != interfaces.OPERATION_TYPE_VIEW_DETAIL && operation != interfaces.OPERATION_TYPE_QUERY_DATA) {
+		return nil, interfaces.NewDependencyError("vega", "get_resource_schema",
+			interfaces.DependencyInvalidBinding, 0)
+	}
+
+	httpURL := fmt.Sprintf("%s/resources/%s/schema", vba.baseUrl, url.PathEscape(id))
+	params := url.Values{"operation": []string{operation}}
+	account := interfaces.AccountInfo{}
+	if resolvedAccount, ok := interfaces.VerifiedDependencyAccount(ctx, "resource", id, operation); ok {
+		account = resolvedAccount
+	} else if interfaces.HasVerifiedDependencySources(ctx) {
+		return nil, interfaces.NewDependencyError("vega", "get_resource_schema",
+			interfaces.DependencyInvalidResponse, 0)
+	} else if value := ctx.Value(interfaces.ACCOUNT_INFO_KEY); value != nil {
+		account, _ = value.(interfaces.AccountInfo)
+	}
+	if account.ID == "" || account.Type == "" {
+		return nil, interfaces.NewDependencyError("vega", "get_resource_schema",
+			interfaces.DependencyForbidden, http.StatusForbidden)
+	}
+	headers := map[string]string{
+		interfaces.CONTENT_TYPE_NAME:        interfaces.CONTENT_TYPE_JSON,
+		interfaces.HTTP_HEADER_ACCOUNT_ID:   account.ID,
+		interfaces.HTTP_HEADER_ACCOUNT_TYPE: account.Type,
+	}
+
+	respCode, respData, err := vba.httpClient.GetNoUnmarshal(ctx, httpURL, params, headers)
+	logger.Debugf("GetResourceSchema finished, response code is [%d], %s", respCode, common.SafeErrorSummary(err))
+	if err != nil {
+		common.LogSafeError(ctx, "GetResourceSchema request failed", err)
+		kind := interfaces.DependencyTransportKind(err)
+		return nil, interfaces.NewDependencyError("vega", "get_resource_schema", kind, respCode)
+	}
+
+	kind := dependencyKindForStatus(respCode)
+	if kind != "" {
+		logger.Debugf("GetResourceSchema response: %s", common.SafeTextSummary("response", string(respData)))
+		return nil, interfaces.NewDependencyError("vega", "get_resource_schema", kind, respCode)
+	}
+
+	var payload struct {
+		ID               string                  `json:"id"`
+		Name             string                  `json:"name"`
+		SchemaDefinition *[]*interfaces.Property `json:"schema_definition"`
+	}
+	if err := vegaResponseJSON.Unmarshal(respData, &payload); err != nil || payload.ID != id ||
+		payload.Name == "" || payload.SchemaDefinition == nil {
+		invalidErr := interfaces.NewDependencyError("vega", "get_resource_schema",
+			interfaces.DependencyInvalidResponse, respCode)
+		if err != nil {
+			common.LogSafeError(ctx, "GetResourceSchema response was invalid", err)
+		} else {
+			common.LogSafeError(ctx, "GetResourceSchema response was invalid", invalidErr)
+		}
+		return nil, invalidErr
+	}
+	oteltrace.AddHttpAttrs4Ok(span, respCode)
+	return &interfaces.VegaResource{
+		ID: payload.ID, Name: payload.Name, SchemaDefinition: *payload.SchemaDefinition,
+	}, nil
+}
+
+func dependencyKindForStatus(status int) interfaces.DependencyErrorKind {
+	switch status {
+	case http.StatusOK:
+		return ""
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return interfaces.DependencyForbidden
+	case http.StatusNotFound:
+		return interfaces.DependencyNotFound
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return interfaces.DependencyTimeout
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable:
+		return interfaces.DependencyUnavailable
+	default:
+		return interfaces.DependencyDownstreamError
+	}
+}
+
 func (vba *vegaBackendAccess) CreateResource(ctx context.Context, req *interfaces.VegaResource) error {
 	ctx, span := oteltrace.StartNamedClientSpan(ctx, "driven layer: Create resource")
 	defer span.End()

--- a/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access_test.go
+++ b/adp/bkn/bkn-backend/server/drivenadapters/vega_backend/vega_backend_access_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -53,6 +54,125 @@ func TestResourceDataQueryRequestUsesPagingContract(t *testing.T) {
 		_, err := resourceDataQueryRequest(&interfaces.ResourceDataQueryParams{})
 		require.Error(t, err)
 	})
+}
+
+func TestGetResourceSchemaUsesResolvedDelegatorAndOperation(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+	var gotHeaders map[string]string
+	mockHTTPClient.EXPECT().
+		GetNoUnmarshal(gomock.Any(), "http://vega/resources/resource-1/schema", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, params url.Values, headers map[string]string) (int, []byte, error) {
+			gotHeaders = headers
+			assert.Equal(t, interfaces.OPERATION_TYPE_QUERY_DATA, params.Get("operation"))
+			return http.StatusOK, []byte(`{"id":"resource-1","name":"orders","schema_definition":[{"name":"order_id","type":"integer"}]}`), nil
+		})
+
+	access := &vegaBackendAccess{httpClient: mockHTTPClient, baseUrl: "http://vega"}
+	ctx := context.WithValue(context.Background(), interfaces.ACCOUNT_INFO_KEY,
+		interfaces.AccountInfo{ID: "current-editor", Type: interfaces.ACCESSOR_TYPE_USER})
+	ctx = interfaces.WithVerifiedDependencySources(ctx, []interfaces.ProxyGrantResolvedSource{{
+		ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_QUERY_DATA,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_RELATION_TYPE, BindingID: "rt-1",
+		},
+		GrantedBy: "historical-grantor",
+	}})
+	ctx = interfaces.WithDependencyBindingScope(ctx, "kn-1", interfaces.MODULE_TYPE_RELATION_TYPE, "rt-1")
+
+	resource, err := access.GetResourceSchema(ctx, "resource-1", interfaces.OPERATION_TYPE_QUERY_DATA)
+
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+	assert.Equal(t, "orders", resource.Name)
+	assert.Equal(t, "historical-grantor", gotHeaders[interfaces.HTTP_HEADER_ACCOUNT_ID])
+	assert.Equal(t, interfaces.ACCESSOR_TYPE_USER, gotHeaders[interfaces.HTTP_HEADER_ACCOUNT_TYPE])
+}
+
+func TestGetResourceSchemaRefusesWithoutCallerIdentity(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+	// No GetNoUnmarshal expectation: falling back to the platform administrator
+	// and reaching Vega would bypass the resource-scoped permission check.
+	access := &vegaBackendAccess{httpClient: mockHTTPClient, baseUrl: "http://vega"}
+
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+	}{
+		{name: "missing identity", ctx: context.Background()},
+		{name: "empty identity", ctx: context.WithValue(context.Background(),
+			interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := access.GetResourceSchema(tc.ctx, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+			var dependencyErr *interfaces.DependencyError
+			require.ErrorAs(t, err, &dependencyErr)
+			assert.Equal(t, interfaces.DependencyForbidden, dependencyErr.Kind)
+		})
+	}
+}
+
+func TestGetResourceSchemaClassifiesSafeDependencyErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       []byte
+		requestErr error
+		kind       interfaces.DependencyErrorKind
+	}{
+		{name: "forbidden", status: http.StatusForbidden, body: []byte(`{"secret":"permission detail"}`), kind: interfaces.DependencyForbidden},
+		{name: "not found", status: http.StatusNotFound, kind: interfaces.DependencyNotFound},
+		{name: "timeout", requestErr: context.DeadlineExceeded, kind: interfaces.DependencyTimeout},
+		{name: "unavailable", requestErr: errors.New("dial tcp 10.0.0.1: refused"), kind: interfaces.DependencyUnavailable},
+		{name: "downstream 4xx", status: http.StatusBadRequest, body: []byte(`{"secret":"contract detail"}`), kind: interfaces.DependencyDownstreamError},
+		{name: "downstream 5xx", status: http.StatusInternalServerError, body: []byte(`{"secret":"sql text"}`), kind: interfaces.DependencyDownstreamError},
+		{name: "invalid response", status: http.StatusOK, body: []byte(`not-json-with-secret`), kind: interfaces.DependencyInvalidResponse},
+		{name: "missing schema", status: http.StatusOK, body: []byte(`{"id":"resource-1","name":"orders"}`), kind: interfaces.DependencyInvalidResponse},
+		{name: "null schema", status: http.StatusOK, body: []byte(`{"id":"resource-1","name":"orders","schema_definition":null}`), kind: interfaces.DependencyInvalidResponse},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+			mockHTTPClient.EXPECT().GetNoUnmarshal(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(tc.status, tc.body, tc.requestErr)
+			access := &vegaBackendAccess{httpClient: mockHTTPClient, baseUrl: "http://vega"}
+			ctx := context.WithValue(context.Background(), interfaces.ACCOUNT_INFO_KEY,
+				interfaces.AccountInfo{ID: "user-1", Type: interfaces.ACCESSOR_TYPE_USER})
+
+			_, err := access.GetResourceSchema(ctx, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+			var dependencyErr *interfaces.DependencyError
+			require.ErrorAs(t, err, &dependencyErr)
+			assert.Equal(t, tc.kind, dependencyErr.Kind)
+			assert.NotContains(t, err.Error(), "secret")
+			assert.NotContains(t, err.Error(), "10.0.0.1")
+		})
+	}
+}
+
+func TestGetResourceSchemaRejectsVerifiedSourcesWithoutExactBindingScope(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockHTTPClient := rmock.NewMockHTTPClient(mockCtrl)
+	access := &vegaBackendAccess{httpClient: mockHTTPClient, baseUrl: "http://vega"}
+	ctx := context.WithValue(context.Background(), interfaces.ACCOUNT_INFO_KEY,
+		interfaces.AccountInfo{ID: "current-editor", Type: interfaces.ACCESSOR_TYPE_USER})
+	ctx = interfaces.WithVerifiedDependencySources(ctx, []interfaces.ProxyGrantResolvedSource{{
+		ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+		},
+		GrantedBy: "historical-grantor",
+	}})
+
+	_, err := access.GetResourceSchema(ctx, "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL)
+
+	var dependencyErr *interfaces.DependencyError
+	require.ErrorAs(t, err, &dependencyErr)
+	assert.Equal(t, interfaces.DependencyInvalidResponse, dependencyErr.Kind)
 }
 
 func TestQueryResourceDataPreservesLargeIntegers(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/action_type_handler.go
@@ -300,6 +300,9 @@ func (r *restHandler) ValidateActionTypesForKN(c *gin.Context, visitor hydra.Vis
 		return
 	}
 	if err = r.ats.ValidateActionTypes(ctx, knID, branch, actionTypes, strictMode, nil, mode); err != nil {
+		if replyDependencyValidationError(c, span, err) {
+			return
+		}
 		oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 		rest.ReplyOK(c, http.StatusOK, map[string]any{"valid": false, "detail": err.Error()})
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/concept_group_handler.go
@@ -311,6 +311,9 @@ func (r *restHandler) ValidateConceptGroups(c *gin.Context, visitor hydra.Visito
 		}
 	}
 	if err = r.cgs.ValidateConceptGroups(ctx, knID, branch, conceptGroups, strictMode, nil, mode); err != nil {
+		if replyDependencyValidationError(c, span, err) {
+			return
+		}
 		oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 		rest.ReplyOK(c, http.StatusOK, map[string]any{"valid": false, "detail": err.Error()})
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/knowledge_network_handler.go
@@ -338,6 +338,9 @@ func (r *restHandler) ValidateKN(c *gin.Context, visitor hydra.Visitor) {
 		}
 	}
 	if err = r.kns.ValidateKN(ctx, &kn, strictMode, mode); err != nil {
+		if replyDependencyValidationError(c, span, err) {
+			return
+		}
 		oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 		rest.ReplyOK(c, http.StatusOK, map[string]any{"valid": false, "detail": err.Error()})
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/object_type_handler.go
@@ -303,6 +303,9 @@ func (r *restHandler) ValidateObjectTypesForKN(c *gin.Context, visitor hydra.Vis
 		return
 	}
 	if err = r.ots.ValidateObjectTypes(ctx, knID, branch, objectTypes, strictMode, nil, mode); err != nil {
+		if replyDependencyValidationError(c, span, err) {
+			return
+		}
 		oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 		rest.ReplyOK(c, http.StatusOK, map[string]any{"valid": false, "detail": err.Error()})
 		return

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -302,6 +303,9 @@ func (r *restHandler) ValidateRelationTypesForKN(c *gin.Context, visitor hydra.V
 		return
 	}
 	if err = r.rts.ValidateRelationTypes(ctx, knID, branch, relationTypes, strictMode, nil, mode); err != nil {
+		if replyDependencyValidationError(c, span, err) {
+			return
+		}
 		oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
 		rest.ReplyOK(c, http.StatusOK, map[string]any{"valid": false, "detail": err.Error()})
 		return
@@ -449,7 +453,11 @@ func (r *restHandler) UpdateRelationType(c *gin.Context, visitor hydra.Visitor) 
 	// Update the resource by ID.
 	err = r.updateRelationType(ctx, &relationType, strictMode)
 	if err != nil {
-		httpErr := err.(*rest.HTTPError)
+		var httpErr *rest.HTTPError
+		if !errors.As(err, &httpErr) {
+			httpErr = rest.NewHTTPError(ctx, http.StatusBadGateway,
+				berrors.BknBackend_RelationType_InternalError)
+		}
 
 		// Set trace attributes for the error.
 		oteltrace.AddHttpAttrs4HttpError(span, httpErr)

--- a/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/relation_type_handler_test.go
@@ -8,6 +8,7 @@ package driveradapters
 
 import (
 	"bytes"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -317,6 +318,21 @@ func Test_RelationTypeRestHandler_UpdateRelationType(t *testing.T) {
 			engine.ServeHTTP(w, req)
 
 			So(w.Result().StatusCode, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("Generic dependency failure is returned without panic\n", func() {
+			kns.EXPECT().CheckKNExistByID(gomock.Any(), knID, gomock.Any()).Return(knID, true, nil)
+			rts.EXPECT().CheckRelationTypeExistByID(gomock.Any(), knID, gomock.Any(), rtID).Return("relation2", true, nil)
+			rts.EXPECT().UpdateRelationType(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(errors.New("untyped dependency failure"))
+
+			reqParamByte, _ := sonic.Marshal(relationType)
+			req := httptest.NewRequest(http.MethodPut, url, bytes.NewReader(reqParamByte))
+			req.Header.Set(interfaces.CONTENT_TYPE_NAME, interfaces.CONTENT_TYPE_JSON)
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			So(w.Result().StatusCode, ShouldEqual, http.StatusBadGateway)
 		})
 
 		Convey("UpdateRelationTypeByIn - Success\n", func() {

--- a/adp/bkn/bkn-backend/server/driveradapters/validation_dependency_error.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validation_dependency_error.go
@@ -1,0 +1,32 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"errors"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"go.opentelemetry.io/otel/trace"
+
+	"bkn-backend/logics"
+)
+
+// replyDependencyValidationError keeps validate-only endpoints machine
+// readable for dependency failures while preserving HTTP 200 valid:false for
+// ordinary model-validation feedback.
+func replyDependencyValidationError(c *gin.Context, span trace.Span, err error) bool {
+	if !logics.IsDependencyHTTPError(err) {
+		return false
+	}
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+	rest.ReplyError(c, httpErr)
+	return true
+}

--- a/adp/bkn/bkn-backend/server/driveradapters/validation_dependency_error_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/validation_dependency_error_test.go
@@ -1,0 +1,51 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package driveradapters
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+
+	berrors "bkn-backend/errors"
+	"bkn-backend/interfaces"
+	"bkn-backend/logics"
+)
+
+func TestReplyDependencyValidationErrorPreservesMachineReadableContract(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/validation", nil)
+	err := logics.MapDependencyError(context.Background(),
+		interfaces.NewDependencyError("vega", "get_resource_schema", interfaces.DependencyTimeout, 0),
+		false,
+		rest.NewHTTPError(context.Background(), http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter),
+		berrors.BknBackend_ObjectType_InternalError)
+
+	replied := replyDependencyValidationError(ctx, trace.SpanFromContext(context.Background()), err)
+
+	require.True(t, replied)
+	assert.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), `"dependency_kind":"timeout"`)
+	assert.NotContains(t, recorder.Body.String(), "vega")
+}
+
+func TestReplyDependencyValidationErrorLeavesOrdinaryValidationFeedbackAlone(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+
+	assert.False(t, replyDependencyValidationError(ctx,
+		trace.SpanFromContext(context.Background()), errors.New("invalid model")))
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}

--- a/adp/bkn/bkn-backend/server/interfaces/dependency_error.go
+++ b/adp/bkn/bkn-backend/server/interfaces/dependency_error.go
@@ -1,0 +1,56 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type DependencyErrorKind string
+
+const (
+	DependencyInvalidBinding  DependencyErrorKind = "invalid_binding"
+	DependencyForbidden       DependencyErrorKind = "forbidden"
+	DependencyNotFound        DependencyErrorKind = "not_found"
+	DependencyTimeout         DependencyErrorKind = "timeout"
+	DependencyUnavailable     DependencyErrorKind = "unavailable"
+	DependencyDownstreamError DependencyErrorKind = "downstream_error"
+	DependencyInvalidResponse DependencyErrorKind = "invalid_response"
+)
+
+// DependencyError carries only a safe machine-readable category. Raw response
+// bodies and transport causes belong in controlled logs and traces.
+type DependencyError struct {
+	Dependency string
+	Operation  string
+	Kind       DependencyErrorKind
+	HTTPStatus int
+}
+
+func (e *DependencyError) Error() string {
+	if e == nil {
+		return "dependency request failed"
+	}
+	return fmt.Sprintf("%s dependency %s failed: %s", e.Dependency, e.Operation, e.Kind)
+}
+
+func NewDependencyError(dependency, operation string, kind DependencyErrorKind, status int) error {
+	return &DependencyError{Dependency: dependency, Operation: operation, Kind: kind, HTTPStatus: status}
+}
+
+// DependencyTransportKind distinguishes timeouts without retaining the raw
+// network error in the error returned across the adapter boundary.
+func DependencyTransportKind(err error) DependencyErrorKind {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return DependencyTimeout
+	}
+	var timeout interface{ Timeout() bool }
+	if errors.As(err, &timeout) && timeout.Timeout() {
+		return DependencyTimeout
+	}
+	return DependencyUnavailable
+}

--- a/adp/bkn/bkn-backend/server/interfaces/dependency_lookup.go
+++ b/adp/bkn/bkn-backend/server/interfaces/dependency_lookup.go
@@ -1,0 +1,61 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import "context"
+
+type verifiedDependencySourcesContextKey struct{}
+type dependencyBindingScopeContextKey struct{}
+
+type dependencyBindingScope struct {
+	KNID        string
+	BindingType string
+	BindingID   string
+}
+
+// WithVerifiedDependencySources makes a server-resolved proxy preflight result
+// available to strict dependency validation in the same publication request.
+func WithVerifiedDependencySources(ctx context.Context, sources []ProxyGrantResolvedSource) context.Context {
+	if len(sources) == 0 {
+		return ctx
+	}
+	copyOfSources := append([]ProxyGrantResolvedSource(nil), sources...)
+	return context.WithValue(ctx, verifiedDependencySourcesContextKey{}, copyOfSources)
+}
+
+// WithDependencyBindingScope identifies the concrete server-built KN binding
+// whose downstream dependency is about to be read.
+func WithDependencyBindingScope(ctx context.Context, knID, bindingType, bindingID string) context.Context {
+	return context.WithValue(ctx, dependencyBindingScopeContextKey{}, dependencyBindingScope{
+		KNID: knID, BindingType: bindingType, BindingID: bindingID,
+	})
+}
+
+// HasVerifiedDependencySources reports whether proxy preflight established a
+// controlled dependency lookup for this publication request.
+func HasVerifiedDependencySources(ctx context.Context) bool {
+	sources, ok := ctx.Value(verifiedDependencySourcesContextKey{}).([]ProxyGrantResolvedSource)
+	return ok && len(sources) > 0
+}
+
+// VerifiedDependencyAccount returns the effective delegator for one exact
+// target operation. The target list comes from the server-built candidate
+// model and bkn-safe preflight, never from a client assertion.
+func VerifiedDependencyAccount(ctx context.Context, resourceType, resourceID, operation string) (AccountInfo, bool) {
+	sources, _ := ctx.Value(verifiedDependencySourcesContextKey{}).([]ProxyGrantResolvedSource)
+	scope, scoped := ctx.Value(dependencyBindingScopeContextKey{}).(dependencyBindingScope)
+	if len(sources) > 0 && !scoped {
+		return AccountInfo{}, false
+	}
+	for _, source := range sources {
+		if source.ResourceType == resourceType && source.ResourceID == resourceID &&
+			source.Operation == operation && source.KNID == scope.KNID &&
+			source.BindingType == scope.BindingType && source.BindingID == scope.BindingID &&
+			source.GrantedBy != "" {
+			return AccountInfo{ID: source.GrantedBy, Type: ACCESSOR_TYPE_USER}, true
+		}
+	}
+	return AccountInfo{}, false
+}

--- a/adp/bkn/bkn-backend/server/interfaces/dependency_lookup_test.go
+++ b/adp/bkn/bkn-backend/server/interfaces/dependency_lookup_test.go
@@ -1,0 +1,45 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package interfaces
+
+import (
+	"context"
+	"testing"
+)
+
+func TestVerifiedDependencyAccountUsesExactBindingIdentity(t *testing.T) {
+	ctx := WithVerifiedDependencySources(context.Background(), []ProxyGrantResolvedSource{
+		{
+			ProxyGrantSourceSpec: ProxyGrantSourceSpec{
+				ResourceType: "resource", ResourceID: "resource-1", Operation: OPERATION_TYPE_QUERY_DATA,
+				KNID: "kn-1", BindingType: MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+			},
+			GrantedBy: "object-grantor",
+		},
+		{
+			ProxyGrantSourceSpec: ProxyGrantSourceSpec{
+				ResourceType: "resource", ResourceID: "resource-1", Operation: OPERATION_TYPE_QUERY_DATA,
+				KNID: "kn-1", BindingType: MODULE_TYPE_RELATION_TYPE, BindingID: "rt-1",
+			},
+			GrantedBy: "relation-grantor",
+		},
+	})
+
+	objectCtx := WithDependencyBindingScope(ctx, "kn-1", MODULE_TYPE_OBJECT_TYPE, "ot-1")
+	objectAccount, ok := VerifiedDependencyAccount(objectCtx, "resource", "resource-1", OPERATION_TYPE_QUERY_DATA)
+	if !ok || objectAccount.ID != "object-grantor" {
+		t.Fatalf("object binding account = (%+v, %v), want object-grantor", objectAccount, ok)
+	}
+
+	relationCtx := WithDependencyBindingScope(ctx, "kn-1", MODULE_TYPE_RELATION_TYPE, "rt-1")
+	relationAccount, ok := VerifiedDependencyAccount(relationCtx, "resource", "resource-1", OPERATION_TYPE_QUERY_DATA)
+	if !ok || relationAccount.ID != "relation-grantor" {
+		t.Fatalf("relation binding account = (%+v, %v), want relation-grantor", relationAccount, ok)
+	}
+
+	if _, ok := VerifiedDependencyAccount(ctx, "resource", "resource-1", OPERATION_TYPE_QUERY_DATA); ok {
+		t.Fatal("unscoped lookup unexpectedly selected one of multiple binding delegators")
+	}
+}

--- a/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
+++ b/adp/bkn/bkn-backend/server/interfaces/kn_proxy.go
@@ -121,7 +121,15 @@ type ProxyGrantCheckResult struct {
 }
 
 type ProxyGrantBatchCheckResult struct {
-	DeniedSources []ProxyGrantSourceSpec `json:"denied_sources"`
+	DeniedSources   []ProxyGrantSourceSpec     `json:"denied_sources"`
+	ResolvedSources []ProxyGrantResolvedSource `json:"resolved_sources"`
+}
+
+// ProxyGrantResolvedSource identifies the effective delegator retained or
+// selected by bkn-safe for an allowed source.
+type ProxyGrantResolvedSource struct {
+	ProxyGrantSourceSpec
+	GrantedBy string `json:"granted_by"`
 }
 
 type ProxyGrantSyncResult struct {

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_vega_backend_access.go
@@ -142,6 +142,21 @@ func (mr *MockVegaBackendAccessMockRecorder) GetResourceByID(ctx, id any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceByID", reflect.TypeOf((*MockVegaBackendAccess)(nil).GetResourceByID), ctx, id)
 }
 
+// GetResourceSchema mocks base method.
+func (m *MockVegaBackendAccess) GetResourceSchema(ctx context.Context, id, operation string) (*interfaces.VegaResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceSchema", ctx, id, operation)
+	ret0, _ := ret[0].(*interfaces.VegaResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceSchema indicates an expected call of GetResourceSchema.
+func (mr *MockVegaBackendAccessMockRecorder) GetResourceSchema(ctx, id, operation any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceSchema", reflect.TypeOf((*MockVegaBackendAccess)(nil).GetResourceSchema), ctx, id, operation)
+}
+
 // QueryResourceData mocks base method.
 func (m *MockVegaBackendAccess) QueryResourceData(ctx context.Context, resourceID string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_vega_backend_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_vega_backend_service.go
@@ -142,6 +142,21 @@ func (mr *MockVegaBackendServiceMockRecorder) GetResourceByID(ctx, id any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceByID", reflect.TypeOf((*MockVegaBackendService)(nil).GetResourceByID), ctx, id)
 }
 
+// GetResourceSchema mocks base method.
+func (m *MockVegaBackendService) GetResourceSchema(ctx context.Context, id, operation string) (*interfaces.VegaResource, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetResourceSchema", ctx, id, operation)
+	ret0, _ := ret[0].(*interfaces.VegaResource)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetResourceSchema indicates an expected call of GetResourceSchema.
+func (mr *MockVegaBackendServiceMockRecorder) GetResourceSchema(ctx, id, operation any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourceSchema", reflect.TypeOf((*MockVegaBackendService)(nil).GetResourceSchema), ctx, id, operation)
+}
+
 // QueryResourceData mocks base method.
 func (m *MockVegaBackendService) QueryResourceData(ctx context.Context, resourceID string, params *interfaces.ResourceDataQueryParams) (*interfaces.DatasetQueryResponse, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_access.go
@@ -69,6 +69,9 @@ type VegaBackendAccess interface {
 	// GetResourceByID gets resource by ID
 	GetResourceByID(ctx context.Context, id string) (*VegaResource, error)
 
+	// GetResourceSchema gets the minimal schema view after checking the exact operation.
+	GetResourceSchema(ctx context.Context, id, operation string) (*VegaResource, error)
+
 	// CreateResource creates a new resource
 	CreateResource(ctx context.Context, req *VegaResource) error
 

--- a/adp/bkn/bkn-backend/server/interfaces/vega_backend_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/vega_backend_service.go
@@ -15,6 +15,7 @@ type VegaBackendService interface {
 	GetCatalogByID(ctx context.Context, id string) (*Catalog, error)
 	CreateCatalog(ctx context.Context, req *CatalogRequest) (*Catalog, error)
 	GetResourceByID(ctx context.Context, id string) (*VegaResource, error)
+	GetResourceSchema(ctx context.Context, id, operation string) (*VegaResource, error)
 	CreateResource(ctx context.Context, req *VegaResource) error
 	DeleteResource(ctx context.Context, id string) error
 	QueryResourceData(ctx context.Context, resourceID string, params *ResourceDataQueryParams) (*DatasetQueryResponse, error)

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -148,6 +148,9 @@ func (ats *actionTypeService) validateActionSourceStrict(ctx context.Context, at
 					"boxID":      src.BoxID,
 					"toolID":     src.ToolID,
 				}))
+			// The execution-factory internal metadata endpoint does not perform
+			// caller resource authorization. A 403 therefore indicates an
+			// internal identity/configuration failure, not a user-scoped denial.
 			return logics.MapDependencyError(ctx, err, false, invalidErr,
 				berrors.BknBackend_ActionType_InternalError)
 		}
@@ -164,6 +167,9 @@ func (ats *actionTypeService) validateActionSourceStrict(ctx context.Context, at
 					"mcpID":      src.McpID,
 					"toolName":   src.ToolName,
 				}))
+			// The execution-factory internal metadata endpoint does not perform
+			// caller resource authorization. A 403 therefore indicates an
+			// internal identity/configuration failure, not a user-scoped denial.
 			return logics.MapDependencyError(ctx, err, false, invalidErr,
 				berrors.BknBackend_ActionType_InternalError)
 		}

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service.go
@@ -142,12 +142,14 @@ func (ats *actionTypeService) validateActionSourceStrict(ctx context.Context, at
 		if err := ats.aoa.GetToolByID(ctx, src.BoxID, src.ToolID); err != nil {
 			logger.Errorf("validate action type tool binding failed: action_type=%s box_id=%s tool_id=%s err=%v",
 				at.ATName, src.BoxID, src.ToolID, err)
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
+			invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
 				WithErrorDetails(invalidParameterDetail(ctx, "ToolBindingInvalid", map[string]any{
 					"actionType": at.ATName,
 					"boxID":      src.BoxID,
 					"toolID":     src.ToolID,
 				}))
+			return logics.MapDependencyError(ctx, err, false, invalidErr,
+				berrors.BknBackend_ActionType_InternalError)
 		}
 	case interfaces.ACTION_SOURCE_TYPE_MCP:
 		if src.McpID == "" || src.ToolName == "" {
@@ -156,12 +158,14 @@ func (ats *actionTypeService) validateActionSourceStrict(ctx context.Context, at
 		if err := ats.aoa.GetMcpToolByName(ctx, src.McpID, src.ToolName); err != nil {
 			logger.Errorf("validate action type MCP tool binding failed: action_type=%s mcp_id=%s tool_name=%s err=%v",
 				at.ATName, src.McpID, src.ToolName, err)
-			return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
+			invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ActionType_InvalidParameter).
 				WithErrorDetails(invalidParameterDetail(ctx, "MCPBindingInvalid", map[string]any{
 					"actionType": at.ATName,
 					"mcpID":      src.McpID,
 					"toolName":   src.ToolName,
 				}))
+			return logics.MapDependencyError(ctx, err, false, invalidErr,
+				berrors.BknBackend_ActionType_InternalError)
 		}
 	}
 	return nil

--- a/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/action_type/action_type_service_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
@@ -23,6 +25,7 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
+	rootlogics "bkn-backend/logics"
 	"bkn-backend/logics/batchindex"
 )
 
@@ -1847,13 +1850,16 @@ func Test_actionTypeService_ValidateActionTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectATImportOK()
-			aoa.EXPECT().GetToolByID(gomock.Any(), "b1", "t1").Return(errors.New("tool not found"))
+			aoa.EXPECT().GetToolByID(gomock.Any(), "b1", "t1").Return(
+				interfaces.NewDependencyError("execution-factory", "get_tool", interfaces.DependencyNotFound, http.StatusNotFound))
 			err := svc.ValidateActionTypes(ctx, "kn1", interfaces.MAIN_BRANCH, actionTypes, true, nil, interfaces.ImportMode_Normal)
 			So(err, ShouldNotBeNil)
 			httpErr, ok := err.(*rest.HTTPError)
 			So(ok, ShouldBeTrue)
-			So(httpErr.BaseError.ErrorDetails, ShouldEqual, "行动类 [at1] 的工具绑定缺失或无效（box_id=b1，tool_id=t1）。")
-			So(httpErr.BaseError.ErrorDetails, ShouldNotContainSubstring, "tool not found")
+			dependencyDetails, ok := httpErr.BaseError.ErrorDetails.(rootlogics.DependencyPublicErrorDetails)
+			So(ok, ShouldBeTrue)
+			So(dependencyDetails.Detail, ShouldEqual, "行动类 [at1] 的工具绑定缺失或无效（box_id=b1，tool_id=t1）。")
+			So(dependencyDetails.Detail, ShouldNotContainSubstring, "tool not found")
 		})
 
 		Convey("strictMode true succeeds when tool binding check passes\n", func() {
@@ -1907,7 +1913,8 @@ func Test_actionTypeService_ValidateActionTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectATImportOK()
-			aoa.EXPECT().GetMcpToolByName(gomock.Any(), "m1", "fn").Return(errors.New("mcp tool not found"))
+			aoa.EXPECT().GetMcpToolByName(gomock.Any(), "m1", "fn").Return(
+				interfaces.NewDependencyError("execution-factory", "get_mcp_tool", interfaces.DependencyNotFound, http.StatusNotFound))
 			err := svc.ValidateActionTypes(ctx, "kn1", interfaces.MAIN_BRANCH, actionTypes, true, nil, interfaces.ImportMode_Normal)
 			So(err, ShouldNotBeNil)
 		})
@@ -1922,7 +1929,8 @@ func Test_actionTypeService_validateActionSourceStrictLocalizesBindingErrors(t *
 			aoa := bmock.NewMockAgentOperatorAccess(mockCtrl)
 			svc := &actionTypeService{aoa: aoa}
 			ctx := rest.WithLanguage(context.Background(), rest.SimplifiedChinese)
-			aoa.EXPECT().GetToolByID(gomock.Any(), "box-1", "tool-1").Return(errors.New("downstream tool lookup failed"))
+			aoa.EXPECT().GetToolByID(gomock.Any(), "box-1", "tool-1").Return(
+				interfaces.NewDependencyError("execution-factory", "get_tool", interfaces.DependencyNotFound, http.StatusNotFound))
 
 			err := svc.validateActionSourceStrict(ctx, &interfaces.ActionType{
 				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
@@ -1937,8 +1945,10 @@ func Test_actionTypeService_validateActionSourceStrictLocalizesBindingErrors(t *
 
 			httpErr, ok := err.(*rest.HTTPError)
 			So(ok, ShouldBeTrue)
-			So(httpErr.BaseError.ErrorDetails, ShouldEqual, "行动类 [create_order] 的工具绑定缺失或无效（box_id=box-1，tool_id=tool-1）。")
-			So(httpErr.BaseError.ErrorDetails, ShouldNotContainSubstring, "downstream")
+			dependencyDetails, ok := httpErr.BaseError.ErrorDetails.(rootlogics.DependencyPublicErrorDetails)
+			So(ok, ShouldBeTrue)
+			So(dependencyDetails.Detail, ShouldEqual, "行动类 [create_order] 的工具绑定缺失或无效（box_id=box-1，tool_id=tool-1）。")
+			So(dependencyDetails.Detail, ShouldNotContainSubstring, "downstream")
 		})
 
 		Convey("MCP binding error uses the English catalog and omits the downstream error\n", func() {
@@ -1947,7 +1957,8 @@ func Test_actionTypeService_validateActionSourceStrictLocalizesBindingErrors(t *
 			aoa := bmock.NewMockAgentOperatorAccess(mockCtrl)
 			svc := &actionTypeService{aoa: aoa}
 			ctx := rest.WithLanguage(context.Background(), rest.AmericanEnglish)
-			aoa.EXPECT().GetMcpToolByName(gomock.Any(), "mcp-1", "create_order").Return(errors.New("downstream MCP lookup failed"))
+			aoa.EXPECT().GetMcpToolByName(gomock.Any(), "mcp-1", "create_order").Return(
+				interfaces.NewDependencyError("execution-factory", "get_mcp_tool", interfaces.DependencyNotFound, http.StatusNotFound))
 
 			err := svc.validateActionSourceStrict(ctx, &interfaces.ActionType{
 				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
@@ -1962,8 +1973,64 @@ func Test_actionTypeService_validateActionSourceStrictLocalizesBindingErrors(t *
 
 			httpErr, ok := err.(*rest.HTTPError)
 			So(ok, ShouldBeTrue)
-			So(httpErr.BaseError.ErrorDetails, ShouldEqual, "Action type [create_order] MCP tool binding is missing or invalid (mcp_id=mcp-1, tool_name=create_order).")
-			So(httpErr.BaseError.ErrorDetails, ShouldNotContainSubstring, "downstream")
+			dependencyDetails, ok := httpErr.BaseError.ErrorDetails.(rootlogics.DependencyPublicErrorDetails)
+			So(ok, ShouldBeTrue)
+			So(dependencyDetails.Detail, ShouldEqual, "Action type [create_order] MCP tool binding is missing or invalid (mcp_id=mcp-1, tool_name=create_order).")
+			So(dependencyDetails.Detail, ShouldNotContainSubstring, "downstream")
 		})
 	})
+}
+
+func TestActionTypeStrictDependencyErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceType string
+		kind       interfaces.DependencyErrorKind
+		status     int
+		code       string
+	}{
+		{name: "tool invalid binding", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyInvalidBinding, status: http.StatusBadRequest, code: berrors.BknBackend_ActionType_InvalidParameter},
+		{name: "tool missing", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyNotFound, status: http.StatusBadRequest, code: berrors.BknBackend_ActionType_InvalidParameter},
+		{name: "tool forbidden", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyForbidden, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "tool timeout", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyTimeout, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "tool unavailable", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyUnavailable, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "tool downstream", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyDownstreamError, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "tool invalid response", sourceType: interfaces.ACTION_SOURCE_TYPE_TOOL, kind: interfaces.DependencyInvalidResponse, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "mcp invalid binding", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyInvalidBinding, status: http.StatusBadRequest, code: berrors.BknBackend_ActionType_InvalidParameter},
+		{name: "mcp missing", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyNotFound, status: http.StatusBadRequest, code: berrors.BknBackend_ActionType_InvalidParameter},
+		{name: "mcp forbidden", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyForbidden, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "mcp timeout", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyTimeout, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "mcp unavailable", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyUnavailable, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "mcp downstream", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyDownstreamError, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+		{name: "mcp invalid response", sourceType: interfaces.ACTION_SOURCE_TYPE_MCP, kind: interfaces.DependencyInvalidResponse, status: http.StatusBadGateway, code: berrors.BknBackend_ActionType_InternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			aoa := bmock.NewMockAgentOperatorAccess(ctrl)
+			dependencyErr := interfaces.NewDependencyError("execution-factory", "lookup", tc.kind, 0)
+			if tc.sourceType == interfaces.ACTION_SOURCE_TYPE_TOOL {
+				aoa.EXPECT().GetToolByID(gomock.Any(), "box-1", "tool-1").Return(dependencyErr)
+			} else {
+				aoa.EXPECT().GetMcpToolByName(gomock.Any(), "mcp-1", "create_order").Return(dependencyErr)
+			}
+			service := &actionTypeService{aoa: aoa}
+
+			err := service.validateActionSourceStrict(context.Background(), &interfaces.ActionType{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATName: "create_order",
+					ActionSource: interfaces.ActionSource{
+						Type: tc.sourceType, BoxID: "box-1", ToolID: "tool-1",
+						McpID: "mcp-1", ToolName: "create_order",
+					},
+				},
+			})
+
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, tc.status, httpErr.HTTPCode)
+			assert.Equal(t, tc.code, httpErr.BaseError.ErrorCode)
+		})
+	}
 }

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service.go
@@ -243,9 +243,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateObjectTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建对象类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateObjectTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateObjectTypesFailed)
 			}
 
 			// Import path: process group-to-concept relationships.
@@ -264,9 +263,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateRelationTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建关系类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateRelationTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateRelationTypesFailed)
 			}
 		}
 
@@ -275,9 +273,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateActionTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建概念分组动作类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateActionTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateActionTypesFailed)
 			}
 		}
 	}
@@ -299,9 +296,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateObjectTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建对象类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateObjectTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateObjectTypesFailed)
 			}
 			// Import path: create only relationships between this group and current object types.
 			// Updating groups requires full synchronization.
@@ -320,9 +316,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateRelationTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建关系类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateRelationTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateRelationTypesFailed)
 			}
 		}
 
@@ -331,9 +326,8 @@ func (cgs *conceptGroupService) CreateConceptGroup(ctx context.Context, tx *sql.
 			if err != nil {
 				logger.Errorf("CreateActionTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建动作类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_ConceptGroup_InternalError_CreateActionTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_ConceptGroup_InternalError_CreateActionTypesFailed)
 			}
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/concept_group/concept_group_service_test.go
@@ -9,6 +9,7 @@ package concept_group
 import (
 	"context"
 	"database/sql"
+	"net/http"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -21,6 +22,7 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
+	rootlogics "bkn-backend/logics"
 	"bkn-backend/logics/permission"
 )
 
@@ -1662,12 +1664,21 @@ func Test_conceptGroupService_CreateConceptGroup(t *testing.T) {
 			cga.EXPECT().CheckConceptGroupExistByID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			cga.EXPECT().CheckConceptGroupExistByName(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			cga.EXPECT().CreateConceptGroup(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ots.EXPECT().CreateObjectTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_ConceptGroup_InternalError))
+			childErr := rootlogics.MapDependencyError(ctx,
+				interfaces.NewDependencyError("vega", "get_resource_schema", interfaces.DependencyTimeout, 0),
+				false,
+				rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter),
+				berrors.BknBackend_ObjectType_InternalError)
+			ots.EXPECT().CreateObjectTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, childErr)
 			smock.ExpectRollback()
 
 			cgID, err := service.CreateConceptGroup(ctx, nil, conceptGroup, mode, true)
 			So(err, ShouldNotBeNil)
 			So(cgID, ShouldEqual, "")
+			So(err, ShouldEqual, childErr)
+			httpErr := err.(*rest.HTTPError)
+			details := httpErr.BaseError.ErrorDetails.(rootlogics.DependencyPublicErrorDetails)
+			So(details.Kind, ShouldEqual, interfaces.DependencyTimeout)
 		})
 
 		Convey("Failed when AddObjectTypesToConceptGroup returns error\n", func() {

--- a/adp/bkn/bkn-backend/server/logics/dependency_error.go
+++ b/adp/bkn/bkn-backend/server/logics/dependency_error.go
@@ -1,0 +1,89 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package logics
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
+	"bkn-backend/interfaces"
+)
+
+type DependencyPublicErrorDetails struct {
+	Kind   interfaces.DependencyErrorKind `json:"dependency_kind"`
+	Detail any                            `json:"detail,omitempty"`
+}
+
+// MapDependencyError converts a transport-neutral dependency error into a
+// stable public contract. forbiddenIsUserScoped is false for controlled
+// lookups whose identity was resolved by proxy preflight.
+func MapDependencyError(ctx context.Context, err error, forbiddenIsUserScoped bool,
+	invalidError *rest.HTTPError, internalCode string) error {
+	if err == nil {
+		return nil
+	}
+	var httpErr *rest.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr
+	}
+	var dependencyErr *interfaces.DependencyError
+	if !errors.As(err, &dependencyErr) {
+		return rest.NewHTTPError(ctx, http.StatusBadGateway, internalCode)
+	}
+	switch dependencyErr.Kind {
+	case interfaces.DependencyInvalidBinding, interfaces.DependencyNotFound:
+		return markDependencyHTTPError(invalidError, dependencyErr.Kind)
+	case interfaces.DependencyForbidden:
+		if forbiddenIsUserScoped {
+			return markDependencyHTTPError(
+				rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden), dependencyErr.Kind)
+		}
+		return markDependencyHTTPError(
+			rest.NewHTTPError(ctx, http.StatusBadGateway, internalCode), dependencyErr.Kind)
+	case interfaces.DependencyTimeout, interfaces.DependencyUnavailable:
+		return markDependencyHTTPError(
+			rest.NewHTTPError(ctx, http.StatusServiceUnavailable, internalCode), dependencyErr.Kind)
+	default:
+		return markDependencyHTTPError(
+			rest.NewHTTPError(ctx, http.StatusBadGateway, internalCode), dependencyErr.Kind)
+	}
+}
+
+func markDependencyHTTPError(httpErr *rest.HTTPError, kind interfaces.DependencyErrorKind) *rest.HTTPError {
+	httpErr.BaseError.ErrorDetails = DependencyPublicErrorDetails{
+		Kind: kind, Detail: httpErr.BaseError.ErrorDetails,
+	}
+	return httpErr
+}
+
+func IsDependencyHTTPError(err error) bool {
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) {
+		return false
+	}
+	_, ok := httpErr.BaseError.ErrorDetails.(DependencyPublicErrorDetails)
+	return ok
+}
+
+func DependencyErrorKind(err error) (interfaces.DependencyErrorKind, bool) {
+	var dependencyErr *interfaces.DependencyError
+	if !errors.As(err, &dependencyErr) {
+		return "", false
+	}
+	return dependencyErr.Kind, true
+}
+
+// PreserveHTTPError keeps a child resource's public contract at aggregate
+// entry points while converting unexpected generic errors to a safe fallback.
+func PreserveHTTPError(ctx context.Context, err error, fallbackCode string) error {
+	var httpErr *rest.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr
+	}
+	return rest.NewHTTPError(ctx, http.StatusInternalServerError, fallbackCode)
+}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -261,6 +261,9 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 				kns.abortCreatedProxy(context.WithoutCancel(ctx), proxyPlan)
 			}
 		}()
+		if proxyPlan != nil {
+			ctx = interfaces.WithVerifiedDependencySources(ctx, proxyPlan.resolvedSources)
+		}
 	}
 
 	tx, err := kns.db.Begin()
@@ -291,9 +294,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 				if err != nil {
 					logger.Errorf("CreateObjectTypes error: %s", err.Error())
 					span.SetStatus(codes.Error, "创建业务知识网络概念分组失败")
-					return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-						berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed).
-						WithErrorDetails(err.Error())
+					return "", logics.PreserveHTTPError(ctx, err,
+						berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed)
 				}
 			}
 		}
@@ -303,9 +305,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateObjectTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络对象类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed)
 			}
 		}
 
@@ -314,9 +315,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateRelationTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络关系类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateRelationTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateRelationTypesFailed)
 			}
 		}
 
@@ -325,9 +325,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateActionTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络动作类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateActionTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateActionTypesFailed)
 			}
 		}
 
@@ -370,9 +369,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 				if err != nil {
 					logger.Errorf("CreateObjectTypes error: %s", err.Error())
 					span.SetStatus(codes.Error, "创建业务知识网络概念分组失败")
-					return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-						berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed).
-						WithErrorDetails(err.Error())
+					return "", logics.PreserveHTTPError(ctx, err,
+						berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed)
 				}
 			}
 		}
@@ -382,9 +380,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateObjectTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络对象类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateObjectTypesFailed)
 			}
 		}
 
@@ -393,9 +390,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateRelationTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络关系类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateRelationTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateRelationTypesFailed)
 			}
 		}
 
@@ -404,9 +400,8 @@ func (kns *knowledgeNetworkService) CreateKN(ctx context.Context, kn *interfaces
 			if err != nil {
 				logger.Errorf("CreateActionTypes error: %s", err.Error())
 				span.SetStatus(codes.Error, "创建业务知识网络动作类失败")
-				return "", rest.NewHTTPError(ctx, http.StatusInternalServerError,
-					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateActionTypesFailed).
-					WithErrorDetails(err.Error())
+				return "", logics.PreserveHTTPError(ctx, err,
+					berrors.BknBackend_KnowledgeNetwork_InternalError_CreateActionTypesFailed)
 			}
 		}
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -24,6 +24,7 @@ import (
 	berrors "bkn-backend/errors"
 	"bkn-backend/interfaces"
 	bmock "bkn-backend/interfaces/mock"
+	rootlogics "bkn-backend/logics"
 	"bkn-backend/logics/permission"
 )
 
@@ -2256,12 +2257,21 @@ func Test_knowledgeNetworkService_CreateKN(t *testing.T) {
 			kna.EXPECT().CheckKNExistByID(gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			kna.EXPECT().CheckKNExistByName(gomock.Any(), gomock.Any(), gomock.Any()).Return("", false, nil)
 			kna.EXPECT().CreateKN(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-			ots.EXPECT().CreateObjectTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, rest.NewHTTPError(ctx, 500, berrors.BknBackend_KnowledgeNetwork_InternalError))
+			childErr := rootlogics.MapDependencyError(ctx,
+				interfaces.NewDependencyError("vega", "get_resource_schema", interfaces.DependencyTimeout, 0),
+				false,
+				rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter),
+				berrors.BknBackend_ObjectType_InternalError)
+			ots.EXPECT().CreateObjectTypes(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, childErr)
 			smock.ExpectRollback()
 
 			knID, err := service4.CreateKN(ctx, kn, mode, true)
 			So(err, ShouldNotBeNil)
 			So(knID, ShouldEqual, "")
+			So(err, ShouldEqual, childErr)
+			httpErr := err.(*rest.HTTPError)
+			details := httpErr.BaseError.ErrorDetails.(rootlogics.DependencyPublicErrorDetails)
+			So(details.Kind, ShouldEqual, interfaces.DependencyTimeout)
 		})
 
 		Convey("Failed when CreateRelationTypes fails\n", func() {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -438,6 +438,13 @@ func prepareProxyMutationIDs(ctx context.Context, changes *interfaces.KN) error 
 func mergeProxyMutationChanges(current, changes *interfaces.KN, mergeMode string) *interfaces.KN {
 	candidate := *current
 	keepExisting := mergeMode != interfaces.ImportMode_Overwrite
+	candidate.ConceptGroups = mergeProxyItems(current.ConceptGroups, changes.ConceptGroups, keepExisting,
+		func(item *interfaces.ConceptGroup) (string, bool) {
+			if item == nil {
+				return "", false
+			}
+			return item.CGID, true
+		})
 	candidate.ObjectTypes = mergeProxyItems(current.ObjectTypes, changes.ObjectTypes, keepExisting,
 		func(item *interfaces.ObjectType) (string, bool) {
 			if item == nil {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration.go
@@ -28,11 +28,12 @@ const (
 )
 
 type proxyPublishPlan struct {
-	mapping        *interfaces.KNProxyAccount
-	delegatorID    string
-	modelVersion   string
-	lockOwner      string
-	createdMapping bool
+	mapping         *interfaces.KNProxyAccount
+	delegatorID     string
+	modelVersion    string
+	resolvedSources []interfaces.ProxyGrantResolvedSource
+	lockOwner       string
+	createdMapping  bool
 }
 
 type publishedProxyBindingCacheEntry struct {
@@ -98,9 +99,11 @@ func (kns *knowledgeNetworkService) prepareProxyPublishWithBaseline(ctx context.
 	// historical delegator and asks the current editor to take over only when that
 	// delegator has lost the exact downstream operation. Doing this before the
 	// business write avoids discovering an invalid retained source after commit.
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources); err != nil {
+	resolvedSources, err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources)
+	if err != nil {
 		return nil, err
 	}
+	plan.resolvedSources = resolvedSources
 	plan.modelVersion = version
 	releaseOnError = false
 	return plan, nil
@@ -241,13 +244,13 @@ func (kns *knowledgeNetworkService) abortCreatedProxy(ctx context.Context, plan 
 }
 
 func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, proxyID, delegatorID string,
-	sources []interfaces.ProxyGrantSourceSpec) error {
+	sources []interfaces.ProxyGrantSourceSpec) ([]interfaces.ProxyGrantResolvedSource, error) {
 	if len(sources) == 0 {
-		return nil
+		return nil, nil
 	}
 	result, err := kns.mpa.CheckGrants(ctx, proxyID, delegatorID, sources)
 	if err != nil {
-		return proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
+		return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable, "proxy permission preflight failed")
 	}
 	missing := make([]missingProxyPermission, 0, len(result.DeniedSources))
 	for _, source := range result.DeniedSources {
@@ -267,11 +270,29 @@ func (kns *knowledgeNetworkService) preflightProxySources(ctx context.Context, p
 				missing[j].ResourceID, missing[j].Operation, missing[j].BindingType, missing[j].BindingID)
 			return left < right
 		})
-		return rest.NewHTTPError(ctx, http.StatusForbidden,
+		return nil, rest.NewHTTPError(ctx, http.StatusForbidden,
 			berrors.BknBackend_KnowledgeNetwork_ProxyPermissionMissing).
 			WithErrorDetails(missingProxyPermissionDetails{MissingPermissions: missing})
 	}
-	return nil
+	resolved := make(map[string]bool, len(result.ResolvedSources))
+	for _, source := range result.ResolvedSources {
+		if source.GrantedBy == "" {
+			continue
+		}
+		resolved[proxySourceResolutionKey(source.ProxyGrantSourceSpec)] = true
+	}
+	for _, source := range sources {
+		if !resolved[proxySourceResolutionKey(source)] {
+			return nil, proxyHTTPError(ctx, http.StatusServiceUnavailable,
+				"proxy preflight response omitted an effective delegator")
+		}
+	}
+	return result.ResolvedSources, nil
+}
+
+func proxySourceResolutionKey(source interfaces.ProxyGrantSourceSpec) string {
+	return strings.Join([]string{source.ResourceType, source.ResourceID, source.Operation,
+		source.SourceType, source.SourceID, source.KNID, source.BindingType, source.BindingID}, "\x00")
 }
 
 // PublishKNChildMutation applies one standalone child-resource write through
@@ -320,12 +341,15 @@ func (kns *knowledgeNetworkService) PublishKNChildMutation(ctx context.Context, 
 	// historical delegator is still valid, and requires this editor's exact
 	// downstream operation only for additions or an explicit delegator transfer.
 	// Removed sources are absent from the candidate and therefore need no check.
-	if err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources); err != nil {
+	resolvedSources, err := kns.preflightProxySources(ctx, plan.mapping.ProxyAccountID, plan.delegatorID, sources)
+	if err != nil {
 		return err
 	}
+	plan.resolvedSources = resolvedSources
 	plan.modelVersion = version
 
-	mutationCtx, parentTracker, parentTrackerOwner := permission.WithResourceParentTracker(ctx)
+	mutationCtx := interfaces.WithVerifiedDependencySources(ctx, plan.resolvedSources)
+	mutationCtx, parentTracker, parentTrackerOwner := permission.WithResourceParentTracker(mutationCtx)
 	mutationCtx, policyTracker, policyTrackerOwner := permission.WithCreatedPolicyTracker(mutationCtx)
 	mutationCtx, cleanupTracker, cleanupTrackerOwner := permission.WithAuthorizationCleanupTracker(mutationCtx)
 	tx, err := kns.db.BeginTx(mutationCtx, nil)

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -81,6 +81,8 @@ func (s *proxyAccessStub) ListProxyConflicts(context.Context) (map[string][]stri
 type managedProxyAccessStub struct {
 	allowed          bool
 	deniedResources  map[string]bool
+	resolvedGrantors map[string]string
+	omitResolved     bool
 	createCount      int
 	disabled         bool
 	disableLifecycle string
@@ -146,17 +148,57 @@ func (s *managedProxyAccessStub) CheckGrant(_ context.Context, _, _ string, sour
 	s.checked = append(s.checked, source)
 	return interfaces.ProxyGrantCheckResult{Allowed: s.allowed && !s.deniedResources[source.ResourceID]}, nil
 }
-func (s *managedProxyAccessStub) CheckGrants(_ context.Context, _, _ string,
+func (s *managedProxyAccessStub) CheckGrants(_ context.Context, _, grantorID string,
 	sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantBatchCheckResult, error) {
 	s.checked = append(s.checked, sources...)
 	result := interfaces.ProxyGrantBatchCheckResult{DeniedSources: []interfaces.ProxyGrantSourceSpec{}}
 	for _, source := range sources {
 		if !s.allowed || s.deniedResources[source.ResourceID] {
 			result.DeniedSources = append(result.DeniedSources, source)
+		} else if !s.omitResolved {
+			resolvedGrantor := grantorID
+			if historical := s.resolvedGrantors[source.SourceID]; historical != "" {
+				resolvedGrantor = historical
+			}
+			result.ResolvedSources = append(result.ResolvedSources, interfaces.ProxyGrantResolvedSource{
+				ProxyGrantSourceSpec: source, GrantedBy: resolvedGrantor,
+			})
 		}
 	}
 	return result, nil
 }
+
+func TestPreflightProxySourcesRejectsLegacySafeResponseWithoutDelegators(t *testing.T) {
+	service := &knowledgeNetworkService{mpa: &managedProxyAccessStub{allowed: true, omitResolved: true}}
+	_, err := service.preflightProxySources(t.Context(), "proxy-1", "editor-1", []interfaces.ProxyGrantSourceSpec{{
+		ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		SourceType: interfaces.ProxyGrantSourceTypeKNBinding, SourceID: "source-1",
+		KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+	}})
+	var httpErr *rest.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.HTTPCode != http.StatusServiceUnavailable {
+		t.Fatalf("preflight legacy response error = %#v, want HTTP 503", err)
+	}
+}
+
+func TestProxySourceResolutionKeyIncludesBindingIdentity(t *testing.T) {
+	base := interfaces.ProxyGrantSourceSpec{
+		ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+		SourceType: interfaces.ProxyGrantSourceTypeKNBinding, SourceID: "source-1",
+		KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+	}
+	baseKey := proxySourceResolutionKey(base)
+	variants := []interfaces.ProxyGrantSourceSpec{base, base, base}
+	variants[0].KNID = "kn-2"
+	variants[1].BindingType = interfaces.MODULE_TYPE_RELATION_TYPE
+	variants[2].BindingID = "ot-2"
+	for _, variant := range variants {
+		if proxySourceResolutionKey(variant) == baseKey {
+			t.Fatalf("resolution key accepted mismatched binding identity: %#v", variant)
+		}
+	}
+}
+
 func (s *managedProxyAccessStub) SyncGrants(_ context.Context, _, _ string, sources []interfaces.ProxyGrantSourceSpec) (interfaces.ProxyGrantSyncResult, error) {
 	s.syncCalls++
 	s.synced = append([]interfaces.ProxyGrantSourceSpec(nil), sources...)
@@ -306,7 +348,11 @@ func TestPrepareProxyImportPreflightsRelationAgainstExistingBoundObject(t *testi
 	kpa := &proxyAccessStub{mapping: &interfaces.KNProxyAccount{
 		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
 	}}
-	mpa := &managedProxyAccessStub{allowed: true}
+	sourceID := stableProxySourceID("kn-1", interfaces.MODULE_TYPE_OBJECT_TYPE, "ot-1")
+	mpa := &managedProxyAccessStub{
+		allowed:          true,
+		resolvedGrantors: map[string]string{sourceID: "historical-grantor"},
+	}
 	service := &knowledgeNetworkService{kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa}
 	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{ID: "grantor-1"})
 	changes := &interfaces.KN{
@@ -526,7 +572,11 @@ func TestPublishKNChildMutationAddsFirstBindingToEmptyNetwork(t *testing.T) {
 		KNID: "kn-1", ProxyAccountID: "proxy-1", LifecycleStatus: interfaces.KNProxyLifecycleActive,
 		SyncStatus: interfaces.KNProxySyncReady,
 	}}
-	mpa := &managedProxyAccessStub{allowed: true}
+	sourceID := stableProxySourceID("kn-1", interfaces.MODULE_TYPE_OBJECT_TYPE, "ot-1")
+	mpa := &managedProxyAccessStub{
+		allowed:          true,
+		resolvedGrantors: map[string]string{sourceID: "historical-grantor"},
+	}
 	service := &knowledgeNetworkService{
 		db: db, kna: kna, cga: cga, ota: ota, rta: rta, ata: ata, ma: ma, kpa: kpa, mpa: mpa,
 	}
@@ -535,10 +585,17 @@ func TestPublishKNChildMutationAddsFirstBindingToEmptyNetwork(t *testing.T) {
 	err = service.PublishKNChildMutation(ctx,
 		&interfaces.KN{KNID: "kn-1", Branch: interfaces.MAIN_BRANCH, ObjectTypes: []*interfaces.ObjectType{objectType}},
 		interfaces.ImportMode_Normal,
-		func(_ context.Context, tx *sql.Tx) error {
+		func(mutationCtx context.Context, tx *sql.Tx) error {
 			mutationCalled = true
 			if tx == nil {
 				t.Fatal("mutation transaction is nil")
+			}
+			lookupCtx := interfaces.WithDependencyBindingScope(mutationCtx, "kn-1",
+				interfaces.MODULE_TYPE_OBJECT_TYPE, "ot-1")
+			account, ok := interfaces.VerifiedDependencyAccount(lookupCtx, "resource", "resource-first",
+				interfaces.OPERATION_TYPE_VIEW_DETAIL)
+			if !ok || account.ID != "historical-grantor" || account.Type != interfaces.ACCESSOR_TYPE_USER {
+				t.Fatalf("verified dependency account = (%+v, %v), want historical delegator", account, ok)
 			}
 			return nil
 		})

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_orchestration_test.go
@@ -269,6 +269,20 @@ func TestMergeProxyMutationChangesAppliesModeForEveryChildResource(t *testing.T)
 		target  func(*interfaces.KN) string
 	}{
 		{
+			name: "concept group",
+			current: &interfaces.KN{ConceptGroups: []*interfaces.ConceptGroup{{
+				CGID: "cg-1", ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: "ot-1", DataSource: &interfaces.ResourceInfo{ID: "old"},
+				}}},
+			}}},
+			changes: &interfaces.KN{ConceptGroups: []*interfaces.ConceptGroup{{
+				CGID: "cg-1", ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: "ot-1", DataSource: &interfaces.ResourceInfo{ID: "new"},
+				}}},
+			}}},
+			target: func(kn *interfaces.KN) string { return kn.ConceptGroups[0].ObjectTypes[0].DataSource.ID },
+		},
+		{
 			name: "object type",
 			current: &interfaces.KN{ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
 				OTID: "ot-1", DataSource: &interfaces.ResourceInfo{ID: "old"},
@@ -378,6 +392,54 @@ func TestPrepareProxyImportPreflightsRelationAgainstExistingBoundObject(t *testi
 	}
 	if relationChecks != 1 {
 		t.Fatalf("import preflight sources = %#v, want relation grant plus retained object grants", mpa.checked)
+	}
+}
+
+func TestPrepareProxyImportPreflightsNestedConceptGroupBinding(t *testing.T) {
+	kpa := &proxyAccessStub{}
+	nestedObjectSourceID := stableProxySourceID("kn-1", interfaces.MODULE_TYPE_OBJECT_TYPE, "nested-ot")
+	mpa := &managedProxyAccessStub{
+		allowed: true,
+		resolvedGrantors: map[string]string{
+			nestedObjectSourceID: "historical-grantor",
+		},
+	}
+	service := &knowledgeNetworkService{kpa: kpa, mpa: mpa}
+	ctx := context.WithValue(t.Context(), interfaces.ACCOUNT_INFO_KEY,
+		interfaces.AccountInfo{ID: "current-editor", Type: interfaces.ACCESSOR_TYPE_USER})
+	kn := &interfaces.KN{
+		KNID: "kn-1", KNName: "network", Branch: interfaces.MAIN_BRANCH,
+		ConceptGroups: []*interfaces.ConceptGroup{{
+			CGID: "cg-1",
+			ObjectTypes: []*interfaces.ObjectType{{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+				OTID: "nested-ot", DataSource: &interfaces.ResourceInfo{
+					Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "nested-resource",
+				},
+			}}},
+		}},
+		ActionTypes: []*interfaces.ActionType{{ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+			ATID: "top-level-action", ActionSource: interfaces.ActionSource{
+				Type: interfaces.ACTION_SOURCE_TYPE_TOOL, BoxID: "box-1", ToolID: "tool-1",
+			},
+		}}},
+	}
+
+	plan, err := service.prepareProxyImport(ctx, kn, false, interfaces.ImportMode_Normal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer service.releaseProxyLock(t.Context(), plan)
+	if len(mpa.checked) != 3 {
+		t.Fatalf("nested import preflight sources = %#v, want two resource operations and one action source", mpa.checked)
+	}
+
+	lookupCtx := interfaces.WithVerifiedDependencySources(ctx, plan.resolvedSources)
+	lookupCtx = interfaces.WithDependencyBindingScope(lookupCtx, "kn-1",
+		interfaces.MODULE_TYPE_OBJECT_TYPE, "nested-ot")
+	account, ok := interfaces.VerifiedDependencyAccount(lookupCtx, "resource", "nested-resource",
+		interfaces.OPERATION_TYPE_VIEW_DETAIL)
+	if !ok || account.ID != "historical-grantor" {
+		t.Fatalf("nested strict lookup account = %#v, %t; want historical-grantor", account, ok)
 	}
 }
 

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources.go
@@ -31,11 +31,28 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		return nil, "", fmt.Errorf("knowledge network is required")
 	}
 
-	objectResources := make(map[string]string, len(kn.ObjectTypes))
-	objectTypes := make(map[string]struct{}, len(kn.ObjectTypes))
+	// Whole-network imports persist concept-group children through the same
+	// object/relation/action services as top-level children. Include both
+	// representations so proxy preflight covers every strict lookup that can
+	// run later in the request.
+	projectedObjectTypes := append([]*interfaces.ObjectType(nil), kn.ObjectTypes...)
+	projectedRelationTypes := append([]*interfaces.RelationType(nil), kn.RelationTypes...)
+	projectedActionTypes := append([]*interfaces.ActionType(nil), kn.ActionTypes...)
+	for _, conceptGroup := range kn.ConceptGroups {
+		if conceptGroup == nil {
+			continue
+		}
+		projectedObjectTypes = append(projectedObjectTypes, conceptGroup.ObjectTypes...)
+		projectedRelationTypes = append(projectedRelationTypes, conceptGroup.RelationTypes...)
+		projectedActionTypes = append(projectedActionTypes, conceptGroup.ActionTypes...)
+	}
+
+	objectResources := make(map[string]string, len(projectedObjectTypes))
+	objectTypes := make(map[string]struct{}, len(projectedObjectTypes))
 	sources := make([]interfaces.ProxyGrantSourceSpec, 0)
 	bindings := make([]proxyModelBinding, 0)
 	seen := make(map[string]struct{})
+	seenBindings := make(map[string]struct{})
 
 	add := func(bindingType, bindingID, resourceType, resourceID, operation, detail string) error {
 		bindingID = strings.TrimSpace(bindingID)
@@ -59,13 +76,18 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 			seen[key] = struct{}{}
 			sources = append(sources, spec)
 		}
-		bindings = append(bindings, proxyModelBinding{
+		binding := proxyModelBinding{
 			Type: bindingType, ID: bindingID, TargetType: resourceType, TargetID: resourceID, Detail: detail,
-		})
+		}
+		bindingKey := strings.Join([]string{binding.Type, binding.ID, binding.TargetType, binding.TargetID, binding.Detail}, "\x00")
+		if _, ok := seenBindings[bindingKey]; !ok {
+			seenBindings[bindingKey] = struct{}{}
+			bindings = append(bindings, binding)
+		}
 		return nil
 	}
 
-	for _, objectType := range kn.ObjectTypes {
+	for _, objectType := range projectedObjectTypes {
 		if objectType == nil {
 			continue
 		}
@@ -111,7 +133,7 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		}
 	}
 
-	for _, relationType := range kn.RelationTypes {
+	for _, relationType := range projectedRelationTypes {
 		if relationType == nil {
 			continue
 		}
@@ -177,7 +199,7 @@ func buildProxyGrantSources(kn *interfaces.KN) ([]interfaces.ProxyGrantSourceSpe
 		}
 	}
 
-	for _, actionType := range kn.ActionTypes {
+	for _, actionType := range projectedActionTypes {
 		if actionType == nil || strings.TrimSpace(actionType.ActionSource.Type) == "" {
 			continue
 		}

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/proxy_sources_test.go
@@ -5,6 +5,7 @@
 package knowledge_network
 
 import (
+	"strings"
 	"testing"
 
 	"bkn-backend/interfaces"
@@ -202,5 +203,89 @@ func TestBuildProxyGrantSourcesIncludesBoundLogicPropertyTool(t *testing.T) {
 	if len(sources) != 1 || sources[0].ResourceType != "tool_box" ||
 		sources[0].ResourceID != "box-1" || sources[0].Operation != interfaces.OPERATION_TYPE_EXECUTE {
 		t.Fatalf("logic property sources = %#v", sources)
+	}
+}
+
+func TestBuildProxyGrantSourcesIncludesNestedConceptGroupBindings(t *testing.T) {
+	kn := &interfaces.KN{
+		KNID: "kn-1",
+		ConceptGroups: []*interfaces.ConceptGroup{{
+			CGID: "cg-1",
+			ObjectTypes: []*interfaces.ObjectType{{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: "nested-ot", DataSource: &interfaces.ResourceInfo{
+						Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "nested-resource",
+					},
+				},
+			}},
+			RelationTypes: []*interfaces.RelationType{{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID: "nested-rt", SourceObjectTypeID: "nested-ot", TargetObjectTypeID: "nested-ot",
+				},
+			}},
+			ActionTypes: []*interfaces.ActionType{{
+				ActionTypeWithKeyField: interfaces.ActionTypeWithKeyField{
+					ATID: "nested-at", ActionSource: interfaces.ActionSource{
+						Type: interfaces.ACTION_SOURCE_TYPE_TOOL, BoxID: "nested-box", ToolID: "nested-tool",
+					},
+				},
+			}},
+		}},
+	}
+
+	sources, _, err := buildProxyGrantSources(kn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{
+		interfaces.MODULE_TYPE_OBJECT_TYPE + "\x00nested-ot\x00resource\x00nested-resource\x00" + interfaces.OPERATION_TYPE_VIEW_DETAIL:  false,
+		interfaces.MODULE_TYPE_OBJECT_TYPE + "\x00nested-ot\x00resource\x00nested-resource\x00" + interfaces.OPERATION_TYPE_QUERY_DATA:   false,
+		interfaces.MODULE_TYPE_RELATION_TYPE + "\x00nested-rt\x00resource\x00nested-resource\x00" + interfaces.OPERATION_TYPE_QUERY_DATA: false,
+		interfaces.MODULE_TYPE_ACTION_TYPE + "\x00nested-at\x00tool_box\x00nested-box\x00" + interfaces.OPERATION_TYPE_EXECUTE:           false,
+	}
+	for _, source := range sources {
+		key := strings.Join([]string{source.BindingType, source.BindingID, source.ResourceType,
+			source.ResourceID, source.Operation}, "\x00")
+		if _, exists := want[key]; exists {
+			want[key] = true
+		}
+	}
+	for key, found := range want {
+		if !found {
+			t.Fatalf("nested concept-group source %q missing from %#v", key, sources)
+		}
+	}
+}
+
+func TestBuildProxyGrantSourcesDeduplicatesTopLevelAndNestedCopies(t *testing.T) {
+	objectType := &interfaces.ObjectType{ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+		OTID: "ot-1", DataSource: &interfaces.ResourceInfo{
+			Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1",
+		},
+	}}
+	topLevel := &interfaces.KN{KNID: "kn-1", ObjectTypes: []*interfaces.ObjectType{objectType}}
+	withGroupCopy := &interfaces.KN{
+		KNID:        "kn-1",
+		ObjectTypes: []*interfaces.ObjectType{objectType},
+		ConceptGroups: []*interfaces.ConceptGroup{{
+			CGID: "cg-1", ObjectTypes: []*interfaces.ObjectType{objectType},
+		}},
+	}
+
+	topLevelSources, topLevelVersion, err := buildProxyGrantSources(topLevel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withGroupSources, withGroupVersion, err := buildProxyGrantSources(withGroupCopy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(withGroupSources) != len(topLevelSources) {
+		t.Fatalf("duplicate concept-group copy changed source count: got %d, want %d",
+			len(withGroupSources), len(topLevelSources))
+	}
+	if withGroupVersion != topLevelVersion {
+		t.Fatalf("duplicate concept-group copy changed proxy version: got %q, want %q",
+			withGroupVersion, topLevelVersion)
 	}
 }

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -126,6 +126,9 @@ func (ots *objectTypeService) validateObjectTypeStrictExternalDeps(ctx context.C
 			if err := ots.aoa.GetToolByID(ctx, lp.DataSource.BoxID, lp.DataSource.ToolID); err != nil {
 				invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
 					WithErrorDetails(invalidParameterDetail(ctx, "ToolLookupFailed", map[string]any{"objectType": objectType.OTName, "property": lp.Name, "box": lp.DataSource.BoxID, "tool": lp.DataSource.ToolID}))
+				// The execution-factory internal metadata endpoint does not perform
+				// caller resource authorization. A 403 therefore indicates an
+				// internal identity/configuration failure, not a user-scoped denial.
 				return logics.MapDependencyError(ctx, err, false, invalidErr,
 					berrors.BknBackend_ObjectType_InternalError)
 			}

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service.go
@@ -84,11 +84,23 @@ func (ots *objectTypeService) validateObjectTypeStrictExternalDeps(ctx context.C
 	if objectType.DataSource != nil && objectType.DataSource.ID != "" {
 		switch objectType.DataSource.Type {
 		case interfaces.DATA_SOURCE_TYPE_RESOURCE:
-			res, err := ots.vbs.GetResourceByID(ctx, objectType.DataSource.ID)
+			lookupCtx := interfaces.WithDependencyBindingScope(ctx, objectType.KNID,
+				interfaces.MODULE_TYPE_OBJECT_TYPE, objectType.OTID)
+			_, controlledLookup := interfaces.VerifiedDependencyAccount(lookupCtx, "resource", objectType.DataSource.ID,
+				interfaces.OPERATION_TYPE_VIEW_DETAIL)
+			res, err := ots.vbs.GetResourceSchema(lookupCtx, objectType.DataSource.ID, interfaces.OPERATION_TYPE_VIEW_DETAIL)
 			if err != nil {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest,
+				detailKey := "ResourceLookupFailed"
+				if kind, ok := logics.DependencyErrorKind(err); ok && kind == interfaces.DependencyNotFound {
+					detailKey = "ResourceNotFound"
+				}
+				invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest,
 					berrors.BknBackend_ObjectType_InvalidParameter).
-					WithErrorDetails(invalidParameterDetail(ctx, "ResourceLookupFailed", map[string]any{"objectType": objectType.OTName, "resource": objectType.DataSource.ID}))
+					WithErrorDetails(invalidParameterDetail(ctx, detailKey, map[string]any{
+						"objectType": objectType.OTName, "resource": objectType.DataSource.ID,
+					}))
+				return logics.MapDependencyError(ctx, err, !controlledLookup, invalidErr,
+					berrors.BknBackend_ObjectType_InternalError)
 			}
 			if res == nil {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest,
@@ -112,8 +124,10 @@ func (ots *objectTypeService) validateObjectTypeStrictExternalDeps(ctx context.C
 					WithErrorDetails(invalidParameterDetail(ctx, "LogicPropertyDataSourceRequired", map[string]any{"objectType": objectType.OTName, "property": lp.Name}))
 			}
 			if err := ots.aoa.GetToolByID(ctx, lp.DataSource.BoxID, lp.DataSource.ToolID); err != nil {
-				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
+				invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_ObjectType_InvalidParameter).
 					WithErrorDetails(invalidParameterDetail(ctx, "ToolLookupFailed", map[string]any{"objectType": objectType.OTName, "property": lp.Name, "box": lp.DataSource.BoxID, "tool": lp.DataSource.ToolID}))
+				return logics.MapDependencyError(ctx, err, false, invalidErr,
+					berrors.BknBackend_ObjectType_InternalError)
 			}
 		}
 	}

--- a/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/object_type/object_type_service_test.go
@@ -9,11 +9,14 @@ package object_type
 import (
 	"context"
 	"database/sql"
+	"net/http"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
@@ -908,7 +911,7 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
-		Convey("Strict mode validates resource data source via GetResourceByID not data view\n", func() {
+		Convey("Strict mode validates resource data source via operation-scoped schema lookup\n", func() {
 			objectTypes := []*interfaces.ObjectType{
 				{
 					ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
@@ -923,7 +926,8 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectImportModeOK()
-			vbs.EXPECT().GetResourceByID(gomock.Any(), "res1").Return(&interfaces.VegaResource{Name: "r1"}, nil)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "res1", interfaces.OPERATION_TYPE_VIEW_DETAIL).
+				Return(&interfaces.VegaResource{Name: "r1"}, nil)
 			err := service.ValidateObjectTypes(ctx, "kn1", interfaces.MAIN_BRANCH, objectTypes, true, nil, interfaces.ImportMode_Normal)
 			So(err, ShouldBeNil)
 		})
@@ -943,7 +947,7 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectImportModeOK()
-			vbs.EXPECT().GetResourceByID(gomock.Any(), "res_missing").Return(nil, nil)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "res_missing", interfaces.OPERATION_TYPE_VIEW_DETAIL).Return(nil, nil)
 			err := service.ValidateObjectTypes(ctx, "kn1", interfaces.MAIN_BRANCH, objectTypes, true, nil, interfaces.ImportMode_Normal)
 			So(err, ShouldNotBeNil)
 		})
@@ -993,7 +997,8 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectImportModeOK()
-			vbs.EXPECT().GetResourceByID(gomock.Any(), "res1").Return(&interfaces.VegaResource{Name: "r1"}, nil)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "res1", interfaces.OPERATION_TYPE_VIEW_DETAIL).
+				Return(&interfaces.VegaResource{Name: "r1"}, nil)
 			ma.EXPECT().GetMetricByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH, "mid1").Return(nil, nil)
 			err := service.ValidateObjectTypes(ctx, "kn1", interfaces.MAIN_BRANCH, objectTypes, true, nil, interfaces.ImportMode_Normal)
 			So(err, ShouldNotBeNil)
@@ -1026,7 +1031,8 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			}
 			ps.EXPECT().CheckPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			expectImportModeOK()
-			vbs.EXPECT().GetResourceByID(gomock.Any(), "res1").Return(&interfaces.VegaResource{Name: "r1"}, nil)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "res1", interfaces.OPERATION_TYPE_VIEW_DETAIL).
+				Return(&interfaces.VegaResource{Name: "r1"}, nil)
 			ma.EXPECT().GetMetricByID(gomock.Any(), "kn1", interfaces.MAIN_BRANCH, "mid1").Return(&interfaces.MetricDefinition{
 				ID:       "mid1",
 				ScopeRef: "ot1",
@@ -1168,6 +1174,134 @@ func Test_objectTypeService_ValidateObjectTypes(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+}
+
+func TestObjectTypeStrictResourceDependencyErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       interfaces.DependencyErrorKind
+		controlled bool
+		status     int
+		code       string
+	}{
+		{name: "missing binding", kind: interfaces.DependencyNotFound, status: http.StatusBadRequest, code: berrors.BknBackend_ObjectType_InvalidParameter},
+		{name: "invalid binding", kind: interfaces.DependencyInvalidBinding, status: http.StatusBadRequest, code: berrors.BknBackend_ObjectType_InvalidParameter},
+		{name: "current editor forbidden", kind: interfaces.DependencyForbidden, status: http.StatusForbidden, code: rest.PublicError_Forbidden},
+		{name: "resolved delegator forbidden", kind: interfaces.DependencyForbidden, controlled: true, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+		{name: "timeout", kind: interfaces.DependencyTimeout, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ObjectType_InternalError},
+		{name: "unavailable", kind: interfaces.DependencyUnavailable, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ObjectType_InternalError},
+		{name: "downstream failure", kind: interfaces.DependencyDownstreamError, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+		{name: "invalid response", kind: interfaces.DependencyInvalidResponse, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			vbs := bmock.NewMockVegaBackendService(ctrl)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL).
+				Return(nil, interfaces.NewDependencyError("vega", "get_resource_schema", tc.kind, 0))
+			service := &objectTypeService{vbs: vbs}
+			ctx := context.Background()
+			if tc.controlled {
+				ctx = interfaces.WithVerifiedDependencySources(ctx, []interfaces.ProxyGrantResolvedSource{{
+					ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+						ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+						KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+					},
+					GrantedBy: "historical-grantor",
+				}})
+			}
+
+			err := service.validateObjectTypeStrictExternalDeps(ctx, &interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTID: "ot-1", OTName: "orders", DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1"},
+				},
+				KNID: "kn-1",
+			})
+
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, tc.status, httpErr.HTTPCode)
+			assert.Equal(t, tc.code, httpErr.BaseError.ErrorCode)
+		})
+	}
+}
+
+func TestObjectTypeStrictLookupUsesBindingScopedDelegator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vbs := bmock.NewMockVegaBackendService(ctrl)
+	vbs.EXPECT().GetResourceSchema(gomock.Any(), "resource-1", interfaces.OPERATION_TYPE_VIEW_DETAIL).
+		DoAndReturn(func(ctx context.Context, _, _ string) (*interfaces.VegaResource, error) {
+			account, ok := interfaces.VerifiedDependencyAccount(ctx, "resource", "resource-1",
+				interfaces.OPERATION_TYPE_VIEW_DETAIL)
+			require.True(t, ok)
+			assert.Equal(t, "object-grantor", account.ID)
+			return &interfaces.VegaResource{ID: "resource-1", Name: "orders"}, nil
+		})
+	service := &objectTypeService{vbs: vbs}
+	ctx := interfaces.WithVerifiedDependencySources(context.Background(), []interfaces.ProxyGrantResolvedSource{
+		{ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_RELATION_TYPE, BindingID: "rt-1",
+		}, GrantedBy: "relation-grantor"},
+		{ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_VIEW_DETAIL,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+		}, GrantedBy: "object-grantor"},
+	})
+
+	err := service.validateObjectTypeStrictExternalDeps(ctx, &interfaces.ObjectType{
+		ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+			OTID: "ot-1", OTName: "orders",
+			DataSource: &interfaces.ResourceInfo{Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1"},
+		},
+		KNID: "kn-1",
+	})
+
+	require.NoError(t, err)
+}
+
+func TestObjectTypeStrictToolDependencyErrorMapping(t *testing.T) {
+	tests := []struct {
+		kind   interfaces.DependencyErrorKind
+		status int
+		code   string
+	}{
+		{kind: interfaces.DependencyInvalidBinding, status: http.StatusBadRequest, code: berrors.BknBackend_ObjectType_InvalidParameter},
+		{kind: interfaces.DependencyNotFound, status: http.StatusBadRequest, code: berrors.BknBackend_ObjectType_InvalidParameter},
+		{kind: interfaces.DependencyForbidden, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+		{kind: interfaces.DependencyTimeout, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ObjectType_InternalError},
+		{kind: interfaces.DependencyUnavailable, status: http.StatusServiceUnavailable, code: berrors.BknBackend_ObjectType_InternalError},
+		{kind: interfaces.DependencyDownstreamError, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+		{kind: interfaces.DependencyInvalidResponse, status: http.StatusBadGateway, code: berrors.BknBackend_ObjectType_InternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			aoa := bmock.NewMockAgentOperatorAccess(ctrl)
+			aoa.EXPECT().GetToolByID(gomock.Any(), "box-1", "tool-1").Return(
+				interfaces.NewDependencyError("execution-factory", "get_tool", tc.kind, 0))
+			service := &objectTypeService{aoa: aoa}
+
+			err := service.validateObjectTypeStrictExternalDeps(context.Background(), &interfaces.ObjectType{
+				ObjectTypeWithKeyField: interfaces.ObjectTypeWithKeyField{
+					OTName: "orders",
+					LogicProperties: []*interfaces.LogicProperty{{
+						Name: "calculate", Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL,
+						DataSource: &interfaces.ResourceInfo{
+							Type: interfaces.LOGIC_PROPERTY_TYPE_TOOL, BoxID: "box-1", ToolID: "tool-1",
+						},
+					}},
+				},
+			})
+
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, tc.status, httpErr.HTTPCode)
+			assert.Equal(t, tc.code, httpErr.BaseError.ErrorCode)
+		})
+	}
 }
 
 func Test_objectTypeService_ListObjectTypes(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service.go
@@ -1317,9 +1317,17 @@ func (rts *relationTypeService) validateDependency(ctx context.Context, tx *sql.
 			if mappingRules.BackingDataSource.Type != interfaces.DATA_SOURCE_TYPE_RESOURCE {
 				return logics.UnsupportedRelationBackingDataSourceError(ctx, relationType.RTID, mappingRules.BackingDataSource.Type)
 			}
-			res, err := rts.vbs.GetResourceByID(ctx, mappingRules.BackingDataSource.ID)
+			lookupCtx := interfaces.WithDependencyBindingScope(ctx, relationType.KNID,
+				interfaces.MODULE_TYPE_RELATION_TYPE, relationType.RTID)
+			_, controlledLookup := interfaces.VerifiedDependencyAccount(lookupCtx, "resource", mappingRules.BackingDataSource.ID,
+				interfaces.OPERATION_TYPE_QUERY_DATA)
+			res, err := rts.vbs.GetResourceSchema(lookupCtx, mappingRules.BackingDataSource.ID,
+				interfaces.OPERATION_TYPE_QUERY_DATA)
 			if err != nil {
-				return err
+				invalidErr := rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).
+					WithErrorDetails(invalidParameterDetail(ctx, "BackingDataSourceNotFound", map[string]any{"resource": mappingRules.BackingDataSource.ID}))
+				return logics.MapDependencyError(ctx, err, !controlledLookup, invalidErr,
+					berrors.BknBackend_RelationType_InternalError)
 			}
 			if res == nil {
 				return rest.NewHTTPError(ctx, http.StatusBadRequest, berrors.BknBackend_RelationType_InvalidParameter).

--- a/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/relation_type/relation_type_service_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
@@ -1939,6 +1941,98 @@ func Test_relationTypeService_validateDependency(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+}
+
+func TestRelationTypeStrictBackingResourceDependencyErrorMapping(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       interfaces.DependencyErrorKind
+		controlled bool
+		status     int
+		code       string
+	}{
+		{name: "missing binding", kind: interfaces.DependencyNotFound, status: http.StatusBadRequest, code: berrors.BknBackend_RelationType_InvalidParameter},
+		{name: "invalid binding", kind: interfaces.DependencyInvalidBinding, status: http.StatusBadRequest, code: berrors.BknBackend_RelationType_InvalidParameter},
+		{name: "current editor forbidden", kind: interfaces.DependencyForbidden, status: http.StatusForbidden, code: rest.PublicError_Forbidden},
+		{name: "resolved delegator forbidden", kind: interfaces.DependencyForbidden, controlled: true, status: http.StatusBadGateway, code: berrors.BknBackend_RelationType_InternalError},
+		{name: "timeout", kind: interfaces.DependencyTimeout, status: http.StatusServiceUnavailable, code: berrors.BknBackend_RelationType_InternalError},
+		{name: "unavailable", kind: interfaces.DependencyUnavailable, status: http.StatusServiceUnavailable, code: berrors.BknBackend_RelationType_InternalError},
+		{name: "downstream failure", kind: interfaces.DependencyDownstreamError, status: http.StatusBadGateway, code: berrors.BknBackend_RelationType_InternalError},
+		{name: "invalid response", kind: interfaces.DependencyInvalidResponse, status: http.StatusBadGateway, code: berrors.BknBackend_RelationType_InternalError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			vbs := bmock.NewMockVegaBackendService(ctrl)
+			vbs.EXPECT().GetResourceSchema(gomock.Any(), "resource-1", interfaces.OPERATION_TYPE_QUERY_DATA).
+				Return(nil, interfaces.NewDependencyError("vega", "get_resource_schema", tc.kind, 0))
+			service := &relationTypeService{vbs: vbs}
+			ctx := context.Background()
+			if tc.controlled {
+				ctx = interfaces.WithVerifiedDependencySources(ctx, []interfaces.ProxyGrantResolvedSource{{
+					ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+						ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_QUERY_DATA,
+						KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_RELATION_TYPE, BindingID: "rt-1",
+					},
+					GrantedBy: "historical-grantor",
+				}})
+			}
+			relationType := &interfaces.RelationType{
+				RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+					RTID: "rt-1", RTName: "orders", Type: interfaces.RELATION_TYPE_INDIRECT,
+					MappingRules: &interfaces.InDirectMapping{BackingDataSource: &interfaces.ResourceInfo{
+						Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1",
+					}},
+				},
+				KNID: "kn-1",
+			}
+
+			err := service.validateDependency(ctx, nil, relationType, true, nil)
+
+			var httpErr *rest.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, tc.status, httpErr.HTTPCode)
+			assert.Equal(t, tc.code, httpErr.BaseError.ErrorCode)
+		})
+	}
+}
+
+func TestRelationTypeStrictLookupUsesBindingScopedDelegator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	vbs := bmock.NewMockVegaBackendService(ctrl)
+	vbs.EXPECT().GetResourceSchema(gomock.Any(), "resource-1", interfaces.OPERATION_TYPE_QUERY_DATA).
+		DoAndReturn(func(ctx context.Context, _, _ string) (*interfaces.VegaResource, error) {
+			account, ok := interfaces.VerifiedDependencyAccount(ctx, "resource", "resource-1",
+				interfaces.OPERATION_TYPE_QUERY_DATA)
+			require.True(t, ok)
+			assert.Equal(t, "relation-grantor", account.ID)
+			return &interfaces.VegaResource{ID: "resource-1", Name: "orders"}, nil
+		})
+	service := &relationTypeService{vbs: vbs}
+	ctx := interfaces.WithVerifiedDependencySources(context.Background(), []interfaces.ProxyGrantResolvedSource{
+		{ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_QUERY_DATA,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_OBJECT_TYPE, BindingID: "ot-1",
+		}, GrantedBy: "object-grantor"},
+		{ProxyGrantSourceSpec: interfaces.ProxyGrantSourceSpec{
+			ResourceType: "resource", ResourceID: "resource-1", Operation: interfaces.OPERATION_TYPE_QUERY_DATA,
+			KNID: "kn-1", BindingType: interfaces.MODULE_TYPE_RELATION_TYPE, BindingID: "rt-1",
+		}, GrantedBy: "relation-grantor"},
+	})
+	relationType := &interfaces.RelationType{
+		RelationTypeWithKeyField: interfaces.RelationTypeWithKeyField{
+			RTID: "rt-1", RTName: "orders", Type: interfaces.RELATION_TYPE_INDIRECT,
+			MappingRules: &interfaces.InDirectMapping{BackingDataSource: &interfaces.ResourceInfo{
+				Type: interfaces.DATA_SOURCE_TYPE_RESOURCE, ID: "resource-1",
+			}},
+		},
+		KNID: "kn-1",
+	}
+
+	err := service.validateDependency(ctx, nil, relationType, true, nil)
+
+	require.NoError(t, err)
 }
 
 func Test_relationTypeService_ValidateRelationTypes(t *testing.T) {

--- a/adp/bkn/bkn-backend/server/logics/vega_backend/vega_backend_service.go
+++ b/adp/bkn/bkn-backend/server/logics/vega_backend/vega_backend_service.go
@@ -46,6 +46,10 @@ func (vbs *vegaBackendService) GetResourceByID(ctx context.Context, id string) (
 	return vbs.vba.GetResourceByID(ctx, id)
 }
 
+func (vbs *vegaBackendService) GetResourceSchema(ctx context.Context, id, operation string) (*interfaces.VegaResource, error) {
+	return vbs.vba.GetResourceSchema(ctx, id, operation)
+}
+
 func (vbs *vegaBackendService) CreateResource(ctx context.Context, req *interfaces.VegaResource) error {
 	return vbs.vba.CreateResource(ctx, req)
 }

--- a/adp/vega/vega-backend/server/driveradapters/dependency_schema_handler.go
+++ b/adp/vega/vega-backend/server/driveradapters/dependency_schema_handler.go
@@ -1,0 +1,70 @@
+// Copyright openbkn.ai
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/otel/oteltrace"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
+
+	"vega-backend/common/visitor"
+	verrors "vega-backend/errors"
+	"vega-backend/interfaces"
+)
+
+// GetResourceSchemaForDependency returns only the schema needed for strict
+// model validation. It checks the exact operation declared by the binding
+// source and never exposes the unrestricted internal resource read.
+func (r *restHandler) GetResourceSchemaForDependency(c *gin.Context) {
+	ctx, span := oteltrace.StartServerSpan(c)
+	defer span.End()
+
+	operation := strings.TrimSpace(c.Query("operation"))
+	if operation != interfaces.OPERATION_TYPE_VIEW_DETAIL && operation != interfaces.OPERATION_TYPE_QUERY_DATA {
+		httpErr := rest.NewHTTPError(ctx, http.StatusBadRequest, verrors.VegaBackend_InvalidParameter_ID)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	resourceID := strings.TrimSpace(c.Param("id"))
+	resource, err := r.rs.InternalGetByID(ctx, nil, resourceID)
+	if err != nil {
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_Resource_InternalError_GetFailed)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+	if resource == nil {
+		httpErr := rest.NewHTTPError(ctx, http.StatusNotFound, verrors.VegaBackend_Resource_NotFound)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
+	caller := visitor.GenerateVisitor(c)
+	ctx = context.WithValue(ctx, interfaces.ACCOUNT_INFO_KEY, interfaces.AccountInfo{
+		ID: caller.ID, Type: string(caller.Type),
+	})
+	if err := r.rs.CheckResourcePermission(ctx, resourceID, operation); err != nil {
+		httpErr := httpErrorOrInternal(ctx, err, verrors.VegaBackend_InternalError_CheckPermissionFailed)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
+	schema := resource.SchemaDefinition
+	if schema == nil {
+		schema = []*interfaces.Property{}
+	}
+	emitResourceReadEvidence(c, ctx, "data.resource.schema", []*interfaces.Resource{resource}, 1,
+		map[string]string{"resource_id": resource.ID, "operation": operation})
+	oteltrace.AddHttpAttrs4Ok(span, http.StatusOK)
+	rest.ReplyOK(c, http.StatusOK, map[string]any{
+		"id": resource.ID, "name": resource.Name, "schema_definition": schema,
+	})
+}

--- a/adp/vega/vega-backend/server/driveradapters/dependency_schema_handler_test.go
+++ b/adp/vega/vega-backend/server/driveradapters/dependency_schema_handler_test.go
@@ -1,0 +1,85 @@
+// Copyright openbkn.ai
+// Licensed under the Apache License, Version 2.0.
+
+package driveradapters
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"vega-backend/interfaces"
+	vmock "vega-backend/interfaces/mock"
+)
+
+func TestGetResourceSchemaForDependencyChecksExactOperation(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	ctrl := gomock.NewController(t)
+	resources := vmock.NewMockResourceService(ctrl)
+	resources.EXPECT().InternalGetByID(gomock.Any(), nil, "resource-1").Return(&interfaces.Resource{
+		ID:               "resource-1",
+		SchemaDefinition: []*interfaces.Property{{Name: "order_id", Type: "integer"}},
+	}, nil)
+	resources.EXPECT().CheckResourcePermission(gomock.Any(), "resource-1", interfaces.OPERATION_TYPE_QUERY_DATA).
+		DoAndReturn(func(ctx context.Context, _ string, _ string) error {
+			account, _ := ctx.Value(interfaces.ACCOUNT_INFO_KEY).(interfaces.AccountInfo)
+			assert.Equal(t, interfaces.AccountInfo{ID: "historical-grantor", Type: interfaces.ACCESSOR_TYPE_USER}, account)
+			return nil
+		})
+
+	engine := gin.New()
+	engine.GET("/api/vega-backend/in/v1/resources/:id/schema", (&restHandler{rs: resources}).GetResourceSchemaForDependency)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/vega-backend/in/v1/resources/resource-1/schema?operation=query_data", nil)
+	req.Header.Set(interfaces.HTTP_HEADER_ACCOUNT_ID, "historical-grantor")
+	req.Header.Set(interfaces.HTTP_HEADER_ACCOUNT_TYPE, interfaces.ACCESSOR_TYPE_USER)
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"schema_definition"`)
+	assert.Contains(t, w.Body.String(), `"order_id"`)
+}
+
+func TestGetResourceSchemaForDependencyRejectsUnknownOperation(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	engine := gin.New()
+	engine.GET("/api/vega-backend/in/v1/resources/:id/schema", (&restHandler{}).GetResourceSchemaForDependency)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/vega-backend/in/v1/resources/resource-1/schema?operation=modify", nil)
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetResourceSchemaForDependencyReturnsNotFoundBeforeAuthorization(t *testing.T) {
+	restoreGinMode := setGinMode()
+	defer restoreGinMode()
+
+	ctrl := gomock.NewController(t)
+	resources := vmock.NewMockResourceService(ctrl)
+	resources.EXPECT().InternalGetByID(gomock.Any(), nil, "missing").Return(nil, nil)
+
+	engine := gin.New()
+	engine.GET("/api/vega-backend/in/v1/resources/:id/schema", (&restHandler{rs: resources}).GetResourceSchemaForDependency)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/vega-backend/in/v1/resources/missing/schema?operation=view_detail", nil)
+	w := httptest.NewRecorder()
+
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/adp/vega/vega-backend/server/driveradapters/router.go
+++ b/adp/vega/vega-backend/server/driveradapters/router.go
@@ -261,6 +261,7 @@ func (r *restHandler) RegisterPublic(c *gin.Engine) {
 		{
 			resources.GET("", r.ListResourcesByIn)
 			resources.POST("", r.verifyJsonContentType(), r.CreateResourceByIn)
+			resources.GET("/:id/schema", r.GetResourceSchemaForDependency)
 			resources.GET("/:id", r.GetResourcesByIn) // The ID is the resource ID, and multiple resource ids are separated by commas
 			resources.PUT("/:id", r.verifyJsonContentType(), r.UpdateResourceByIn)
 			resources.DELETE("/:id", r.DeleteResourcesByIn) // The ID is the resource ID, and multiple resource ids are separated by commas

--- a/bkn-safe/server/internal/proxygrant/service.go
+++ b/bkn-safe/server/internal/proxygrant/service.go
@@ -86,7 +86,17 @@ type CheckResult struct {
 }
 
 type BatchCheckResult struct {
-	DeniedSources []SourceSpec `json:"denied_sources"`
+	DeniedSources   []SourceSpec     `json:"denied_sources"`
+	ResolvedSources []ResolvedSource `json:"resolved_sources"`
+}
+
+// ResolvedSource records the effective delegator that made a preflight source
+// valid. Callers use it only for a subsequent least-privilege dependency read;
+// the downstream service still rechecks the exact operation before returning
+// data.
+type ResolvedSource struct {
+	SourceSpec
+	GrantedBy string `json:"granted_by"`
 }
 
 type SyncResult struct {
@@ -338,7 +348,7 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 		return BatchCheckResult{}, err
 	}
 
-	result := BatchCheckResult{DeniedSources: []SourceSpec{}}
+	result := BatchCheckResult{DeniedSources: []SourceSpec{}, ResolvedSources: []ResolvedSource{}}
 	err = s.enforcer.Transaction(ctx, func(tx *authz.PolicyTransaction) error {
 		mapping, mappingErr := loadProxy(tx.DB(), req.ProxyAccountID)
 		if mappingErr != nil && !errors.Is(mappingErr, ErrProxyInactive) &&
@@ -370,7 +380,7 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 		}
 
 		needsActor := make([]SourceSpec, 0, len(sources))
-		allowed := make(map[sourceKey]bool, len(sources))
+		allowedBy := make(map[sourceKey]string, len(sources))
 		for _, spec := range sources {
 			key := keyForSpec(spec)
 			if mappingErr != nil || spec.KNID != mapping.ManagedResourceID {
@@ -381,7 +391,7 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 					return ErrInvalidRequest
 				}
 				if row.LifecycleStatus == StatusActive && validCurrent[row.ID] {
-					allowed[key] = true
+					allowedBy[key] = row.GrantedBy
 					continue
 				}
 			}
@@ -435,7 +445,7 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 					ResourceID:   spec.ResourceID,
 					Operation:    spec.Operation,
 				}] {
-					allowed[keyForSpec(spec)] = true
+					allowedBy[keyForSpec(spec)] = req.GrantorID
 				}
 			}
 		}
@@ -445,9 +455,10 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 			decision := "allow"
 			reason := "actor or retained delegator holds the required operation"
 			key := keyForSpec(spec)
-			isAllowed := allowed[key]
+			_, isAllowed := allowedBy[key]
 			for _, required := range requiredBySource[key] {
-				isAllowed = isAllowed && allowed[required]
+				_, requirementAllowed := allowedBy[required]
+				isAllowed = isAllowed && requirementAllowed
 			}
 			if !isAllowed {
 				decision = "deny"
@@ -459,6 +470,14 @@ func (s *Service) CheckMany(ctx context.Context, req BatchCheckRequest) (BatchCh
 				return err
 			}
 			audits = append(audits, audit)
+		}
+		for _, source := range sources {
+			if grantorID, ok := allowedBy[keyForSpec(source)]; ok {
+				result.ResolvedSources = append(result.ResolvedSources, ResolvedSource{
+					SourceSpec: source,
+					GrantedBy:  grantorID,
+				})
+			}
 		}
 		if len(audits) > 0 {
 			return tx.DB().Create(&audits).Error

--- a/bkn-safe/server/internal/proxygrant/service_test.go
+++ b/bkn-safe/server/internal/proxygrant/service_test.go
@@ -647,6 +647,18 @@ func TestCheckManyPreservesValidDelegatorAndReturnsAllDeniedSources(t *testing.T
 		result.DeniedSources[1].SourceID != deniedB.SourceID {
 		t.Fatalf("denied sources = %#v, want both unavailable sources", result.DeniedSources)
 	}
+	resolvedBySource := make(map[string]string, len(result.ResolvedSources))
+	for _, source := range result.ResolvedSources {
+		resolvedBySource[source.SourceID] = source.GrantedBy
+	}
+	if resolvedBySource[retained.Source.SourceID] != f.grantor {
+		t.Fatalf("retained source delegator = %q, want historical delegator %q",
+			resolvedBySource[retained.Source.SourceID], f.grantor)
+	}
+	if resolvedBySource[newSource.SourceID] != editor {
+		t.Fatalf("new source delegator = %q, want current editor %q",
+			resolvedBySource[newSource.SourceID], editor)
+	}
 }
 
 func TestManagedProxyFilterBatchesSourceValidityQueries(t *testing.T) {

--- a/docs/api/_shared/errors.yaml
+++ b/docs/api/_shared/errors.yaml
@@ -18,6 +18,31 @@
 # Note: mf-model uses FastAPI and a different code/detail/link envelope. It must
 # use a separate errors-fastapi.yaml rather than being forced into this schema.
 components:
+  responses:
+    StrictDependencyBadRequest:
+      description: The submitted strict dependency binding is invalid, missing, or unpublished.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    StrictDependencyForbidden:
+      description: The current user is not allowed to perform the dependency operation required by validation.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    StrictDependencyBadGateway:
+      description: A controlled dependency lookup was denied, returned a downstream error, or returned an invalid response.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    StrictDependencyUnavailable:
+      description: A strict dependency lookup timed out or its service is unavailable.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
   schemas:
     Error:
       description: |
@@ -43,7 +68,10 @@ components:
           type: string
           description: Link to detailed error documentation.
         error_details:
-          description: Error details with a service-defined type.
+          description: |
+            Error details with a service-defined type. Strict dependency failures use an object
+            containing `dependency_kind` and may include a safe nested `detail`; raw downstream
+            response bodies and network errors are never included.
 
     ErrorCompact:
       description: |

--- a/docs/api/bkn-safe/proxy-grants.yaml
+++ b/docs/api/bkn-safe/proxy-grants.yaml
@@ -144,6 +144,10 @@ paths:
         Applies the same retained-delegator and replacement rules as the single-source check,
         but loads source, operation, user, and delegator state in batches. Insufficient authority
         is returned in `denied_sources`; the request does not change source or policy state.
+        `resolved_sources` records the enabled effective delegator for every allowed normalized
+        source so the publishing service can perform a least-privilege dependency lookup. This
+        response contract is required by bkn-backend and is not backward compatible with an older
+        bkn-safe that omits the field.
       requestBody:
         required: true
         content:
@@ -450,13 +454,64 @@ components:
     BatchCheckResult:
       type: object
       additionalProperties: false
-      required: [denied_sources]
+      required: [denied_sources, resolved_sources]
       properties:
         denied_sources:
           type: array
           description: Sources that need the current actor to hold the operation but failed that check.
           items:
             $ref: '#/components/schemas/SourceSpec'
+        resolved_sources:
+          type: array
+          description: Allowed explicit and derived sources with the effective delegator selected by preflight.
+          items:
+            $ref: '#/components/schemas/ResolvedSource'
+    ResolvedSource:
+      type: object
+      additionalProperties: false
+      required:
+        - resource_type
+        - resource_id
+        - operation
+        - source_id
+        - kn_id
+        - binding_type
+        - binding_id
+        - granted_by
+      properties:
+        resource_type:
+          type: string
+          enum: [resource, tool_box, mcp]
+        resource_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        operation:
+          type: string
+          enum: [view_detail, query_data, execute]
+        source_type:
+          type: string
+          enum: [kn_proxy_binding, manual, admin]
+          default: kn_proxy_binding
+        source_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        kn_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        binding_type:
+          type: string
+          minLength: 1
+          maxLength: 64
+        binding_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        granted_by:
+          type: string
+          minLength: 1
     SyncResult:
       type: object
       additionalProperties: false

--- a/docs/api/bkn/action-type.yaml
+++ b/docs/api/bkn/action-type.yaml
@@ -10,6 +10,11 @@ info:
     rule exists it falls back to `execute` on the owning knowledge network.
     A direct child allow or deny takes precedence, and a deny wins when both
     effects exist on the same resource. See `../knowledge-network-authorization.md`.
+
+    Strict Tool Box and MCP binding validation uses controlled execution-factory existence
+    lookups. A missing or unpublished binding returns 400. Permission/configuration failures,
+    downstream 5xx responses, and invalid responses return 502; timeout or unavailable failures
+    return 503. Raw dependency response bodies are not included in public errors.
 security:
   - OAuth2: []
 paths:
@@ -220,6 +225,14 @@ paths:
             default: main
           in: query
       responses:
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
         "200":
           content:
             application/json:
@@ -395,6 +408,14 @@ paths:
       responses:
         "204":
           description: ok
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Update an action type
     parameters:
       - name: kn_id
@@ -469,7 +490,7 @@ paths:
       description: |
         Validates only action type dependency existence and does not persist data. It validates dependencies such as bound and affected object types.
 
-        Response: HTTP 200 with valid and detail follows the other validation APIs. Parameter and authentication errors are non-2xx.
+        Response: HTTP 200 uses valid and detail for ordinary model validation. Strict dependency failures return the documented 400/403/502/503 error envelope, whose error_details includes a safe dependency_kind.
 
         Internal API: the corresponding internal path resolves the caller from headers and does not use OAuth.
       parameters:
@@ -511,7 +532,7 @@ paths:
                     type: object
       responses:
         "200":
-          description: Validation result returned. Both pass and fail can return 200.
+          description: Ordinary model-validation result. Strict dependency failures use the non-2xx responses below.
           content:
             application/json:
               schema:
@@ -525,7 +546,13 @@ paths:
                     type: string
                     description: Explanation when valid is false
         "400":
-          description: Invalid request parameters and similar errors. Business validation failures use 200 with valid=false.
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
 components:
   securitySchemes:
     OAuth2:

--- a/docs/api/bkn/business-knowledge-network.yaml
+++ b/docs/api/bkn/business-knowledge-network.yaml
@@ -8,6 +8,11 @@ info:
     `knowledge_network:*:create`; detail, list, update, and delete use the
     corresponding instance operations. Lists are authorization-filtered before
     total and pagination. See `../knowledge-network-authorization.md`.
+
+    Main-branch import and overwrite perform Proxy source preflight before strict child validation.
+    The effective delegator chosen for retained or new sources is reused for the corresponding
+    operation-scoped dependency lookup. Nested child dependency errors keep their 400/403/502/503
+    status and child error code instead of being rewritten as a generic knowledge-network error.
 security:
   - OAuth2: []
 paths:
@@ -124,6 +129,14 @@ paths:
               example:
                 id: "example-knowledge-network-id"
           description: Creation succeeded
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Create a business knowledge network
   /api/bkn-backend/v1/knowledge-networks/{kn_id}:
     get:
@@ -295,7 +308,7 @@ paths:
         Validates only knowledge network dependency existence and does not persist data. It validates all dependencies including object types, relation types, action types, and concept groups.
         The server builds one BatchIDIndex from the four top-level request buckets and nested concept_groups buckets, allowing references to types present only in nested groups.
 
-        Response: HTTP 200 indicates processing completed. valid=true means validation passed; valid=false means validation failed or an error occurred, with detail explaining the cause. Invalid bodies, invalid strict_mode, missing knowledge networks, and authorization failures return non-2xx responses.
+        Response: HTTP 200 uses valid and detail for ordinary model validation. Nested strict dependency failures return the documented 400/403/502/503 error envelope, whose error_details includes a safe dependency_kind.
 
         Internal API: the corresponding internal path uses the same request and response contract, resolves the caller from headers, and does not use OAuth.
       parameters:
@@ -331,7 +344,7 @@ paths:
               $ref: "#/components/schemas/ValidateKNRequestBody"
       responses:
         "200":
-          description: Validation result returned. Both pass and fail can return 200.
+          description: Ordinary model-validation result. Strict dependency failures use the non-2xx responses below.
           content:
             application/json:
               schema:
@@ -346,7 +359,13 @@ paths:
                     type: string
                     description: Explanation when valid is false
         "400":
-          description: Invalid request parameters, such as an invalid body, unparseable strict_mode, or invalid import_mode or mode. This is not a business validation result.
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
 components:
   securitySchemes:
     OAuth2:

--- a/docs/api/bkn/concept-group.yaml
+++ b/docs/api/bkn/concept-group.yaml
@@ -8,6 +8,10 @@ info:
     require `view_detail`; updates use `modify`; deletion uses `delete`.
     Lists are filtered before total and pagination. See
     `../knowledge-network-authorization.md`.
+
+    Strict validation of nested object, relation, and action types preserves each child's public
+    dependency error contract: invalid bindings remain 400, user-scoped authorization remains
+    403, controlled dependency failures are 502, and timeout/unavailable failures are 503.
 security:
   - OAuth2: []
 paths:
@@ -72,6 +76,14 @@ paths:
       responses:
         "204":
           description: ok
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Update a concept group
     delete:
       parameters:
@@ -206,6 +218,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/ID"
           description: Creation or import succeeded
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Create a concept group
       description: Create a concept group
     parameters:
@@ -293,7 +313,7 @@ paths:
         Validates only concept group dependency existence and does not persist data. It validates nested object types, relation types, action types, and their dependencies.
         Concept IDs in the same batch are collected from the requested concept_groups tree, including nested buckets, so strict mode can resolve references that have not yet been persisted.
 
-        Response: HTTP 200 with valid and detail uses the same semantics as knowledge network validation. Parameter and authentication errors are non-2xx.
+        Response: HTTP 200 uses valid and detail for ordinary model validation. Nested strict dependency failures return the documented 400/403/502/503 error envelope, whose error_details includes a safe dependency_kind.
 
         Internal API: the corresponding internal path has the same semantics, resolves the caller from headers, and does not use OAuth.
       parameters:
@@ -335,7 +355,7 @@ paths:
                     type: object
       responses:
         "200":
-          description: Validation result returned. Both pass and fail can return 200.
+          description: Ordinary model-validation result. Strict dependency failures use the non-2xx responses below.
           content:
             application/json:
               schema:
@@ -349,7 +369,13 @@ paths:
                     type: string
                     description: Explanation when valid is false
         "400":
-          description: Invalid request parameters and similar errors. Business validation failures use 200 with valid=false.
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
 components:
   securitySchemes:
     OAuth2:

--- a/docs/api/bkn/object-type.yaml
+++ b/docs/api/bkn/object-type.yaml
@@ -8,6 +8,14 @@ info:
     require `view_detail`; data reads require `query_data`; updates and deletes
     use `modify` and `delete`. Lists and searches are filtered before total and
     pagination. See `../knowledge-network-authorization.md`.
+
+    With `strict_mode=true`, resource-backed object types read only the Vega schema under
+    `view_detail`. Main-branch publication reuses the effective delegator selected by Proxy
+    preflight instead of requiring the current editor to repeat the downstream permission.
+    Missing bindings return 400; a current-user permission denial returns 403; controlled lookup
+    failures return 502, and timeout/unavailable dependencies return 503. Downstream bodies are
+    never copied into the public response. Tool-backed logical properties use the same 400/502/503
+    dependency classification.
 security:
   - OAuth2: []
 paths:
@@ -645,6 +653,14 @@ paths:
             default: true
           in: query
       responses:
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
         "201":
           content:
             application/json:
@@ -1332,6 +1348,14 @@ paths:
       responses:
         "204":
           description: ok
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Update an object type
     parameters:
       - name: kn_id
@@ -1574,7 +1598,7 @@ paths:
         In that case, use full knowledge-network validation with the same structure as the create API, or concept-group validation with nested object_types, relation_types, and action_types. The server derives BatchIDIndex from the submitted JSON, making entries visible within the same create transaction.
         Relation-mapping validation requires object type data properties. If a batch declares only object type IDs without property definitions, existence validation may pass while mapping-rule validation is reduced.
 
-        Response: HTTP 200 with valid set to true indicates success. When valid is false, detail contains the server error message. Invalid parameters, authentication failures, and missing resources still return non-2xx statuses.
+        Response: HTTP 200 with valid set to true indicates success. Ordinary model validation failures use valid=false and detail. Strict dependency failures return the documented 400/403/502/503 error envelope, whose error_details includes a safe dependency_kind.
 
         Internal API: POST /api/bkn-backend/in/v1/.../object-types/validation. Other behavior is the same; the caller is resolved from headers and OAuth is not required.
       parameters:
@@ -1616,7 +1640,7 @@ paths:
                     type: object
       responses:
         "200":
-          description: Validation result returned. Both pass and fail can return 200.
+          description: Ordinary model-validation result. Strict dependency failures use the non-2xx responses below.
           content:
             application/json:
               schema:
@@ -1630,7 +1654,13 @@ paths:
                     type: string
                     description: Explanation when valid is false (error.Error()).
         "400":
-          description: Invalid request parameters and similar errors. A business validation failure is represented by 200 plus valid false and detail, not this status.
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
 components:
   securitySchemes:
     OAuth2:

--- a/docs/api/bkn/relation-type.yaml
+++ b/docs/api/bkn/relation-type.yaml
@@ -8,6 +8,13 @@ info:
     lists require `view_detail`; data reads require `query_data`; updates and
     deletes use `modify` and `delete`. Lists and searches are filtered before
     total and pagination. See `../knowledge-network-authorization.md`.
+
+    With `strict_mode=true`, indirect relation mappings read the backing Vega schema under the
+    source contract's `query_data` operation; they do not introduce an implicit `view_detail`
+    requirement. Main-branch publication reuses the effective delegator selected by Proxy
+    preflight. Missing bindings return 400; a current-user denial returns 403; controlled lookup
+    failures return 502, and timeout/unavailable dependencies return 503 without exposing the
+    downstream response body.
 security:
   - OAuth2: []
 paths:
@@ -211,6 +218,14 @@ paths:
             default: true
           in: query
       responses:
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
         "200":
           content:
             application/json:
@@ -346,6 +361,14 @@ paths:
       responses:
         "204":
           description: ok
+        "400":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
       summary: Update a relation type
     parameters:
       - name: kn_id
@@ -826,7 +849,7 @@ paths:
       description: |
         Validates relation type dependency existence only and does not write data. It verifies dependencies such as source and target object types and indirect data views.
 
-        Response: HTTP 200 uses valid and detail in the same way as other validation APIs; parameter and authentication failures return non-2xx statuses.
+        Response: HTTP 200 uses valid and detail for ordinary model validation. Strict dependency failures return the documented 400/403/502/503 error envelope, whose error_details includes a safe dependency_kind.
 
         Internal API: POST /api/bkn-backend/in/v1/.../relation-types/validation. The caller is resolved from headers and OAuth is not required.
       parameters:
@@ -868,7 +891,7 @@ paths:
                     type: object
       responses:
         "200":
-          description: Validation result returned. Both pass and fail can return 200.
+          description: Ordinary model-validation result. Strict dependency failures use the non-2xx responses below.
           content:
             application/json:
               schema:
@@ -882,7 +905,13 @@ paths:
                     type: string
                     description: Explanation when valid is false (error.Error()).
         "400":
-          description: Invalid request parameters and similar errors. Business validation failures use 200 plus valid false.
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadRequest"
+        "403":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyForbidden"
+        "502":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyBadGateway"
+        "503":
+          $ref: "../_shared/errors.yaml#/components/responses/StrictDependencyUnavailable"
 components:
   securitySchemes:
     OAuth2:

--- a/docs/api/vega/proxy-resource-read.yaml
+++ b/docs/api/vega/proxy-resource-read.yaml
@@ -23,6 +23,49 @@ servers:
   - url: /api/vega-backend/in/v1
 security: []
 paths:
+  /resources/{id}/schema:
+    get:
+      summary: Read a resource schema for strict dependency validation
+      description: |
+        Cluster-internal endpoint used by bkn-backend after it derives a binding target from the
+        candidate model. The caller identity is the effective delegator returned by bkn-safe
+        preflight. Vega rechecks exactly the requested `view_detail` or `query_data` operation and
+        returns only the resource identity, name, and schema. It does not expose the unrestricted
+        internal resource detail API.
+      parameters:
+        - $ref: "#/components/parameters/ResourceID"
+        - name: operation
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [view_detail, query_data]
+        - name: X-Account-ID
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: X-Account-Type
+          in: header
+          required: true
+          schema:
+            type: string
+            const: user
+      responses:
+        "200":
+          description: The operation-authorized resource schema
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DependencySchemaResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /proxy/resources/{id}/schema:
     get:
       summary: Read the minimal schema for a proxied resource
@@ -261,6 +304,18 @@ components:
       type: object
       required: [schema_definition]
       properties:
+        schema_definition:
+          type: array
+          items:
+            $ref: "resource.yaml#/components/schemas/Property"
+    DependencySchemaResponse:
+      type: object
+      required: [id, name, schema_definition]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
         schema_definition:
           type: array
           items:


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Preserve and consume binding-scoped historical delegators returned by bkn-safe proxy preflight.
- [x] Add strict, typed downstream error handling for Vega resources, tools, and MCP tools across all affected KN child resources.
- [x] Add a minimal operation-scoped Vega schema endpoint and validate successful downstream payloads fail-closed.
- [x] Update API documentation and focused regression coverage for object types, relation types, action types, concept groups, and KN aggregate flows.

---

## Why

- Related Issue: [Issue #1406](https://github.com/openbkn-ai/bkn-foundry/issues/1406)
- Related Feature: KN child-resource publication and dependency authorization
- Background: KN child-resource writes repeated downstream checks using the current editor identity, which rejected valid updates backed by retained historical proxy grants. Downstream 403, 5xx, transport, and malformed JSON failures were also flattened into ordinary validation errors, preventing correct public error mapping.

Closes #1406

---

## How

- Key implementation points:
  - bkn-safe CheckMany returns the effective granted_by identity for every resolved source.
  - bkn-backend binds each verified source to the exact KN ID, binding type, binding ID, resource, and operation before using its delegator.
  - Vega schema reads recheck the declared operation and reject missing or malformed success fields.
  - execution-factory tool and MCP responses preserve forbidden, not-found, timeout, unavailable, downstream, transport, and invalid-response semantics.
  - aggregate handlers retain structured dependency details instead of collapsing them into generic errors.
- Breaking changes (API, config, database, etc.):
  - Deployment compatibility requirement: this bkn-backend version must not run with an older bkn-safe version. The services must be upgraded together because bkn-backend requires resolved_sources[].granted_by and intentionally fails closed when it is absent.
  - No database schema or configuration changes.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; no external integration environment was used.
- [ ] Verified in test environment — pending CI/test-environment validation.

Test notes:

- I18N_MODE_UT=true go test ./server/driveradapters ./server/interfaces ./server/drivenadapters/agent_operator ./server/drivenadapters/kn_proxy ./server/drivenadapters/vega_backend ./server/logics/object_type ./server/logics/relation_type ./server/logics/action_type ./server/logics/concept_group ./server/logics/knowledge_network ./server/logics/vega_backend -count=1 -p 1
- make lint in adp/bkn/bkn-backend
- go test ./server/internal/proxygrant -count=1 in bkn-safe
- golangci-lint run ./... for bkn-safe server, contract, and cmd/authz-shadow modules
- GOWORK=off make ci in adp/vega/vega-backend
- git diff --check

---

## Risk & Rollback

- Potential risks:
  - A partial rollout with old bkn-safe will reject KN publications by design.
  - Strict success-payload validation can expose previously hidden malformed downstream responses as dependency_invalid_response.
- Rollback plan:
  - Roll back bkn-backend and bkn-safe together to the prior compatible versions. No data or schema rollback is required.

---

## Additional Notes

- Full bkn-backend go vet remains blocked by pre-existing unreachable-code findings in generated Cypher parser files; the repository golangci-lint check passes with zero issues.
- The root API-doc lint remains blocked by a pre-existing unregistered execution-factory-internal definition; all changed API specifications were linted without errors.
