### PR TITLE
fix(deploy): harden permission migration recovery

### DIFF
--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/authz_migrate/config.go
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/authz_migrate/config.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v3"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 type databaseConfig struct {
@@ -92,10 +93,20 @@ func openDatabase(cfg databaseConfig) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open openbkn-rds: %w", err)
 	}
-	db, err := gorm.Open(mysql.New(mysql.Config{Conn: connection}), &gorm.Config{})
+	db, err := gorm.Open(
+		mysql.New(mysql.Config{Conn: connection}),
+		migrationGORMConfig(),
+	)
 	if err != nil {
 		_ = connection.Close()
 		return nil, fmt.Errorf("gorm open: %w", err)
 	}
 	return db, nil
+}
+
+func migrationGORMConfig() *gorm.Config {
+	// Standard output is reserved for the machine-readable migration report.
+	// The command wraps database failures with actionable errors, so suppress
+	// GORM's independent SQL logger rather than allowing it to corrupt JSON.
+	return &gorm.Config{Logger: logger.Discard}
 }

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/authz_migrate/config_test.go
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/authz_migrate/config_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gorm.io/gorm/logger"
 )
 
 func TestLoadDatabaseConfigUsesFileThenEnvironment(t *testing.T) {
@@ -26,5 +28,12 @@ func TestLoadDatabaseConfigUsesFileThenEnvironment(t *testing.T) {
 	if cfg.Host != "environment-host" || cfg.Port != 4406 ||
 		cfg.User != "file-user" || cfg.Name != "file-safe" {
 		t.Fatalf("config = %+v", cfg)
+	}
+}
+
+func TestMigrationGORMConfigKeepsStandardOutputMachineReadable(t *testing.T) {
+	cfg := migrationGORMConfig()
+	if cfg.Logger != logger.Discard {
+		t.Fatalf("migration logger = %T, want logger.Discard", cfg.Logger)
 	}
 }

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/bkn_data.py
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/bkn_data.py
@@ -156,6 +156,7 @@ class ProxyNetworkPlan:
 @dataclass
 class ProxyMigrationPlan:
     networks: list[ProxyNetworkPlan] = field(default_factory=list)
+    archived_tombstones: list[tuple[str, str]] = field(default_factory=list)
     failures: list[Failure] = field(default_factory=list)
 
 
@@ -735,6 +736,37 @@ def load_grant_index(connection, grantor_id: str) -> GrantIndex:
     )
 
 
+def load_proxy_authorization_references(
+    cursor, proxy_ids: Sequence[str]
+) -> set[str]:
+    """Return proxies that still have an effective or materialized grant."""
+    if not proxy_ids:
+        return set()
+    placeholders = ",".join(["%s"] * len(proxy_ids))
+    references: set[str] = set()
+    queries = (
+        ("casbin_rule", "v0", "", ()),
+        (
+            "proxy_grant_source",
+            "proxy_account_id",
+            " AND lifecycle_status = %s",
+            ("active",),
+        ),
+        ("proxy_grant_policy", "proxy_account_id", "", ()),
+        ("authorization_grant", "accessor_id", "", ()),
+    )
+    for table, column, predicate, extra_parameters in queries:
+        cursor.execute(
+            f"SELECT DISTINCT {column} AS proxy_account_id FROM {table} "
+            f"WHERE {column} IN ({placeholders}){predicate}",
+            (*proxy_ids, *extra_parameters),
+        )
+        references.update(
+            normalize_text(row["proxy_account_id"]) for row in cursor.fetchall()
+        )
+    return references
+
+
 def load_proxy_plan(
     bkn_connection, safe_connection, grantor_id: str
 ) -> ProxyMigrationPlan:
@@ -820,21 +852,9 @@ def load_proxy_plan(
                 tuple(proxy_ids),
             )
             safe_users = {normalize_text(row["id"]): row for row in cursor.fetchall()}
-            for table, column in (
-                ("casbin_rule", "v0"),
-                ("proxy_grant_source", "proxy_account_id"),
-                ("proxy_grant_policy", "proxy_account_id"),
-                ("authorization_grant", "accessor_id"),
-            ):
-                cursor.execute(
-                    f"SELECT DISTINCT {column} AS proxy_account_id FROM {table} "
-                    f"WHERE {column} IN ({placeholders})",
-                    tuple(proxy_ids),
-                )
-                authorization_references.update(
-                    normalize_text(row["proxy_account_id"])
-                    for row in cursor.fetchall()
-                )
+            authorization_references = load_proxy_authorization_references(
+                cursor, proxy_ids
+            )
 
     plan = ProxyMigrationPlan()
     known_networks = {normalize_text(row["f_id"]) for row in networks}
@@ -844,6 +864,7 @@ def load_proxy_plan(
         if is_inert_archived_proxy(
             managed, safe_users.get(proxy_id), authorization_references
         ):
+            plan.archived_tombstones.append((orphan_kn, proxy_id))
             continue
         plan.failures.append(
             Failure(
@@ -1921,6 +1942,13 @@ def migration_report(
         "managed_proxies": {
             "networks": len(proxy_plan.networks),
             "sources": sum(len(network.sources) for network in proxy_plan.networks),
+            "archived_tombstones": [
+                {
+                    "knowledge_network_id": kn_id,
+                    "proxy_account_id": proxy_id,
+                }
+                for kn_id, proxy_id in proxy_plan.archived_tombstones
+            ],
             "planned": [
                 {
                     "knowledge_network_id": network.kn_id,

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/bkn_data.py
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/bkn_data.py
@@ -170,6 +170,23 @@ def normalize_text(value: Any) -> str:
     return str(value)
 
 
+def is_inert_archived_proxy(
+    mapping: Mapping[str, Any],
+    user: Optional[Mapping[str, Any]],
+    authorization_references: set[str],
+) -> bool:
+    """Recognize the durable tombstone left by normal network deletion."""
+    proxy_id = normalize_text(mapping.get("proxy_account_id"))
+    return (
+        normalize_text(mapping.get("lifecycle_status")) == "archived"
+        and user is not None
+        and normalize_text(user.get("account_type")) == "app"
+        and normalize_text(user.get("password_hash")) == ""
+        and not bool(user.get("enabled"))
+        and proxy_id not in authorization_references
+    )
+
+
 def utc_now() -> datetime:
     """Return a timezone-naive UTC timestamp accepted by MySQL DATETIME."""
     return datetime.now(timezone.utc).replace(tzinfo=None)
@@ -794,6 +811,7 @@ def load_proxy_plan(
         }
         proxy_ids = [normalize_text(row["proxy_account_id"]) for row in managed_by_kn.values()]
         safe_users: dict[str, Mapping[str, Any]] = {}
+        authorization_references: set[str] = set()
         if proxy_ids:
             placeholders = ",".join(["%s"] * len(proxy_ids))
             cursor.execute(
@@ -802,10 +820,31 @@ def load_proxy_plan(
                 tuple(proxy_ids),
             )
             safe_users = {normalize_text(row["id"]): row for row in cursor.fetchall()}
+            for table, column in (
+                ("casbin_rule", "v0"),
+                ("proxy_grant_source", "proxy_account_id"),
+                ("proxy_grant_policy", "proxy_account_id"),
+                ("authorization_grant", "accessor_id"),
+            ):
+                cursor.execute(
+                    f"SELECT DISTINCT {column} AS proxy_account_id FROM {table} "
+                    f"WHERE {column} IN ({placeholders})",
+                    tuple(proxy_ids),
+                )
+                authorization_references.update(
+                    normalize_text(row["proxy_account_id"])
+                    for row in cursor.fetchall()
+                )
 
     plan = ProxyMigrationPlan()
     known_networks = {normalize_text(row["f_id"]) for row in networks}
     for orphan_kn in sorted(set(managed_by_kn) - known_networks):
+        managed = managed_by_kn[orphan_kn]
+        proxy_id = normalize_text(managed["proxy_account_id"])
+        if is_inert_archived_proxy(
+            managed, safe_users.get(proxy_id), authorization_references
+        ):
+            continue
         plan.failures.append(
             Failure(
                 "orphan_managed_proxy",

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/service_control.sh
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/service_control.sh
@@ -22,8 +22,8 @@ readonly -a STOP_ORDER=(
 )
 readonly -a START_ORDER=(
   bkn-safe
-  bkn-backend
   vega-backend
+  bkn-backend
   ontology-query
   agent-operator-integration
 )

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_bkn_data.py
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_bkn_data.py
@@ -31,6 +31,7 @@ from bkn_data import (
     apply_parent_plan,
     build_plan,
     derive_proxy_sources,
+    is_inert_archived_proxy,
     load_proxy_plan,
     stable_proxy_account_id,
     sync_proxy_sources,
@@ -127,6 +128,29 @@ class ApplyParentPlanTest(unittest.TestCase):
 
 
 class ProxyPlanTest(unittest.TestCase):
+    def test_only_inert_archived_proxy_is_a_valid_deleted_network_tombstone(self):
+        mapping = {
+            "proxy_account_id": "proxy-1",
+            "lifecycle_status": "archived",
+        }
+        user = {
+            "id": "proxy-1",
+            "enabled": 0,
+            "account_type": "app",
+            "password_hash": "",
+        }
+
+        self.assertTrue(is_inert_archived_proxy(mapping, user, set()))
+        self.assertFalse(is_inert_archived_proxy(mapping, user, {"proxy-1"}))
+        self.assertFalse(
+            is_inert_archived_proxy(mapping, {**user, "enabled": 1}, set())
+        )
+        self.assertFalse(
+            is_inert_archived_proxy(
+                {**mapping, "lifecycle_status": "active"}, user, set()
+            )
+        )
+
     def test_new_proxy_identity_is_stable_between_dry_run_and_apply(self):
         self.assertEqual(
             stable_proxy_account_id("kn-1"),

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_bkn_data.py
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_bkn_data.py
@@ -32,7 +32,9 @@ from bkn_data import (
     build_plan,
     derive_proxy_sources,
     is_inert_archived_proxy,
+    load_proxy_authorization_references,
     load_proxy_plan,
+    migration_report,
     stable_proxy_account_id,
     sync_proxy_sources,
 )
@@ -128,6 +130,17 @@ class ApplyParentPlanTest(unittest.TestCase):
 
 
 class ProxyPlanTest(unittest.TestCase):
+    def test_revoked_proxy_sources_do_not_keep_an_archived_proxy_active(self):
+        cursor = MagicMock()
+        cursor.fetchall.side_effect = [[], [], [], []]
+
+        references = load_proxy_authorization_references(cursor, ["proxy-1"])
+
+        self.assertEqual(set(), references)
+        source_query = cursor.execute.call_args_list[1]
+        self.assertIn("lifecycle_status = %s", source_query.args[0])
+        self.assertEqual(("proxy-1", "active"), source_query.args[1])
+
     def test_only_inert_archived_proxy_is_a_valid_deleted_network_tombstone(self):
         mapping = {
             "proxy_account_id": "proxy-1",
@@ -149,6 +162,25 @@ class ProxyPlanTest(unittest.TestCase):
             is_inert_archived_proxy(
                 {**mapping, "lifecycle_status": "active"}, user, set()
             )
+        )
+
+    def test_migration_report_lists_ignored_archived_tombstones(self):
+        proxy_plan = ProxyMigrationPlan(
+            archived_tombstones=[("kn-deleted", "proxy-archived")]
+        )
+
+        report = migration_report(
+            "dry-run", MigrationPlan({}, 0), proxy_plan
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "knowledge_network_id": "kn-deleted",
+                    "proxy_account_id": "proxy-archived",
+                }
+            ],
+            report["managed_proxies"]["archived_tombstones"],
         )
 
     def test_new_proxy_identity_is_stable_between_dry_run_and_apply(self):

--- a/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_service_control.sh
+++ b/deploy/scripts/upgrades/0.1.5/permission_model_transition/test_service_control.sh
@@ -134,7 +134,7 @@ run_control start --state-file "$state_file" >/dev/null
 [[ ! -e $state_file ]] || fail "successful start did not remove the consumed state"
 start_order=$(grep ' scale deployment/' "$calls_file" |
   sed -E 's#.*deployment/([^ ]+) --replicas=[0-9]+#\1#')
-expected_start_order=$'bkn-safe\nbkn-backend\nvega-backend\nontology-query\nagent-operator-integration'
+expected_start_order=$'bkn-safe\nvega-backend\nbkn-backend\nontology-query\nagent-operator-integration'
 [[ $start_order == "$expected_start_order" ]] ||
   fail "unexpected start order: $start_order"
 [[ $(<"$fake_cluster_directory/bkn-backend") == 2 ]] ||


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Allow only inert archived managed-proxy tombstones to pass the 0.1.5 BKN migration preflight, ignoring revoked audit sources while reporting every accepted tombstone.
- [x] Restore Vega before BKN Backend so the backend's startup catalog dependency is available.
- [x] Keep authorization migration standard output valid JSON by disabling GORM's independent SQL logger.
- [ ] Docs/doc 1 — Not applicable; operator commands and workflow are unchanged.

---

## Why

- Related Issue: Closes #1434
- Related Feature: OpenBKN 0.1.5 permission-model transition
- Background: A real 0.1.4-to-0.1.5 environment validation exposed three recovery-path defects: archived deletion tombstones blocked the dry-run, BKN Backend was restored before its Vega dependency, and a normal GORM record-not-found message corrupted the machine-readable authorization report.

---

## How

- Key implementation points:
  - Treat an orphaned managed proxy as an inert deletion tombstone only when it is archived, credential-free, disabled, and absent from Casbin, proxy-source, proxy-policy, and authorization-grant references.
  - Count only active proxy-grant sources as effective references; revoked source rows remain audit history and are listed through `archived_tombstones` in the migration report.
  - Preserve fail-closed behavior for active, inconsistent, or still-authorized orphaned proxies.
  - Change the restore order to `bkn-safe -> vega-backend -> bkn-backend -> ontology-query -> agent-operator-integration`.
  - Use GORM's discard logger in the migration executable because stdout is reserved for the JSON report and command errors are already propagated explicitly.
- Breaking changes (API, config, database, etc.): None.

---

## Testing

- [x] Unit tests passed locally
- [x] Integration tests passed locally
- [x] Verified in test environment

Test notes:

- `python3 -m unittest -v test_bkn_data.py test_migrate.py` — 32 tests passed.
- `./test_service_control.sh` — passed.
- `(cd authz_migrate && go test -p=1 ./...)` — passed.
- Real environment dry-run passed after recognizing two fully inert archived tombstones.
- Real environment apply completed with verified BKN and Safe backups.
- Post-apply dry-run completed without anomalies or pending Core changes.
- Fixed authorization executable produced JSON that passed `jq` parsing.
- BKN Safe, BKN Backend, Vega Backend, Ontology Query, and Operator Integration all restored to Ready; Safe/BKN health and Vega catalog authorization requests returned HTTP 200.

---

## Risk & Rollback

- Potential risks:
  - Incorrectly accepting a stale managed proxy could hide data inconsistency. The new predicate remains conservative and rejects any tombstone with an enabled/credentialed account or any remaining authorization reference.
  - Restore ordering changes availability sequencing but not saved replica counts.
  - Suppressing GORM logs removes incidental SQL diagnostics from stdout; structured command errors remain available.
- Rollback plan:
  - Revert this commit to restore the previous preflight, startup order, and logger behavior.
  - For an applied migration, use the verified BKN and Safe logical backups created before the first write and restore the previous workload replica snapshot.

---

## Additional Notes

- Based on `main` commit `ccfcf9453835a2414a312b5cfdb8cbc786f78a3a`.
- The test-environment migration completed successfully; no rollback was required.
