### PR TITLE
feat(bkn-safe): audit the authorization face and record decisions

### DIFF
--- a/bkn-safe/charts/bkn-safe/templates/configmap.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/configmap.yaml
@@ -36,6 +36,16 @@ data:
   SAFE_LICENSE_SERVER_URL: {{ .Values.config.license.serverURL | quote }}
   SAFE_LICENSE_CA_FILE: {{ .Values.config.license.caFile | quote }}
   SAFE_LICENSE_INSECURE_SKIP_VERIFY: {{ .Values.config.license.insecureSkipVerify | quote }}
+  {{- with .Values.config.audit }}
+  SAFE_AUDIT_CHAIN_HEAD_LOG_INTERVAL: {{ .chainHeadLogInterval | default "15m" | quote }}
+  {{- with .decisionLog }}
+  {{- /* `default` would turn an explicit false back into true; test the kind. */}}
+  SAFE_AUTHZ_DECISION_LOG_ENABLED: {{ if kindIs "bool" .enabled }}{{ .enabled | toString | quote }}{{ else }}"true"{{ end }}
+  SAFE_AUTHZ_DECISION_LOG_ALLOW_SAMPLE_RATE: {{ .allowSampleRate | default "1" | quote }}
+  SAFE_AUTHZ_DECISION_LOG_QUEUE_SIZE: {{ .queueSize | default "4096" | quote }}
+  SAFE_AUTHZ_DECISION_LOG_RETENTION_DAYS: {{ .retentionDays | default "90" | quote }}
+  {{- end }}
+  {{- end }}
   {{- /* OPENBKN_INSTANCE_ID is NOT here — the instance identity lives in its
          own ConfigMap (templates/instance-id.yaml) so that it survives
          `helm uninstall`. Both are pulled in via envFrom. */}}

--- a/bkn-safe/charts/bkn-safe/templates/configmap.yaml
+++ b/bkn-safe/charts/bkn-safe/templates/configmap.yaml
@@ -37,13 +37,15 @@ data:
   SAFE_LICENSE_CA_FILE: {{ .Values.config.license.caFile | quote }}
   SAFE_LICENSE_INSECURE_SKIP_VERIFY: {{ .Values.config.license.insecureSkipVerify | quote }}
   {{- with .Values.config.audit }}
-  SAFE_AUDIT_CHAIN_HEAD_LOG_INTERVAL: {{ .chainHeadLogInterval | default "15m" | quote }}
+  {{- /* No `default` here: it treats false and 0 as unset, and 0 is a documented
+         value for every one of these knobs (disable / keep all / record no
+         allows). Only a missing key falls back. */}}
+  SAFE_AUDIT_CHAIN_HEAD_LOG_INTERVAL: {{ if kindIs "invalid" .chainHeadLogInterval }}"15m"{{ else }}{{ .chainHeadLogInterval | toString | quote }}{{ end }}
   {{- with .decisionLog }}
-  {{- /* `default` would turn an explicit false back into true; test the kind. */}}
   SAFE_AUTHZ_DECISION_LOG_ENABLED: {{ if kindIs "bool" .enabled }}{{ .enabled | toString | quote }}{{ else }}"true"{{ end }}
-  SAFE_AUTHZ_DECISION_LOG_ALLOW_SAMPLE_RATE: {{ .allowSampleRate | default "1" | quote }}
-  SAFE_AUTHZ_DECISION_LOG_QUEUE_SIZE: {{ .queueSize | default "4096" | quote }}
-  SAFE_AUTHZ_DECISION_LOG_RETENTION_DAYS: {{ .retentionDays | default "90" | quote }}
+  SAFE_AUTHZ_DECISION_LOG_ALLOW_SAMPLE_RATE: {{ if kindIs "invalid" .allowSampleRate }}"1"{{ else }}{{ .allowSampleRate | toString | quote }}{{ end }}
+  SAFE_AUTHZ_DECISION_LOG_QUEUE_SIZE: {{ if kindIs "invalid" .queueSize }}"4096"{{ else }}{{ .queueSize | toString | quote }}{{ end }}
+  SAFE_AUTHZ_DECISION_LOG_RETENTION_DAYS: {{ if kindIs "invalid" .retentionDays }}"90"{{ else }}{{ .retentionDays | toString | quote }}{{ end }}
   {{- end }}
   {{- end }}
   {{- /* OPENBKN_INSTANCE_ID is NOT here — the instance identity lives in its

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -154,8 +154,8 @@ config:
   # the chain-anchor export and the authorization decision log.
   audit:
     # How often the audit chain head (seq + hash) is written to the service
-    # log so the log pipeline holds anchors outside the database. Go duration;
-    # "0" disables.
+    # log so the log pipeline holds anchors outside the database. Go duration
+    # string; "0s" disables.
     chainHeadLogInterval: "15m"
     decisionLog:
       # Record every authorization decision (/authz/check, batch summaries for

--- a/bkn-safe/charts/bkn-safe/values.yaml
+++ b/bkn-safe/charts/bkn-safe/values.yaml
@@ -150,6 +150,25 @@ config:
     # is what made every Helm upgrade invalidate an activated license
     # (openbkn-ai/bkn-foundry#508).
     instanceId: ""
+  # Audit subsystem (#334). The audit trail itself is always on; these tune
+  # the chain-anchor export and the authorization decision log.
+  audit:
+    # How often the audit chain head (seq + hash) is written to the service
+    # log so the log pipeline holds anchors outside the database. Go duration;
+    # "0" disables.
+    chainHeadLogInterval: "15m"
+    decisionLog:
+      # Record every authorization decision (/authz/check, batch summaries for
+      # /operations and /resource-filter, admin gate and permission points).
+      # Written off the request path; a full queue drops rows, never blocks.
+      enabled: true
+      # Fraction [0,1] of ALLOW decisions kept. Denies are always kept. Lower
+      # it on a busy cluster; 1 keeps everything.
+      allowSampleRate: "1"
+      # Rows waiting to be written before Record starts dropping.
+      queueSize: "4096"
+      # Purge decision rows older than this many days (daily). 0 = keep all.
+      retentionDays: "90"
 
 resources:
   requests:

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -39,6 +40,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authzgate"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/decisionlog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/httpapi"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
@@ -61,6 +63,9 @@ type App struct {
 	enforcer *authz.Enforcer
 	deps     httpapi.Deps
 	licSvc   *license.Service
+	// decisions is the authorization decision log; its retention purge runs
+	// alongside the listener.
+	decisions *decisionlog.Store
 	// freshAuthorizationStore is captured before AutoMigrate creates the
 	// Casbin/marker schema. An old but empty store must still run the explicit
 	// offline migration and therefore is never inferred as fresh later.
@@ -126,6 +131,16 @@ func Boot(opts Options) (*App, error) {
 	dir := directory.New(db)
 	auditStore := audit.New(db)
 	accessLogStore := accesslog.New(db)
+	decisionStore := decisionlog.New(db, decisionlog.Options{
+		Enabled:         cfg.Audit.DecisionLog.Enabled,
+		AllowSampleRate: cfg.Audit.DecisionLog.AllowSampleRate,
+		QueueSize:       cfg.Audit.DecisionLog.QueueSize,
+	})
+	if decisionStore.Enabled() {
+		slog.Info("authz decision log enabled",
+			"allow_sample_rate", cfg.Audit.DecisionLog.AllowSampleRate,
+			"retention_days", cfg.Audit.DecisionLog.RetentionDays)
+	}
 
 	// Cluster license hub: hold the one .lic, be the only egress to the
 	// license-server, distribute to modules.
@@ -157,6 +172,7 @@ func Boot(opts Options) (*App, error) {
 		enforcer:                enforcer,
 		licSvc:                  licSvc,
 		freshAuthorizationStore: freshAuthorizationStore,
+		decisions:               decisionStore,
 		deps: httpapi.Deps{
 			Enforcer:  enforcer,
 			DB:        db,
@@ -166,6 +182,7 @@ func Boot(opts Options) (*App, error) {
 			Users:     userStore,
 			Audit:     auditStore,
 			AccessLog: accessLogStore,
+			Decisions: decisionStore,
 			License:   licSvc,
 		},
 	}, nil
@@ -192,6 +209,13 @@ func (a *App) Run() error {
 	}
 	entitlement.Freeze()
 	slog.Info("extensions assembled", "assembled", entitlement.Assembled())
+
+	// Background audit work lives for as long as the listener: the chain head
+	// anchor export and the decision-log retention purge.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go a.deps.Audit.LogHead(ctx, a.cfg.Audit.ChainHeadLogInterval)
+	go a.decisions.RunRetention(ctx, a.cfg.Audit.DecisionLog.RetentionDays, 24*time.Hour)
 
 	r := httpapi.New(a.deps)
 	slog.Info("bkn-safe listening", "addr", a.cfg.HTTPAddr)

--- a/bkn-safe/server/app/app.go
+++ b/bkn-safe/server/app/app.go
@@ -219,7 +219,10 @@ func (a *App) Run() error {
 
 	r := httpapi.New(a.deps)
 	slog.Info("bkn-safe listening", "addr", a.cfg.HTTPAddr)
-	return r.Run(a.cfg.HTTPAddr)
+	err := r.Run(a.cfg.HTTPAddr)
+	// The listener is gone; drain the queued decisions before reporting why.
+	a.decisions.Close()
+	return err
 }
 
 func (a *App) ensureAuthorizationMigrationReady(ctx context.Context) error {

--- a/bkn-safe/server/config/config.go
+++ b/bkn-safe/server/config/config.go
@@ -6,7 +6,10 @@
 // file (SAFE_CONFIG or -config), and environment variable overrides.
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Config is the full bkn-safe configuration.
 type Config struct {
@@ -18,6 +21,31 @@ type Config struct {
 	// SeedOnStart controls whether roles/resource-types/operations/grants are
 	// seeded into the DB at startup (idempotent). Default true.
 	SeedOnStart bool `yaml:"seed_on_start"`
+	// Audit tunes the audit chain anchor export and the authorization
+	// decision log (#334).
+	Audit AuditConfig `yaml:"audit"`
+}
+
+// AuditConfig tunes what the audit subsystem does beyond recording rows.
+type AuditConfig struct {
+	// ChainHeadLogInterval is how often the audit chain head (seq + hash) is
+	// written to the service log, so an external append-only log store holds
+	// anchors a verifier can compare the database against. 0 disables.
+	ChainHeadLogInterval time.Duration `yaml:"chain_head_log_interval"`
+	// DecisionLog configures the authorization decision log.
+	DecisionLog DecisionLogConfig `yaml:"decision_log"`
+}
+
+// DecisionLogConfig tunes the authorization decision log. Denies are always
+// recorded; only the allow side is sampled.
+type DecisionLogConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// AllowSampleRate in [0,1] is the fraction of allow decisions kept.
+	AllowSampleRate float64 `yaml:"allow_sample_rate"`
+	// QueueSize bounds the rows waiting to be written; beyond it rows drop.
+	QueueSize int `yaml:"queue_size"`
+	// RetentionDays purges older rows daily. 0 keeps everything.
+	RetentionDays int `yaml:"retention_days"`
 }
 
 // LicenseConfig points bkn-safe at the license-server (activation + renewal).

--- a/bkn-safe/server/config/config.go
+++ b/bkn-safe/server/config/config.go
@@ -30,7 +30,9 @@ type Config struct {
 type AuditConfig struct {
 	// ChainHeadLogInterval is how often the audit chain head (seq + hash) is
 	// written to the service log, so an external append-only log store holds
-	// anchors a verifier can compare the database against. 0 disables.
+	// anchors a verifier can compare the database against. 0 disables. In a
+	// YAML file write it as a duration string ("15m", "0s"): yaml.v3 decodes
+	// those into time.Duration but rejects a bare number.
 	ChainHeadLogInterval time.Duration `yaml:"chain_head_log_interval"`
 	// DecisionLog configures the authorization decision log.
 	DecisionLog DecisionLogConfig `yaml:"decision_log"`

--- a/bkn-safe/server/config/defaults.go
+++ b/bkn-safe/server/config/defaults.go
@@ -4,6 +4,8 @@
 
 package config
 
+import "time"
+
 // defaultConfig returns dev-friendly defaults (same as historical env-only Load).
 func defaultConfig() *Config {
 	return &Config{
@@ -26,6 +28,15 @@ func defaultConfig() *Config {
 		},
 		License: LicenseConfig{
 			ServerURL: "https://license.openbkn.ai",
+		},
+		Audit: AuditConfig{
+			ChainHeadLogInterval: 15 * time.Minute,
+			DecisionLog: DecisionLogConfig{
+				Enabled:         true,
+				AllowSampleRate: 1,
+				QueueSize:       4096,
+				RetentionDays:   90,
+			},
 		},
 	}
 }

--- a/bkn-safe/server/config/load.go
+++ b/bkn-safe/server/config/load.go
@@ -7,6 +7,8 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 )
 
 // LoadOptions controls config resolution order: defaults → file → env overrides.
@@ -107,6 +109,25 @@ func applyEnv(cfg *Config) {
 	}
 	if v, ok := envBool("SAFE_LICENSE_INSECURE_SKIP_VERIFY"); ok {
 		cfg.License.InsecureSkipVerify = v
+	}
+	if v := os.Getenv("SAFE_AUDIT_CHAIN_HEAD_LOG_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.Audit.ChainHeadLogInterval = d
+		}
+	}
+	if v, ok := envBool("SAFE_AUTHZ_DECISION_LOG_ENABLED"); ok {
+		cfg.Audit.DecisionLog.Enabled = v
+	}
+	if v := os.Getenv("SAFE_AUTHZ_DECISION_LOG_ALLOW_SAMPLE_RATE"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.Audit.DecisionLog.AllowSampleRate = f
+		}
+	}
+	if v, ok := envInt("SAFE_AUTHZ_DECISION_LOG_QUEUE_SIZE"); ok {
+		cfg.Audit.DecisionLog.QueueSize = v
+	}
+	if v, ok := envInt("SAFE_AUTHZ_DECISION_LOG_RETENTION_DAYS"); ok {
+		cfg.Audit.DecisionLog.RetentionDays = v
 	}
 }
 

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -48,8 +49,9 @@ type Entry struct {
 	ClientIP          string
 }
 
-// Record persists one audit entry. The returned error is for logging only —
-// auditing must never break the request it is recording, so callers swallow it.
+// Record persists one audit entry as the next link of the tamper-evidence
+// chain (see chain.go). The returned error is for logging only — auditing must
+// never break the request it is recording, so callers swallow it.
 func (s *Store) Record(ctx context.Context, e Entry) error {
 	row := model.AuditLog{
 		ID:                NewID(),
@@ -68,8 +70,20 @@ func (s *Store) Record(ctx context.Context, e Entry) error {
 		Detail:            e.Detail,
 		Status:            e.Status,
 		ClientIP:          e.ClientIP,
+		CreatedAt:         chainTimestamp(),
 	}
-	return s.db.WithContext(ctx).Create(&row).Error
+	chainMu.Lock()
+	defer chainMu.Unlock()
+	var err error
+	for attempt := 0; attempt < chainAppendAttempts; attempt++ {
+		err = s.append(ctx, &row)
+		if err == nil || !isDuplicateKey(err) {
+			return err
+		}
+		// Another replica took this seq between our head read and insert:
+		// re-read the head and link behind it instead.
+	}
+	return fmt.Errorf("audit chain append lost the sequence race %d times: %w", chainAppendAttempts, err)
 }
 
 // Filter narrows a List query. Zero-value fields are not applied. From/To bound

--- a/bkn-safe/server/internal/audit/audit.go
+++ b/bkn-safe/server/internal/audit/audit.go
@@ -24,6 +24,9 @@ import (
 // Store reads and writes the audit trail over GORM.
 type Store struct {
 	db *gorm.DB
+	// cachedHead is the last row this process appended, guarded by chainMu.
+	// nil means "read it from the database before the next append".
+	cachedHead *Head
 }
 
 // New builds an audit store.

--- a/bkn-safe/server/internal/audit/chain.go
+++ b/bkn-safe/server/internal/audit/chain.go
@@ -1,0 +1,296 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package audit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// chainMu serialises chain appends within one process so two concurrent audit
+// writes cannot read the same head. Across replicas the unique index on seq is
+// the arbiter: a lost race surfaces as a duplicate-key error and the append is
+// retried on the new head (see Record).
+var chainMu sync.Mutex
+
+// chainAppendAttempts bounds the duplicate-key retry loop. Audit writes are
+// low-frequency, so losing the race this many times in a row means something
+// other than contention is wrong.
+const chainAppendAttempts = 5
+
+// canonicalRow is the byte-stable form the row hash is computed over. It is a
+// struct, not a map, so encoding/json emits the fields in this fixed order;
+// CreatedAt is rendered in UTC so the hash does not depend on the DSN's loc.
+// Every field that a reader relies on is included — a change to any of them
+// changes the hash.
+type canonicalRow struct {
+	Seq               uint64 `json:"seq"`
+	ID                string `json:"id"`
+	ActorID           string `json:"actor_id"`
+	ActorNameSnapshot string `json:"actor_name_snapshot"`
+	ActorType         string `json:"actor_type"`
+	AuthMethod        string `json:"auth_method"`
+	CredentialID      string `json:"credential_id"`
+	RequestID         string `json:"request_id"`
+	SourceChannel     string `json:"source_channel"`
+	Method            string `json:"method"`
+	Resource          string `json:"resource"`
+	Action            string `json:"action"`
+	TargetID          string `json:"target_id"`
+	TargetName        string `json:"target_name"`
+	Detail            string `json:"detail"`
+	Status            int    `json:"status"`
+	ClientIP          string `json:"client_ip"`
+	CreatedAt         string `json:"created_at"`
+	PrevHash          string `json:"prev_hash"`
+}
+
+// rowHash computes the chain hash of row at position seq, linked to prev.
+func rowHash(row model.AuditLog, seq uint64, prev string) string {
+	c := canonicalRow{
+		Seq: seq, ID: row.ID, ActorID: row.ActorID, ActorNameSnapshot: row.ActorNameSnapshot,
+		ActorType: row.ActorType, AuthMethod: row.AuthMethod, CredentialID: row.CredentialID,
+		RequestID: row.RequestID, SourceChannel: row.SourceChannel, Method: row.Method,
+		Resource: row.Resource, Action: row.Action, TargetID: row.TargetID, TargetName: row.TargetName,
+		Detail: row.Detail, Status: row.Status, ClientIP: row.ClientIP,
+		CreatedAt: row.CreatedAt.UTC().Format(time.RFC3339Nano), PrevHash: prev,
+	}
+	b, err := json.Marshal(c)
+	if err != nil {
+		// A struct of strings and ints cannot fail to marshal; keep the
+		// signature honest anyway.
+		panic(fmt.Sprintf("audit: canonical row marshal: %v", err))
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// chainTimestamp is the CreatedAt an appended row carries. Millisecond
+// precision matches what the MySQL dialect stores (datetime(3)), so the value
+// read back for verification is byte-identical to the one that was hashed.
+func chainTimestamp() time.Time {
+	return time.Now().UTC().Truncate(time.Millisecond)
+}
+
+// LogHead writes the chain head to the service log at start and then every
+// interval until ctx ends, so the platform's log pipeline — an append-only
+// store outside this database — holds anchors a later Verify can be compared
+// against. interval<=0 disables it.
+func (s *Store) LogHead(ctx context.Context, interval time.Duration) {
+	if s == nil || interval <= 0 {
+		return
+	}
+	emit := func() {
+		head, found, err := s.Head(ctx)
+		switch {
+		case err != nil:
+			slog.Warn("audit chain head unavailable", "error", err)
+		case !found:
+			slog.Info("audit chain head", "seq", 0, "row_hash", "")
+		default:
+			slog.Info("audit chain head", "seq", head.Seq, "row_hash", head.RowHash,
+				"created_at", head.CreatedAt.UTC().Format(time.RFC3339Nano))
+		}
+	}
+	emit()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			emit()
+		}
+	}
+}
+
+// Head is the current end of the chain.
+type Head struct {
+	Seq       uint64    `json:"seq"`
+	RowHash   string    `json:"row_hash"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Head returns the last chained row's position and hash. found is false on an
+// empty chain (no row has been appended since the chain was introduced).
+func (s *Store) Head(ctx context.Context) (Head, bool, error) {
+	// Limit+Find rather than First: an empty chain is the normal state of a
+	// fresh install, not a "record not found" worth a log line.
+	var rows []model.AuditLog
+	if err := s.db.WithContext(ctx).Where("seq IS NOT NULL").Order("seq DESC").Limit(1).Find(&rows).Error; err != nil {
+		return Head{}, false, err
+	}
+	if len(rows) == 0 || rows[0].Seq == nil {
+		return Head{}, false, nil
+	}
+	row := rows[0]
+	return Head{Seq: *row.Seq, RowHash: row.RowHash, CreatedAt: row.CreatedAt}, true, nil
+}
+
+// append links row to the current head and inserts it. The caller holds
+// chainMu. A duplicate-key error means another replica appended first; the
+// caller re-reads the head and tries again.
+func (s *Store) append(ctx context.Context, row *model.AuditLog) error {
+	head, _, err := s.Head(ctx)
+	if err != nil {
+		return err
+	}
+	seq := head.Seq + 1
+	row.Seq = &seq
+	row.PrevHash = head.RowHash
+	row.RowHash = rowHash(*row, seq, head.RowHash)
+	return s.db.WithContext(ctx).Create(row).Error
+}
+
+// isDuplicateKey recognises the unique-index violation of every backend this
+// service runs on (MySQL wire via openbkn-rds, sqlite in tests) without
+// enabling GORM's error translation globally.
+func isDuplicateKey(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Duplicate entry") || // MySQL/MariaDB 1062
+		strings.Contains(msg, "Error 1062") ||
+		strings.Contains(msg, "UNIQUE constraint failed") // sqlite
+}
+
+// VerifyResult reports a chain walk. OK is true when every checked row
+// re-hashes to its stored RowHash, links to its predecessor, and no position
+// is missing. When a break is found BrokenSeq names the first bad position and
+// Reason says what failed: hash_mismatch (row content or hash edited),
+// prev_hash_mismatch (predecessor edited or replaced), or gap (row deleted).
+// Rows appended before the chain existed carry no seq; they are reported as
+// UnchainedRows and never verified.
+type VerifyResult struct {
+	OK            bool    `json:"ok"`
+	FromSeq       uint64  `json:"from_seq"`
+	ToSeq         uint64  `json:"to_seq"`
+	Checked       int64   `json:"checked"`
+	BrokenSeq     *uint64 `json:"broken_seq,omitempty"`
+	Reason        string  `json:"reason,omitempty"`
+	Head          *Head   `json:"head,omitempty"`
+	UnchainedRows int64   `json:"unchained_rows"`
+	// Truncated is true when limit stopped the walk before toSeq; resume from
+	// ToSeq+1 to continue.
+	Truncated bool `json:"truncated"`
+}
+
+const (
+	verifyBatch      = 500
+	verifyDefaultMax = 10000
+	verifyHardMax    = 100000
+)
+
+// Verify walks the chain from fromSeq (0 or 1 = the beginning) to toSeq (0 =
+// the head), at most limit rows (0 = 10000, capped at 100000), and reports the
+// first break. It reads in batches so a long chain does not load into memory
+// at once.
+func (s *Store) Verify(ctx context.Context, fromSeq, toSeq uint64, limit int) (VerifyResult, error) {
+	res := VerifyResult{OK: true}
+	if limit <= 0 {
+		limit = verifyDefaultMax
+	}
+	if limit > verifyHardMax {
+		limit = verifyHardMax
+	}
+	if err := s.db.WithContext(ctx).Model(&model.AuditLog{}).Where("seq IS NULL").Count(&res.UnchainedRows).Error; err != nil {
+		return res, err
+	}
+	head, found, err := s.Head(ctx)
+	if err != nil {
+		return res, err
+	}
+	if found {
+		h := head
+		res.Head = &h
+	}
+	if !found {
+		return res, nil
+	}
+	if fromSeq == 0 {
+		fromSeq = 1
+	}
+	if toSeq == 0 || toSeq > head.Seq {
+		toSeq = head.Seq
+	}
+	res.FromSeq = fromSeq
+	res.ToSeq = fromSeq - 1
+	if fromSeq > toSeq {
+		return res, nil
+	}
+	// Expected link into the first checked row.
+	expectedPrev := ""
+	if fromSeq > 1 {
+		var prev []model.AuditLog
+		if err := s.db.WithContext(ctx).Where("seq = ?", fromSeq-1).Limit(1).Find(&prev).Error; err != nil {
+			return res, err
+		}
+		if len(prev) == 0 {
+			// The row just before the window is gone: report it as the gap.
+			broken := fromSeq - 1
+			res.OK, res.BrokenSeq, res.Reason = false, &broken, "gap"
+			return res, nil
+		}
+		expectedPrev = prev[0].RowHash
+	}
+	expectedSeq := fromSeq
+	for res.Checked < int64(limit) && expectedSeq <= toSeq {
+		batch := verifyBatch
+		if remaining := int64(limit) - res.Checked; remaining < int64(batch) {
+			batch = int(remaining)
+		}
+		var rows []model.AuditLog
+		if err := s.db.WithContext(ctx).Where("seq >= ? AND seq <= ?", expectedSeq, toSeq).
+			Order("seq ASC").Limit(batch).Find(&rows).Error; err != nil {
+			return res, err
+		}
+		if len(rows) == 0 {
+			// Nothing at or after expectedSeq although toSeq says there should be.
+			broken := expectedSeq
+			res.OK, res.BrokenSeq, res.Reason = false, &broken, "gap"
+			return res, nil
+		}
+		for _, row := range rows {
+			if row.Seq == nil || *row.Seq != expectedSeq {
+				broken := expectedSeq
+				res.OK, res.BrokenSeq, res.Reason = false, &broken, "gap"
+				return res, nil
+			}
+			if row.PrevHash != expectedPrev {
+				broken := *row.Seq
+				res.OK, res.BrokenSeq, res.Reason = false, &broken, "prev_hash_mismatch"
+				return res, nil
+			}
+			if rowHash(row, *row.Seq, row.PrevHash) != row.RowHash {
+				broken := *row.Seq
+				res.OK, res.BrokenSeq, res.Reason = false, &broken, "hash_mismatch"
+				return res, nil
+			}
+			res.Checked++
+			res.ToSeq = *row.Seq
+			expectedPrev = row.RowHash
+			expectedSeq = *row.Seq + 1
+		}
+	}
+	res.Truncated = expectedSeq <= toSeq
+	return res, nil
+}

--- a/bkn-safe/server/internal/audit/chain.go
+++ b/bkn-safe/server/internal/audit/chain.go
@@ -143,18 +143,29 @@ func (s *Store) Head(ctx context.Context) (Head, bool, error) {
 }
 
 // append links row to the current head and inserts it. The caller holds
-// chainMu. A duplicate-key error means another replica appended first; the
-// caller re-reads the head and tries again.
+// chainMu. The head is cached after the first append so the steady state is
+// one INSERT per row, not SELECT + INSERT; any failure drops the cache, and a
+// duplicate-key error in particular means another replica appended first —
+// the caller retries, and the retry re-reads the head from the database.
 func (s *Store) append(ctx context.Context, row *model.AuditLog) error {
-	head, _, err := s.Head(ctx)
-	if err != nil {
-		return err
+	head := s.cachedHead
+	if head == nil {
+		h, _, err := s.Head(ctx)
+		if err != nil {
+			return err
+		}
+		head = &h
 	}
 	seq := head.Seq + 1
 	row.Seq = &seq
 	row.PrevHash = head.RowHash
 	row.RowHash = rowHash(*row, seq, head.RowHash)
-	return s.db.WithContext(ctx).Create(row).Error
+	if err := s.db.WithContext(ctx).Create(row).Error; err != nil {
+		s.cachedHead = nil
+		return err
+	}
+	s.cachedHead = &Head{Seq: seq, RowHash: row.RowHash, CreatedAt: row.CreatedAt}
+	return nil
 }
 
 // isDuplicateKey recognises the unique-index violation of every backend this

--- a/bkn-safe/server/internal/audit/chain_test.go
+++ b/bkn-safe/server/internal/audit/chain_test.go
@@ -1,0 +1,226 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package audit
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func chainTestStore(t *testing.T) (*Store, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.AuditLog{}); err != nil {
+		t.Fatal(err)
+	}
+	return New(db), db
+}
+
+func record(t *testing.T, s *Store, action string) {
+	t.Helper()
+	if err := s.Record(context.Background(), Entry{
+		ActorID: "admin-1", ActorType: "user", AuthMethod: "oauth", Method: "POST",
+		Resource: "users", Action: action, Detail: `{"name":"` + action + `"}`, Status: 201,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecordLinksRowsIntoChain(t *testing.T) {
+	s, db := chainTestStore(t)
+	record(t, s, "first")
+	record(t, s, "second")
+	record(t, s, "third")
+
+	var rows []model.AuditLog
+	if err := db.Order("seq ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d, want 3", len(rows))
+	}
+	prev := ""
+	for i, row := range rows {
+		if row.Seq == nil || *row.Seq != uint64(i+1) {
+			t.Fatalf("row %d seq = %v, want %d", i, row.Seq, i+1)
+		}
+		if row.PrevHash != prev {
+			t.Fatalf("row %d prev_hash = %q, want %q", i, row.PrevHash, prev)
+		}
+		if row.RowHash == "" || rowHash(row, *row.Seq, row.PrevHash) != row.RowHash {
+			t.Fatalf("row %d hash does not recompute", i)
+		}
+		if row.CreatedAt.IsZero() || row.CreatedAt.Nanosecond()%int(time.Millisecond) != 0 {
+			t.Fatalf("row %d created_at %v is not millisecond-truncated", i, row.CreatedAt)
+		}
+		prev = row.RowHash
+	}
+	head, found, err := s.Head(context.Background())
+	if err != nil || !found || head.Seq != 3 || head.RowHash != prev {
+		t.Fatalf("head = %+v found=%v err=%v, want seq 3 hash %s", head, found, err, prev)
+	}
+}
+
+func TestVerifyPassesOnIntactChainAndSkipsLegacyRows(t *testing.T) {
+	s, db := chainTestStore(t)
+	// Two rows from before the chain existed: no seq, no hashes.
+	for _, id := range []string{"legacy-a", "legacy-b"} {
+		if err := db.Create(&model.AuditLog{ID: id, ActorID: "old", Action: "create"}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	record(t, s, "first")
+	record(t, s, "second")
+
+	res, err := s.Verify(context.Background(), 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Checked != 2 || res.FromSeq != 1 || res.ToSeq != 2 || res.UnchainedRows != 2 || res.Truncated {
+		t.Fatalf("intact chain verify = %+v", res)
+	}
+	if res.Head == nil || res.Head.Seq != 2 {
+		t.Fatalf("verify head = %+v", res.Head)
+	}
+}
+
+func TestVerifyDetectsEditedRow(t *testing.T) {
+	s, db := chainTestStore(t)
+	record(t, s, "first")
+	record(t, s, "second")
+	record(t, s, "third")
+
+	// Edit the second row's content in place: the classic "make it look like
+	// nothing happened" change.
+	if err := db.Model(&model.AuditLog{}).Where("seq = ?", 2).Update("detail", `{"name":"innocent"}`).Error; err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.Verify(context.Background(), 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || res.BrokenSeq == nil || *res.BrokenSeq != 2 || res.Reason != "hash_mismatch" {
+		t.Fatalf("edited row not detected: %+v", res)
+	}
+	// Re-hashing the edited row to cover the edit still breaks the link from
+	// the next row.
+	var edited model.AuditLog
+	if err := db.Where("seq = ?", 2).First(&edited).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&model.AuditLog{}).Where("seq = ?", 2).Update("row_hash", rowHash(edited, 2, edited.PrevHash)).Error; err != nil {
+		t.Fatal(err)
+	}
+	res, err = s.Verify(context.Background(), 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || res.BrokenSeq == nil || *res.BrokenSeq != 3 || res.Reason != "prev_hash_mismatch" {
+		t.Fatalf("re-hashed edit not detected at the successor: %+v", res)
+	}
+}
+
+func TestVerifyDetectsDeletedRow(t *testing.T) {
+	s, db := chainTestStore(t)
+	record(t, s, "first")
+	record(t, s, "second")
+	record(t, s, "third")
+	if err := db.Where("seq = ?", 2).Delete(&model.AuditLog{}).Error; err != nil {
+		t.Fatal(err)
+	}
+	res, err := s.Verify(context.Background(), 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || res.BrokenSeq == nil || *res.BrokenSeq != 2 || res.Reason != "gap" {
+		t.Fatalf("deleted row not detected: %+v", res)
+	}
+	// A window starting after the gap still links to its predecessor.
+	res, err = s.Verify(context.Background(), 3, 3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.OK || res.Reason != "gap" {
+		t.Fatalf("window after a deleted predecessor verified: %+v", res)
+	}
+}
+
+func TestVerifyWindowAndLimit(t *testing.T) {
+	s, _ := chainTestStore(t)
+	for i := 0; i < 5; i++ {
+		record(t, s, "row")
+	}
+	res, err := s.Verify(context.Background(), 2, 4, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.FromSeq != 2 || res.ToSeq != 4 || res.Checked != 3 || res.Truncated {
+		t.Fatalf("window verify = %+v", res)
+	}
+	res, err = s.Verify(context.Background(), 0, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Checked != 2 || res.ToSeq != 2 || !res.Truncated {
+		t.Fatalf("limited verify = %+v (want 2 checked, truncated)", res)
+	}
+	res, err = s.Verify(context.Background(), 3, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.FromSeq != 3 || res.ToSeq != 5 || res.Checked != 3 {
+		t.Fatalf("resume verify = %+v", res)
+	}
+}
+
+func TestRecordRetriesWhenAnotherWriterTookTheSeq(t *testing.T) {
+	s, db := chainTestStore(t)
+	record(t, s, "first")
+	// Simulate a second replica that appended seq 2 between our head read and
+	// insert: pre-insert a foreign row at seq 2 through a wrapped store whose
+	// head read is stale.
+	stale := &Store{db: db}
+	head, _, err := stale.Head(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq := head.Seq + 1
+	foreign := model.AuditLog{ID: "foreign", ActorID: "other-replica", Action: "create", CreatedAt: chainTimestamp(), Seq: &seq, PrevHash: head.RowHash}
+	foreign.RowHash = rowHash(foreign, seq, head.RowHash)
+	if err := db.Create(&foreign).Error; err != nil {
+		t.Fatal(err)
+	}
+	// Our own append now finds seq 2 taken on the first attempt only if the
+	// head were stale; Record re-reads the head under the lock, so it lands
+	// at seq 3 linked to the foreign row.
+	record(t, s, "second")
+	res, err := s.Verify(context.Background(), 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Checked != 3 {
+		t.Fatalf("chain after concurrent append = %+v", res)
+	}
+	// And the duplicate-key path itself: inserting at an occupied seq must be
+	// recognised as a race, not as a storage failure.
+	dup := model.AuditLog{ID: "dup", Seq: &seq}
+	err = db.Create(&dup).Error
+	if err == nil || !isDuplicateKey(err) {
+		t.Fatalf("duplicate seq error not recognised: %v", err)
+	}
+	if isDuplicateKey(errors.New("connection refused")) {
+		t.Fatal("unrelated error treated as duplicate key")
+	}
+}

--- a/bkn-safe/server/internal/authz/authz.go
+++ b/bkn-safe/server/internal/authz/authz.go
@@ -347,6 +347,20 @@ func (en *Enforcer) CanAdmin(accessorID string) (bool, error) {
 	return en.Check(accessorID, "safe_admin", "console", "manage")
 }
 
+// AdminResource is the (type, id, op) triple CanAdmin evaluates, exported so
+// the decision log can name it.
+const (
+	AdminResourceType = "safe_admin"
+	AdminResourceID   = "console"
+	AdminOperation    = "manage"
+)
+
+// AdminDecision is CanAdmin with the full evaluation (decision + basis), for
+// call sites that record the decision.
+func (en *Enforcer) AdminDecision(ctx context.Context, accessorID string) (Evaluation, error) {
+	return en.OperationDecision(ctx, accessorID, AdminResourceType, AdminResourceID, AdminOperation)
+}
+
 // AssignRole binds an accessor (user/app) to a role. Idempotent.
 func (en *Enforcer) AssignRole(accessorID, roleID string) error {
 	en.transactionMu.Lock()

--- a/bkn-safe/server/internal/decisionlog/decisionlog.go
+++ b/bkn-safe/server/internal/decisionlog/decisionlog.go
@@ -1,0 +1,380 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+// Package decisionlog records authorization decisions (#334): for every
+// evaluation the HTTP layer asks the enforcer for, one row saying who asked for
+// what on which resource, what the answer was and on what basis. It exists so
+// that "why was this allowed", "what did this account touch" and "what would
+// removing this role affect" can be answered from data rather than guessed.
+//
+// The decision path is hot (every list page calls /resource-filter, every
+// admin request passes a permission point), so writes never block a request:
+// Record hands the row to a bounded queue and returns; one writer goroutine
+// drains it in batches. When the queue is full the row is dropped and counted
+// — losing a decision row is preferable to slowing down or failing the
+// decision itself. Allow decisions may be sampled; deny decisions never are.
+package decisionlog
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"math/big"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// Decision values (mirror authz.Decision; kept as strings so this package does
+// not depend on the enforcer).
+const (
+	DecisionAllow = "allow"
+	DecisionDeny  = "deny"
+	DecisionNone  = "none"
+)
+
+// Entry is one decision to record. The timestamp and id are assigned here.
+type Entry struct {
+	AccessorID        string
+	ResourceType      string
+	ResourceID        string
+	Operation         string
+	Scope             string
+	Decision          string
+	Basis             string
+	DeniedRequirement string
+	Source            string
+	RequestID         string
+	TraceID           string
+	ClientIP          string
+	Detail            string
+}
+
+// Options tune the store. The zero value is a disabled store.
+type Options struct {
+	// Enabled turns recording on. A disabled store accepts Record calls and
+	// discards them, so call sites need no nil checks.
+	Enabled bool
+	// AllowSampleRate in [0,1] is the fraction of allow decisions kept; deny
+	// and none are always kept. 0 keeps no allow rows, 1 keeps all.
+	AllowSampleRate float64
+	// QueueSize bounds the in-flight rows; beyond it Record drops. Default 4096.
+	QueueSize int
+	// BatchSize is the largest insert batch. Default 200.
+	BatchSize int
+	// FlushInterval is how long a partial batch waits before it is written.
+	// Default 250ms.
+	FlushInterval time.Duration
+	// Synchronous writes every row inline instead of through the queue. It is
+	// for tests and single-request tooling where ordering must be observable
+	// immediately; production keeps it false.
+	Synchronous bool
+}
+
+// Store records and queries authorization decisions.
+type Store struct {
+	db      *gorm.DB
+	opts    Options
+	queue   chan model.AuthzDecision
+	flushCh chan chan struct{}
+	stop    chan struct{}
+	stopped chan struct{}
+	once    sync.Once
+	dropped atomic.Uint64
+	lastErr atomic.Int64 // unix seconds of the last logged write error
+}
+
+// New builds a store and, when enabled and not synchronous, starts its writer.
+func New(db *gorm.DB, opts Options) *Store {
+	s := newStore(db, opts)
+	if s.opts.Enabled && !s.opts.Synchronous {
+		go s.run()
+	}
+	return s
+}
+
+func newStore(db *gorm.DB, opts Options) *Store {
+	if opts.QueueSize <= 0 {
+		opts.QueueSize = 4096
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 200
+	}
+	if opts.FlushInterval <= 0 {
+		opts.FlushInterval = 250 * time.Millisecond
+	}
+	if opts.AllowSampleRate < 0 {
+		opts.AllowSampleRate = 0
+	}
+	if opts.AllowSampleRate > 1 {
+		opts.AllowSampleRate = 1
+	}
+	return &Store{
+		db:      db,
+		opts:    opts,
+		queue:   make(chan model.AuthzDecision, opts.QueueSize),
+		flushCh: make(chan chan struct{}),
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+}
+
+// Enabled reports whether the store records anything.
+func (s *Store) Enabled() bool { return s != nil && s.opts.Enabled }
+
+// Dropped is the number of rows discarded because the queue was full.
+func (s *Store) Dropped() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.dropped.Load()
+}
+
+// Record queues one decision. It never blocks and never returns an error: a
+// full queue drops the row and bumps Dropped. Safe on a nil or disabled store.
+func (s *Store) Record(e Entry) {
+	if s == nil || !s.opts.Enabled || s.db == nil {
+		return
+	}
+	if e.Decision == DecisionAllow && !s.sampled() {
+		return
+	}
+	row := model.AuthzDecision{
+		ID: newID(), AccessorID: e.AccessorID, ResourceType: e.ResourceType, ResourceID: e.ResourceID,
+		Operation: e.Operation, Scope: e.Scope, Decision: e.Decision, Basis: e.Basis,
+		DeniedRequirement: e.DeniedRequirement, Source: e.Source, RequestID: e.RequestID,
+		TraceID: e.TraceID, ClientIP: e.ClientIP, Detail: e.Detail,
+		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+	}
+	if s.opts.Synchronous {
+		s.write([]model.AuthzDecision{row})
+		return
+	}
+	select {
+	case s.queue <- row:
+	default:
+		if s.dropped.Add(1)%1000 == 1 {
+			slog.Warn("authz decision log queue full, dropping decisions", "dropped_total", s.dropped.Load())
+		}
+	}
+}
+
+func (s *Store) sampled() bool {
+	rate := s.opts.AllowSampleRate
+	if rate >= 1 {
+		return true
+	}
+	if rate <= 0 {
+		return false
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(1_000_000))
+	if err != nil {
+		return true
+	}
+	return float64(n.Int64()) < rate*1_000_000
+}
+
+// Flush writes everything queued so far and returns when it is persisted (or
+// ctx ends). No-op on a synchronous or disabled store.
+func (s *Store) Flush(ctx context.Context) {
+	if s == nil || !s.opts.Enabled || s.opts.Synchronous {
+		return
+	}
+	done := make(chan struct{})
+	select {
+	case s.flushCh <- done:
+	case <-s.stopped:
+		return
+	case <-ctx.Done():
+		return
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+}
+
+// Close stops the writer after draining the queue. Idempotent.
+func (s *Store) Close() {
+	if s == nil || !s.opts.Enabled || s.opts.Synchronous {
+		return
+	}
+	s.once.Do(func() { close(s.stop) })
+	<-s.stopped
+}
+
+func (s *Store) run() {
+	defer close(s.stopped)
+	ticker := time.NewTicker(s.opts.FlushInterval)
+	defer ticker.Stop()
+	batch := make([]model.AuthzDecision, 0, s.opts.BatchSize)
+	flush := func() {
+		if len(batch) == 0 {
+			return
+		}
+		s.write(batch)
+		batch = batch[:0]
+	}
+	drain := func() {
+		for {
+			select {
+			case row := <-s.queue:
+				batch = append(batch, row)
+				if len(batch) >= s.opts.BatchSize {
+					flush()
+				}
+			default:
+				flush()
+				return
+			}
+		}
+	}
+	for {
+		select {
+		case row := <-s.queue:
+			batch = append(batch, row)
+			if len(batch) >= s.opts.BatchSize {
+				flush()
+			}
+		case <-ticker.C:
+			flush()
+		case done := <-s.flushCh:
+			drain()
+			close(done)
+		case <-s.stop:
+			drain()
+			return
+		}
+	}
+}
+
+func (s *Store) write(rows []model.AuthzDecision) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := s.db.WithContext(ctx).CreateInBatches(rows, 100).Error; err != nil {
+		// One warning per 30s at most: a database outage must not turn into a
+		// log storm on top of the outage itself.
+		now := time.Now().Unix()
+		if last := s.lastErr.Load(); now-last >= 30 && s.lastErr.CompareAndSwap(last, now) {
+			slog.Warn("authz decision log write failed, decisions lost", "rows", len(rows), "error", err)
+		}
+	}
+}
+
+// Filter narrows List. Zero-value fields are not applied. From/To bound
+// CreatedAt (inclusive lower, exclusive upper).
+type Filter struct {
+	AccessorID   string
+	ResourceType string
+	ResourceID   string
+	Operation    string
+	Decision     string
+	Source       string
+	From         time.Time
+	To           time.Time
+	Offset       int
+	Limit        int
+}
+
+// List returns a page of decisions (newest first) plus the total match count.
+// Limit<=0 defaults to 50 and is capped at 500.
+func (s *Store) List(ctx context.Context, f Filter) ([]model.AuthzDecision, int64, error) {
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	q := s.db.WithContext(ctx).Model(&model.AuthzDecision{})
+	if f.AccessorID != "" {
+		q = q.Where("accessor_id = ?", f.AccessorID)
+	}
+	if f.ResourceType != "" {
+		q = q.Where("resource_type = ?", f.ResourceType)
+	}
+	if f.ResourceID != "" {
+		q = q.Where("resource_id = ?", f.ResourceID)
+	}
+	if f.Operation != "" {
+		q = q.Where("operation = ?", f.Operation)
+	}
+	if f.Decision != "" {
+		q = q.Where("decision = ?", f.Decision)
+	}
+	if f.Source != "" {
+		q = q.Where("source = ?", f.Source)
+	}
+	if !f.From.IsZero() {
+		q = q.Where("created_at >= ?", f.From)
+	}
+	if !f.To.IsZero() {
+		q = q.Where("created_at < ?", f.To)
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	// No capacity hint from limit: it is caller-supplied (bounded above, but
+	// CodeQL flags the pattern) and GORM sizes the slice from the result anyway.
+	var rows []model.AuthzDecision
+	if err := q.Order("created_at DESC").Order("id ASC").Offset(offset).Limit(limit).Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
+}
+
+// Purge deletes decisions older than cutoff and returns how many went.
+func (s *Store) Purge(ctx context.Context, cutoff time.Time) (int64, error) {
+	res := s.db.WithContext(ctx).Where("created_at < ?", cutoff).Delete(&model.AuthzDecision{})
+	return res.RowsAffected, res.Error
+}
+
+// RunRetention purges rows older than days once now and then every interval,
+// until ctx ends. days<=0 keeps everything and returns at once.
+func (s *Store) RunRetention(ctx context.Context, days int, interval time.Duration) {
+	if s == nil || !s.opts.Enabled || days <= 0 {
+		return
+	}
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	purge := func() {
+		cutoff := time.Now().UTC().AddDate(0, 0, -days)
+		n, err := s.Purge(ctx, cutoff)
+		if err != nil {
+			slog.Warn("authz decision log retention purge failed", "error", err)
+			return
+		}
+		if n > 0 {
+			slog.Info("authz decision log retention purge", "deleted", n, "older_than", cutoff.Format(time.RFC3339))
+		}
+	}
+	purge()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			purge()
+		}
+	}
+}
+
+func newID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/bkn-safe/server/internal/decisionlog/decisionlog.go
+++ b/bkn-safe/server/internal/decisionlog/decisionlog.go
@@ -145,12 +145,26 @@ func (s *Store) Record(e Entry) {
 	if e.Decision == DecisionAllow && !s.sampled() {
 		return
 	}
+	// Clip every string to its column width. The resource and operation
+	// names come straight from unvalidated /authz request bodies; one
+	// over-long value would fail the whole insert batch under strict mode
+	// and take up to BatchSize unrelated decisions with it.
 	row := model.AuthzDecision{
-		ID: newID(), AccessorID: e.AccessorID, ResourceType: e.ResourceType, ResourceID: e.ResourceID,
-		Operation: e.Operation, Scope: e.Scope, Decision: e.Decision, Basis: e.Basis,
-		DeniedRequirement: e.DeniedRequirement, Source: e.Source, RequestID: e.RequestID,
-		TraceID: e.TraceID, ClientIP: e.ClientIP, Detail: e.Detail,
-		CreatedAt: time.Now().UTC().Truncate(time.Millisecond),
+		ID:                newID(),
+		AccessorID:        clip(e.AccessorID, 64),
+		ResourceType:      clip(e.ResourceType, 64),
+		ResourceID:        clip(e.ResourceID, 128),
+		Operation:         clip(e.Operation, 128),
+		Scope:             clip(e.Scope, 16),
+		Decision:          clip(e.Decision, 16),
+		Basis:             clip(e.Basis, 32),
+		DeniedRequirement: clip(e.DeniedRequirement, 64),
+		Source:            clip(e.Source, 32),
+		RequestID:         clip(e.RequestID, 128),
+		TraceID:           clip(e.TraceID, 64),
+		ClientIP:          clip(e.ClientIP, 64),
+		Detail:            clip(e.Detail, 1024),
+		CreatedAt:         time.Now().UTC().Truncate(time.Millisecond),
 	}
 	if s.opts.Synchronous {
 		s.write([]model.AuthzDecision{row})
@@ -371,6 +385,19 @@ func (s *Store) RunRetention(ctx context.Context, days int, interval time.Durati
 			purge()
 		}
 	}
+}
+
+// clip truncates s to at most n characters (runes, matching how varchar(n)
+// counts), never splitting a multi-byte character.
+func clip(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n])
 }
 
 func newID() string {

--- a/bkn-safe/server/internal/decisionlog/decisionlog_test.go
+++ b/bkn-safe/server/internal/decisionlog/decisionlog_test.go
@@ -1,0 +1,157 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package decisionlog
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+func testDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	// A shared-cache in-memory database, and one connection, so the writer
+	// goroutine and the test see the same tables.
+	db, err := gorm.Open(sqlite.Open("file:decisionlog_"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.AuthzDecision{}); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestAsyncRecordIsQueryableAfterFlush(t *testing.T) {
+	db := testDB(t)
+	s := New(db, Options{Enabled: true, AllowSampleRate: 1, FlushInterval: time.Hour})
+	defer s.Close()
+	s.Record(Entry{AccessorID: "u1", ResourceType: "knowledge_network", ResourceID: "kn-1", Operation: "view_detail", Decision: DecisionAllow, Basis: "direct", Source: "check"})
+	s.Record(Entry{AccessorID: "u1", ResourceType: "knowledge_network", ResourceID: "kn-2", Operation: "delete", Decision: DecisionDeny, Basis: "default", Source: "check"})
+	s.Record(Entry{AccessorID: "u2", ResourceType: "agent", ResourceID: "a-1", Operation: "use", Decision: DecisionAllow, Basis: "inherited", Source: "check"})
+	s.Flush(context.Background())
+
+	rows, total, err := s.List(context.Background(), Filter{AccessorID: "u1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("u1 decisions = %d/%d, want 2", len(rows), total)
+	}
+	for _, row := range rows {
+		if row.ID == "" || row.CreatedAt.IsZero() || row.AccessorID != "u1" {
+			t.Fatalf("row not fully populated: %+v", row)
+		}
+	}
+	rows, total, err = s.List(context.Background(), Filter{Decision: DecisionDeny})
+	if err != nil || total != 1 || rows[0].ResourceID != "kn-2" || rows[0].Basis != "default" {
+		t.Fatalf("deny filter = %+v total=%d err=%v", rows, total, err)
+	}
+	if s.Dropped() != 0 {
+		t.Fatalf("dropped = %d, want 0", s.Dropped())
+	}
+}
+
+func TestTimeWindowFilterListsAnAccountsDecisionsInAPeriod(t *testing.T) {
+	db := testDB(t)
+	s := New(db, Options{Enabled: true, AllowSampleRate: 1, Synchronous: true})
+	base := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	for i, d := range []time.Duration{-2 * time.Hour, -time.Hour, 0, time.Hour} {
+		row := model.AuthzDecision{ID: string(rune('a' + i)), AccessorID: "u1", Decision: DecisionAllow, Source: "check", CreatedAt: base.Add(d)}
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, total, err := s.List(context.Background(), Filter{AccessorID: "u1", From: base.Add(-time.Hour), To: base.Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(rows) != 2 || rows[0].ID != "c" || rows[1].ID != "b" {
+		t.Fatalf("window rows = %+v total=%d (want c then b)", rows, total)
+	}
+}
+
+func TestFullQueueDropsWithoutBlocking(t *testing.T) {
+	db := testDB(t)
+	// Writer deliberately not started: nothing drains the queue.
+	s := newStore(db, Options{Enabled: true, AllowSampleRate: 1, QueueSize: 2})
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 5; i++ {
+			s.Record(Entry{AccessorID: "u1", Decision: DecisionDeny, Source: "check"})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Record blocked on a full queue")
+	}
+	if s.Dropped() != 3 {
+		t.Fatalf("dropped = %d, want 3", s.Dropped())
+	}
+}
+
+func TestSamplingKeepsEveryDenyAndDropsSampledAllows(t *testing.T) {
+	db := testDB(t)
+	s := New(db, Options{Enabled: true, AllowSampleRate: 0, Synchronous: true})
+	s.Record(Entry{AccessorID: "u1", Decision: DecisionAllow, Source: "check"})
+	s.Record(Entry{AccessorID: "u1", Decision: DecisionDeny, Source: "check"})
+	s.Record(Entry{AccessorID: "u1", Decision: DecisionNone, Source: "check"})
+	rows, total, err := s.List(context.Background(), Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("rows with allow sampling off = %d (%+v), want 2 (deny + none)", total, rows)
+	}
+	for _, row := range rows {
+		if row.Decision == DecisionAllow {
+			t.Fatalf("allow row recorded despite sample rate 0: %+v", row)
+		}
+	}
+}
+
+func TestDisabledAndNilStoresAcceptRecords(t *testing.T) {
+	var nilStore *Store
+	nilStore.Record(Entry{Decision: DecisionDeny})
+	nilStore.Flush(context.Background())
+	nilStore.Close()
+	off := New(testDB(t), Options{})
+	off.Record(Entry{Decision: DecisionDeny})
+	if off.Enabled() || off.Dropped() != 0 {
+		t.Fatal("disabled store must discard silently")
+	}
+}
+
+func TestPurgeRemovesOnlyOldRows(t *testing.T) {
+	db := testDB(t)
+	s := New(db, Options{Enabled: true, AllowSampleRate: 1, Synchronous: true})
+	now := time.Now().UTC()
+	for i, age := range []time.Duration{100 * 24 * time.Hour, 80 * 24 * time.Hour, time.Hour} {
+		row := model.AuthzDecision{ID: string(rune('a' + i)), AccessorID: "u1", Decision: DecisionAllow, CreatedAt: now.Add(-age)}
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	n, err := s.Purge(context.Background(), now.AddDate(0, 0, -90))
+	if err != nil || n != 1 {
+		t.Fatalf("purge = %d, %v; want 1", n, err)
+	}
+	_, total, err := s.List(context.Background(), Filter{})
+	if err != nil || total != 2 {
+		t.Fatalf("after purge total = %d err=%v, want 2", total, err)
+	}
+}

--- a/bkn-safe/server/internal/decisionlog/decisionlog_test.go
+++ b/bkn-safe/server/internal/decisionlog/decisionlog_test.go
@@ -6,8 +6,10 @@ package decisionlog
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
@@ -121,6 +123,23 @@ func TestSamplingKeepsEveryDenyAndDropsSampledAllows(t *testing.T) {
 		if row.Decision == DecisionAllow {
 			t.Fatalf("allow row recorded despite sample rate 0: %+v", row)
 		}
+	}
+}
+
+func TestRecordClipsValuesToColumnWidths(t *testing.T) {
+	db := testDB(t)
+	s := New(db, Options{Enabled: true, AllowSampleRate: 1, Synchronous: true})
+	long := strings.Repeat("操作", 200) // 200 runes, 600 bytes: clipped by rune count
+	s.Record(Entry{AccessorID: "u1", ResourceType: strings.Repeat("t", 100), Operation: long, Decision: DecisionDeny, Source: "check"})
+	rows, total, err := s.List(context.Background(), Filter{AccessorID: "u1"})
+	if err != nil || total != 1 {
+		t.Fatalf("over-long values must still insert: total=%d err=%v", total, err)
+	}
+	if got := []rune(rows[0].Operation); len(got) != 128 || !utf8.ValidString(rows[0].Operation) {
+		t.Fatalf("operation clipped to %d runes (valid=%v), want 128", len(got), utf8.ValidString(rows[0].Operation))
+	}
+	if len(rows[0].ResourceType) != 64 {
+		t.Fatalf("resource_type clipped to %d, want 64", len(rows[0].ResourceType))
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/admin_test.go
+++ b/bkn-safe/server/internal/httpapi/admin_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/database"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/decisionlog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
@@ -82,8 +83,11 @@ func newAdminServer(t *testing.T) (*gin.Engine, *authz.Enforcer, *gorm.DB, *auth
 	finegrained.Register(licverify.EditionProfessional)
 	r := New(Deps{
 		Enforcer: e, DB: db, Directory: directory.New(db), Users: users,
-		Audit:         audit.New(db),
-		AccessLog:     accesslog.New(db),
+		Audit:     audit.New(db),
+		AccessLog: accesslog.New(db),
+		// Synchronous so a test can read a decision right after the request
+		// that produced it; production writes through the queue.
+		Decisions:     decisionlog.New(db, decisionlog.Options{Enabled: true, AllowSampleRate: 1, Synchronous: true}),
 		TokenVerifier: stubVerifier{},
 	})
 	return r, e, db, users

--- a/bkn-safe/server/internal/httpapi/adminauth.go
+++ b/bkn-safe/server/internal/httpapi/adminauth.go
@@ -35,21 +35,23 @@ func RequireAdmin(v TokenVerifier, e *authz.Enforcer) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tok := bearerToken(c)
 		if tok == "" {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
 		sub, err := v.VerifyToken(c.Request.Context(), tok)
 		if err != nil {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
-		ok, err := e.CanAdmin(sub)
+		c.Set(ctxAuthnSubject, sub)
+		decision, err := e.AdminDecision(c.Request.Context(), sub)
 		if err != nil {
 			abortInternalError(c)
 			return
 		}
-		if !ok {
-			abortPublicError(c, http.StatusForbidden)
+		recordEvaluation(c, decisionSourceAdmin, sub, authz.AdminResourceType, authz.AdminResourceID, authz.AdminOperation, decision, "")
+		if !decision.Allowed() {
+			abortGate(c, http.StatusForbidden, gateAuthz)
 			return
 		}
 		c.Set(ctxAccessorID, sub)
@@ -65,7 +67,7 @@ func RequireActiveAccount(db *gorm.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		sub := c.GetString(ctxAccessorID)
 		if sub == "" {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
 		active, err := activeAccount(c, db, sub)
@@ -74,7 +76,7 @@ func RequireActiveAccount(db *gorm.DB) gin.HandlerFunc {
 			return
 		}
 		if !active {
-			abortPublicError(c, http.StatusForbidden)
+			abortGate(c, http.StatusForbidden, gateInactive)
 			return
 		}
 		c.Next()
@@ -97,16 +99,17 @@ func RequirePermission(e *authz.Enforcer, resourceType, op string) gin.HandlerFu
 func authorizePermission(c *gin.Context, e *authz.Enforcer, resourceType, op string) bool {
 	sub := c.GetString(ctxAccessorID)
 	if sub == "" {
-		abortPublicError(c, http.StatusUnauthorized)
+		abortGate(c, http.StatusUnauthorized, gateAuthn)
 		return false
 	}
-	ok, err := e.CheckContext(c.Request.Context(), sub, resourceType, "*", op)
+	decision, err := e.OperationDecision(c.Request.Context(), sub, resourceType, "*", op)
 	if err != nil {
 		abortInternalError(c)
 		return false
 	}
-	if !ok {
-		abortPublicError(c, http.StatusForbidden)
+	recordEvaluation(c, decisionSourceAdmin, sub, resourceType, "*", op, decision, "")
+	if !decision.Allowed() {
+		abortGate(c, http.StatusForbidden, gatePermission)
 		return false
 	}
 	return true
@@ -137,16 +140,17 @@ func RequireAnyPermission(e *authz.Enforcer, points ...PermissionPoint) gin.Hand
 	return func(c *gin.Context) {
 		sub := c.GetString(ctxAccessorID)
 		if sub == "" {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
 		for i, p := range points {
-			ok, err := e.CheckContext(c.Request.Context(), sub, p.ResourceType, "*", p.Op)
+			decision, err := e.OperationDecision(c.Request.Context(), sub, p.ResourceType, "*", p.Op)
 			if err != nil {
 				abortInternalError(c)
 				return
 			}
-			if !ok {
+			recordEvaluation(c, decisionSourceAdmin, sub, p.ResourceType, "*", p.Op, decision, "")
+			if !decision.Allowed() {
 				continue
 			}
 			if i > 0 {
@@ -157,7 +161,7 @@ func RequireAnyPermission(e *authz.Enforcer, points ...PermissionPoint) gin.Hand
 			c.Next()
 			return
 		}
-		abortPublicError(c, http.StatusForbidden)
+		abortGate(c, http.StatusForbidden, gatePermission)
 	}
 }
 
@@ -168,14 +172,15 @@ func RequireUser(v TokenVerifier) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		tok := bearerToken(c)
 		if tok == "" {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
 		sub, err := v.VerifyToken(c.Request.Context(), tok)
 		if err != nil {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
+		c.Set(ctxAuthnSubject, sub)
 		c.Set(ctxAccessorID, sub)
 		c.Next()
 	}
@@ -225,20 +230,22 @@ func RequireAdminOrResourceOwner(v TokenVerifier, e *authz.Enforcer) gin.Handler
 	return func(c *gin.Context) {
 		tok := bearerToken(c)
 		if tok == "" {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
 		sub, err := v.VerifyToken(c.Request.Context(), tok)
 		if err != nil {
-			abortPublicError(c, http.StatusUnauthorized)
+			abortGate(c, http.StatusUnauthorized, gateAuthn)
 			return
 		}
-		admin, err := e.CanAdmin(sub)
+		c.Set(ctxAuthnSubject, sub)
+		decision, err := e.AdminDecision(c.Request.Context(), sub)
 		if err != nil {
 			abortInternalError(c)
 			return
 		}
-		if admin {
+		if decision.Allowed() {
+			recordEvaluation(c, decisionSourceAdmin, sub, authz.AdminResourceType, authz.AdminResourceID, authz.AdminOperation, decision, "")
 			c.Set(ctxAccessorID, sub)
 			c.Set(ctxDirectoryReadAuthority, directoryReadAdmin)
 			c.Next()
@@ -249,17 +256,25 @@ func RequireAdminOrResourceOwner(v TokenVerifier, e *authz.Enforcer) gin.Handler
 			abortInternalError(c)
 			return
 		}
+		owner := false
 		for _, grant := range grants {
 			for _, op := range grant.Operations {
 				if op == opAuthorize {
-					c.Set(ctxAccessorID, sub)
-					c.Set(ctxDirectoryReadAuthority, directoryReadOwner)
-					c.Next()
-					return
+					owner = true
 				}
 			}
 		}
-		abortPublicError(c, http.StatusForbidden)
+		// The admin decision was a deny; the row says whether the owner
+		// fallback let the request through instead.
+		recordEvaluation(c, decisionSourceAdmin, sub, authz.AdminResourceType, authz.AdminResourceID, authz.AdminOperation, decision,
+			decisionDetail(map[string]any{"fallback": "resource_owner", "fallback_allowed": owner}))
+		if owner {
+			c.Set(ctxAccessorID, sub)
+			c.Set(ctxDirectoryReadAuthority, directoryReadOwner)
+			c.Next()
+			return
+		}
+		abortGate(c, http.StatusForbidden, gateAuthz)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -66,6 +66,13 @@ func auditMiddleware(store *audit.Store, dir *directory.Service, db *gorm.DB) gi
 		action := auditAction(c.Request.Method, c.FullPath())
 		targetID := c.Param("id")
 		detail := auditDetail(raw)
+		if detail == "" && len(raw) >= maxAuditBody {
+			// The snapshot hit the cap, so the JSON is cut mid-way. Salvage the
+			// top-level fields that precede the oversized part — for a
+			// resource-parents batch that is resource_type and parent_type,
+			// for a policy grant the resource — and say the snapshot is partial.
+			detail = auditDetailFromPrefix(raw)
+		}
 		if targetID == "" {
 			targetID = auditDetailTargetID(resource, detail)
 		}
@@ -186,6 +193,50 @@ func auditDetail(raw []byte) string {
 	}
 	if len(b) > maxAuditDetail {
 		return string(b[:maxAuditDetail])
+	}
+	return string(b)
+}
+
+// auditDetailFromPrefix builds the Detail snapshot of a body that was cut at
+// maxAuditBody. It walks the top-level object in order and keeps every member
+// that still decodes whole — scalars and small objects — and stops at the
+// first value the cut runs through (in practice the large array). Arrays are
+// never kept: a complete one would only bloat the row, and the cut one does
+// not decode. The result always carries "_body_truncated": true so a reader
+// knows the row describes a prefix, not the request.
+func auditDetailFromPrefix(raw []byte) string {
+	const marker = `{"_body_truncated":true}`
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	if tok, err := dec.Token(); err != nil || tok != json.Delim('{') {
+		return marker
+	}
+	m := map[string]any{"_body_truncated": true}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			break
+		}
+		var value any
+		if err := dec.Decode(&value); err != nil {
+			break
+		}
+		if _, isArray := value.([]any); isArray {
+			continue
+		}
+		m[key] = value
+	}
+	for _, k := range sensitiveBodyKeys {
+		if _, ok := m[k]; ok {
+			m[k] = "***"
+		}
+	}
+	b, err := json.Marshal(m)
+	if err != nil || len(b) > maxAuditDetail {
+		return marker
 	}
 	return string(b)
 }

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -91,14 +91,24 @@ func auditMiddleware(store *audit.Store, dir *directory.Service, db *gorm.DB) gi
 			}
 		}
 		detail = withAuditOutcome(detail, c)
+		detail = withAuditGate(detail, c)
 		actorID := c.GetString(ctxAccessorID)
+		actorType, authMethod, sourceChannel := "user", "oauth", "api"
+		if actorID == "" {
+			// Tokenless service face (/authz policy and hierarchy writes): the
+			// platform network boundary is the credential, so there is no
+			// subject to name — only the peer address, plus the caller's
+			// self-declared service name in Detail when it sends one.
+			actorType, authMethod, sourceChannel = "service", "network", "internal"
+			detail = withAuditCallerService(detail, c)
+		}
 		if err := store.Record(c.Request.Context(), audit.Entry{
 			ActorID:           actorID,
 			ActorNameSnapshot: auditActorName(c.Request.Context(), dir, actorID),
-			ActorType:         "user",
-			AuthMethod:        "oauth",
+			ActorType:         actorType,
+			AuthMethod:        authMethod,
 			RequestID:         requestID,
-			SourceChannel:     "api",
+			SourceChannel:     sourceChannel,
 			Method:            c.Request.Method,
 			Resource:          resource,
 			Action:            action,
@@ -116,6 +126,7 @@ func auditMiddleware(store *audit.Store, dir *directory.Service, db *gorm.DB) gi
 			)
 			_ = c.Error(err)
 		}
+		c.Set(ctxAuditRecorded, true)
 	}
 }
 
@@ -197,6 +208,50 @@ func setAuditOperation(c *gin.Context, action, targetID, targetName string) {
 // read): the value is then simply never consumed.
 func setAuditOutcome(c *gin.Context, outcome map[string]any) {
 	c.Set(ctxAuditOutcome, outcome)
+}
+
+// withAuditGate notes in Detail which gate refused a mutating request that a
+// permission point turned away, so a reader can tell a refused attempt from a
+// failed one without decoding the status code.
+func withAuditGate(detail string, c *gin.Context) string {
+	gate := c.GetString(ctxGateFailure)
+	if gate == "" {
+		return detail
+	}
+	return withAuditFact(detail, "_gate", gate)
+}
+
+// maxCallerServiceLen bounds the self-declared x-caller-service header value.
+const maxCallerServiceLen = 64
+
+// withAuditCallerService records the caller's self-declared service name for
+// a tokenless write. It is metadata for correlation only — nothing trusts it —
+// which is why it lives in Detail and never in the actor columns.
+func withAuditCallerService(detail string, c *gin.Context) string {
+	name := strings.TrimSpace(c.GetHeader("x-caller-service"))
+	if name == "" || len(name) > maxCallerServiceLen || strings.ContainsFunc(name, func(r rune) bool {
+		return r < 0x21 || r > 0x7e
+	}) {
+		return detail
+	}
+	return withAuditFact(detail, "_caller_service", name)
+}
+
+// withAuditFact merges one key into the Detail JSON object, keeping the
+// original snapshot when the merged form would not fit the column.
+func withAuditFact(detail, key string, value any) string {
+	m := map[string]any{}
+	if detail != "" {
+		if err := json.Unmarshal([]byte(detail), &m); err != nil {
+			m = map[string]any{}
+		}
+	}
+	m[key] = value
+	b, err := json.Marshal(m)
+	if err != nil || len(b) > maxAuditDetail {
+		return detail
+	}
+	return string(b)
 }
 
 // withAuditOutcome folds any handler-supplied outcome facts into the Detail
@@ -334,6 +389,13 @@ func auditDetailTargetID(resource, detail string) string {
 	case "role-bindings":
 		id, _ := body["accessor_id"].(string)
 		return id
+	case "policies":
+		ref, _ := body["resource"].(map[string]any)
+		id, _ := ref["id"].(string)
+		return id
+	case "resource-parents":
+		rt, _ := body["resource_type"].(string)
+		return rt
 	default:
 		return ""
 	}
@@ -424,6 +486,16 @@ func auditAction(method, fullPath string) string {
 		return "revoke"
 	case "/api/safe/v1/authz/explain":
 		return "explain"
+	case "/api/safe/v1/authz/policies":
+		if method == http.MethodDelete {
+			return "revoke"
+		}
+		return "grant"
+	case "/api/safe/v1/authz/resource-parents":
+		if method == http.MethodDelete {
+			return "drop_parent"
+		}
+		return "set_parent"
 	case "/api/safe/v1/admin/roles/:id/permissions":
 		if method == http.MethodDelete {
 			return "revoke_permission"

--- a/bkn-safe/server/internal/httpapi/audit.go
+++ b/bkn-safe/server/internal/httpapi/audit.go
@@ -54,9 +54,13 @@ func auditMiddleware(store *audit.Store, dir *directory.Service, db *gorm.DB) gi
 		c.Header("x-request-id", requestID)
 		var raw []byte
 		if isMutating(c.Request.Method) && c.Request.Body != nil {
-			// Buffer (bounded) then restore the body so the handler still reads it.
+			// Buffer a bounded prefix for the Detail snapshot, then hand the
+			// handler that prefix followed by whatever is still unread. The
+			// snapshot is capped; the request is not — a resource-parents batch
+			// at the documented 1000-item limit runs past 64KB and must still
+			// parse whole.
 			raw, _ = io.ReadAll(io.LimitReader(c.Request.Body, maxAuditBody))
-			c.Request.Body = io.NopCloser(bytes.NewReader(raw))
+			c.Request.Body = io.NopCloser(io.MultiReader(bytes.NewReader(raw), c.Request.Body))
 		}
 		resource, _ := auditTarget(c.FullPath())
 		action := auditAction(c.Request.Method, c.FullPath())

--- a/bkn-safe/server/internal/httpapi/audit_authz_test.go
+++ b/bkn-safe/server/internal/httpapi/audit_authz_test.go
@@ -1,0 +1,398 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
+)
+
+// serviceReq issues a tokenless request the way an in-cluster service would,
+// with the self-declared caller header.
+func serviceReq(t *testing.T, r *gin.Engine, method, path string, body any, caller string) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	if caller != "" {
+		req.Header.Set("x-caller-service", caller)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestTokenlessPolicyWritesAreAuditedAsServiceActor(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	grant := map[string]any{
+		"accessor_id": adminSub,
+		"resource":    map[string]any{"type": "knowledge_network", "id": "kn-334"},
+		"operations":  []string{"view_detail"},
+	}
+	if w := serviceReq(t, r, http.MethodPost, "/api/safe/v1/authz/policies", grant, "bkn-backend"); w.Code != http.StatusNoContent {
+		t.Fatalf("grant: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := serviceReq(t, r, http.MethodDelete, "/api/safe/v1/authz/policies", map[string]any{
+		"resource": map[string]any{"type": "knowledge_network", "id": "kn-334"},
+	}, ""); w.Code != http.StatusNoContent {
+		t.Fatalf("revoke: want 204, got %d (%s)", w.Code, w.Body.String())
+	}
+
+	var rows []model.AuditLog
+	if err := db.Where("resource = ?", "policies").Order("seq ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("policy audit rows = %d, want 2: %+v", len(rows), rows)
+	}
+	grantRow, revokeRow := rows[0], rows[1]
+	if grantRow.Action != "grant" || grantRow.Method != http.MethodPost || grantRow.Status != http.StatusNoContent || grantRow.TargetID != "kn-334" {
+		t.Fatalf("grant row facts: %+v", grantRow)
+	}
+	if grantRow.ActorID != "" || grantRow.ActorType != "service" || grantRow.AuthMethod != "network" || grantRow.SourceChannel != "internal" {
+		t.Fatalf("grant row actor must be the unnamed service peer: %+v", grantRow)
+	}
+	if !strings.Contains(grantRow.Detail, `"_caller_service":"bkn-backend"`) || !strings.Contains(grantRow.Detail, `"accessor_id":"`+adminSub+`"`) {
+		t.Fatalf("grant row detail lacks caller/body facts: %s", grantRow.Detail)
+	}
+	if revokeRow.Action != "revoke" || revokeRow.Method != http.MethodDelete || revokeRow.TargetID != "kn-334" || strings.Contains(revokeRow.Detail, "_caller_service") {
+		t.Fatalf("revoke row facts: %+v", revokeRow)
+	}
+	if grantRow.Seq == nil || revokeRow.Seq == nil || revokeRow.PrevHash != grantRow.RowHash {
+		t.Fatalf("service rows are not chained: %+v -> %+v", grantRow, revokeRow)
+	}
+}
+
+func TestTokenlessPolicyWriteRefusalIsAudited(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	w := serviceReq(t, r, http.MethodPost, "/api/safe/v1/authz/policies", map[string]any{
+		"accessor_id": adminSub, "resource": map[string]any{"type": "*", "id": "x"}, "operations": []string{"view_detail"},
+	}, "vega")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("wildcard grant: want 400, got %d", w.Code)
+	}
+	var row model.AuditLog
+	if err := db.Where("resource = ? AND status = ?", "policies", http.StatusBadRequest).First(&row).Error; err != nil {
+		t.Fatalf("refused service write not audited: %v", err)
+	}
+	if row.Action != "grant" || row.ActorType != "service" {
+		t.Fatalf("refused row facts: %+v", row)
+	}
+}
+
+func TestAuthenticationFailuresAreAuditedAndThrottled(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	for i := 0; i < 3; i++ {
+		if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil, ""); w.Code != http.StatusUnauthorized {
+			t.Fatalf("no token: want 401, got %d", w.Code)
+		}
+	}
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil, "bad"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token: want 401, got %d", w.Code)
+	}
+	var rows []model.AuditLog
+	if err := db.Where("status = ?", http.StatusUnauthorized).Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("401 rows = %d, want 1 (same client+route within the window is throttled): %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.ActorID != "" || row.ActorType != "anonymous" || row.AuthMethod != "none" || row.Resource != "roles" || row.Method != http.MethodGet {
+		t.Fatalf("401 row facts: %+v", row)
+	}
+	if !strings.Contains(row.Detail, `"_gate":"authn"`) {
+		t.Fatalf("401 row must name the gate: %s", row.Detail)
+	}
+	// A different route is a different key and gets its own row.
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/me", nil, ""); w.Code != http.StatusUnauthorized {
+		t.Fatalf("me without token: want 401, got %d", w.Code)
+	}
+	var n int64
+	db.Model(&model.AuditLog{}).Where("status = ?", http.StatusUnauthorized).Count(&n)
+	if n != 2 {
+		t.Fatalf("401 rows after a second route = %d, want 2", n)
+	}
+}
+
+func TestAuthorizationRefusalsAreAuditedWithSubjectAndDecision(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	const outsider = "user-outsider"
+	if err := users.CreateLocalUser(t.Context(), &model.User{ID: outsider, Account: outsider, Name: "Out Sider", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	// A read refused at the admin gate.
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil, outsider); w.Code != http.StatusForbidden {
+		t.Fatalf("outsider read: want 403, got %d", w.Code)
+	}
+	// A write refused at the admin gate: exactly one row, from the failure
+	// recorder (the mutation audit never ran).
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", map[string]any{"id": "d-x", "name": "X"}, outsider); w.Code != http.StatusForbidden {
+		t.Fatalf("outsider write: want 403, got %d", w.Code)
+	}
+	var rows []model.AuditLog
+	if err := db.Where("actor_id = ?", outsider).Order("seq ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("403 rows for outsider = %d, want 2: %+v", len(rows), rows)
+	}
+	for _, row := range rows {
+		if row.Status != http.StatusForbidden || row.ActorType != "user" || row.AuthMethod != "oauth" || row.ActorNameSnapshot != "Out Sider" {
+			t.Fatalf("403 row facts: %+v", row)
+		}
+		if !strings.Contains(row.Detail, `"_gate":"authz"`) {
+			t.Fatalf("403 row must name the gate: %s", row.Detail)
+		}
+	}
+	if rows[0].Resource != "roles" || rows[0].Method != http.MethodGet || rows[1].Resource != "departments" || rows[1].Method != http.MethodPost || rows[1].Action != "create" {
+		t.Fatalf("403 rows must keep what was attempted: %+v", rows)
+	}
+	// Both refusals are also decisions: safe_admin console manage, denied.
+	var decisions []model.AuthzDecision
+	if err := db.Where("accessor_id = ?", outsider).Find(&decisions).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 2 {
+		t.Fatalf("outsider decisions = %d, want 2: %+v", len(decisions), decisions)
+	}
+	for _, d := range decisions {
+		if d.Source != decisionSourceAdmin || d.ResourceType != "safe_admin" || d.ResourceID != "console" || d.Operation != "manage" || d.Decision != "deny" || d.Basis == "" {
+			t.Fatalf("admin gate decision facts: %+v", d)
+		}
+	}
+}
+
+func TestPermissionPointRefusalOnMutationIsRecordedOnceWithGate(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	// A console administrator without the department create point.
+	const limited = "user-limited"
+	if err := users.CreateLocalUser(t.Context(), &model.User{ID: limited, Account: limited, Name: limited, Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	if err := e.Grant(limited, "safe_admin:*", "manage"); err != nil {
+		t.Fatal(err)
+	}
+	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", map[string]any{"id": "d-y", "name": "Y"}, limited); w.Code != http.StatusForbidden {
+		t.Fatalf("limited write: want 403, got %d (%s)", w.Code, w.Body.String())
+	}
+	var rows []model.AuditLog
+	if err := db.Where("actor_id = ?", limited).Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("refused mutation rows = %d, want exactly 1: %+v", len(rows), rows)
+	}
+	if rows[0].Status != http.StatusForbidden || rows[0].Resource != "departments" || !strings.Contains(rows[0].Detail, `"_gate":"permission"`) || !strings.Contains(rows[0].Detail, `"name":"Y"`) {
+		t.Fatalf("refused mutation row must carry the body and the gate: %+v", rows[0])
+	}
+	var decision model.AuthzDecision
+	if err := db.Where("accessor_id = ? AND resource_type = ?", limited, "admin-dept").First(&decision).Error; err != nil {
+		t.Fatalf("permission point decision not recorded: %v", err)
+	}
+	if decision.Operation != "create" || decision.Decision != "deny" || decision.Source != decisionSourceAdmin {
+		t.Fatalf("permission point decision facts: %+v", decision)
+	}
+}
+
+func TestCheckRecordsDecisionsForActiveInactiveAndUnknownAccessors(t *testing.T) {
+	r, _, db, users := newAdminServer(t)
+	const plain = "user-plain"
+	if err := users.CreateLocalUser(t.Context(), &model.User{ID: plain, Account: plain, Name: plain, Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	check := func(accessor string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/api/safe/v1/authz/check", strings.NewReader(`{"accessor_id":"`+accessor+`","resource":{"type":"knowledge_network","id":"kn-1"},"operation":"view_detail"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")
+		req.Header.Set("x-request-id", "req-"+accessor)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("check %s: want 200, got %d (%s)", accessor, w.Code, w.Body.String())
+		}
+		var body map[string]any
+		_ = json.Unmarshal(w.Body.Bytes(), &body)
+		return body
+	}
+	if body := check(adminSub); body["allowed"] != true {
+		t.Fatalf("admin check = %v", body)
+	}
+	if body := check(plain); body["allowed"] != false {
+		t.Fatalf("plain check = %v", body)
+	}
+	if body := check("nobody"); body["allowed"] != false {
+		t.Fatalf("unknown check = %v", body)
+	}
+	var rows []model.AuthzDecision
+	if err := db.Where("source = ?", decisionSourceCheck).Order("request_id ASC").Find(&rows).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("check decisions = %d, want 3: %+v", len(rows), rows)
+	}
+	byAccessor := map[string]model.AuthzDecision{}
+	for _, row := range rows {
+		byAccessor[row.AccessorID] = row
+		if row.ResourceType != "knowledge_network" || row.ResourceID != "kn-1" || row.Operation != "view_detail" || row.Scope != "effective" {
+			t.Fatalf("check decision target facts: %+v", row)
+		}
+		if row.RequestID != "req-"+row.AccessorID || row.TraceID != "0af7651916cd43dd8448eb211c80319c" || row.ClientIP == "" {
+			t.Fatalf("check decision correlation facts: %+v", row)
+		}
+	}
+	if d := byAccessor[adminSub]; d.Decision != "allow" || d.Basis == "" {
+		t.Fatalf("admin decision: %+v", d)
+	}
+	if d := byAccessor[plain]; d.Decision != "deny" || d.Basis != "default" {
+		t.Fatalf("plain decision: %+v", d)
+	}
+	if d := byAccessor["nobody"]; d.Decision != "deny" || d.Basis != basisInactiveAccount {
+		t.Fatalf("unknown accessor decision: %+v", d)
+	}
+}
+
+func TestOperationsAndResourceFilterRecordOneRowPerCall(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/operations", map[string]any{
+		"accessor_id": adminSub, "resource": map[string]any{"type": "knowledge_network", "id": "kn-1"},
+	}); w.Code != http.StatusOK {
+		t.Fatalf("operations: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := do(t, r, http.MethodPost, "/api/safe/v1/authz/resource-filter", map[string]any{
+		"accessor_id": adminSub, "resource_type": "knowledge_network", "resource_ids": []string{"kn-1", "kn-2", "kn-3"},
+		"visibility_operations": []string{"view_detail"}, "candidate_operations": []string{"view_detail", "delete"},
+	}); w.Code != http.StatusOK {
+		t.Fatalf("resource-filter: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var ops model.AuthzDecision
+	if err := db.Where("source = ?", decisionSourceOperations).First(&ops).Error; err != nil {
+		t.Fatalf("operations decision: %v", err)
+	}
+	if ops.Operation != "*" || ops.ResourceID != "kn-1" || ops.Detail == "" {
+		t.Fatalf("operations decision facts: %+v", ops)
+	}
+	var filters []model.AuthzDecision
+	if err := db.Where("source = ?", decisionSourceFilter).Find(&filters).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(filters) != 1 {
+		t.Fatalf("resource-filter decisions = %d, want exactly 1 for a 3-resource batch", len(filters))
+	}
+	if filters[0].ResourceType != "knowledge_network" || filters[0].Operation != "view_detail" || !strings.Contains(filters[0].Detail, `"requested":3`) {
+		t.Fatalf("resource-filter decision facts: %+v", filters[0])
+	}
+}
+
+func TestDecisionReadEndpointListsAnAccountsDecisionsInAWindow(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	// A permission-point decision from the request itself plus two planted
+	// rows on either side of the window.
+	old := model.AuthzDecision{ID: "old", AccessorID: "acct-x", Decision: "deny", Source: "check", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	in := model.AuthzDecision{ID: "in", AccessorID: "acct-x", Decision: "allow", Source: "check", CreatedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)}
+	for _, row := range []model.AuthzDecision{old, in} {
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/authz-decisions?accessor_id=acct-x&from=2026-05-01T00:00:00Z&to=2026-07-01T00:00:00Z", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var body struct {
+		Decisions []model.AuthzDecision `json:"decisions"`
+		Total     int64                 `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.Total != 1 || len(body.Decisions) != 1 || body.Decisions[0].ID != "in" {
+		t.Fatalf("window list = %+v", body)
+	}
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/authz-decisions?from=not-a-time", nil); w.Code != http.StatusBadRequest {
+		t.Fatalf("bad from: want 400, got %d", w.Code)
+	}
+	// The read itself passed a permission point, which is a decision too.
+	var mine model.AuthzDecision
+	if err := db.Where("accessor_id = ? AND resource_type = ? AND operation = ?", adminSub, "admin-audit", "view").First(&mine).Error; err != nil {
+		t.Fatalf("permission point decision for the read: %v", err)
+	}
+	if mine.Decision != "allow" {
+		t.Fatalf("read decision: %+v", mine)
+	}
+}
+
+func TestAuditChainEndpointsReportHeadAndDetectTampering(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", map[string]any{"id": "d-1", "name": "Root"})
+	adminReq(t, r, http.MethodPut, "/api/safe/v1/admin/departments/d-1", map[string]any{"name": "Renamed"})
+
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-chain", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("chain head: want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	var head struct {
+		Head *struct {
+			Seq     uint64 `json:"seq"`
+			RowHash string `json:"row_hash"`
+		} `json:"head"`
+		Unchained int64 `json:"unchained_rows"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &head); err != nil {
+		t.Fatal(err)
+	}
+	if head.Head == nil || head.Head.Seq != 2 || len(head.Head.RowHash) != 64 || head.Unchained != 0 {
+		t.Fatalf("chain head = %s", w.Body.String())
+	}
+	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-chain/verify", nil)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"ok":true`) || !strings.Contains(w.Body.String(), `"checked":2`) {
+		t.Fatalf("verify intact: %d %s", w.Code, w.Body.String())
+	}
+	if err := db.Model(&model.AuditLog{}).Where("seq = ?", 1).Update("target_name", "Forged").Error; err != nil {
+		t.Fatal(err)
+	}
+	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-chain/verify", nil)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), `"ok":false`) || !strings.Contains(w.Body.String(), `"broken_seq":1`) || !strings.Contains(w.Body.String(), `"reason":"hash_mismatch"`) {
+		t.Fatalf("verify tampered: %d %s", w.Code, w.Body.String())
+	}
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/audit-chain/verify?from_seq=x", nil); w.Code != http.StatusBadRequest {
+		t.Fatalf("bad from_seq: want 400, got %d", w.Code)
+	}
+	// Chain reads are GETs: they left no audit rows of their own.
+	var n int64
+	db.Model(&model.AuditLog{}).Where("resource = ?", "audit-chain").Count(&n)
+	if n != 0 {
+		t.Fatalf("chain reads produced %d audit rows", n)
+	}
+}
+
+func TestFailureLimiterWindow(t *testing.T) {
+	now := time.Date(2026, 9, 12, 10, 0, 0, 0, time.UTC)
+	l := newFailureLimiter(time.Minute)
+	l.now = func() time.Time { return now }
+	if !l.allow("k") || l.allow("k") {
+		t.Fatal("first hit allowed, repeat within window throttled")
+	}
+	now = now.Add(61 * time.Second)
+	if !l.allow("k") {
+		t.Fatal("hit after the window must be allowed again")
+	}
+	if !l.allow("other") {
+		t.Fatal("different key is independent")
+	}
+}

--- a/bkn-safe/server/internal/httpapi/audit_authz_test.go
+++ b/bkn-safe/server/internal/httpapi/audit_authz_test.go
@@ -115,6 +115,15 @@ func TestAuthenticationFailuresAreAuditedAndThrottled(t *testing.T) {
 	if row.ActorID != "" || row.ActorType != "anonymous" || row.AuthMethod != "none" || row.Resource != "roles" || row.Method != http.MethodGet {
 		t.Fatalf("401 row facts: %+v", row)
 	}
+	if row.RequestID == "" {
+		t.Fatalf("401 row has no request id: %+v", row)
+	}
+	// The client received the same id, so the refusal can be matched to its
+	// row from either side. The header must be set before the gate writes
+	// the response, or it never leaves the server.
+	if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/me", nil, ""); w.Header().Get("x-request-id") == "" {
+		t.Fatal("refused request carries no x-request-id header")
+	}
 	if !strings.Contains(row.Detail, `"_gate":"authn"`) {
 		t.Fatalf("401 row must name the gate: %s", row.Detail)
 	}
@@ -144,12 +153,20 @@ func TestAuthorizationRefusalsAreAuditedWithSubjectAndDecision(t *testing.T) {
 	if w := tokReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", map[string]any{"id": "d-x", "name": "X"}, outsider); w.Code != http.StatusForbidden {
 		t.Fatalf("outsider write: want 403, got %d", w.Code)
 	}
+	// The same account looping over the same route is one row per window,
+	// not one per request: the chain must not become a write amplifier for
+	// whoever holds a valid but unprivileged token.
+	for i := 0; i < 5; i++ {
+		if w := tokReq(t, r, http.MethodGet, "/api/safe/v1/admin/roles", nil, outsider); w.Code != http.StatusForbidden {
+			t.Fatalf("outsider repeat read: want 403, got %d", w.Code)
+		}
+	}
 	var rows []model.AuditLog
 	if err := db.Where("actor_id = ?", outsider).Order("seq ASC").Find(&rows).Error; err != nil {
 		t.Fatal(err)
 	}
 	if len(rows) != 2 {
-		t.Fatalf("403 rows for outsider = %d, want 2: %+v", len(rows), rows)
+		t.Fatalf("403 rows for outsider = %d, want 2 (repeats within the window folded): %+v", len(rows), rows)
 	}
 	for _, row := range rows {
 		if row.Status != http.StatusForbidden || row.ActorType != "user" || row.AuthMethod != "oauth" || row.ActorNameSnapshot != "Out Sider" {
@@ -162,13 +179,14 @@ func TestAuthorizationRefusalsAreAuditedWithSubjectAndDecision(t *testing.T) {
 	if rows[0].Resource != "roles" || rows[0].Method != http.MethodGet || rows[1].Resource != "departments" || rows[1].Method != http.MethodPost || rows[1].Action != "create" {
 		t.Fatalf("403 rows must keep what was attempted: %+v", rows)
 	}
-	// Both refusals are also decisions: safe_admin console manage, denied.
+	// Every refusal is also a decision (decisions are not throttled): safe_admin
+	// console manage, denied — 2 distinct requests + 5 repeats.
 	var decisions []model.AuthzDecision
 	if err := db.Where("accessor_id = ?", outsider).Find(&decisions).Error; err != nil {
 		t.Fatal(err)
 	}
-	if len(decisions) != 2 {
-		t.Fatalf("outsider decisions = %d, want 2: %+v", len(decisions), decisions)
+	if len(decisions) != 7 {
+		t.Fatalf("outsider decisions = %d, want 7: %+v", len(decisions), decisions)
 	}
 	for _, d := range decisions {
 		if d.Source != decisionSourceAdmin || d.ResourceType != "safe_admin" || d.ResourceID != "console" || d.Operation != "manage" || d.Decision != "deny" || d.Basis == "" {
@@ -378,6 +396,54 @@ func TestAuditChainEndpointsReportHeadAndDetectTampering(t *testing.T) {
 	db.Model(&model.AuditLog{}).Where("resource = ?", "audit-chain").Count(&n)
 	if n != 0 {
 		t.Fatalf("chain reads produced %d audit rows", n)
+	}
+}
+
+func TestAuditedMutationKeepsBodiesLargerThanTheSnapshotCap(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	// A body past maxAuditBody: the snapshot is capped, the handler must still
+	// see the whole JSON (a resource-parents batch at its documented 1000-item
+	// limit is well past 64KB).
+	body := map[string]any{"id": "d-big", "name": "Big", "padding": strings.Repeat("x", 70<<10)}
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("oversized body: want 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	if w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/departments/d-big", nil); w.Code != http.StatusOK {
+		t.Fatalf("department from the oversized body was not created: %d", w.Code)
+	}
+	var row model.AuditLog
+	if err := db.Where("request_id = ?", w.Header().Get("x-request-id")).First(&row).Error; err != nil {
+		t.Fatalf("oversized mutation not audited: %v", err)
+	}
+	if row.Status != http.StatusCreated || row.Resource != "departments" || len(row.Detail) > maxAuditDetail {
+		t.Fatalf("oversized mutation row: %+v", row)
+	}
+}
+
+func TestOneRequestIDTiesResponseAuditAndDecisions(t *testing.T) {
+	r, _, db, _ := newAdminServer(t)
+	w := adminReq(t, r, http.MethodPost, "/api/safe/v1/admin/departments", map[string]any{"id": "d-rid", "name": "RID"})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: want 201, got %d (%s)", w.Code, w.Body.String())
+	}
+	rid := w.Header().Get("x-request-id")
+	if rid == "" {
+		t.Fatal("no x-request-id on the response")
+	}
+	var row model.AuditLog
+	if err := db.Where("request_id = ?", rid).First(&row).Error; err != nil {
+		t.Fatalf("no audit row carries the response's request id %q: %v", rid, err)
+	}
+	if row.Resource != "departments" || row.Method != http.MethodPost || row.Status != http.StatusCreated {
+		t.Fatalf("audit row for the request id: %+v", row)
+	}
+	var decisions []model.AuthzDecision
+	if err := db.Where("request_id = ?", rid).Find(&decisions).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) < 2 {
+		t.Fatalf("decisions sharing the request id = %d, want the console gate and the permission point: %+v", len(decisions), decisions)
 	}
 }
 

--- a/bkn-safe/server/internal/httpapi/audit_authz_test.go
+++ b/bkn-safe/server/internal/httpapi/audit_authz_test.go
@@ -419,6 +419,46 @@ func TestAuditedMutationKeepsBodiesLargerThanTheSnapshotCap(t *testing.T) {
 	if row.Status != http.StatusCreated || row.Resource != "departments" || len(row.Detail) > maxAuditDetail {
 		t.Fatalf("oversized mutation row: %+v", row)
 	}
+	// The snapshot is partial, says so, and still carries the top-level
+	// fields that came before the oversized one.
+	if !strings.Contains(row.Detail, `"_body_truncated":true`) || !strings.Contains(row.Detail, `"name":"Big"`) || strings.Contains(row.Detail, "padding") {
+		t.Fatalf("truncated snapshot detail: %.200s", row.Detail)
+	}
+}
+
+func TestAuditDetailFromPrefixKeepsLeadingFieldsAndSkipsArrays(t *testing.T) {
+	// A resource-parents batch shape: two scalars, one nested object, then an
+	// array the cut runs through.
+	head := `{"resource_type":"resource","parent_type":"catalog","resource":{"type":"knowledge_network","id":"kn-1"},"password":"x","tags":["a","b"],"items":[`
+	body := head + strings.Repeat(`{"resource_id":"r","parent_id":"p"},`, 4000)
+	cut := body[:maxAuditBody]
+	got := auditDetailFromPrefix([]byte(cut))
+	var m map[string]any
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("prefix detail is not JSON: %s", got)
+	}
+	if m["_body_truncated"] != true || m["resource_type"] != "resource" || m["parent_type"] != "catalog" || m["password"] != "***" {
+		t.Fatalf("prefix detail = %s", got)
+	}
+	if ref, _ := m["resource"].(map[string]any); ref["id"] != "kn-1" {
+		t.Fatalf("small nested object dropped: %s", got)
+	}
+	if _, kept := m["tags"]; kept {
+		t.Fatalf("array kept in prefix detail: %s", got)
+	}
+	if _, kept := m["items"]; kept {
+		t.Fatalf("cut array kept in prefix detail: %s", got)
+	}
+	// And the target id derivation works off the salvaged snapshot.
+	if id := auditDetailTargetID("resource-parents", got); id != "resource" {
+		t.Fatalf("resource-parents target from prefix = %q", id)
+	}
+	if id := auditDetailTargetID("policies", got); id != "kn-1" {
+		t.Fatalf("policies target from prefix = %q", id)
+	}
+	if got := auditDetailFromPrefix([]byte("[1,2")); got != `{"_body_truncated":true}` {
+		t.Fatalf("non-object prefix = %s", got)
+	}
 }
 
 func TestOneRequestIDTiesResponseAuditAndDecisions(t *testing.T) {

--- a/bkn-safe/server/internal/httpapi/audit_gate.go
+++ b/bkn-safe/server/internal/httpapi/audit_gate.go
@@ -1,0 +1,160 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
+)
+
+// Context keys shared between the gates and the audit middlewares.
+const (
+	// ctxAuthnSubject is set by every gate the moment the bearer token verifies,
+	// before any authorization check — so a 403 can still be attributed to the
+	// subject that was refused.
+	ctxAuthnSubject = "authn_subject"
+	// ctxGateFailure names which gate refused the request: authn (no/invalid
+	// token), inactive (account disabled), authz (not an administrator / not
+	// an owner), permission (permission point not held).
+	ctxGateFailure = "gate_failure"
+	// ctxAuditRecorded is set by auditMiddleware once it has written a row, so
+	// the failure recorder does not write a second one for the same request.
+	ctxAuditRecorded = "audit_recorded"
+)
+
+const (
+	gateAuthn      = "authn"
+	gateInactive   = "inactive"
+	gateAuthz      = "authz"
+	gatePermission = "permission"
+)
+
+// abortGate refuses the request and records which gate did it.
+func abortGate(c *gin.Context, status int, gate string) {
+	c.Set(ctxGateFailure, gate)
+	abortPublicError(c, status)
+}
+
+// failureLimiter throttles authentication-failure rows per (client, route).
+// One expired token polled by a frontend would otherwise write a row per poll;
+// one row per window per source is enough to show the pattern, and it keeps a
+// credential-stuffing burst from filling the audit table faster than it can
+// be read. Authorization failures (403) are never throttled: they carry a
+// verified subject and are rare.
+type failureLimiter struct {
+	mu     sync.Mutex
+	window time.Duration
+	seen   map[string]time.Time
+	now    func() time.Time
+}
+
+const failureLimiterWindow = time.Minute
+
+// failureLimiterMaxKeys bounds the map; when exceeded, expired keys are swept
+// and, if still too large, the map is reset (throttling restarts, nothing
+// else is affected).
+const failureLimiterMaxKeys = 10000
+
+func newFailureLimiter(window time.Duration) *failureLimiter {
+	return &failureLimiter{window: window, seen: map[string]time.Time{}, now: time.Now}
+}
+
+// allow reports whether a failure for key should be recorded now.
+func (l *failureLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	if last, ok := l.seen[key]; ok && now.Sub(last) < l.window {
+		return false
+	}
+	if len(l.seen) >= failureLimiterMaxKeys {
+		for k, t := range l.seen {
+			if now.Sub(t) >= l.window {
+				delete(l.seen, k)
+			}
+		}
+		if len(l.seen) >= failureLimiterMaxKeys {
+			l.seen = map[string]time.Time{}
+		}
+	}
+	l.seen[key] = now
+	return true
+}
+
+// auditAuthFailures records the 401/403 responses produced by the gates in
+// front of a token-gated group. It must be registered BEFORE those gates —
+// gin runs it first and it observes their abort on the way back — and it stays
+// quiet when auditMiddleware already recorded the request (a mutating request
+// refused by a permission point is recorded there, with the gate noted).
+//
+// A refused request still carries what the caller tried to do: method, route,
+// path target and the verified subject when the token was good. The body is
+// not read — a refused request's payload is untrusted and the gate never saw
+// it either.
+func auditAuthFailures(store *audit.Store, dir *directory.Service, limiter *failureLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+		status := c.Writer.Status()
+		if status != http.StatusUnauthorized && status != http.StatusForbidden {
+			return
+		}
+		if c.GetBool(ctxAuditRecorded) {
+			return
+		}
+		gate := c.GetString(ctxGateFailure)
+		if gate == "" {
+			gate = gateAuthz
+			if status == http.StatusUnauthorized {
+				gate = gateAuthn
+			}
+		}
+		if status == http.StatusUnauthorized && limiter != nil && !limiter.allow(c.ClientIP()+"|"+c.Request.Method+"|"+c.FullPath()) {
+			return
+		}
+		requestID := requestIDFromHeader(c)
+		if requestID == "" {
+			requestID = audit.NewID()
+		}
+		c.Header("x-request-id", requestID)
+		resource, _ := auditTarget(c.FullPath())
+		action := auditAction(c.Request.Method, c.FullPath())
+		actorID := c.GetString(ctxAuthnSubject)
+		actorType := "user"
+		if actorID == "" {
+			actorType = "anonymous"
+		}
+		authMethod := "oauth"
+		if bearerToken(c) == "" {
+			authMethod = "none"
+		}
+		detail, _ := json.Marshal(map[string]any{"_gate": gate})
+		if err := store.Record(c.Request.Context(), audit.Entry{
+			ActorID:           actorID,
+			ActorNameSnapshot: auditActorName(c.Request.Context(), dir, actorID),
+			ActorType:         actorType,
+			AuthMethod:        authMethod,
+			RequestID:         requestID,
+			SourceChannel:     "api",
+			Method:            c.Request.Method,
+			Resource:          resource,
+			Action:            action,
+			TargetID:          c.Param("id"),
+			Detail:            string(detail),
+			Status:            status,
+			ClientIP:          c.ClientIP(),
+		}); err != nil {
+			slog.Error("failed to persist auth failure audit record",
+				"request_id", requestID, "resource", resource, "action", action, "status", status, "error", err)
+		}
+	}
+}

--- a/bkn-safe/server/internal/httpapi/audit_gate.go
+++ b/bkn-safe/server/internal/httpapi/audit_gate.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -45,12 +46,15 @@ func abortGate(c *gin.Context, status int, gate string) {
 	abortPublicError(c, status)
 }
 
-// failureLimiter throttles authentication-failure rows per (client, route).
-// One expired token polled by a frontend would otherwise write a row per poll;
-// one row per window per source is enough to show the pattern, and it keeps a
-// credential-stuffing burst from filling the audit table faster than it can
-// be read. Authorization failures (403) are never throttled: they carry a
-// verified subject and are rare.
+// failureLimiter throttles refusal rows per source and route. One expired
+// token polled by a frontend, or one non-administrator account looping over an
+// admin route, would otherwise write a chained row per request — and every
+// chained append holds the chain lock, so the looping caller's request rate
+// would become the ceiling for every other audit write. One row per window is
+// enough to show the pattern. 401s are keyed by client address (there is no
+// subject to key on); 403s are keyed by the verified subject, so the first
+// refusal of every account on every route is always recorded and only its
+// repeats within the window are folded.
 type failureLimiter struct {
 	mu     sync.Mutex
 	window time.Duration
@@ -103,6 +107,18 @@ func (l *failureLimiter) allow(key string) bool {
 // it either.
 func auditAuthFailures(store *audit.Store, dir *directory.Service, limiter *failureLimiter) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Settle the request id before the gates run: a refused request has
+		// its response written by the gate, so a header set afterwards would
+		// never reach the client. Putting it on the request as well makes the
+		// mutation audit and the decision log reuse the same id, so one
+		// x-request-id ties the client's view, the audit row and the decision
+		// rows together.
+		requestID := requestIDFromHeader(c)
+		if requestID == "" {
+			requestID = audit.NewID()
+			c.Request.Header.Set("x-request-id", requestID)
+		}
+		c.Header("x-request-id", requestID)
 		c.Next()
 		status := c.Writer.Status()
 		if status != http.StatusUnauthorized && status != http.StatusForbidden {
@@ -118,17 +134,18 @@ func auditAuthFailures(store *audit.Store, dir *directory.Service, limiter *fail
 				gate = gateAuthn
 			}
 		}
-		if status == http.StatusUnauthorized && limiter != nil && !limiter.allow(c.ClientIP()+"|"+c.Request.Method+"|"+c.FullPath()) {
-			return
+		actorID := c.GetString(ctxAuthnSubject)
+		if limiter != nil {
+			source := "ip:" + c.ClientIP()
+			if status == http.StatusForbidden && actorID != "" {
+				source = "sub:" + actorID
+			}
+			if !limiter.allow(strconv.Itoa(status) + "|" + source + "|" + c.Request.Method + "|" + c.FullPath()) {
+				return
+			}
 		}
-		requestID := requestIDFromHeader(c)
-		if requestID == "" {
-			requestID = audit.NewID()
-		}
-		c.Header("x-request-id", requestID)
 		resource, _ := auditTarget(c.FullPath())
 		action := auditAction(c.Request.Method, c.FullPath())
-		actorID := c.GetString(ctxAuthnSubject)
 		actorType := "user"
 		if actorID == "" {
 			actorType = "anonymous"

--- a/bkn-safe/server/internal/httpapi/authz.go
+++ b/bkn-safe/server/internal/httpapi/authz.go
@@ -14,7 +14,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/decisionlog"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 )
@@ -34,9 +37,16 @@ type resourceRef struct {
 // registerAuthz mounts bkn-safe's clean authorization API under /api/safe/v1/authz.
 // This is a redesign — it deliberately drops ISF's quirks (GET-in-body,
 // array-vs-map responses, policy-delete double form, public/private split).
-func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
+func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB, auditStore *audit.Store, dir *directory.Service) {
 	g := r.Group("/api/safe/v1/authz")
 	registerPropertyLevels(g, e, db)
+	// Policy and hierarchy writes are the authorization changes this tokenless
+	// face accepts. They are audited like the token-gated ones (#334); the
+	// actor is the service peer, see auditMiddleware.
+	writes := g.Group("")
+	if auditStore != nil {
+		writes.Use(auditMiddleware(auditStore, dir, db))
+	}
 
 	// POST /check — single decision. { accessor_id, resource{type,id}, operation } -> { allowed }
 	g.POST("/check", func(c *gin.Context) {
@@ -64,6 +74,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		if !active {
+			recordInactiveDeny(c, decisionSourceCheck, req.AccessorID, req.Resource.Type, req.Resource.ID, req.Operation)
 			c.JSON(http.StatusOK, gin.H{"allowed": false})
 			return
 		}
@@ -79,6 +90,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			serverError(c, err)
 			return
 		}
+		recordEvaluation(c, decisionSourceCheck, req.AccessorID, req.Resource.Type, req.Resource.ID, req.Operation, decision, "")
 		response := gin.H{
 			"allowed":          decision.Allowed(),
 			"evaluation_scope": decision.Scope,
@@ -111,6 +123,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		if !active {
+			recordInactiveDeny(c, decisionSourceOperations, req.AccessorID, req.Resource.Type, req.Resource.ID, "*")
 			c.JSON(http.StatusOK, gin.H{"operations": []string{}})
 			return
 		}
@@ -124,6 +137,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			serverError(c, err)
 			return
 		}
+		recordOperationsDecision(c, req.AccessorID, req.Resource.Type, req.Resource.ID, allowed)
 		c.JSON(http.StatusOK, gin.H{"operations": allowed})
 	})
 
@@ -193,6 +207,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 			return
 		}
 		if !active {
+			recordInactiveDeny(c, decisionSourceFilter, req.AccessorID, filterResourceType(refs), "", strings.Join(req.VisibilityOperations, ","))
 			c.JSON(http.StatusOK, gin.H{"resources": []gin.H{}})
 			return
 		}
@@ -239,6 +254,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 				return
 			}
 			appendResults(results)
+			recordFilterDecision(c, req.AccessorID, refs, req.VisibilityOperations, req.CandidateOperations, scope, len(out))
 			c.JSON(http.StatusOK, gin.H{"resources": out})
 			return
 		}
@@ -281,12 +297,13 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 				appendResults([]authz.FilteredResource{result})
 			}
 		}
+		recordFilterDecision(c, req.AccessorID, refs, req.VisibilityOperations, nil, scope, len(out))
 		c.JSON(http.StatusOK, gin.H{"resources": out})
 	})
 
 	// POST /policies — grant an accessor concrete ops on one resource instance
 	// (the create-resource pattern). { accessor_id, resource, operations:[...] }
-	g.POST("/policies", func(c *gin.Context) {
+	writes.POST("/policies", func(c *gin.Context) {
 		var req struct {
 			AccessorID string      `json:"accessor_id" binding:"required"`
 			Resource   resourceRef `json:"resource" binding:"required"`
@@ -364,7 +381,7 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 
 	// DELETE /policies — drop all policies targeting a resource instance
 	// (used when the resource is deleted). { resource{type,id} }
-	g.DELETE("/policies", func(c *gin.Context) {
+	writes.DELETE("/policies", func(c *gin.Context) {
 		var req struct {
 			Resource resourceRef `json:"resource" binding:"required"`
 		}
@@ -458,8 +475,65 @@ func registerAuthz(r *gin.Engine, e *authz.Enforcer, db *gorm.DB) {
 	// Instance-level hierarchy (which catalog a table belongs to). Same tokenless
 	// service face; see resourceparents.go for why the shape check is the guard.
 	if db != nil {
-		registerResourceParents(g, e, db)
+		registerResourceParents(writes, e, db)
 	}
+}
+
+// recordOperationsDecision records one row for a POST /operations call: the
+// projected operation set as a whole, not one row per candidate.
+func recordOperationsDecision(c *gin.Context, accessorID, resourceType, resourceID string, allowed []string) {
+	decision := decisionlog.DecisionDeny
+	if len(allowed) > 0 {
+		decision = decisionlog.DecisionAllow
+	}
+	recordDecision(c, decisionlog.Entry{
+		AccessorID: accessorID, ResourceType: resourceType, ResourceID: resourceID, Operation: "*",
+		Scope: string(authz.ScopeEffective), Decision: decision, Source: decisionSourceOperations,
+		Detail: decisionDetail(map[string]any{"operations": capStrings(allowed, 32)}),
+	})
+}
+
+// recordFilterDecision records one row for a POST /resource-filter call. A
+// list page asks about tens or hundreds of resources at once; one row per
+// resource would make the decision log larger than the data it describes, so
+// the batch is summarised: how many were asked about, how many came back.
+func recordFilterDecision(c *gin.Context, accessorID string, refs []authz.ResourceRef, visibility, candidates []string, scope authz.EvaluationScope, visible int) {
+	decision := decisionlog.DecisionDeny
+	switch {
+	case len(refs) == 0:
+		decision = decisionlog.DecisionNone
+	case visible > 0:
+		decision = decisionlog.DecisionAllow
+	}
+	recordDecision(c, decisionlog.Entry{
+		AccessorID: accessorID, ResourceType: filterResourceType(refs), Operation: strings.Join(visibility, ","),
+		Scope: string(scope), Decision: decision, Source: decisionSourceFilter,
+		Detail: decisionDetail(map[string]any{
+			"requested": len(refs), "visible": visible, "candidate_operations": capStrings(candidates, 32),
+		}),
+	})
+}
+
+// filterResourceType names a batch's resource type, or "mixed" when the
+// request spans more than one.
+func filterResourceType(refs []authz.ResourceRef) string {
+	if len(refs) == 0 {
+		return ""
+	}
+	first := refs[0].Type
+	for _, r := range refs[1:] {
+		if r.Type != first {
+			return "mixed"
+		}
+	}
+	return first
+}
+
+func capStrings(values []string, n int) []string {
+	if len(values) <= n {
+		return values
+	}
+	return values[:n]
 }
 
 // registerAuthzExplain mounts the authenticated administrator-only diagnostic
@@ -792,6 +866,7 @@ func isSuperAdminRoleID(c *gin.Context, db *gorm.DB, roleID string) (bool, error
 // may remove one, because after a removal nothing could put it back and the
 // platform would be left with no wildcard authority until a restart re-seeded
 // it. Changing the holder is a deliberate, out-of-band operation.
+//
 //nolint:unused // Retained as the stable seed-only membership message.
 const superAdminSeedOnlyMsg = "super_admin membership is fixed by the seed and cannot be changed through the API"
 

--- a/bkn-safe/server/internal/httpapi/decisions.go
+++ b/bkn-safe/server/internal/httpapi/decisions.go
@@ -1,0 +1,196 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package httpapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/decisionlog"
+)
+
+// ctxDecisionLog is the gin context key under which withDecisionLog stores the
+// decision store, so gates and handlers deep in the chain can record without
+// every constructor growing a parameter.
+const ctxDecisionLog = "authz_decision_log"
+
+// Decision sources: which entry point produced the row.
+const (
+	decisionSourceCheck      = "check"
+	decisionSourceOperations = "operations"
+	decisionSourceFilter     = "resource-filter"
+	decisionSourceAdmin      = "admin"
+)
+
+// basisInactiveAccount marks a deny that came from the local account state
+// rather than from policy: the accessor is disabled.
+const basisInactiveAccount = "inactive_account"
+
+// withDecisionLog makes store reachable from any handler on the engine.
+func withDecisionLog(store *decisionlog.Store) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(ctxDecisionLog, store)
+		c.Next()
+	}
+}
+
+func decisionLogFrom(c *gin.Context) *decisionlog.Store {
+	raw, ok := c.Get(ctxDecisionLog)
+	if !ok {
+		return nil
+	}
+	store, _ := raw.(*decisionlog.Store)
+	return store
+}
+
+// recordDecision writes one decision row for the current request. Request
+// correlation (x-request-id, traceparent, client ip) is filled in here so call
+// sites only state the authorization facts. Safe when no store is mounted.
+func recordDecision(c *gin.Context, e decisionlog.Entry) {
+	store := decisionLogFrom(c)
+	if store == nil {
+		return
+	}
+	if e.RequestID == "" {
+		e.RequestID = requestIDFromHeader(c)
+	}
+	if e.TraceID == "" {
+		e.TraceID = traceIDFromHeader(c)
+	}
+	if e.ClientIP == "" {
+		e.ClientIP = c.ClientIP()
+	}
+	store.Record(e)
+}
+
+// recordEvaluation records an enforcer evaluation for one (resource, op).
+func recordEvaluation(c *gin.Context, source, accessorID, resourceType, resourceID, op string, ev authz.Evaluation, detail string) {
+	recordDecision(c, decisionlog.Entry{
+		AccessorID: accessorID, ResourceType: resourceType, ResourceID: resourceID, Operation: op,
+		Scope: string(ev.Scope), Decision: string(ev.Decision), Basis: string(ev.Basis),
+		DeniedRequirement: ev.DeniedRequirement, Source: source, Detail: detail,
+	})
+}
+
+// recordInactiveDeny records the deny that a disabled account receives before
+// any policy is consulted.
+func recordInactiveDeny(c *gin.Context, source, accessorID, resourceType, resourceID, op string) {
+	recordDecision(c, decisionlog.Entry{
+		AccessorID: accessorID, ResourceType: resourceType, ResourceID: resourceID, Operation: op,
+		Scope: string(authz.ScopeEffective), Decision: decisionlog.DecisionDeny, Basis: basisInactiveAccount,
+		Source: source,
+	})
+}
+
+// traceIDFromHeader extracts the trace id of a W3C traceparent header
+// (00-<32 hex trace id>-<16 hex span id>-<2 hex flags>), or "".
+func traceIDFromHeader(c *gin.Context) string {
+	parts := strings.Split(strings.TrimSpace(c.GetHeader("traceparent")), "-")
+	if len(parts) < 3 || len(parts[1]) != 32 {
+		return ""
+	}
+	for _, r := range parts[1] {
+		if !isHexRune(r) {
+			return ""
+		}
+	}
+	return strings.ToLower(parts[1])
+}
+
+func isHexRune(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+}
+
+// decisionDetail renders a small JSON object for the Detail column, dropping
+// it when it would not fit rather than storing a truncated fragment.
+func decisionDetail(m map[string]any) string {
+	b, err := json.Marshal(m)
+	if err != nil || len(b) > 1000 {
+		return ""
+	}
+	return string(b)
+}
+
+// registerDecisionReads mounts the decision-log read endpoint under the admin
+// group, behind the same permission point as the audit log.
+func registerDecisionReads(g *gin.RouterGroup, store *decisionlog.Store, e *authz.Enforcer) {
+	// GET /authz-decisions — list decisions newest-first. Query:
+	// ?accessor_id=&resource_type=&resource_id=&operation=&decision=&source=
+	// &from=&to=&offset=&limit= (from/to RFC3339). -> { decisions:[...], total }
+	g.GET("/authz-decisions", RequirePermission(e, "admin-audit", "view"), func(c *gin.Context) {
+		f := decisionlog.Filter{
+			AccessorID:   c.Query("accessor_id"),
+			ResourceType: c.Query("resource_type"),
+			ResourceID:   c.Query("resource_id"),
+			Operation:    c.Query("operation"),
+			Decision:     c.Query("decision"),
+			Source:       c.Query("source"),
+			Offset:       atoiDefault(c.Query("offset"), 0),
+			Limit:        atoiDefault(c.Query("limit"), 0),
+		}
+		if !accessLogTimeFilter(c, "from", &f.From) || !accessLogTimeFilter(c, "to", &f.To) {
+			return
+		}
+		rows, total, err := store.List(c.Request.Context(), f)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"decisions": rows, "total": total, "dropped": store.Dropped()})
+	})
+}
+
+// registerAuditChainReads mounts the chain anchor and verification endpoints
+// under the admin group. They are reads and produce no audit rows themselves.
+func registerAuditChainReads(g *gin.RouterGroup, store *audit.Store, e *authz.Enforcer) {
+	// GET /audit-chain — the current chain head, for export to an external
+	// append-only store. -> { head:{seq,row_hash,created_at}|null, unchained_rows }
+	g.GET("/audit-chain", RequirePermission(e, "admin-audit", "view"), func(c *gin.Context) {
+		res, err := store.Verify(c.Request.Context(), 0, 0, 1)
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"head": res.Head, "unchained_rows": res.UnchainedRows})
+	})
+	// GET /audit-chain/verify?from_seq=&to_seq=&limit= — re-hash the chain
+	// and report the first break. -> audit.VerifyResult
+	g.GET("/audit-chain/verify", RequirePermission(e, "admin-audit", "view"), func(c *gin.Context) {
+		from, ok := parseSeq(c.Query("from_seq"))
+		if !ok {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		to, ok := parseSeq(c.Query("to_seq"))
+		if !ok {
+			replyPublicError(c, http.StatusBadRequest)
+			return
+		}
+		res, err := store.Verify(c.Request.Context(), from, to, atoiDefault(c.Query("limit"), 0))
+		if err != nil {
+			serverError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, res)
+	})
+}
+
+func parseSeq(v string) (uint64, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, true
+	}
+	n, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/bkn-safe/server/internal/httpapi/router.go
+++ b/bkn-safe/server/internal/httpapi/router.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/audit"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/auth"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/decisionlog"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/directory"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/license"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
@@ -42,6 +43,9 @@ type Deps struct {
 	Audit *audit.Store
 	// AccessLog records login/logout outcomes separately from management audit.
 	AccessLog *accesslog.Store
+	// Decisions records authorization decisions (#334). When nil, nothing is
+	// recorded and the decision read endpoint is not mounted.
+	Decisions *decisionlog.Store
 	// TokenVerifier validates admin-API bearer tokens. Defaults to Hydra when
 	// nil (production); tests inject a stub.
 	TokenVerifier TokenVerifier
@@ -66,6 +70,16 @@ func New(deps Deps) *gin.Engine {
 		abortInternalError(c)
 	}))
 	r.Use(sharedrest.LanguageMiddleware())
+	if deps.Decisions != nil {
+		r.Use(withDecisionLog(deps.Decisions))
+	}
+	// Authentication and authorization refusals (401/403) at the token gates
+	// are audited too; the recorder runs in front of each gate. Without an
+	// audit store it is a pass-through.
+	gateAudit := func(c *gin.Context) { c.Next() }
+	if deps.Audit != nil {
+		gateAudit = auditAuthFailures(deps.Audit, deps.Directory, newFailureLimiter(failureLimiterWindow))
+	}
 
 	r.GET("/health/ready", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"status": "ok"}) })
 	r.GET("/health/alive", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"status": "ok"}) })
@@ -74,7 +88,7 @@ func New(deps Deps) *gin.Engine {
 	// local intermediate mode relies on the platform network boundary (#333),
 	// never on a caller-supplied service-name header. Callers resolve the end-user
 	// identity at their own boundary and pass accessor_id.
-	registerAuthz(r, deps.Enforcer, deps.DB)
+	registerAuthz(r, deps.Enforcer, deps.DB, deps.Audit, deps.Directory)
 
 	// AppKey (user-issued API key) store. Verification is internal, tokenless and
 	// ClusterIP-only (same trust face as /authz) — the Context Loader MCP/REST
@@ -125,14 +139,14 @@ func New(deps Deps) *gin.Engine {
 		meVerifier = newCachingVerifier(meVerifier, verifierCacheTTL)
 	}
 	if deps.Enforcer != nil && verifier != nil && deps.Users != nil && deps.Directory != nil {
-		authzExplain := r.Group("/api/safe/v1/authz", sharedrest.PrivateNoCacheMiddleware(),
+		authzExplain := r.Group("/api/safe/v1/authz", sharedrest.PrivateNoCacheMiddleware(), gateAudit,
 			RequireUser(verifier), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			authzExplain.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}
 		registerAuthzExplain(authzExplain, deps.Enforcer, deps.DB)
 
-		admin := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), RequireAdmin(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
+		admin := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireAdmin(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
 		// Audit every mutating admin request. Use() must precede the route
 		// registrations below: gin snapshots the group's handler chain at
 		// register time. The middleware sits after RequireAdmin, so it only runs
@@ -140,9 +154,13 @@ func New(deps Deps) *gin.Engine {
 		if deps.Audit != nil {
 			admin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 			registerAuditReads(admin, deps.Audit, deps.Enforcer)
+			registerAuditChainReads(admin, deps.Audit, deps.Enforcer)
 		}
 		if deps.AccessLog != nil {
 			registerAccessLogReads(admin, deps.AccessLog, deps.Enforcer)
+		}
+		if deps.Decisions != nil {
+			registerDecisionReads(admin, deps.Decisions, deps.Enforcer)
 		}
 		registerUserAdmin(admin, deps.Users, deps.Enforcer, deps.Directory)
 		registerAdminReads(admin, deps.Directory, deps.Enforcer)
@@ -151,7 +169,7 @@ func New(deps Deps) *gin.Engine {
 		// off the `admin` group because gin fixes a group's handler chain at
 		// register time — the relaxation has to be its own group or it would be
 		// no relaxation at all.
-		ownerDirectory := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(),
+		ownerDirectory := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), gateAudit,
 			RequireAdminOrResourceOwner(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			ownerDirectory.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
@@ -163,7 +181,7 @@ func New(deps Deps) *gin.Engine {
 		registerObjectGrants(admin, deps.Enforcer, deps.DB)
 		if permobject.ManagementRegistered() {
 			enterpriseObjectGrants := r.Group("/api/safe/v1/admin", permobject.ManagementGate(),
-				sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier), RequireActiveAccount(deps.DB))
+				sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireUser(verifier), RequireActiveAccount(deps.DB))
 			if deps.Audit != nil {
 				enterpriseObjectGrants.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 			}
@@ -181,7 +199,7 @@ func New(deps Deps) *gin.Engine {
 		// identifiable without any credential at all. Audit sits after the gate
 		// for the same reason: a hidden route must not produce a record shaped
 		// differently from a route that does not exist.
-		gatedAdmin := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), adminwrite.Gate(), RequireAdmin(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
+		gatedAdmin := r.Group("/api/safe/v1/admin", sharedrest.PrivateNoCacheMiddleware(), adminwrite.Gate(), gateAudit, RequireAdmin(verifier, deps.Enforcer), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			gatedAdmin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}
@@ -194,7 +212,7 @@ func New(deps Deps) *gin.Engine {
 		// gate still runs first, before authentication, so an unavailable paid
 		// surface is indistinguishable from Community's unmounted route.
 		propertyGrantAdmin := r.Group("/api/safe/v1/admin", permdata.ManagementGate(),
-			sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier), RequireActiveAccount(deps.DB))
+			sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireUser(verifier), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			propertyGrantAdmin.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))
 		}
@@ -247,13 +265,13 @@ func New(deps Deps) *gin.Engine {
 		// Read-only /me (GET "" + GET /permissions): the login burst fires these
 		// two in parallel, so they get the cached, singleflight-deduplicated
 		// verifier.
-		meReads := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), RequireUser(meVerifier))
+		meReads := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireUser(meVerifier))
 		registerMeReads(meReads, deps.Enforcer, deps.DB, deps.Directory)
 
 		// What this deployment can do, for the frontend's menu. Authn only:
 		// it describes the cluster, not the caller. Enforcement stays at each
 		// gated call site (open-core-gating §2.5).
-		caps := r.Group("/api/safe/v1", sharedrest.PrivateNoCacheMiddleware(), RequireUser(meVerifier))
+		caps := r.Group("/api/safe/v1", sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireUser(meVerifier))
 		registerCapabilities(caps, deps.License)
 
 		// Voluntary logout only records an access fact before the browser clears
@@ -261,7 +279,7 @@ func New(deps Deps) *gin.Engine {
 		// can still record that explicit action; it does not mutate authorization
 		// state and must not be blocked by the active-account write gate below.
 		if deps.AccessLog != nil {
-			meLogout := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), RequireUser(verifier))
+			meLogout := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), gateAudit, RequireUser(verifier))
 			registerLogout(meLogout, deps.AccessLog, deps.Directory)
 		}
 
@@ -270,7 +288,7 @@ func New(deps Deps) *gin.Engine {
 		// the read cache's TTL window. The local account check separately makes an
 		// administrator disable effective immediately even while Hydra still
 		// considers an already-issued token active.
-		meWrites := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(),
+		meWrites := r.Group("/api/safe/v1/me", sharedrest.PrivateNoCacheMiddleware(), gateAudit,
 			RequireUser(verifier), RequireActiveAccount(deps.DB))
 		if deps.Audit != nil {
 			meWrites.Use(auditMiddleware(deps.Audit, deps.Directory, deps.DB))

--- a/bkn-safe/server/internal/model/model.go
+++ b/bkn-safe/server/internal/model/model.go
@@ -326,7 +326,50 @@ type AuditLog struct {
 	Status    int       `json:"status"` // HTTP status code of the response
 	ClientIP  string    `json:"client_ip" gorm:"size:64"`
 	CreatedAt time.Time `json:"created_at" gorm:"index"`
+	// Tamper-evidence chain (#334). Seq is the row's append position, PrevHash
+	// the RowHash of the row at Seq-1, and RowHash SHA-256 over this row's
+	// canonical form plus PrevHash — so editing, deleting or reordering any
+	// chained row breaks verification from that point on. Rows written before
+	// the chain existed keep a NULL Seq and empty hashes: they are counted but
+	// never verified, and the chain starts at the first row written after the
+	// upgrade. Seq is nullable precisely so that AutoMigrate can add the unique
+	// index on a table that already holds rows.
+	Seq      *uint64 `json:"seq,omitempty" gorm:"uniqueIndex"`
+	PrevHash string  `json:"prev_hash,omitempty" gorm:"size:64"`
+	RowHash  string  `json:"row_hash,omitempty" gorm:"size:64"`
 }
+
+// AuthzDecision is one recorded authorization decision (#334): which accessor
+// asked for which operation on which resource, what the engine answered and on
+// what basis. It is a query log, not the chained audit trail: rows are written
+// asynchronously, allow decisions may be sampled, and the table is purged by
+// retention. Deny decisions are always recorded.
+type AuthzDecision struct {
+	ID           string `json:"id" gorm:"primaryKey;size:64"`
+	AccessorID   string `json:"accessor_id" gorm:"size:64;index:idx_authz_decision_accessor_time,priority:1"`
+	ResourceType string `json:"resource_type" gorm:"size:64;index"`
+	ResourceID   string `json:"resource_id" gorm:"size:128"`
+	Operation    string `json:"operation" gorm:"size:128"`
+	// Scope is the evaluation scope the caller asked for (effective | local).
+	Scope string `json:"scope" gorm:"size:16"`
+	// Decision is allow | deny | none; Basis is the authz.DecisionBasis that
+	// produced it, or "inactive_account" when the accessor was disabled.
+	Decision          string `json:"decision" gorm:"size:16;index"`
+	Basis             string `json:"basis" gorm:"size:32"`
+	DeniedRequirement string `json:"denied_requirement" gorm:"size:64"`
+	// Source names the entry point: check | operations | resource-filter |
+	// admin (management gates and permission points).
+	Source    string `json:"source" gorm:"size:32;index"`
+	RequestID string `json:"request_id" gorm:"size:128"`
+	TraceID   string `json:"trace_id" gorm:"size:64"`
+	ClientIP  string `json:"client_ip" gorm:"size:64"`
+	// Detail is a small JSON object with source-specific facts (batch sizes,
+	// projected operations, gate name). "" when there is nothing to add.
+	Detail    string    `json:"detail" gorm:"size:1024"`
+	CreatedAt time.Time `json:"created_at" gorm:"index:idx_authz_decision_accessor_time,priority:2;index"`
+}
+
+func (AuthzDecision) TableName() string { return "authz_decision_log" }
 
 // AccessLog records an authentication fact. It is deliberately separate from
 // AuditLog: login and logout explain who entered or left the platform, while
@@ -394,7 +437,7 @@ func AllModels() []any {
 	return []any{
 		&User{}, &Role{}, &Department{}, &UserDepartment{},
 		&Group{}, &GroupMember{}, &ResourceType{}, &Operation{},
-		&AuditLog{}, &AccessLog{}, &APIKey{}, &License{}, &ResourceParent{},
+		&AuditLog{}, &AccessLog{}, &AuthzDecision{}, &APIKey{}, &License{}, &ResourceParent{},
 		&ManagedProxyAccount{}, &ProxyGrantSource{}, &ProxyGrantPolicy{},
 		&ProxyGrantAuditLog{}, &AuthorizationGrant{},
 	}

--- a/docs/api/bkn-safe/audit.yaml
+++ b/docs/api/bkn-safe/audit.yaml
@@ -1,0 +1,435 @@
+# Copyright openbkn.ai
+#
+# Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+openapi: 3.0.3
+info:
+  title: bkn-safe audit and authorization-decision API
+  version: 0.1.0
+  description: |
+    Administrator read surface over the bkn-safe audit trail (#334).
+
+    Three records are kept, in three tables, and they answer different
+    questions:
+
+    - **Audit log** (`/admin/audit-logs`): one row per management mutation —
+      admin API writes, self-service writes (profile, AppKey issue/revoke,
+      object-grant delegation), tokenless `/authz` policy and hierarchy
+      writes, and every 401/403 refused at a token gate. Rows form a
+      tamper-evidence hash chain: each carries `seq`, `prev_hash` and
+      `row_hash`; editing, deleting or reordering a chained row is detected by
+      `/admin/audit-chain/verify`. Rows written before the chain existed have
+      no `seq` and are reported as `unchained_rows`, never verified.
+    - **Access log** (`/admin/access-logs`): login and logout facts.
+    - **Authorization decision log** (`/admin/authz-decisions`): one row per
+      authorization evaluation — `/authz/check`, one summary row per
+      `/authz/operations` and `/authz/resource-filter` call, the admin console
+      gate and every admin permission point — with the decision and the basis
+      that produced it. Rows are written asynchronously off the request path
+      and may be dropped under pressure (`dropped` in the list response);
+      allow decisions may be sampled (`audit.decision_log.allow_sample_rate`),
+      deny decisions never are; rows are purged after
+      `audit.decision_log.retention_days`.
+
+    Every endpoint here requires the `admin-audit:view` permission point and
+    is a read: none of them produces an audit row of its own.
+servers:
+  - url: /api/safe/v1
+security:
+  - BearerAuth: []
+tags:
+  - name: Audit
+    description: Management audit trail and its hash chain.
+  - name: Authorization decisions
+    description: Recorded authorization evaluations.
+paths:
+  /admin/audit-logs:
+    get:
+      tags: [Audit]
+      operationId: listAuditLogs
+      summary: List audit entries, newest first
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
+        - name: actor_id
+          in: query
+          schema: { type: string }
+        - name: resource
+          in: query
+          description: Top-level noun of the route, e.g. `users`, `role-bindings`, `policies`.
+          schema: { type: string }
+        - name: action
+          in: query
+          description: Business verb, e.g. `create`, `grant`, `revoke`, `reset_password`.
+          schema: { type: string }
+        - name: target_id
+          in: query
+          schema: { type: string }
+        - name: failed_only
+          in: query
+          description: Only rows whose status is 4xx/5xx — refused and failed attempts.
+          schema: { type: boolean }
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - name: before_id
+          in: query
+          description: Keyset tiebreaker for rows sharing the `to` timestamp.
+          schema: { type: string }
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of audit entries
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [logs, total]
+                properties:
+                  logs:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AuditLog'
+                  total:
+                    type: integer
+                    format: int64
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/audit-logs/{id}:
+    get:
+      tags: [Audit]
+      operationId: getAuditLog
+      summary: Get one audit entry
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: The audit entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditLog'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          description: No entry with this id
+          content:
+            application/json:
+              schema:
+                $ref: '../_shared/errors.yaml#/components/schemas/Error'
+  /admin/audit-chain:
+    get:
+      tags: [Audit]
+      operationId: getAuditChainHead
+      summary: Get the audit chain head
+      description: |
+        The position and hash of the last chained row. Export it to a store
+        outside this database (the service also logs it every
+        `audit.chain_head_log_interval`, 15 minutes by default) so that a
+        later verification can be compared against an anchor the database
+        cannot rewrite.
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
+      responses:
+        '200':
+          description: Chain head
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [head, unchained_rows]
+                properties:
+                  head:
+                    type: object
+                    nullable: true
+                    description: '`null` when no row has been chained yet.'
+                    allOf:
+                      - $ref: '#/components/schemas/ChainHead'
+                  unchained_rows:
+                    type: integer
+                    format: int64
+                    description: Rows written before the chain existed (no `seq`).
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/audit-chain/verify:
+    get:
+      tags: [Audit]
+      operationId: verifyAuditChain
+      summary: Re-hash the chain and report the first break
+      description: |
+        Walks rows in `seq` order recomputing every hash and link. Stops at the
+        first break. `limit` bounds the work of one call (default 10000, max
+        100000); when `truncated` is true, continue from `to_seq + 1`.
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
+        - name: from_seq
+          in: query
+          description: First position to check (0 or omitted = the beginning).
+          schema: { type: integer, format: int64, minimum: 0 }
+        - name: to_seq
+          in: query
+          description: Last position to check (0 or omitted = the head).
+          schema: { type: integer, format: int64, minimum: 0 }
+        - name: limit
+          in: query
+          schema: { type: integer, minimum: 0 }
+      responses:
+        '200':
+          description: Verification result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChainVerifyResult'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /admin/authz-decisions:
+    get:
+      tags: [Authorization decisions]
+      operationId: listAuthzDecisions
+      summary: List authorization decisions, newest first
+      description: |
+        Given an account and a period, the full list of what it asked for and
+        what it was answered. Filters combine with AND.
+      parameters:
+        - $ref: '#/components/parameters/AcceptLanguage'
+        - name: accessor_id
+          in: query
+          schema: { type: string }
+        - name: resource_type
+          in: query
+          schema: { type: string }
+        - name: resource_id
+          in: query
+          schema: { type: string }
+        - name: operation
+          in: query
+          schema: { type: string }
+        - name: decision
+          in: query
+          schema:
+            type: string
+            enum: [allow, deny, none]
+        - name: source
+          in: query
+          schema:
+            $ref: '#/components/schemas/DecisionSource'
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - $ref: '#/components/parameters/Offset'
+        - $ref: '#/components/parameters/Limit'
+      responses:
+        '200':
+          description: A page of decisions
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [decisions, total, dropped]
+                properties:
+                  decisions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AuthzDecision'
+                  total:
+                    type: integer
+                    format: int64
+                  dropped:
+                    type: integer
+                    format: int64
+                    description: Decisions discarded since start because the write queue was full. Non-zero means the log has gaps.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    AcceptLanguage:
+      name: Accept-Language
+      in: header
+      required: false
+      description: Requested language for human-readable errors. Supports `zh-CN` and `en-US`.
+      schema:
+        type: string
+        example: en-US
+    From:
+      name: from
+      in: query
+      description: Inclusive lower bound on `created_at`, RFC 3339.
+      schema: { type: string, format: date-time }
+    To:
+      name: to
+      in: query
+      description: Exclusive upper bound on `created_at`, RFC 3339.
+      schema: { type: string, format: date-time }
+    Offset:
+      name: offset
+      in: query
+      schema: { type: integer, minimum: 0, default: 0 }
+    Limit:
+      name: limit
+      in: query
+      description: Page size; default 50, capped at 500.
+      schema: { type: integer, minimum: 0 }
+  responses:
+    BadRequest:
+      description: Malformed query (unparseable timestamp or sequence number)
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    Unauthorized:
+      description: Missing or invalid bearer token
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+    Forbidden:
+      description: Caller lacks `admin-audit:view`
+      content:
+        application/json:
+          schema:
+            $ref: '../_shared/errors.yaml#/components/schemas/Error'
+  schemas:
+    AuditLog:
+      type: object
+      properties:
+        id: { type: string }
+        actor_id:
+          type: string
+          description: Token subject. Empty for a tokenless service write or an unauthenticated refusal.
+        actor_name_snapshot: { type: string }
+        actor_type:
+          type: string
+          enum: [user, service, anonymous]
+          description: '`service` for tokenless `/authz` writes (the peer address is the only attribution); `anonymous` for a 401 with no verified subject.'
+        auth_method:
+          type: string
+          enum: [oauth, network, none]
+        credential_id: { type: string }
+        request_id: { type: string }
+        source_channel:
+          type: string
+          enum: [api, internal]
+        method: { type: string }
+        resource: { type: string }
+        action: { type: string }
+        target_id: { type: string }
+        target_name: { type: string }
+        detail:
+          type: string
+          description: |
+            Redacted JSON snapshot of the request body. Underscore keys are
+            added by the server: `_outcome` (handler facts), `_gate` (which
+            gate refused a 401/403: `authn`, `inactive`, `authz`,
+            `permission`), `_caller_service` (self-declared `x-caller-service`
+            of a tokenless write — correlation metadata, never trusted).
+        status: { type: integer }
+        client_ip: { type: string }
+        created_at: { type: string, format: date-time }
+        seq:
+          type: integer
+          format: int64
+          description: Chain position. Absent on rows written before the chain existed.
+        prev_hash:
+          type: string
+          description: '`row_hash` of the row at `seq - 1`; empty for the first chained row.'
+        row_hash:
+          type: string
+          description: SHA-256 (hex) over the row's canonical form and `prev_hash`.
+    ChainHead:
+      type: object
+      required: [seq, row_hash, created_at]
+      properties:
+        seq: { type: integer, format: int64 }
+        row_hash: { type: string }
+        created_at: { type: string, format: date-time }
+    ChainVerifyResult:
+      type: object
+      required: [ok, from_seq, to_seq, checked, unchained_rows, truncated]
+      properties:
+        ok: { type: boolean }
+        from_seq: { type: integer, format: int64 }
+        to_seq:
+          type: integer
+          format: int64
+          description: Last position actually checked.
+        checked: { type: integer, format: int64 }
+        broken_seq:
+          type: integer
+          format: int64
+          description: First bad position; present only when `ok` is false.
+        reason:
+          type: string
+          enum: [hash_mismatch, prev_hash_mismatch, gap]
+          description: '`hash_mismatch`: row content or hash edited. `prev_hash_mismatch`: predecessor edited or replaced. `gap`: a position is missing (row deleted).'
+        head:
+          type: object
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ChainHead'
+        unchained_rows: { type: integer, format: int64 }
+        truncated:
+          type: boolean
+          description: '`limit` stopped the walk before `to_seq`; resume from `to_seq + 1`.'
+    DecisionSource:
+      type: string
+      enum: [check, operations, resource-filter, admin]
+      description: '`check`: `POST /authz/check`. `operations`: one row per `POST /authz/operations` call. `resource-filter`: one summary row per `POST /authz/resource-filter` call. `admin`: the admin console gate (`safe_admin` / `console` / `manage`) and admin permission points.'
+    AuthzDecision:
+      type: object
+      properties:
+        id: { type: string }
+        accessor_id: { type: string }
+        resource_type:
+          type: string
+          description: '`mixed` for a resource-filter batch spanning several types.'
+        resource_id:
+          type: string
+          description: '`*` for a permission point; empty for a resource-filter batch.'
+        operation:
+          type: string
+          description: '`*` for an operations projection; the comma-joined visibility operations for a resource-filter batch.'
+        scope:
+          type: string
+          enum: [effective, local]
+        decision:
+          type: string
+          enum: [allow, deny, none]
+        basis:
+          type: string
+          description: The `authz` decision basis (`direct`, `inherited`, `bundle`, `wildcard`, `default`, `requires`, `none`), or `inactive_account` when the accessor is disabled.
+        denied_requirement: { type: string }
+        source:
+          $ref: '#/components/schemas/DecisionSource'
+        request_id:
+          type: string
+          description: '`x-request-id` of the request, when the caller sent one.'
+        trace_id:
+          type: string
+          description: Trace id of the `traceparent` header, when the caller sent one.
+        client_ip: { type: string }
+        detail:
+          type: string
+          description: 'Small JSON object with source-specific facts: `operations` (projected set), `requested` / `visible` / `candidate_operations` (batch sizes), `fallback` / `fallback_allowed` (owner fallback at the directory gate).'
+        created_at: { type: string, format: date-time }

--- a/docs/api/bkn-safe/audit.yaml
+++ b/docs/api/bkn-safe/audit.yaml
@@ -15,7 +15,10 @@ info:
     - **Audit log** (`/admin/audit-logs`): one row per management mutation —
       admin API writes, self-service writes (profile, AppKey issue/revoke,
       object-grant delegation), tokenless `/authz` policy and hierarchy
-      writes, and every 401/403 refused at a token gate. Rows form a
+      writes, and 401/403 refusals at the token gates (throttled to one row
+      per minute per client and route for 401, per subject and route for
+      403, so a looping caller shows as a pattern rather than a flood). Rows
+      form a
       tamper-evidence hash chain: each carries `seq`, `prev_hash` and
       `row_hash`; editing, deleting or reordering a chained row is detected by
       `/admin/audit-chain/verify`. Rows written before the chain existed have


### PR DESCRIPTION
## Summary

Closes #334 (Epic #328, batch B-3).

Since the issue was filed, #830 / #852 / #1463 already covered login/logout access facts, `/me` writes (AppKey issue/revoke, object-grant delegation) and `/authz/explain`, and bkn-agent's OpenInference redaction defaults. This PR closes what was still missing:

- **Tokenless `/authz` writes are audited.** `POST/DELETE /policies` and `PUT/DELETE /resource-parents` move to a sub-group carrying the audit middleware. Rows record `actor_type=service`, `auth_method=network`, `source_channel=internal`; the self-declared `x-caller-service` header lands in `detail._caller_service` as correlation metadata only (never in actor columns). Refused writes (400/403/409) are recorded too.
- **401/403 at the token gates are audited.** A recorder registered in front of each gate sees the abort and writes a row with the verified subject (when the token was good) and the refusing gate in `detail._gate` (`authn` / `inactive` / `authz` / `permission`). 401s are throttled to one row per client+method+route per minute, 403s to one row per verified subject+method+route per minute (the first refusal of every account on every route is always recorded; decisions are never throttled). Mutations refused at a permission point stay a single row (the mutation audit records them and flags the request so the recorder skips it). Edition-hidden routes remain unrecorded (404 before the recorder).
- **Authorization decision log.** New `authz_decision_log` table and `internal/decisionlog`: one row per `/authz/check`, one summary row per `/operations` and `/resource-filter` call, and one row per admin console gate and permission point — decision, basis, denied requirement, `x-request-id`, `traceparent` trace id, client ip. Writes go through a bounded queue drained by one writer; a full queue drops and counts (`dropped` in the list response), never blocks. Allow decisions can be sampled; denies never are. Daily retention purge (90 days default). Read via `GET /admin/authz-decisions` (`admin-audit:view`).
- **Audit hash chain.** `audit_logs` gains nullable `seq` (unique index), `prev_hash`, `row_hash`. Appends link to the current head under a process lock (head cached in-process, so the steady state is one INSERT per row); across replicas the unique index arbitrates (duplicate key → re-read head, retry). `created_at` is truncated to the millisecond so the stored value re-hashes identically under `datetime(3)`. Rows written before the upgrade keep a NULL `seq` and are reported as `unchained_rows`. `GET /admin/audit-chain` returns the head; `GET /admin/audit-chain/verify` reports the first break (`hash_mismatch` / `prev_hash_mismatch` / `gap`) with windowing and a work limit. The head is also logged every `audit.chain_head_log_interval` so the log pipeline holds anchors outside the database.
- **Audit body pass-through.** The audit middleware buffers only a 64KB prefix for the Detail snapshot and hands the handler the prefix plus the unread remainder; previously the truncated bytes were handed over, so any audited mutation past 64KB (a full-size resource-parents batch) failed to parse.
- **Config / chart / docs.** `config.audit.*` with `SAFE_AUDIT_CHAIN_HEAD_LOG_INTERVAL` and `SAFE_AUTHZ_DECISION_LOG_{ENABLED,ALLOW_SAMPLE_RATE,QUEUE_SIZE,RETENTION_DAYS}`; chart `config.audit.*`; new `docs/api/bkn-safe/audit.yaml` (redocly lint clean).

Out of scope, recorded in the design doc's open questions: the execution-factory tool-execution parameter digest — that audit goes to the legacy `isf.audit_log.log` outbox topic, which has no consumer in the repo, so it belongs with the #852 `operation-audits` surface.

## Links

- Issue: #334
- Design: openbkn-ai/bkn-docs#122 — `docs/foundry/bkn-safe/design/issue-334-审计覆盖授权面并记录鉴权决策-技术设计.md`
- Branch: `feat/334-authz-audit`

## Compatibility

Additive schema only, applied by AutoMigrate: nullable `seq` with a unique index (legal on a table that already holds rows), two varchar columns, one new table. No data-migrator script. bkn-trace's `bknsafeaudit` adapter ignores the extra fields and already lists `policies` as a management resource. Rolling back to an older binary keeps working (extra columns ignored). Decision logging can be switched off (`enabled=false`); the audit trail itself is unchanged in cost except for one indexed head read per append.

## Testing

- `go build ./... && go vet ./... && go test ./...` in `bkn-safe/server` (new: `internal/audit/chain_test.go`, `internal/decisionlog/decisionlog_test.go`, `internal/httpapi/audit_authz_test.go`).
- `helm lint` and `helm template` for the chart, including `--set config.audit.decisionLog.enabled=false`.
- `npx @redocly/cli lint docs/api/bkn-safe/audit.yaml`.
- Local MariaDB 11.4: fresh install with this binary, and upgrade (schema created by the `origin/main` binary with rows, then this binary) — columns, unique index and chain verified.
- Test server 14.103.77.23, both paths, in isolated pods against isolated databases (the live `safe` database untouched; pods, DB copies, image and token removed afterwards):
  - fresh (`safe_334_fresh`): schema created, seed rows chained from `seq=1`, head/verify OK via admin token;
  - upgrade (mysqldump copy of `safe`, 1369 existing audit rows): AutoMigrate succeeded, `unchained_rows=1369`; service grant/revoke rows with `actor_type=service` and `_caller_service`; two token-less requests → one throttled 401 row; bad token → 401 row; disabled admin → 403 `_gate=inactive`; `/check` allow/direct for admin and deny/inactive_account for an unknown accessor; one summary row for a 3-resource `/resource-filter`; AppKey issue/revoke chained; verify OK over 33 rows, then editing one row reported `seq=27 hash_mismatch` and deleting one reported `seq=30 gap`.

## Pre-merge checklist

- [x] Design doc status `in-review` (bkn-docs#122)
- [x] Tests added and passing
- [x] OpenAPI updated (`docs/api/bkn-safe/audit.yaml`)
- [x] Verified on the test server (fresh install + upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
