### PR TITLE
docs(context-loader): give the execute_tool request examples the kn_id the schema requires

### DIFF
--- a/docs/api/context-loader/tool.yaml
+++ b/docs/api/context-loader/tool.yaml
@@ -204,6 +204,7 @@ paths:
             examples:
               调用:
                 value:
+                  kn_id: kn_finance
                   toolbox_id: box_finance
                   tool_id: tool_fx_convert
                   arguments:
@@ -215,6 +216,7 @@ paths:
                   bkn_context:
                     conversation_id: conv_01J8Z
                     interaction_id: int_01J8Z
+                  kn_id: kn_finance
                   toolbox_id: box_finance
                   tool_id: tool_fx_convert
                   arguments:


### PR DESCRIPTION
Both request examples on `POST /kn/execute_tool` omitted `kn_id`, which `ExecuteToolRequest` marks required and the handler refuses without — a reader copying the example got a 400. The OpenAPI lint's two findings on this file were exactly these; the file now lints clean with the pinned `@redocly/cli` 1.34.17.

Context: the docs `lint` job's red on 9/9–9/10 was a YAML duplicate key in `bkn-safe/property-grants.yaml` (introduced by #1420, fixed by #1452), not these warnings — `.redocly.yaml` keeps every rule but `no-unresolved-refs` at `warn`, and warnings never fail the job. This PR only removes the two real defects in the file I own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)