### PR TITLE
fix(authz): hide managed proxy grants from admin inventory

### DIFF
--- a/bkn-safe/server/internal/httpapi/objectgrants.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants.go
@@ -361,7 +361,13 @@ func registerObjectGrants(g *gin.RouterGroup, e *authz.Enforcer, db *gorm.DB) {
 			"INSTR(v1, ':') > 0",               // has the type:id shape
 			ridExpr + " NOT IN ('', '*')",      // concrete instance only (skip type-wide / bare "*")
 			"v0 NOT IN (SELECT id FROM roles)", // role subjects are not user object grants
-			"v0 <> ?",                          // exclude the public accessor
+			// Managed proxies are system-owned runtime identities. Their policies
+			// are maintained through the proxy lifecycle API, not by people in the
+			// authorization-management UI. Keeping them out here also prevents a
+			// client from resolving a proxy accessor through the user directory,
+			// where proxies are intentionally invisible.
+			"v0 NOT IN (SELECT proxy_account_id FROM managed_proxy_accounts)",
+			"v0 <> ?", // exclude the public accessor
 		}
 		args := []any{authz.PublicAccessorID}
 		if accessorID != "" {

--- a/bkn-safe/server/internal/httpapi/objectgrants_test.go
+++ b/bkn-safe/server/internal/httpapi/objectgrants_test.go
@@ -14,6 +14,7 @@ import (
 	"gorm.io/gorm"
 
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/authz"
+	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/managedproxy"
 	"github.com/openbkn-ai/bkn-foundry/bkn-safe/server/internal/model"
 	"github.com/openbkn-ai/bkn-foundry/comm-go/entitlement"
 	"github.com/openbkn-ai/licverify"
@@ -182,6 +183,86 @@ func TestObjectGrantsSetListRevoke(t *testing.T) {
 	}
 	if got := listObjectGrants(t, r, ""); len(got) != 0 {
 		t.Fatalf("list after revoke: %+v", got)
+	}
+}
+
+func TestObjectGrantsListHidesManagedProxyAccounts(t *testing.T) {
+	r, e, db, users := newAdminServer(t)
+	ctx := t.Context()
+	if err := users.CreateLocalUser(ctx, &model.User{ID: "u-visible", Account: "visible", Enabled: true}, "pw-init0"); err != nil {
+		t.Fatal(err)
+	}
+	seedCatalogOps(t, db, "resource", "query_data")
+	if err := e.GrantObjectPermission("u-visible", "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+
+	proxy, _, err := managedproxy.New(db).Create(ctx, managedproxy.CreateRequest{
+		ManagedResourceType: managedproxy.ResourceKnowledgeNetwork,
+		ManagedResourceID:   "kn-hidden-proxy-grant",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := e.GrantObjectPermission(proxy.ProxyAccountID, "resource", "r-1", "query_data"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.ProxyGrantSource{
+		ID: "source-hidden-proxy-grant", ProxyAccountID: proxy.ProxyAccountID,
+		ResourceType: "resource", ResourceID: "r-1", Operation: "query_data",
+		SourceType: model.ProxyGrantSourceTypeManual, SourceID: "hidden-proxy-grant",
+		LifecycleStatus: model.ProxyGrantSourceStatusActive,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	body := listObjectGrantsBody(t, r, "?include_summary=true")
+	if body.Total != 1 || len(body.Entries) != 1 || body.Entries[0].AccessorID != "u-visible" {
+		t.Fatalf("flat object grants = total %d entries %+v, want only the visible user", body.Total, body.Entries)
+	}
+	if body.Summary == nil || body.Summary.Grants != 1 || body.Summary.Objects != 1 || body.Summary.Grantees != 1 {
+		t.Fatalf("summary = %+v, want one visible user grant", body.Summary)
+	}
+
+	w := adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/object-grants?group_by=grantee", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("grouped grants = %d body=%s", w.Code, w.Body.String())
+	}
+	var grouped struct {
+		Groups []struct {
+			AccessorID  string `json:"accessor_id"`
+			ObjectCount int64  `json:"object_count"`
+		} `json:"groups"`
+		Total int64 `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &grouped); err != nil {
+		t.Fatal(err)
+	}
+	if grouped.Total != 1 || len(grouped.Groups) != 1 || grouped.Groups[0].AccessorID != "u-visible" || grouped.Groups[0].ObjectCount != 1 {
+		t.Fatalf("grouped grants = %+v, want only the visible user", grouped)
+	}
+
+	w = adminReq(t, r, http.MethodGet, "/api/safe/v1/admin/object-grants?group_by=object", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("grouped objects = %d body=%s", w.Code, w.Body.String())
+	}
+	var groupedObjects struct {
+		Groups []struct {
+			Object struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+			} `json:"object"`
+			GranteeCount int64 `json:"grantee_count"`
+		} `json:"groups"`
+		Total int64 `json:"total"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &groupedObjects); err != nil {
+		t.Fatal(err)
+	}
+	if groupedObjects.Total != 1 || len(groupedObjects.Groups) != 1 ||
+		groupedObjects.Groups[0].Object.Type != "resource" || groupedObjects.Groups[0].Object.ID != "r-1" ||
+		groupedObjects.Groups[0].GranteeCount != 1 {
+		t.Fatalf("grouped objects = %+v, want one visible user on resource/r-1", groupedObjects)
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## What Changed

Brief description of changes:

- [x] Exclude managed BKN proxy accounts from the administrator object-grant inventory.
- [x] Cover flat, summary, and both grouped list projections with a focused regression test.
- [ ] Docs/doc 1 — not applicable; the public API contract is unchanged.

---

## Why

- Related Issue: Closes #1508
- Related Feature: Knowledge-network proxy authorization
- Background: The authorization-management UI treated a managed proxy accessor as a human user. User-detail lookup then correctly returned 404 because managed proxies are intentionally hidden from the directory.

---

## How

- Key implementation points:
  - Add the managed_proxy_accounts exclusion to the shared SQL predicate used by the flat, summary, group_by=grantee, and group_by=object views.
  - Preserve all Casbin policies and proxy grant-source records; this is a human-administration read-model filter only.
  - Add a regression test with one ordinary user grant and one managed proxy grant for the same resource.
- Breaking changes (API, config, database, etc.): None. Existing response fields are unchanged; managed proxy entries are no longer returned from the human administration inventory.

---

## Testing

- [x] Unit tests passed locally
- [ ] Integration tests passed locally — not applicable; the regression is a database-backed HTTP unit test.
- [ ] Verified in test environment — not deployed.

Test notes:

- GOWORK=/tmp/codex-bkn-safe-work/go.work go test ./internal/httpapi -count=1
- GOWORK=/tmp/codex-bkn-safe-work/go.work golangci-lint run ./internal/httpapi/...
- git diff --check

---

## Risk & Rollback

- Potential risks: The management-page count will decrease by the number of system proxy grants. Runtime authorization is unaffected because enforcement and proxy-source data are untouched.
- Rollback plan: Revert commit 835f7c0b7. No data, schema, or configuration rollback is required.

---

## Additional Notes

- The production-like 14.103.77.23 environment confirmed that the reported accessor is an active managed BKN proxy for ecommerce_ops_bkn_public.
- No deployment, permission change, or data mutation was performed.
