### PR TITLE
fix(bkn): escape table cells on .bkn export and join rows the old exporter split

### DIFF
--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
@@ -158,7 +158,8 @@ func splitRow(row string) []string {
 	}
 	parts = append(parts, cell.String())
 	for i := range parts {
-		parts[i] = strings.TrimSpace(strings.ReplaceAll(parts[i], "<br>", "\n"))
+		cell := strings.ReplaceAll(parts[i], "<br>", "\n")
+		parts[i] = strings.TrimSpace(strings.ReplaceAll(cell, "&lt;br&gt;", "<br>"))
 	}
 	return parts
 }
@@ -418,9 +419,11 @@ func parseLogicPropertySubSection(name, content string) *LogicProperty {
 			currentLabel = m[1]
 			continue
 		}
-		if strings.HasPrefix(trimmed, "|") {
-			tableLines = append(tableLines, trimmed)
-		}
+		// Every line between two labels goes to the table reader as-is. Filtering to lines that
+		// start with a pipe here would drop the tail of a row an old exporter split at a line
+		// break, and parseTable would then join the *next* row onto the open one — losing a
+		// parameter instead of restoring one. parseTable already skips what is not a table.
+		tableLines = append(tableLines, trimmed)
 	}
 	flush()
 	return prop

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/parser.go
@@ -135,13 +135,30 @@ func splitFrontmatter(text string) (fm string, body string) {
 	return fm, body
 }
 
+// splitRow splits one table row into cells. A pipe escaped as \| stays inside its cell, and the
+// <br> the serializer writes for a line break becomes a line break again, so a value survives
+// the round trip through the file unchanged.
 func splitRow(row string) []string {
 	row = strings.TrimSpace(row)
 	row = strings.TrimPrefix(row, "|")
 	row = strings.TrimSuffix(row, "|")
-	parts := strings.Split(row, "|")
+	var parts []string
+	var cell strings.Builder
+	for i := 0; i < len(row); i++ {
+		switch {
+		case row[i] == '\\' && i+1 < len(row) && row[i+1] == '|':
+			cell.WriteByte('|')
+			i++
+		case row[i] == '|':
+			parts = append(parts, cell.String())
+			cell.Reset()
+		default:
+			cell.WriteByte(row[i])
+		}
+	}
+	parts = append(parts, cell.String())
 	for i := range parts {
-		parts[i] = strings.TrimSpace(parts[i])
+		parts[i] = strings.TrimSpace(strings.ReplaceAll(parts[i], "<br>", "\n"))
 	}
 	return parts
 }
@@ -150,12 +167,23 @@ func parseTable(lines []string) []map[string]string {
 	var tableLines []string
 	for _, line := range lines {
 		s := strings.TrimSpace(line)
-		if strings.HasPrefix(s, "|") {
+		switch {
+		case len(tableLines) > 0 && !strings.HasSuffix(tableLines[len(tableLines)-1], "|") && !strings.HasPrefix(s, "#"):
+			// The previous row is still open: an exporter that did not escape a line break inside
+			// a cell wrote the rest of the row on this line. Joining it back is what keeps files
+			// exported before the escape existed importable in full instead of silently losing
+			// every row after the break.
+			tableLines[len(tableLines)-1] += "\n" + s
+		case strings.HasPrefix(s, "|"):
 			tableLines = append(tableLines, s)
-		} else if len(tableLines) > 0 {
-			break
+		case len(tableLines) > 0:
+			return finishTable(tableLines)
 		}
 	}
+	return finishTable(tableLines)
+}
+
+func finishTable(tableLines []string) []map[string]string {
 	if len(tableLines) < 2 {
 		return nil
 	}
@@ -272,6 +300,12 @@ func parseDataProperties(sectionText string) ([]*DataProperty, error) {
 			Type:        row["Type"],
 			Description: row["Description"],
 			MappedField: row["Mapped Field"],
+		}
+		if strings.TrimSpace(property.Name) == "" {
+			// A row without a name is a row the table reader could not rebuild. Refusing it
+			// here is what makes a broken file visible; dropping the row would import an
+			// object type that is quietly missing a property.
+			return nil, fmt.Errorf("data property row %d is malformed: empty Name", len(props)+1)
 		}
 		if rawRule := strings.TrimSpace(row["Mask Rule"]); rawRule != "" {
 			var rule maskrule.Rule

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
@@ -39,6 +39,9 @@ func tableCell(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
 	s = strings.ReplaceAll(s, "|", `\|`)
+	// A literal <br> in the value must not read back as a line break, so it is entity-encoded
+	// before the real line breaks take the <br> spelling.
+	s = strings.ReplaceAll(s, "<br>", "&lt;br&gt;")
 	return strings.ReplaceAll(s, "\n", "<br>")
 }
 

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/serialize.go
@@ -32,6 +32,16 @@ func serializeMaskRule(rule *maskrule.Rule) string {
 }
 
 // encodeMetricFormulaYAML encodes a metric formula fenced with Markdown ```yaml code blocks, matching on-disk examples.
+// tableCell makes a value safe inside a Markdown table row. A line break would end the row and
+// a bare pipe would open a new cell; the importer's table reader can recover neither, so the
+// break is written as <br> and the pipe as \|, and splitRow turns them back.
+func tableCell(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.ReplaceAll(s, "\n", "<br>")
+}
+
 func encodeMetricFormulaYAML(m *MetricFormula) string {
 	var buf bytes.Buffer
 	enc := yaml.NewEncoder(&buf)
@@ -67,13 +77,13 @@ func SerializeMetric(m *BknMetric) string {
 		sb.WriteString("### Metric attributes\n\n")
 		sb.WriteString("| Metric Type | Unit Type | Unit |\n")
 		sb.WriteString("|-------------|-----------|------|\n")
-		fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", mtOut, utOut, uOut)
+		fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", tableCell(mtOut), tableCell(utOut), tableCell(uOut))
 	}
 
 	sb.WriteString("### Scope\n\n")
 	sb.WriteString("| Scope Type | Scope Ref |\n")
 	sb.WriteString("|------------|-----------|\n")
-	fmt.Fprintf(&sb, "| %s | %s |\n\n", m.ScopeType, m.ScopeRef)
+	fmt.Fprintf(&sb, "| %s | %s |\n\n", tableCell(m.ScopeType), tableCell(m.ScopeRef))
 
 	sb.WriteString("### Calculation Formula\n\n")
 	if m.Formula != nil {
@@ -85,7 +95,7 @@ func SerializeMetric(m *BknMetric) string {
 	sb.WriteString("| Property | Default Range Policy |\n")
 	sb.WriteString("|----------|----------------------|\n")
 	for _, row := range m.TimeDimensions {
-		fmt.Fprintf(&sb, "| %s | %s |\n", row.Property, row.Policy)
+		fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(row.Property), tableCell(row.Policy))
 	}
 	sb.WriteString("\n")
 
@@ -93,7 +103,7 @@ func SerializeMetric(m *BknMetric) string {
 	sb.WriteString("| Name | Display Name |\n")
 	sb.WriteString("|------|--------------|\n")
 	for _, row := range m.AnalysisDimensions {
-		fmt.Fprintf(&sb, "| %s | %s |\n", row.Name, row.DisplayName)
+		fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(row.Name), tableCell(row.DisplayName))
 	}
 	sb.WriteString("\n")
 
@@ -144,7 +154,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.ObjectTypes) > 0 {
 		sort.Slice(doc.ObjectTypes, func(i, j int) bool { return doc.ObjectTypes[i].ID < doc.ObjectTypes[j].ID })
 		for _, ot := range doc.ObjectTypes {
-			_, _ = fmt.Fprintf(&sb, "| %s | %s | `object_types/%s.bkn` | %s |\n", ot.ID, ot.Name, ot.ID, ot.Summary)
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | `object_types/%s.bkn` | %s |\n", tableCell(ot.ID), tableCell(ot.Name), tableCell(ot.ID), tableCell(ot.Summary))
 		}
 	}
 
@@ -154,7 +164,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.RelationTypes) > 0 {
 		sort.Slice(doc.RelationTypes, func(i, j int) bool { return doc.RelationTypes[i].ID < doc.RelationTypes[j].ID })
 		for _, rt := range doc.RelationTypes {
-			fmt.Fprintf(&sb, "| %s | %s | `relation_types/%s.bkn` | %s |\n", rt.ID, rt.Name, rt.ID, rt.Summary)
+			fmt.Fprintf(&sb, "| %s | %s | `relation_types/%s.bkn` | %s |\n", tableCell(rt.ID), tableCell(rt.Name), tableCell(rt.ID), tableCell(rt.Summary))
 		}
 	}
 
@@ -164,7 +174,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.ActionTypes) > 0 {
 		sort.Slice(doc.ActionTypes, func(i, j int) bool { return doc.ActionTypes[i].ID < doc.ActionTypes[j].ID })
 		for _, at := range doc.ActionTypes {
-			fmt.Fprintf(&sb, "| %s | %s | `action_types/%s.bkn` | %s |\n", at.ID, at.Name, at.ID, at.Summary)
+			fmt.Fprintf(&sb, "| %s | %s | `action_types/%s.bkn` | %s |\n", tableCell(at.ID), tableCell(at.Name), tableCell(at.ID), tableCell(at.Summary))
 		}
 	}
 
@@ -174,7 +184,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.RiskTypes) > 0 {
 		sort.Slice(doc.RiskTypes, func(i, j int) bool { return doc.RiskTypes[i].ID < doc.RiskTypes[j].ID })
 		for _, rt := range doc.RiskTypes {
-			fmt.Fprintf(&sb, "| %s | %s | `risk_types/%s.bkn` | %s |\n", rt.ID, rt.Name, rt.ID, rt.Summary)
+			fmt.Fprintf(&sb, "| %s | %s | `risk_types/%s.bkn` | %s |\n", tableCell(rt.ID), tableCell(rt.Name), tableCell(rt.ID), tableCell(rt.Summary))
 		}
 	}
 
@@ -184,7 +194,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.ConceptGroups) > 0 {
 		sort.Slice(doc.ConceptGroups, func(i, j int) bool { return doc.ConceptGroups[i].ID < doc.ConceptGroups[j].ID })
 		for _, cg := range doc.ConceptGroups {
-			fmt.Fprintf(&sb, "| %s | %s | `concept_groups/%s.bkn` | %s |\n", cg.ID, cg.Name, cg.ID, cg.Summary)
+			fmt.Fprintf(&sb, "| %s | %s | `concept_groups/%s.bkn` | %s |\n", tableCell(cg.ID), tableCell(cg.Name), tableCell(cg.ID), tableCell(cg.Summary))
 		}
 	}
 
@@ -194,7 +204,7 @@ func SerializeBknNetwork(doc *BknNetwork) string {
 	if len(doc.Metrics) > 0 {
 		sort.Slice(doc.Metrics, func(i, j int) bool { return doc.Metrics[i].ID < doc.Metrics[j].ID })
 		for _, met := range doc.Metrics {
-			fmt.Fprintf(&sb, "| %s | %s | `metrics/%s.bkn` | %s |\n", met.ID, met.Name, met.ID, met.Summary)
+			fmt.Fprintf(&sb, "| %s | %s | `metrics/%s.bkn` | %s |\n", tableCell(met.ID), tableCell(met.Name), tableCell(met.ID), tableCell(met.Summary))
 		}
 	}
 
@@ -289,7 +299,7 @@ func SerializeObjectType(ot *BknObjectType) string {
 	_, _ = fmt.Fprintf(&sb, "|------|----|------|\n")
 	if ot.DataSource != nil {
 		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n",
-			ot.DataSource.Type, ot.DataSource.ID, ot.DataSource.Name)
+			tableCell(ot.DataSource.Type), tableCell(ot.DataSource.ID), tableCell(ot.DataSource.Name))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -313,10 +323,10 @@ func SerializeObjectType(ot *BknObjectType) string {
 		for _, dp := range ot.DataProperties {
 			if hasMaskRule {
 				_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s |\n",
-					dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField, serializeMaskRule(dp.MaskRule))
+					tableCell(dp.Name), tableCell(dp.DisplayName), tableCell(dp.Type), tableCell(dp.Description), tableCell(dp.MappedField), tableCell(serializeMaskRule(dp.MaskRule)))
 			} else {
 				_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
-					dp.Name, dp.DisplayName, dp.Type, dp.Description, dp.MappedField)
+					tableCell(dp.Name), tableCell(dp.DisplayName), tableCell(dp.Type), tableCell(dp.Description), tableCell(dp.MappedField))
 			}
 		}
 	}
@@ -331,14 +341,14 @@ func SerializeObjectType(ot *BknObjectType) string {
 		_, _ = fmt.Fprintf(&sb, "**Meta**\n\n")
 		_, _ = fmt.Fprintf(&sb, "| Display Name | Type | Description |\n")
 		_, _ = fmt.Fprintf(&sb, "|--------------|------|-------------|\n")
-		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", lp.DisplayName, lp.Type, lp.Description)
+		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", tableCell(lp.DisplayName), tableCell(lp.Type), tableCell(lp.Description))
 
 		// Source table
 		_, _ = fmt.Fprintf(&sb, "**Source**\n\n")
 		_, _ = fmt.Fprintf(&sb, "| Source Type | Source ID | Source Name |\n")
 		_, _ = fmt.Fprintf(&sb, "|-------------|-----------|-------------|\n")
 		if lp.DataSource != nil {
-			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", lp.DataSource.Type, lp.DataSource.ID, lp.DataSource.Name)
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", tableCell(lp.DataSource.Type), tableCell(lp.DataSource.ID), tableCell(lp.DataSource.Name))
 		}
 		_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -352,7 +362,7 @@ func SerializeObjectType(ot *BknObjectType) string {
 				v = fmt.Sprintf("%v", p.Value)
 			}
 			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s | %s |\n",
-				p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description)
+				tableCell(p.Name), tableCell(p.Type), tableCell(p.Source), tableCell(p.Operation), tableCell(p.ValueFrom), tableCell(v), tableCell(p.Description))
 		}
 		_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -361,7 +371,7 @@ func SerializeObjectType(ot *BknObjectType) string {
 		_, _ = fmt.Fprintf(&sb, "| Name | Display Name | Type | Description |\n")
 		_, _ = fmt.Fprintf(&sb, "|------|--------------|------|-------------|\n")
 		for _, d := range lp.AnalysisDims {
-			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", d.Name, d.DisplayName, d.Type, d.Description)
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n", tableCell(d.Name), tableCell(d.DisplayName), tableCell(d.Type), tableCell(d.Description))
 		}
 		_, _ = fmt.Fprintf(&sb, "\n")
 	}
@@ -396,7 +406,7 @@ func SerializeRelationType(rt *BknRelationType) string {
 	_, _ = fmt.Fprintf(&sb, "### Endpoint\n\n")
 	_, _ = fmt.Fprintf(&sb, "| Source | Target | Type |\n")
 	_, _ = fmt.Fprintf(&sb, "|--------|--------|------|\n")
-	_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", rt.Endpoint.Source, rt.Endpoint.Target, rt.Endpoint.Type)
+	_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n\n", tableCell(rt.Endpoint.Source), tableCell(rt.Endpoint.Target), tableCell(rt.Endpoint.Type))
 
 	switch rt.Endpoint.Type {
 	case RELATION_MAPPING_TYPE_DIRECT:
@@ -406,7 +416,7 @@ func SerializeRelationType(rt *BknRelationType) string {
 		_, _ = fmt.Fprintf(&sb, "|-----------------|-----------------|\n")
 		if rules, ok := rt.MappingRules.(DirectMappingRule); ok {
 			for _, r := range rules {
-				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(r.SourceProperty), tableCell(r.TargetProperty))
 			}
 		}
 		_, _ = fmt.Fprintf(&sb, "\n")
@@ -417,21 +427,21 @@ func SerializeRelationType(rt *BknRelationType) string {
 		_, _ = fmt.Fprintf(&sb, "|------|----|\n")
 		if rules, ok := rt.MappingRules.(*InDirectMappingRule); ok {
 			if rules.BackingDataSource != nil {
-				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", rules.BackingDataSource.Type, rules.BackingDataSource.ID)
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(rules.BackingDataSource.Type), tableCell(rules.BackingDataSource.ID))
 			}
 			_, _ = fmt.Fprintf(&sb, "\n")
 			_, _ = fmt.Fprintf(&sb, "### Source Mapping\n\n")
 			_, _ = fmt.Fprintf(&sb, "| Source Property | Resource Property |\n")
 			_, _ = fmt.Fprintf(&sb, "|-----------------|-------------------|\n")
 			for _, r := range rules.SourceMappingRules {
-				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(r.SourceProperty), tableCell(r.TargetProperty))
 			}
 			_, _ = fmt.Fprintf(&sb, "\n")
 			_, _ = fmt.Fprintf(&sb, "### Target Mapping\n\n")
 			_, _ = fmt.Fprintf(&sb, "| Resource Property | Target Property |\n")
 			_, _ = fmt.Fprintf(&sb, "|-------------------|-----------------|\n")
 			for _, r := range rules.TargetMappingRules {
-				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", r.SourceProperty, r.TargetProperty)
+				_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(r.SourceProperty), tableCell(r.TargetProperty))
 			}
 			_, _ = fmt.Fprintf(&sb, "\n")
 		}
@@ -487,7 +497,7 @@ func SerializeActionType(at *BknActionType) string {
 	_, _ = fmt.Fprintf(&sb, "| Bound Object |\n")
 	_, _ = fmt.Fprintf(&sb, "|--------------|\n")
 	if at.BoundObject != "" {
-		_, _ = fmt.Fprintf(&sb, "| %s |\n", at.BoundObject)
+		_, _ = fmt.Fprintf(&sb, "| %s |\n", tableCell(at.BoundObject))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -496,7 +506,7 @@ func SerializeActionType(at *BknActionType) string {
 	_, _ = fmt.Fprintf(&sb, "| Affect Object | Affect Description |\n")
 	_, _ = fmt.Fprintf(&sb, "|---------------|--------------------|\n")
 	if at.AffectObject != nil {
-		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", at.AffectObject.ObjectType, at.AffectObject.Description)
+		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(at.AffectObject.ObjectType), tableCell(at.AffectObject.Description))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -522,8 +532,7 @@ func SerializeActionType(at *BknActionType) string {
 	_, _ = fmt.Fprintf(&sb, "|------|-------|--------|-------|----------|\n")
 	if at.ActionSource != nil && at.ActionSource.Type != "" {
 		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s |\n",
-			at.ActionSource.Type, at.ActionSource.BoxID, at.ActionSource.ToolID,
-			at.ActionSource.McpID, at.ActionSource.ToolName)
+			tableCell(at.ActionSource.Type), tableCell(at.ActionSource.BoxID), tableCell(at.ActionSource.ToolID), tableCell(at.ActionSource.McpID), tableCell(at.ActionSource.ToolName))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -537,7 +546,7 @@ func SerializeActionType(at *BknActionType) string {
 			v = ""
 		}
 		_, _ = fmt.Fprintf(&sb, "| %s | %s | %s | %s | %s | %s | %s |\n",
-			p.Name, p.Type, p.Source, p.Operation, p.ValueFrom, v, p.Description)
+			tableCell(p.Name), tableCell(p.Type), tableCell(p.Source), tableCell(p.Operation), tableCell(p.ValueFrom), tableCell(fmt.Sprint(v)), tableCell(p.Description))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -546,7 +555,7 @@ func SerializeActionType(at *BknActionType) string {
 	_, _ = fmt.Fprintf(&sb, "| Type | Expression |\n")
 	_, _ = fmt.Fprintf(&sb, "|------|------------|\n")
 	if at.Schedule != nil && at.Schedule.Type != "" {
-		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", at.Schedule.Type, at.Schedule.Expression)
+		_, _ = fmt.Fprintf(&sb, "| %s | %s |\n", tableCell(at.Schedule.Type), tableCell(at.Schedule.Expression))
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")
 
@@ -598,7 +607,7 @@ func SerializeConceptGroup(cg *BknConceptGroup, otIndex map[string]*BknObjectTyp
 				name = ot.Name
 				desc = ot.Summary
 			}
-			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", id, name, desc)
+			_, _ = fmt.Fprintf(&sb, "| %s | %s | %s |\n", tableCell(id), tableCell(name), tableCell(desc))
 		}
 	}
 	_, _ = fmt.Fprintf(&sb, "\n")

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/table_cell_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/table_cell_test.go
@@ -114,3 +114,52 @@ func TestSplitRow_EscapesAndBreaks(t *testing.T) {
 	assert.Equal(t, []string{"a|b", "x\ny", "z"}, splitRow(`| a\|b | x<br>y | z |`))
 	assert.Equal(t, []string{"plain", "cells"}, splitRow("| plain | cells |"))
 }
+
+// TestTableCell_LiteralBrSurvives: a value that itself contains the text <br> must come back as
+// that text, not as a line break — otherwise the round trip is only exact for values without it.
+func TestTableCell_LiteralBrSurvives(t *testing.T) {
+	value := "第一段<br>第二段\n第三段"
+	assert.Equal(t, []string{value}, splitRow("| "+tableCell(value)+" |"))
+}
+
+// TestParseObjectType_LogicPropertyParameterRowSplit is the case the first review round found:
+// a parameter table under #### keeps its rows only because parseLogicPropertySubSection hands the
+// table reader every line. Filtering to pipe-prefixed lines there made the continuation logic
+// join the *next* parameter onto the split one and lose it.
+func TestParseObjectType_LogicPropertyParameterRowSplit(t *testing.T) {
+	text := `---
+type: object_type
+id: order
+name: Order
+---
+
+## ObjectType: Order
+
+### Logic Properties
+
+#### gmv
+
+**Meta**
+
+| Display Name | Type | Description |
+|--------------|------|-------------|
+| GMV | metric | 成交额 |
+
+**Parameters**
+
+| Name | Type | Source | Operation | ValueFrom | Value | Description |
+|------|------|--------|-----------|-----------|-------|-------------|
+| p1 | string | body |  | input |  | 第一行
+第二行 |
+| p2 | string | body |  | input |  | 第二个参数 |
+`
+	parsed, err := ParseObjectTypeFile(text, "/test/order.bkn")
+	require.NoError(t, err)
+	require.Len(t, parsed.LogicProperties, 1)
+	params := parsed.LogicProperties[0].Parameters
+	require.Len(t, params, 2, "both parameters must survive a split row")
+	assert.Equal(t, "p1", params[0].Name)
+	assert.Equal(t, "第一行\n第二行", params[0].Description)
+	assert.Equal(t, "p2", params[1].Name)
+	assert.Equal(t, "第二个参数", params[1].Description)
+}

--- a/adp/bkn/bkn-backend/server/bkn-specification/bkn/table_cell_test.go
+++ b/adp/bkn/bkn-backend/server/bkn-specification/bkn/table_cell_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 OpenBKN. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See the LICENSE file in the project root.
+
+package bkn
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeObjectType_CellEscapesRoundTrip locks the contract this file exists for: a
+// description carrying a line break or a pipe must come back from the file byte for byte, and
+// the file itself must still hold one row per property.
+func TestSerializeObjectType_CellEscapesRoundTrip(t *testing.T) {
+	original := &BknObjectType{
+		BknObjectTypeFrontmatter: BknObjectTypeFrontmatter{Type: "object_type", ID: "bom", Name: "BOM"},
+		DataSource:               &ResourceInfo{Type: "resource", ID: "res-1"},
+		DataProperties: []*DataProperty{
+			{Name: "seq_no", DisplayName: "序号", Type: "integer",
+				Description: "第一行。\n第二行，含竖线 a|b。", MappedField: "seq_no"},
+			{Name: "standard_usage", DisplayName: "标准用量", Type: "decimal",
+				Description: "组装时的标准用量。", MappedField: "standard_usage"},
+		},
+	}
+
+	text := SerializeObjectType(original)
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "| seq_no") {
+			assert.Contains(t, line, "<br>", "line break must be escaped inside the row")
+			assert.Contains(t, line, `a\|b`, "pipe must be escaped inside the row")
+			assert.True(t, strings.HasSuffix(line, "|"), "row must close on its own line")
+		}
+	}
+
+	parsed, err := ParseObjectTypeFile(text, "/test/bom.bkn")
+	require.NoError(t, err)
+	require.Len(t, parsed.DataProperties, 2)
+	assert.Equal(t, original.DataProperties[0].Description, parsed.DataProperties[0].Description)
+	assert.Equal(t, "seq_no", parsed.DataProperties[0].MappedField)
+	assert.Equal(t, "standard_usage", parsed.DataProperties[1].Name)
+	assert.Equal(t, "standard_usage", parsed.DataProperties[1].MappedField)
+}
+
+// TestParseObjectType_LegacyBrokenRowIsJoined covers files exported before cells were escaped:
+// the row with the line break arrives split across two lines. Every row after the break used
+// to be lost and the broken row lost its Mapped Field; both must now import intact.
+func TestParseObjectType_LegacyBrokenRowIsJoined(t *testing.T) {
+	text := `---
+type: object_type
+id: bom
+name: BOM
+---
+
+## ObjectType: BOM
+
+### Data Source
+
+| Type | ID | Name |
+|------|----|------|
+| resource | res-1 |  |
+
+### Data Properties
+
+| Name | Display Name | Type | Description | Mapped Field |
+|------|--------------|------|-------------|--------------|
+| material_code | 物料编码 | string |  | material_code |
+| seq_no | 序号 | integer | 序号用来跟踪一个产品中每个物料的位置。比如产品A
+A产品的BOM中都有一个序号。 | seq_no |
+| standard_usage | 标准用量 | decimal | 组装时的标准用量。 | standard_usage |
+| variable_loss_rate | 变动损耗率 | decimal | 0 就是没有损耗。 | variable_loss_rate |
+
+### Logic Properties
+
+`
+	parsed, err := ParseObjectTypeFile(text, "/test/bom.bkn")
+	require.NoError(t, err)
+	require.Len(t, parsed.DataProperties, 4)
+	names := make([]string, 0, 4)
+	for _, dp := range parsed.DataProperties {
+		names = append(names, dp.Name)
+		assert.Equal(t, dp.Name, dp.MappedField, "mapped field of %s", dp.Name)
+	}
+	assert.Equal(t, []string{"material_code", "seq_no", "standard_usage", "variable_loss_rate"}, names)
+	assert.Equal(t, "序号用来跟踪一个产品中每个物料的位置。比如产品A\nA产品的BOM中都有一个序号。", parsed.DataProperties[1].Description)
+}
+
+// TestParseObjectType_MalformedPropertyRowIsRejected: a row that cannot be rebuilt (the file ends
+// inside it) is an error naming the row, not a silently shorter object type.
+func TestParseObjectType_MalformedPropertyRowIsRejected(t *testing.T) {
+	text := `---
+type: object_type
+id: bom
+name: BOM
+---
+
+## ObjectType: BOM
+
+### Data Properties
+
+| Name | Display Name | Type | Description | Mapped Field |
+|------|--------------|------|-------------|--------------|
+| material_code | 物料编码 | string |  | material_code |
+|  | 缺名 | string |  | x |
+`
+	_, err := ParseObjectTypeFile(text, "/test/bom.bkn")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "row 2")
+}
+
+func TestSplitRow_EscapesAndBreaks(t *testing.T) {
+	assert.Equal(t, []string{"a|b", "x\ny", "z"}, splitRow(`| a\|b | x<br>y | z |`))
+	assert.Equal(t, []string{"plain", "cells"}, splitRow("| plain | cells |"))
+}


### PR DESCRIPTION
## Summary

Fixes #1496. `.bkn` export wrote table cells raw, so a property description containing a line break split its Markdown row across two lines. On import the table reader stopped at the first line not starting with `|`, silently dropping every property after the break, and the split row itself lost its mapped field. `openbkn bkn validate` and the import both reported success.

## Changes

- **Export** (`serialize.go`): all table cells pass through `tableCell`, writing a line break as `<br>` and a pipe as `\|`. One row per property, always.
- **Import** (`parser.go`):
  - `splitRow` honours `\|` and restores `<br>` to a line break, so values round-trip unchanged.
  - `parseTable` joins a line onto the previous row while that row is still open (no trailing `|`). This is what makes files exported before this fix import in full instead of truncating.
  - `parseDataProperties` rejects a row with an empty `Name`, naming the row, instead of importing a shorter object type.
  - `parseLogicPropertySubSection` hands every line between two labels to the table reader (it used to keep only pipe-prefixed lines, which would have made the continuation rule join the next parameter onto a split one).
  - A literal `<br>` inside a value is entity-encoded on export and restored on import, so the round trip is exact for that text too.
- **Tests** (`table_cell_test.go`): round trip of break/pipe cells; the legacy split-row layout (4 rows, mapped fields intact, description rejoined); malformed row error; `splitRow` escapes; a split parameter row under a logic property (both parameters survive); literal `<br>` round trip.

## Verification

- `go vet` / `go test ./bkn-specification/...` green; `go build ./...` and `go test ./logics/` green.
- Ad-hoc run (not committed) against the real exported object type file that surfaced the bug: 16 of 16 properties parse with correct mapped fields, and re-serializing then re-parsing keeps all 16 with identical descriptions.

Not hot-swapped onto a deployment: the import handler only calls the parser this PR changes, and the parser was exercised on the real file above.

## Compatibility

Additive on both sides. Files written by the old exporter that contain split rows now import completely; well-formed files are unchanged. The escape follows the common Markdown table convention, so the files stay readable in any renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
