### PR TITLE
chore(sandbox): pin bkn-osdk to a main commit that has kn.execute_tool

### DIFF
--- a/docs/templates/skill-package/README.md
+++ b/docs/templates/skill-package/README.md
@@ -16,6 +16,7 @@
 | [`functions/function.py.template`](functions/function.py.template) | 沙箱函数骨架：`handler(event)` + bkn-osdk 读数 |
 | [`examples/demand-deliverability-assessment/`](examples/demand-deliverability-assessment/) | 完整样例：需求可交付性评估 Skill，在测试环境实跑通过 |
 | [`examples/functions/l1_kitting_check.py`](examples/functions/l1_kitting_check.py) | 完整样例：一级 BOM 齐套检查函数，通过 bkn-osdk 读 BOM 与库存 |
+| [`examples/functions/call_l1_check.py`](examples/functions/call_l1_check.py) | 完整样例：函数调函数，通过 `kn.execute_tool` 以同一身份、同一受管会话调用上一个函数 |
 
 ## 一、Skill 包结构
 
@@ -88,6 +89,28 @@ metadata:
 ### 骨架
 
 见 [`functions/function.py.template`](functions/function.py.template)。分页读取、按属性过滤、返回结构化结果三段都在里面；完整可跑的版本见 [`examples/functions/l1_kitting_check.py`](examples/functions/l1_kitting_check.py)。
+
+### 函数调函数
+
+一个函数可以通过平台调用另一个已挂载到同一知识网络的函数：
+
+```python
+from bkn_osdk import kn
+
+def handler(event):
+    answer = kn.execute_tool(event["kn_id"], event["box_id"], event["tool_id"],
+                             {"kn_id": event["kn_id"], "product": event["product"], "qty": 50})
+    body = answer.get("body", answer)          # 被调函数的原始响应
+    if body.get("exit_code") not in (0, None): # HTTP 200 不等于被调函数成功
+        return {"ok": False, "reason": body.get("stderr", "")[-300:]}
+    return {"ok": True, **(body.get("result") or {})}
+```
+
+- `kn.execute_tool` 自动带上当前沙箱的受管会话，被调函数的沙箱因此拿到同一份调用者凭据；trace 里被调函数挂在本函数 `execute_tool` 操作之下，再往下是它自己的读数。
+- 前提：沙箱预装的 bkn-osdk 含 `kn.execute_tool`（bkn-sdk #100 起）。更早的版本只能 `bkn_osdk.call("/api/agent-retrieval/v1/kn/execute_tool", ...)` 裸打，并且**必须**把 `BKN_CONVERSATION_ID` / `BKN_INTERACTION_ID` / `BKN_PARENT_OPERATION_ID` 拼成 `bkn_context` 放进请求体；漏掉的话被调函数的沙箱不会注入任何凭据。
+- 被调函数按自己的挂载与权限独立生效；平台不做调用深度与循环检测，别写互相调用的函数。
+
+完整样例见 [`examples/functions/call_l1_check.py`](examples/functions/call_l1_check.py)。
 
 ### 从代码到工具（openbkn CLI 0.1.5+）
 

--- a/docs/templates/skill-package/examples/functions/call_l1_check.py
+++ b/docs/templates/skill-package/examples/functions/call_l1_check.py
@@ -1,0 +1,28 @@
+"""Function A calling Function B through the platform.
+
+Runs in the platform sandbox as a function tool. Nothing here names a URL, a token or a
+session: bkn-osdk reads BKN_BASE_URL / BKN_TOKEN and the managed turn
+(BKN_CONVERSATION_ID / BKN_INTERACTION_ID / BKN_PARENT_OPERATION_ID) from the sandbox
+environment, so the inner call runs as the same caller and lands in the trace as a child
+of this function's own execute_tool operation.
+
+Requires the sandbox's bkn-osdk to include `kn.execute_tool` (bkn-sdk #100 or later).
+"""
+
+from bkn_osdk import kn
+
+
+def handler(event: dict) -> dict:
+    """event: kn_id, box_id, tool_id (the function to call), product, qty."""
+    kn_id = event["kn_id"]
+    answer = kn.execute_tool(kn_id, event["box_id"], event["tool_id"],
+                             {"kn_id": kn_id, "product": event["product"], "qty": event.get("qty", 1)})
+
+    # execute_tool hands back the tool's raw response: `body.exit_code` says whether B ran,
+    # `body.result` is B's own return value. Read both — an HTTP 200 does not mean B succeeded.
+    body = answer.get("body", answer) if isinstance(answer, dict) else {}
+    if not isinstance(body, dict) or body.get("exit_code") not in (0, None):
+        return {"ok": False, "reason": (body.get("stderr") or "")[-300:] if isinstance(body, dict) else str(answer)[:300]}
+    result = body.get("result") or {}
+    return {"ok": True, "kitting_ok": result.get("kitting_ok"), "gap_count": result.get("gap_count"),
+            "gaps": (result.get("gaps") or [])[:5]}

--- a/infra/sandbox/images/templates/executor/bkn-requirements.txt
+++ b/infra/sandbox/images/templates/executor/bkn-requirements.txt
@@ -9,7 +9,10 @@
 #
 # Not on PyPI, so it is pinned by commit through the source archive. The image
 # has no git, so `git+https://` cannot install it.
-# To upgrade: replace the sha with a newer commit on bkn-sdk main and rebuild.
+# To upgrade: replace the sha with a newer commit ON bkn-sdk MAIN and rebuild.
+# Pin a commit that is on main, never one from a PR branch: the archive URL of a
+# branch commit stops resolving once that branch is deleted, and the image build
+# breaks with it. (The previous pin was such a branch commit.)
 #
 # Its only runtime dependency is httpx. Where the data-science stack is also
 # installed, common-requirements.txt pins httpx==0.27.2 and both files are
@@ -20,4 +23,4 @@
 # Note for mirror-only builds: this is a PEP 508 direct URL, so `USE_MIRROR`
 # does not redirect it -- the build host needs to reach github.com even when pip
 # itself is pointed at a mirror.
-bkn-osdk @ https://github.com/openbkn-ai/bkn-sdk/archive/3d99c6b3d8faec780e728d6c57be381200a1ae18.zip#subdirectory=python
+bkn-osdk @ https://github.com/openbkn-ai/bkn-sdk/archive/a877c3abd6f69cb02bc0c1f6a4ab346619d4afe6.zip#subdirectory=python


### PR DESCRIPTION
## Summary

Fixes #1504. The sandbox executor image pins `bkn-osdk` by source archive. The pinned commit `3d99c6b3` is a PR-branch commit (`fix/1319-function-trace-parent`), so the archive URL only resolves while that branch exists, and it predates bkn-sdk #100, which added `kn.execute_tool` / `kn.search_capabilities`. Inside the sandbox that meant `bkn_osdk.kn` had no way to call another function except a raw `bkn_osdk.call("/api/agent-retrieval/v1/kn/execute_tool", …)` with a hand-built `bkn_context`; leaving `bkn_context` out gives the callee's sandbox no credential at all (the execution factory injects one only when token, conversation and interaction are all present), which is exactly what the #940 verification ran into.

## Changes

- `infra/sandbox/images/templates/executor/bkn-requirements.txt`: pin moved to bkn-sdk main `a877c3abd6f69cb02bc0c1f6a4ab346619d4afe6` (includes #100 and #104); comment now says to pin main commits only and why.
- `docs/templates/skill-package/README.md`: new "函数调函数" section — `kn.execute_tool` usage, how to read the callee's response, the older-SDK fallback with the `bkn_context` requirement, and the note that there is no depth/cycle guard.
- `docs/templates/skill-package/examples/functions/call_l1_check.py`: the worked example.

## Verification

On the test deploy, the new archive was pip-installed into the running sandbox session (`/tmp/osdk-new`, put first on `sys.path`) and the example registered as a tool. Called through the Context Loader `execute_tool` inside a managed interaction:

- `kn.execute_tool` is present and the callee (`l1_kitting_check`) ran with the caller's credential and session — no `bkn_context` assembled by hand — returning its kitting result.
- Trace core index for that interaction: `execute_tool` (caller) → `execute_tool` (callee, `parent_operation_id` = caller's op) → the callee's two `query_object_instance` reads.
- Control from the same day: the pinned SDK's `bkn_osdk.kn` has no `execute_tool`; a raw REST call without `bkn_context` leaves the callee with `No access token`.

`python/pyproject.toml` dependencies are unchanged between the two commits (httpx only), so the single-pass pip resolution in the Dockerfile is unaffected. The executor image itself is rebuilt by CI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
