### PR TITLE
fix(bkn-backend): allow capability menus for navigation-only networks

### DIFF
--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
@@ -124,6 +124,7 @@ func (r *restHandler) AttachCapabilities(c *gin.Context, vis hydra.Visitor) {
 	rest.ReplyOK(c, http.StatusOK, &interfaces.CapabilityBindingsList{
 		Entries:    bindings,
 		TotalCount: len(bindings),
+		Boxes:      make([]*interfaces.CapabilityBoxSummary, 0),
 	})
 }
 

--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler.go
@@ -190,6 +190,14 @@ func (r *restHandler) ListCapabilities(c *gin.Context, vis hydra.Visitor) {
 		return
 	}
 
+	readAccessMode, err := r.kns.ResolveKNReadAccess(ctx, knID, branch)
+	if err != nil {
+		httpErr := err.(*rest.HTTPError)
+		oteltrace.AddHttpAttrs4HttpError(span, httpErr)
+		rest.ReplyError(c, httpErr)
+		return
+	}
+
 	list, err := r.cbs.ListCapabilities(ctx, interfaces.CapabilityBindingsQueryParams{
 		PaginationQueryParameters: interfaces.PaginationQueryParameters{
 			Offset:    pageParam.Offset,
@@ -200,6 +208,7 @@ func (r *restHandler) ListCapabilities(c *gin.Context, vis hydra.Visitor) {
 		KNID:           knID,
 		Branch:         branch,
 		CapabilityType: c.Query("type"),
+		ReadAccessMode: readAccessMode,
 		// Either spelling narrows by tool box; box_id is what every other surface calls it.
 		OwnerID:      firstNonEmpty(c.Query("owner_id"), c.Query("box_id")),
 		WithDetail:   strings.EqualFold(strings.TrimSpace(c.Query("with_detail")), "true"),

--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler_test.go
@@ -7,14 +7,21 @@
 package driveradapters
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/hydra"
+	"github.com/openbkn-ai/bkn-foundry/comm-go/rest"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.uber.org/mock/gomock"
 
 	"bkn-backend/common"
+	"bkn-backend/interfaces"
+	bmock "bkn-backend/interfaces/mock"
 )
 
 // Test_CapabilityRoutes_AllPrefixes locks the four-prefix registration (#1257). Registering only
@@ -82,5 +89,65 @@ func Test_CapabilityRoutes_Audited(t *testing.T) {
 			So(rule.Action, ShouldEqual, tc.action)
 			So(rule.TargetType, ShouldEqual, "kn_capability_binding")
 		}
+	})
+}
+
+func Test_ListCapabilities_KNReadAccess(t *testing.T) {
+	Convey("The capability list honors knowledge-network read access", t, func() {
+		restore := setGinMode()
+		defer restore()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		kns := bmock.NewMockKNService(ctrl)
+		cbs := bmock.NewMockCapabilityBindingService(ctrl)
+		handler := &restHandler{kns: kns, cbs: cbs}
+
+		serve := func() *httptest.ResponseRecorder {
+			engine := gin.New()
+			engine.GET("/knowledge-networks/:kn_id/capabilities", func(c *gin.Context) {
+				handler.ListCapabilities(c, hydra.Visitor{ID: "user-1", Type: hydra.VisitorType_User})
+			})
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
+				"/knowledge-networks/kn1/capabilities?branch=main", nil))
+			return w
+		}
+
+		Convey("Navigation-only access is passed to the list service", func() {
+			kns.EXPECT().CheckKNExistByID(gomock.Any(), "kn1", "main").Return("Network 1", true, nil)
+			kns.EXPECT().ResolveKNReadAccess(gomock.Any(), "kn1", "main").
+				Return(interfaces.KN_READ_ACCESS_NAVIGATION_ONLY, nil)
+			cbs.EXPECT().ListCapabilities(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, query interfaces.CapabilityBindingsQueryParams) (*interfaces.CapabilityBindingsList, error) {
+					So(query.ReadAccessMode, ShouldEqual, interfaces.KN_READ_ACCESS_NAVIGATION_ONLY)
+					return &interfaces.CapabilityBindingsList{
+						Entries: make([]*interfaces.CapabilityBinding, 0), Boxes: make([]*interfaces.CapabilityBoxSummary, 0),
+						MetadataAvailable: true, SourcesAvailable: true,
+					}, nil
+				})
+
+			w := serve()
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+			So(w.Body.String(), ShouldContainSubstring, `"boxes":[]`)
+			var body interfaces.CapabilityBindingsList
+			So(json.Unmarshal(w.Body.Bytes(), &body), ShouldBeNil)
+			So(body.Entries, ShouldNotBeNil)
+			So(body.Entries, ShouldBeEmpty)
+			So(body.TotalCount, ShouldEqual, 0)
+			So(body.Boxes, ShouldNotBeNil)
+			So(body.Boxes, ShouldBeEmpty)
+		})
+
+		Convey("A permission dependency failure remains an error", func() {
+			kns.EXPECT().CheckKNExistByID(gomock.Any(), "kn1", "main").Return("Network 1", true, nil)
+			kns.EXPECT().ResolveKNReadAccess(gomock.Any(), "kn1", "main").Return(interfaces.KNReadAccessMode(""),
+				rest.NewHTTPError(context.Background(), http.StatusServiceUnavailable, rest.PublicError_ServiceUnavailable))
+
+			w := serve()
+
+			So(w.Code, ShouldEqual, http.StatusServiceUnavailable)
+		})
 	})
 }

--- a/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler_test.go
+++ b/adp/bkn/bkn-backend/server/driveradapters/capability_binding_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -149,5 +150,42 @@ func Test_ListCapabilities_KNReadAccess(t *testing.T) {
 
 			So(w.Code, ShouldEqual, http.StatusServiceUnavailable)
 		})
+	})
+}
+
+func Test_AttachCapabilities_ResponseArrayContract(t *testing.T) {
+	Convey("The attach response serializes boxes as an empty array", t, func() {
+		restore := setGinMode()
+		defer restore()
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		kns := bmock.NewMockKNService(ctrl)
+		cbs := bmock.NewMockCapabilityBindingService(ctrl)
+		handler := &restHandler{kns: kns, cbs: cbs}
+		engine := gin.New()
+		engine.POST("/knowledge-networks/:kn_id/capabilities", func(c *gin.Context) {
+			handler.AttachCapabilities(c, hydra.Visitor{ID: "user-1", Type: hydra.VisitorType_User})
+		})
+
+		kns.EXPECT().CheckKNExistByID(gomock.Any(), "kn1", "main").Return("Network 1", true, nil)
+		cbs.EXPECT().AttachCapabilities(gomock.Any(), nil, "kn1", "main", gomock.Any()).
+			Return([]*interfaces.CapabilityBinding{{
+				ID: "bind-1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1",
+			}}, nil)
+
+		request := httptest.NewRequest(http.MethodPost, "/knowledge-networks/kn1/capabilities?branch=main",
+			strings.NewReader(`{"capabilities":[{"capability_type":"skill","capability_id":"skill-1"}]}`))
+		request.Header.Set("Content-Type", "application/json")
+		response := httptest.NewRecorder()
+		engine.ServeHTTP(response, request)
+
+		So(response.Code, ShouldEqual, http.StatusOK)
+		So(response.Body.String(), ShouldContainSubstring, `"boxes":[]`)
+		So(response.Body.String(), ShouldNotContainSubstring, `"boxes":null`)
+		var body interfaces.CapabilityBindingsList
+		So(json.Unmarshal(response.Body.Bytes(), &body), ShouldBeNil)
+		So(body.Boxes, ShouldNotBeNil)
+		So(body.Boxes, ShouldBeEmpty)
 	})
 }

--- a/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
+++ b/adp/bkn/bkn-backend/server/interfaces/capability_binding.go
@@ -104,6 +104,10 @@ type CapabilityBindingsQueryParams struct {
 	CapabilityType string
 	OwnerID        string
 	CapabilityIDs  []string
+	// ReadAccessMode is authorization state resolved by the public knowledge-network
+	// boundary. Navigation-only access may render an empty section but may not read
+	// binding, provenance, or metadata data.
+	ReadAccessMode KNReadAccessMode
 	// MetadataType narrows function bindings to one kind of tool box. The value lives on the box
 	// in the execution factory, not in the binding row, so the service resolves it to the set of
 	// boxes with that kind and puts them in OwnerIDs — filtering the fetched page instead would
@@ -175,7 +179,7 @@ type CapabilityBindingsList struct {
 	Entries    []*CapabilityBinding `json:"entries"`
 	TotalCount int                  `json:"total_count"`
 	// Boxes summarises the tool boxes behind the whole-box mounts on this page.
-	Boxes []*CapabilityBoxSummary `json:"boxes,omitempty"`
+	Boxes []*CapabilityBoxSummary `json:"boxes"`
 	// MetadataAvailable is false when the execution factory could not be reached. The bindings
 	// are still returned in full — the names are missing, not the memberships — and the flag
 	// says so explicitly so an empty name is not read as a deleted capability.

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network.go
@@ -19,7 +19,16 @@ const (
 	DIRECTION_FORWARD       = "forward"
 	DIRECTION_BACKWARD      = "backward"
 	DIRECTION_BIDIRECTIONAL = "bidirectional"
+
+	// KN read access modes distinguish a complete network detail from the
+	// navigation shell exposed through a visible child resource.
+	KN_READ_ACCESS_FULL            KNReadAccessMode = "full"
+	KN_READ_ACCESS_NAVIGATION_ONLY KNReadAccessMode = "navigation_only"
 )
+
+// KNReadAccessMode is the read visibility of one knowledge network for the
+// current caller. It is internal authorization state and is never serialized.
+type KNReadAccessMode string
 
 var (
 	KN_SORT = map[string]string{

--- a/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/knowledge_network_service.go
@@ -15,6 +15,10 @@ import (
 type KNService interface {
 	CheckKNExistByID(ctx context.Context, knID string, branch string) (string, bool, error)
 	CheckKNExistByName(ctx context.Context, knName string, branch string) (string, bool, error)
+	// ResolveKNReadAccess returns full access when the caller can read the network
+	// detail, navigation-only access when a visible child exposes only the shell,
+	// and forbidden when neither condition is met. The network must already exist.
+	ResolveKNReadAccess(ctx context.Context, knID string, branch string) (KNReadAccessMode, error)
 	CreateKN(ctx context.Context, kn *KN, mode string, strictMode bool) (string, error)
 	ListKNs(ctx context.Context, query KNsQueryParams) ([]*KN, int, error)
 	GetKNByID(ctx context.Context, knID string, branch string, mode string) (*KN, error)

--- a/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/interfaces/mock/mock_knowledge_network_service.go
@@ -314,6 +314,21 @@ func (mr *MockKNServiceMockRecorder) ResolveKNProxyBinding(ctx, knID, binding an
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveKNProxyBinding", reflect.TypeOf((*MockKNService)(nil).ResolveKNProxyBinding), ctx, knID, binding)
 }
 
+// ResolveKNReadAccess mocks base method.
+func (m *MockKNService) ResolveKNReadAccess(ctx context.Context, knID, branch string) (interfaces.KNReadAccessMode, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResolveKNReadAccess", ctx, knID, branch)
+	ret0, _ := ret[0].(interfaces.KNReadAccessMode)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveKNReadAccess indicates an expected call of ResolveKNReadAccess.
+func (mr *MockKNServiceMockRecorder) ResolveKNReadAccess(ctx, knID, branch any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveKNReadAccess", reflect.TypeOf((*MockKNService)(nil).ResolveKNReadAccess), ctx, knID, branch)
+}
+
 // RetryKNProxySync mocks base method.
 func (m *MockKNService) RetryKNProxySync(ctx context.Context, knID string) (*interfaces.KNProxyAccount, error) {
 	m.ctrl.T.Helper()

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/backfill.go
@@ -36,7 +36,13 @@ type backfillResult struct {
 func (cbs *capabilityBindingService) backfillMetadata(ctx context.Context,
 	query interfaces.CapabilityBindingsQueryParams, bindings []*interfaces.CapabilityBinding,
 	withDetail bool) backfillResult {
-	result := backfillResult{available: true}
+	// The public response contract requires boxes to be an array. Initialise it here so every
+	// caller gets [] rather than null, including empty, skill-only and MCP-only pages that never
+	// enter the function backfill path.
+	result := backfillResult{
+		boxes:     make([]*interfaces.CapabilityBoxSummary, 0),
+		available: true,
+	}
 	if len(bindings) == 0 {
 		return result
 	}

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service.go
@@ -256,13 +256,6 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "List capabilities")
 	defer span.End()
 
-	if err := cbs.ps.CheckPermission(ctx, interfaces.PermissionResource{
-		Type: interfaces.RESOURCE_TYPE_KN,
-		ID:   query.KNID,
-	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
-		return nil, err
-	}
-
 	if query.CapabilityType != "" && !interfaces.IsValidCapabilityType(query.CapabilityType) {
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
 			berrors.BknBackend_CapabilityBinding_InvalidCapabilityType).
@@ -274,6 +267,29 @@ func (cbs *capabilityBindingService) ListCapabilities(ctx context.Context,
 		return nil, rest.NewHTTPError(ctx, http.StatusBadRequest,
 			berrors.BknBackend_CapabilityBinding_InvalidParameter).
 			WithErrorDetails(fmt.Sprintf("unsupported metadata_type: %s", metadataType))
+	}
+
+	// A child resource may expose the knowledge network as a navigation shell. Capability
+	// bindings are network-detail data and have no child authorization resource, so return a
+	// canonical empty section without consulting storage, provenance, or external metadata.
+	if query.ReadAccessMode == interfaces.KN_READ_ACCESS_NAVIGATION_ONLY {
+		span.SetStatus(codes.Ok, "")
+		return &interfaces.CapabilityBindingsList{
+			Entries:           make([]*interfaces.CapabilityBinding, 0),
+			Boxes:             make([]*interfaces.CapabilityBoxSummary, 0),
+			MetadataAvailable: true,
+			SourcesAvailable:  true,
+		}, nil
+	}
+
+	// Keep the service fail-closed for internal callers and for callers that do not use
+	// the public handler's access-mode resolution. A resolved full mode is deliberately
+	// rechecked here because it permits disclosure rather than merely narrowing a result.
+	if err := cbs.ps.CheckPermission(ctx, interfaces.PermissionResource{
+		Type: interfaces.RESOURCE_TYPE_KN,
+		ID:   query.KNID,
+	}, []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}); err != nil {
+		return nil, err
 	}
 
 	// metadata_type reaches SQL as a set of tool boxes. Resolving it here rather than filtering

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
@@ -240,6 +240,40 @@ func TestListCapabilities(t *testing.T) {
 			So(ok, ShouldBeTrue)
 			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
 		})
+
+		Convey("仅导航可见返回规范空结果且不读取能力数据", func() {
+			service := &capabilityBindingService{
+				cba: bmock.NewMockCapabilityBindingAccess(ctrl),
+				aoa: bmock.NewMockAgentOperatorAccess(ctrl),
+				ps:  bmock.NewMockPermissionService(ctrl),
+			}
+
+			list, err := service.ListCapabilities(context.Background(), interfaces.CapabilityBindingsQueryParams{
+				KNID: "kn1", Branch: "main", ReadAccessMode: interfaces.KN_READ_ACCESS_NAVIGATION_ONLY,
+			})
+
+			So(err, ShouldBeNil)
+			So(list.Entries, ShouldNotBeNil)
+			So(list.Entries, ShouldBeEmpty)
+			So(list.TotalCount, ShouldEqual, 0)
+			So(list.Boxes, ShouldNotBeNil)
+			So(list.Boxes, ShouldBeEmpty)
+			So(list.MetadataAvailable, ShouldBeTrue)
+			So(list.SourcesAvailable, ShouldBeTrue)
+		})
+
+		Convey("仅导航可见仍校验查询条件", func() {
+			service, _ := newTestService(t, ctrl)
+
+			_, err := service.ListCapabilities(context.Background(), interfaces.CapabilityBindingsQueryParams{
+				KNID: "kn1", Branch: "main", CapabilityType: "operator",
+				ReadAccessMode: interfaces.KN_READ_ACCESS_NAVIGATION_ONLY,
+			})
+
+			httpErr, ok := err.(*rest.HTTPError)
+			So(ok, ShouldBeTrue)
+			So(httpErr.HTTPCode, ShouldEqual, http.StatusBadRequest)
+		})
 	})
 }
 

--- a/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/capability_binding/capability_binding_service_test.go
@@ -8,6 +8,7 @@ package capability_binding
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
@@ -227,6 +228,26 @@ func TestListCapabilities(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(list.TotalCount, ShouldEqual, 1)
 			So(len(list.Entries), ShouldEqual, 1)
+		})
+
+		Convey("完整读取没有函数箱摘要时 boxes 仍序列化为空数组", func() {
+			service, cba, aoa := newTestServiceWithFactory(t, ctrl)
+			cba.EXPECT().ListBindings(gomock.Any(), gomock.Any()).Return([]*interfaces.CapabilityBinding{
+				{ID: "bind-1", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL, CapabilityID: "skill-1"},
+			}, nil)
+			aoa.EXPECT().GetSkillNamesByIDs(gomock.Any(), []string{"skill-1"}).
+				Return(map[string]string{"skill-1": "Skill 1"}, nil)
+
+			list, err := service.ListCapabilities(context.Background(), interfaces.CapabilityBindingsQueryParams{
+				KNID: "kn1", Branch: "main", CapabilityType: interfaces.CAPABILITY_TYPE_SKILL,
+			})
+
+			So(err, ShouldBeNil)
+			So(list.Boxes, ShouldNotBeNil)
+			So(list.Boxes, ShouldBeEmpty)
+			body, marshalErr := json.Marshal(list)
+			So(marshalErr, ShouldBeNil)
+			So(string(body), ShouldContainSubstring, `"boxes":[]`)
 		})
 
 		Convey("未知 type 过滤值报 400，不查库", func() {

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service.go
@@ -605,6 +605,30 @@ func (kns *knowledgeNetworkService) resolveKNNavigationVisibility(ctx context.Co
 	return visibility, nil
 }
 
+func (kns *knowledgeNetworkService) ResolveKNReadAccess(ctx context.Context,
+	knID string, branch string) (interfaces.KNReadAccessMode, error) {
+	ctx, span := oteltrace.StartNamedInternalSpan(ctx, "Resolve knowledge network read access")
+	defer span.End()
+
+	visibility, err := kns.resolveKNNavigationVisibility(ctx, []string{knID}, branch)
+	if err != nil {
+		span.SetStatus(codes.Error, common.SafeErrorSummary(err))
+		return "", err
+	}
+	if _, ok := visibility.operations[knID]; ok {
+		span.SetStatus(codes.Ok, "")
+		return interfaces.KN_READ_ACCESS_FULL, nil
+	}
+	if _, ok := visibility.childVisibleKNs[knID]; ok {
+		span.SetStatus(codes.Ok, "")
+		return interfaces.KN_READ_ACCESS_NAVIGATION_ONLY, nil
+	}
+
+	err = rest.NewHTTPError(ctx, http.StatusForbidden, rest.PublicError_Forbidden)
+	span.SetStatus(codes.Error, common.SafeErrorSummary(err))
+	return "", err
+}
+
 func restrictKNToNavigation(kn *interfaces.KN) {
 	kn.SkillContent = ""
 	kn.ConceptGroups = nil

--- a/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
+++ b/adp/bkn/bkn-backend/server/logics/knowledge_network/knowledge_network_service_test.go
@@ -986,6 +986,88 @@ func Test_knowledgeNetworkService_ChildPermissionNavigation(t *testing.T) {
 	})
 }
 
+func Test_knowledgeNetworkService_ResolveKNReadAccess(t *testing.T) {
+	Convey("Resolve knowledge network read access", t, func() {
+		ctx := context.Background()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		kna := bmock.NewMockKNAccess(mockCtrl)
+		ps := bmock.NewMockPermissionService(mockCtrl)
+		service := &knowledgeNetworkService{kna: kna, ps: ps}
+		knID := "kn1"
+		branch := interfaces.MAIN_BRANCH
+
+		Convey("A network detail reader receives full access", func() {
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{knID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{
+					knID: {ResourceID: knID, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+				}, nil)
+
+			mode, err := service.ResolveKNReadAccess(ctx, knID, branch)
+
+			So(err, ShouldBeNil)
+			So(mode, ShouldEqual, interfaces.KN_READ_ACCESS_FULL)
+		})
+
+		Convey("A visible child receives navigation-only access", func() {
+			canonicalID := interfaces.KNChildResourceID(knID, "ot1")
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{knID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil)
+			kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{knID}, branch).
+				Return([]interfaces.KNChildResourceCandidate{{
+					KNID: knID, ResourceID: "ot1", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+				}}, nil)
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE, []string{canonicalID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				permission.KNChildOperationCandidates(interfaces.RESOURCE_TYPE_OBJECT_TYPE)).
+				Return(map[string]interfaces.PermissionResourceOps{
+					canonicalID: {ResourceID: canonicalID, Operations: []string{interfaces.OPERATION_TYPE_VIEW_DETAIL}},
+				}, nil)
+
+			mode, err := service.ResolveKNReadAccess(ctx, knID, branch)
+
+			So(err, ShouldBeNil)
+			So(mode, ShouldEqual, interfaces.KN_READ_ACCESS_NAVIGATION_ONLY)
+		})
+
+		Convey("A caller with neither network nor child visibility is forbidden", func() {
+			canonicalID := interfaces.KNChildResourceID(knID, "ot1")
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{knID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil)
+			kna.EXPECT().ListKNChildResourceCandidates(gomock.Any(), []string{knID}, branch).
+				Return([]interfaces.KNChildResourceCandidate{{
+					KNID: knID, ResourceID: "ot1", Type: interfaces.RESOURCE_TYPE_OBJECT_TYPE,
+				}}, nil)
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_OBJECT_TYPE, []string{canonicalID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true,
+				permission.KNChildOperationCandidates(interfaces.RESOURCE_TYPE_OBJECT_TYPE)).
+				Return(map[string]interfaces.PermissionResourceOps{}, nil)
+
+			mode, err := service.ResolveKNReadAccess(ctx, knID, branch)
+
+			So(mode, ShouldBeEmpty)
+			So(err, ShouldNotBeNil)
+			So(err.(*rest.HTTPError).HTTPCode, ShouldEqual, http.StatusForbidden)
+		})
+
+		Convey("A permission dependency failure is not downgraded", func() {
+			dependencyErr := rest.NewHTTPError(ctx, http.StatusServiceUnavailable, rest.PublicError_ServiceUnavailable)
+			ps.EXPECT().FilterResources(gomock.Any(), interfaces.RESOURCE_TYPE_KN, []string{knID},
+				[]string{interfaces.OPERATION_TYPE_VIEW_DETAIL}, true, interfaces.COMMON_OPERATIONS).
+				Return(nil, dependencyErr)
+
+			mode, err := service.ResolveKNReadAccess(ctx, knID, branch)
+
+			So(mode, ShouldBeEmpty)
+			So(err, ShouldEqual, dependencyErr)
+		})
+	})
+}
+
 func Test_knowledgeNetworkService_ExportKNForProjectionDoesNotUseUserServices(t *testing.T) {
 	Convey("Test projection export bypasses user authorization and enrichment\n", t, func() {
 		ctx := context.Background()

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -127,6 +127,20 @@ info:
     exists so an empty name is not read as a deleted capability; an outage and a deletion must
     not look alike.
 
+    ## Navigation-only knowledge networks
+
+    A caller who cannot view the knowledge-network detail but can view at least one child
+    resource may open the network as a navigation-only shell. For that caller, the public list
+    returns a canonical empty result (`entries: []`, `total_count: 0`, `boxes: []`) for every
+    supported capability filter. Capability bindings belong to the network detail and have no
+    child-level authorization resource, so the service does not read binding rows, model
+    provenance, or execution-factory metadata in this mode. This avoids both a misleading
+    permission error in the shell and disclosure of capabilities the caller cannot view.
+
+    A caller with neither knowledge-network detail access nor any visible child still receives
+    403. Authentication and permission-service failures also remain errors; they are never
+    converted to an empty list.
+
     ## The internal face answers differently
 
     `GET /api/bkn-backend/in/v1/knowledge-networks/{kn_id}/capabilities` returns **bare
@@ -221,7 +235,10 @@ paths:
           in: query
       responses:
         '200':
-          description: Capability bindings of this branch
+          description: >-
+            Capability bindings of this branch for a knowledge-network detail reader. A
+            navigation-only caller who reaches the network through a visible child receives a
+            canonical empty result without binding, provenance, or metadata lookup.
           content:
             application/json:
               schema:
@@ -229,7 +246,9 @@ paths:
         '400':
           description: Invalid capability type or pagination parameter
         '403':
-          description: The caller cannot view this knowledge network
+          description: >-
+            The caller can view neither the knowledge-network detail nor any child resource in
+            this network.
         '404':
           description: Knowledge network or branch not found
       operationId: listCapabilities
@@ -463,6 +482,7 @@ components:
       required:
         - entries
         - total_count
+        - boxes
         - metadata_available
       properties:
         entries:

--- a/docs/api/bkn/bkn-capabilities.yaml
+++ b/docs/api/bkn/bkn-capabilities.yaml
@@ -137,6 +137,10 @@ info:
     provenance, or execution-factory metadata in this mode. This avoids both a misleading
     permission error in the shell and disclosure of capabilities the caller cannot view.
 
+    Both `metadata_available` and `sources_available` are true in this canonical empty result:
+    there are no returned rows or sources left unresolved, so the result is complete. These flags
+    do not imply that the execution-factory or model-provenance dependencies were called.
+
     A caller with neither knowledge-network detail access nor any visible child still receives
     403. Authentication and permission-service failures also remain errors; they are never
     converted to an empty list.


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Distinguish full knowledge-network reads from navigation-only shell access.
- [x] Return a canonical empty capability list for navigation-only callers without reading bindings, provenance, or execution-factory metadata.
- [x] Guarantee that `boxes` is always serialized as an array for full and navigation-only responses.
- [x] Document and test the public capability-list authorization and availability contract.

---

## Why

- Related Issue: Closes #1444
- Related Feature: Knowledge-network capability menus
- Background: Users who can view a child resource but not the knowledge-network detail can enter a restricted network shell. The capability endpoint previously required network `view_detail`, so every capability menu failed with 403 instead of rendering an empty section. The response must also preserve its required-array schema for full readers whose page has no function box summaries.

---

## How

- Key implementation points:
  - Resolve `full`, `navigation_only`, or forbidden access through the existing parent/child visibility algorithm.
  - Pass the trusted access mode from the public handler to the capability service.
  - Keep full reads fail-closed, and propagate authentication and Safe failures unchanged.
  - Initialize box summaries centrally in metadata backfill so empty, skill-only, and MCP-only full pages emit `boxes: []` instead of `null`.
  - Define navigation-only availability flags as confirmation that the canonical empty result is complete, not evidence that metadata dependencies were called.
  - Keep internal capability resolution unchanged.
- Breaking changes (API, config, database, etc.): None. The public GET endpoint now returns HTTP 200 with an empty list for navigation-only callers; fully unauthorized callers still receive 403.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; focused handler and service integration paths are covered by Go tests.
- [ ] Verified in test environment — not performed locally.

Test notes:

- `I18N_MODE_UT=true go test -p=1 ./logics/capability_binding -run 'TestListCapabilities|TestBackfill' -count=1`
- `I18N_MODE_UT=true go test -p=1 ./logics/capability_binding ./driveradapters -count=1`
- `I18N_MODE_UT=true go vet ./logics/capability_binding ./driveradapters`
- `make lint`
- Redocly validation passed; the file retains four pre-existing server/security warnings.

---

## Risk & Rollback

- Potential risks: Navigation-only detection adds the same child-visibility lookup already used by restricted network shells. Full readers retain the existing permission check. Empty box summaries now follow the already-declared required-array schema.
- Rollback plan: Revert commits `51ded148a` and `7bec0d470` to restore strict network-level capability-list authorization and the previous response serialization.

---

## Additional Notes

- Coordinated Studio PR: https://github.com/openbkn-ai/bkn-studio/pull/616
- Rebased onto `origin/main` at `0dca2ac76` before applying the review fix.
- No database or deployment changes.
