### PR TITLE
fix(bkn-safe): make lint work for standalone Go modules

### DIFF
--- a/.github/workflows/ci-bkn-safe.yml
+++ b/.github/workflows/ci-bkn-safe.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'bkn-safe/**'
       - '.github/workflows/ci-bkn-safe.yml'
+      - '.github/actions/golangci-lint/**'
 
 concurrency:
   group: ci-bkn-safe-${{ github.ref }}

--- a/.github/workflows/ci-bkn-safe.yml
+++ b/.github/workflows/ci-bkn-safe.yml
@@ -1,6 +1,6 @@
 name: ci-bkn-safe
 
-# Compile + unit-test gate for PRs touching bkn-safe. The suite is hermetic
+# Compile + unit-test + lint gate for PRs touching bkn-safe. The suite is hermetic
 # (in-memory sqlite, no external services), so it needs no harness setup — it
 # was simply never wired in. While it was not, a seed invariant regressed on
 # main and stayed red for three days unnoticed (#254 changed the code without
@@ -19,13 +19,25 @@ concurrency:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: bkn-safe/server
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: bkn-safe/server/go.mod
-      - run: go build ./...
-      - run: go test ./...
+      - name: Build server
+        working-directory: bkn-safe/server
+        run: go build ./...
+      - name: Test all bkn-safe modules
+        working-directory: bkn-safe
+        run: make test
+      # The action installs the repository-pinned binary for the following
+      # Make target while also linting the smallest standalone module once.
+      - name: Bootstrap golangci-lint
+        uses: ./.github/actions/golangci-lint
+        env:
+          GOWORK: 'off'
+        with:
+          working-directory: bkn-safe/cmd/authz-shadow
+      - name: Lint all bkn-safe modules through the Makefile
+        working-directory: bkn-safe
+        run: make lint

--- a/bkn-safe/Makefile
+++ b/bkn-safe/Makefile
@@ -2,7 +2,8 @@
 
 .PHONY: help lint test
 
-MODULES := server contract cmd/authz-shadow
+WORKSPACE_MODULES := server
+STANDALONE_MODULES := contract cmd/authz-shadow
 
 help:
 	@echo "bkn-safe - available commands:"
@@ -10,13 +11,21 @@ help:
 	@echo "  make test  - run unit tests for every Go module"
 
 lint:
-	@for module in $(MODULES); do \
+	@for module in $(WORKSPACE_MODULES); do \
 		echo "==> lint $$module"; \
 		(cd $$module && golangci-lint run ./...) || exit $$?; \
 	done
+	@for module in $(STANDALONE_MODULES); do \
+		echo "==> lint $$module"; \
+		(cd $$module && GOWORK=off golangci-lint run ./...) || exit $$?; \
+	done
 
 test:
-	@for module in $(MODULES); do \
+	@for module in $(WORKSPACE_MODULES); do \
 		echo "==> test $$module"; \
 		(cd $$module && go test ./...) || exit $$?; \
+	done
+	@for module in $(STANDALONE_MODULES); do \
+		echo "==> test $$module"; \
+		(cd $$module && GOWORK=off go test ./...) || exit $$?; \
 	done


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Split bkn-safe modules into root-workspace and standalone groups.
- [x] Run lint and tests with GOWORK=off only for contract and cmd/authz-shadow.
- [x] Extend ci-bkn-safe to exercise all module tests and the top-level lint target.

---

## Why

- Related Issue: Closes #1476
- Related Feature: N/A — this is a build and lint tooling bug.
- Background: The repository-root go.work includes bkn-safe/server but not the standalone contract and cmd/authz-shadow modules. Go therefore rejected golangci-lint run ./... in those directories before linting could start.

---

## How

- Key implementation points:
  - Keep bkn-safe/server on the repository workspace so local comm-go changes remain visible.
  - Disable workspace discovery only for standalone module lint and test commands.
  - Bootstrap the repository-pinned golangci-lint binary in CI, then run make lint so the advertised Make target is covered against regression.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — N/A: this change has no integration behavior.
- [ ] Verified in test environment — N/A: this is repository tooling with no deployed runtime change.

Test notes:

- make -C bkn-safe lint
- make -C bkn-safe test
- go build ./... from bkn-safe/server
- git diff --check
- YAML syntax validation for .github/workflows/ci-bkn-safe.yml

---

## Risk & Rollback

- Potential risks: CI performs one small duplicate authz-shadow lint while bootstrapping the shared binary; no runtime code is affected.
- Rollback plan: Revert this commit to restore the previous server-only CI and Makefile behavior.

---

## Additional Notes

- No runtime authorization behavior, dependencies, root workspace membership, production configuration, or database state changed.