### PR TITLE
fix(operator-integration): encode unicode skill download filenames per RFC 5987

### DIFF
--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/category.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/category.go
@@ -11,16 +11,14 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"regexp"
-	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 )
 
 type CategoryEntry struct {
 	CategoryType string `json:"category_type"`
 	Name         string `json:"name"`
 }
-
-var filenamePattern = regexp.MustCompile(`filename="?([^";]+)"?`)
 
 func (c *OperatorIntegrationClient) ListCategories(ctx context.Context) ([]CategoryEntry, error) {
 	var resp []CategoryEntry
@@ -84,8 +82,8 @@ func (c *OperatorIntegrationClient) DownloadSkillPackage(
 	}
 
 	filename := "skill.zip"
-	if match := filenamePattern.FindStringSubmatch(res.Header.Get("Content-Disposition")); len(match) > 1 {
-		filename = strings.TrimSpace(match[1])
+	if parsed := utils.ParseContentDispositionFilename(res.Header.Get("Content-Disposition")); parsed != "" {
+		filename = parsed
 	}
 
 	return payload, filename, nil

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/market.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/market.go
@@ -10,7 +10,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
+
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 )
 
 type MarketToolbox struct {
@@ -151,13 +152,8 @@ func (c *OperatorIntegrationClient) DownloadSkillMarketPackage(
 	}
 
 	filename := skillID + ".zip"
-	if cd := res.Header.Get("Content-Disposition"); cd != "" {
-		if idx := strings.Index(cd, "filename="); idx >= 0 {
-			raw := strings.TrimSpace(strings.Trim(cd[idx+len("filename="):], `";`))
-			if raw != "" {
-				filename = raw
-			}
-		}
+	if parsed := utils.ParseContentDispositionFilename(res.Header.Get("Content-Disposition")); parsed != "" {
+		filename = parsed
 	}
 
 	return payload, filename, nil

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration_test.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/client/operator_integration_test.go
@@ -93,3 +93,52 @@ func assertPayloadString(t *testing.T, payload map[string]interface{}, key, want
 		t.Fatalf("payload[%q] = %q, want %q; full payload: %+v", key, got, want, payload)
 	}
 }
+
+func TestDownloadSkillPackagePrefersRFC5987Filename(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agent-operator-integration/v1/skills/skill-1/management/download" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Disposition", `attachment; filename="skill.zip"; filename*=UTF-8''%E9%87%91%E9%A2%9D%E6%A0%B8%E5%AF%B9%E5%87%BD%E6%95%B0.zip`)
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write([]byte("zip-bytes"))
+	}))
+	defer server.Close()
+
+	client := &OperatorIntegrationClient{
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	payload, filename, err := client.DownloadSkillPackage(context.Background(), "skill-1")
+	if err != nil {
+		t.Fatalf("DownloadSkillPackage: %v", err)
+	}
+	if string(payload) != "zip-bytes" {
+		t.Fatalf("payload = %q", payload)
+	}
+	if filename != "金额核对函数.zip" {
+		t.Fatalf("filename = %q, want unicode name from filename*", filename)
+	}
+}
+
+func TestDownloadSkillPackageFallsBackToPlainFilename(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition", `attachment; filename="demo-skill.zip"`)
+		_, _ = w.Write([]byte("zip-bytes"))
+	}))
+	defer server.Close()
+
+	client := &OperatorIntegrationClient{
+		BaseURL: server.URL,
+		HTTP:    server.Client(),
+	}
+
+	_, filename, err := client.DownloadSkillPackage(context.Background(), "skill-1")
+	if err != nil {
+		t.Fatalf("DownloadSkillPackage: %v", err)
+	}
+	if filename != "demo-skill.zip" {
+		t.Fatalf("filename = %q", filename)
+	}
+}

--- a/adp/execution-factory/operator-integration/server/capabilitieslab/handler/gap_fill.go
+++ b/adp/execution-factory/operator-integration/server/capabilitieslab/handler/gap_fill.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/capabilitieslab/model"
+	"github.com/openbkn-ai/bkn-foundry/adp/execution-factory/operator-integration/server/utils"
 )
 
 func (h *CapabilitiesHandler) ListCategories(c *gin.Context) {
@@ -54,7 +55,7 @@ func (h *CapabilitiesHandler) DownloadSkillPackage(c *gin.Context) {
 		return
 	}
 
-	c.Header("Content-Disposition", "attachment; filename=\""+filename+"\"")
+	c.Header("Content-Disposition", utils.AttachmentContentDisposition(filename, "skill.zip"))
 	c.Data(http.StatusOK, "application/octet-stream", payload)
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/index.go
@@ -39,6 +39,11 @@ type SkillHandler interface {
 	DownloadManagementSkill(c *gin.Context)
 }
 
+// skillDownloadASCIIFallback is the plain Content-Disposition filename used
+// when a skill name has no ASCII characters to fall back on; RFC 5987
+// filename* still carries the real (unicode) name.
+const skillDownloadASCIIFallback = "skill.zip"
+
 type skillHandler struct {
 	Logger            interfaces.Logger
 	Registry          interfaces.SkillRegistry

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/mgmt_reader_handler.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/mgmt_reader_handler.go
@@ -1,7 +1,6 @@
 package skill
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -87,6 +86,6 @@ func (h *skillHandler) DownloadManagementSkill(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", resp.FileName))
+	c.Header("Content-Disposition", utils.AttachmentContentDisposition(resp.FileName, skillDownloadASCIIFallback))
 	c.Data(http.StatusOK, "application/zip", resp.Content)
 }

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/skill.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/skill.go
@@ -1,7 +1,6 @@
 package skill
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/creasty/defaults"
@@ -209,7 +208,7 @@ func (h *skillHandler) DownloadSkill(c *gin.Context) {
 		rest.ReplyError(c, err)
 		return
 	}
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", resp.FileName))
+	c.Header("Content-Disposition", utils.AttachmentContentDisposition(resp.FileName, skillDownloadASCIIFallback))
 	c.Data(http.StatusOK, "application/zip", resp.Content)
 }
 

--- a/adp/execution-factory/operator-integration/server/driveradapters/skill/skill_test.go
+++ b/adp/execution-factory/operator-integration/server/driveradapters/skill/skill_test.go
@@ -292,7 +292,61 @@ func TestSkillHandler(t *testing.T) {
 
 			So(recorder.Code, ShouldEqual, http.StatusOK)
 			So(recorder.Header().Get("Content-Type"), ShouldEqual, "application/zip")
-			So(recorder.Header().Get("Content-Disposition"), ShouldContainSubstring, `filename="demo-skill.zip"`)
+			So(recorder.Header().Get("Content-Disposition"), ShouldEqual, `attachment; filename="demo-skill.zip"`)
+			So(recorder.Body.String(), ShouldEqual, "zip-bytes")
+		})
+
+		Convey("DownloadSkill encodes unicode filenames per RFC 5987", func() {
+			mockRegistry := mocks.NewMockSkillRegistry(ctrl)
+			mockMarket := mocks.NewMockSkillMarket(ctrl)
+			mockReader := mocks.NewMockSkillReader(ctrl)
+			handler := &skillHandler{
+				Registry: &skillRegistryAdapter{MockSkillRegistry: mockRegistry},
+				Market:   mockMarket,
+				Reader:   mockReader,
+			}
+			mockRegistry.EXPECT().DownloadSkill(gomock.Any(), gomock.Any()).Return(&interfaces.DownloadSkillResp{
+				SkillID:  "skill-5",
+				FileName: "金额核对函数.zip",
+				Content:  []byte("zip-bytes"),
+			}, nil)
+
+			recorder := performSkillRequest(http.MethodGet, "/skills/:skill_id/download", "", "", map[string]string{}, handler.DownloadSkill, "skill-5")
+
+			So(recorder.Code, ShouldEqual, http.StatusOK)
+			So(recorder.Header().Get("Content-Disposition"), ShouldEqual,
+				`attachment; filename="skill.zip"; filename*=UTF-8''%E9%87%91%E9%A2%9D%E6%A0%B8%E5%AF%B9%E5%87%BD%E6%95%B0.zip`)
+		})
+
+		Convey("DownloadManagementSkill uses the same Content-Disposition encoding", func() {
+			mockRegistry := mocks.NewMockSkillRegistry(ctrl)
+			mockMarket := mocks.NewMockSkillMarket(ctrl)
+			mockReader := mocks.NewMockSkillReader(ctrl)
+			mockMgmtReader := mocks.NewMockSkillManagementReader(ctrl)
+			handler := &skillHandler{
+				Registry:   &skillRegistryAdapter{MockSkillRegistry: mockRegistry},
+				Market:     mockMarket,
+				Reader:     mockReader,
+				MgmtReader: mockMgmtReader,
+			}
+			mockMgmtReader.EXPECT().DownloadManagementSkill(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ any, req *interfaces.DownloadManagementSkillReq) (*interfaces.DownloadSkillResp, error) {
+					So(req.SkillID, ShouldEqual, "skill-6")
+					return &interfaces.DownloadSkillResp{
+						SkillID:  "skill-6",
+						FileName: "金额核对 check.zip\r\nX-Injected: 1",
+						Content:  []byte("zip-bytes"),
+					}, nil
+				},
+			)
+
+			recorder := performSkillRequest(http.MethodGet, "/skills/:skill_id/management/download", "", "", map[string]string{}, handler.DownloadManagementSkill, "skill-6")
+
+			So(recorder.Code, ShouldEqual, http.StatusOK)
+			So(recorder.Header().Get("Content-Type"), ShouldEqual, "application/zip")
+			So(recorder.Header().Get("Content-Disposition"), ShouldEqual,
+				`attachment; filename="check.zipX-Injected_ 1"; filename*=UTF-8''%E9%87%91%E9%A2%9D%E6%A0%B8%E5%AF%B9%20check.zipX-Injected_%201`)
+			So(recorder.Header().Get("X-Injected"), ShouldBeEmpty)
 			So(recorder.Body.String(), ShouldEqual, "zip-bytes")
 		})
 

--- a/adp/execution-factory/operator-integration/server/utils/content_disposition.go
+++ b/adp/execution-factory/operator-integration/server/utils/content_disposition.go
@@ -1,0 +1,185 @@
+// Copyright openbkn.ai
+//
+// Licensed under the OpenBKN License. See LICENSE-OPENBKN.txt in the project root.
+
+package utils
+
+import (
+	"mime"
+	"path"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// defaultAttachmentStem is used when a filename has no usable characters left
+// after sanitization (for example a name made only of path separators).
+const defaultAttachmentStem = "download"
+
+// attachmentIllegalChars covers path separators, Windows-reserved characters
+// and the quote/backslash pair that would need escaping inside a quoted-string.
+var attachmentIllegalChars = regexp.MustCompile(`[/\\:*?"<>|]+`)
+
+// AttachmentContentDisposition builds an RFC 6266 attachment header value that
+// carries the filename twice:
+//
+//	attachment; filename="<ascii fallback>"; filename*=UTF-8''<percent-encoded name>
+//
+// The extended parameter is only emitted when the sanitized filename contains
+// non-ASCII characters. Browsers and HTTP clients that understand RFC 5987
+// pick the UTF-8 name; everything else falls back to the ASCII one.
+//
+// asciiFallback is used as the plain filename when nothing printable survives
+// the ASCII projection (for example a purely Chinese stem). Its extension is
+// replaced by the extension of filename so the two parameters stay consistent.
+func AttachmentContentDisposition(filename, asciiFallback string) string {
+	name := SanitizeAttachmentFilename(filename)
+	ascii := asciiProjection(name, asciiFallback)
+
+	var b strings.Builder
+	b.WriteString(`attachment; filename="`)
+	b.WriteString(ascii)
+	b.WriteByte('"')
+	if ascii != name {
+		b.WriteString("; filename*=UTF-8''")
+		b.WriteString(percentEncodeRFC5987(name))
+	}
+	return b.String()
+}
+
+// SanitizeAttachmentFilename strips everything that must never reach a
+// Content-Disposition header or a client filesystem: CR/LF and other control
+// characters, path separators and platform-reserved characters. Unicode
+// letters (Chinese, emoji, ...) are preserved. The result never contains a
+// directory component and is never empty.
+func SanitizeAttachmentFilename(filename string) string {
+	if cleaned, ok := sanitizeAttachmentFilename(filename); ok {
+		return cleaned
+	}
+	return defaultAttachmentStem
+}
+
+func sanitizeAttachmentFilename(filename string) (string, bool) {
+	cleaned := strings.Map(func(r rune) rune {
+		if r == unicode.ReplacementChar || unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, filename)
+	cleaned = attachmentIllegalChars.ReplaceAllString(cleaned, "_")
+	cleaned = strings.Trim(strings.TrimSpace(cleaned), "._ ")
+	cleaned = strings.TrimSpace(cleaned)
+	return cleaned, cleaned != ""
+}
+
+// ParseContentDispositionFilename extracts the filename from a
+// Content-Disposition header, preferring the RFC 5987 filename* parameter
+// over the plain filename one. The returned value is sanitized so that it can
+// be forwarded as-is to another attachment header or used as a local filename.
+// An empty string is returned when no filename can be recovered.
+func ParseContentDispositionFilename(header string) string {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return ""
+	}
+	raw := ""
+	if _, params, err := mime.ParseMediaType(header); err == nil {
+		// mime.ParseMediaType decodes filename* (RFC 2231/5987) and stores the
+		// result under the bare "filename" key, overriding the plain one.
+		raw = params["filename"]
+	}
+	if raw == "" {
+		raw = legacyFilenameParam(header)
+	}
+	sanitized, ok := sanitizeAttachmentFilename(raw)
+	if !ok {
+		return ""
+	}
+	return sanitized
+}
+
+var legacyFilenamePattern = regexp.MustCompile(`(?i)filename\s*=\s*("([^"]*)"|([^;]*))`)
+
+// legacyFilenameParam recovers the plain filename parameter from headers that
+// mime.ParseMediaType rejects (for example raw UTF-8 inside a token value).
+func legacyFilenameParam(header string) string {
+	match := legacyFilenamePattern.FindStringSubmatch(header)
+	if match == nil {
+		return ""
+	}
+	if match[2] != "" {
+		return match[2]
+	}
+	return match[3]
+}
+
+// asciiProjection reduces name to printable ASCII by dropping every other
+// rune. When nothing usable survives in the stem, the fallback's stem is used
+// together with name's extension so both header parameters share a suffix.
+func asciiProjection(name, fallback string) string {
+	ext := path.Ext(name)
+	stem := trimEdges(asciiOnly(strings.TrimSuffix(name, ext)))
+	if stem == "" {
+		fallbackSanitized := SanitizeAttachmentFilename(fallback)
+		stem = trimEdges(asciiOnly(strings.TrimSuffix(fallbackSanitized, path.Ext(fallbackSanitized))))
+		if stem == "" {
+			stem = defaultAttachmentStem
+		}
+	}
+	extASCII := asciiOnly(ext)
+	if extASCII == "." {
+		extASCII = ""
+	}
+	return stem + extASCII
+}
+
+// trimEdges drops the leading/trailing spaces and dots that an ASCII
+// projection can leave behind (for example " check" from "金额 check").
+func trimEdges(s string) string {
+	return strings.Trim(s, ". ")
+}
+
+// asciiOnly keeps printable ASCII (0x20-0x7E) minus the two characters that
+// would need escaping inside a quoted-string.
+func asciiOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r < 0x20 || r > 0x7e || r == '"' || r == '\\' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// percentEncodeRFC5987 encodes s as an RFC 5987 value-chars sequence: every
+// byte outside attr-char (ALPHA / DIGIT / "!" / "#" / "$" / "&" / "+" / "-" /
+// "." / "^" / "_" / "`" / "|" / "~") is percent-encoded.
+func percentEncodeRFC5987(s string) string {
+	const hex = "0123456789ABCDEF"
+	var b strings.Builder
+	b.Grow(len(s) * 3)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isRFC5987AttrChar(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(hex[c>>4])
+		b.WriteByte(hex[c&0x0f])
+	}
+	return b.String()
+}
+
+func isRFC5987AttrChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	}
+	switch c {
+	case '!', '#', '$', '&', '+', '-', '.', '^', '_', '`', '|', '~':
+		return true
+	}
+	return false
+}

--- a/adp/execution-factory/operator-integration/server/utils/content_disposition_test.go
+++ b/adp/execution-factory/operator-integration/server/utils/content_disposition_test.go
@@ -1,0 +1,136 @@
+//go:build !skiptest
+// +build !skiptest
+
+package utils
+
+import (
+	"mime"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAttachmentContentDisposition(t *testing.T) {
+	Convey("AttachmentContentDisposition", t, func() {
+		cases := []struct {
+			name     string
+			filename string
+			fallback string
+			want     string
+		}{
+			{
+				name:     "ascii name is emitted once without filename*",
+				filename: "demo-skill.zip",
+				fallback: "skill.zip",
+				want:     `attachment; filename="demo-skill.zip"`,
+			},
+			{
+				name:     "chinese name gets ascii fallback plus RFC 5987 parameter",
+				filename: "金额核对函数.zip",
+				fallback: "skill.zip",
+				want:     `attachment; filename="skill.zip"; filename*=UTF-8''%E9%87%91%E9%A2%9D%E6%A0%B8%E5%AF%B9%E5%87%BD%E6%95%B0.zip`,
+			},
+			{
+				name:     "mixed name keeps the ascii part as fallback",
+				filename: "金额核对 check (v2).zip",
+				fallback: "skill.zip",
+				want:     `attachment; filename="check (v2).zip"; filename*=UTF-8''%E9%87%91%E9%A2%9D%E6%A0%B8%E5%AF%B9%20check%20%28v2%29.zip`,
+			},
+			{
+				name:     "spaces and parentheses survive in ascii names",
+				filename: "my skill (final).zip",
+				fallback: "skill.zip",
+				want:     `attachment; filename="my skill (final).zip"`,
+			},
+			{
+				name:     "percent and quotes never break the quoted-string",
+				filename: `100% "done".zip`,
+				fallback: "skill.zip",
+				want:     `attachment; filename="100% _done_.zip"`,
+			},
+			{
+				name:     "emoji is percent-encoded",
+				filename: "rocket 🚀.zip",
+				fallback: "skill.zip",
+				want:     `attachment; filename="rocket.zip"; filename*=UTF-8''rocket%20%F0%9F%9A%80.zip`,
+			},
+			{
+				name:     "CRLF injection is stripped",
+				filename: "evil.zip\r\nX-Injected: 1",
+				fallback: "skill.zip",
+				want:     `attachment; filename="evil.zipX-Injected_ 1"`,
+			},
+			{
+				name:     "path separators are neutralised",
+				filename: `../../etc/passwd\..\win.zip`,
+				fallback: "skill.zip",
+				want:     `attachment; filename="etc_passwd_.._win.zip"`,
+			},
+			{
+				name:     "empty name falls back to the default stem",
+				filename: "",
+				fallback: "skill.zip",
+				want:     `attachment; filename="download"`,
+			},
+			{
+				name:     "extension follows the unicode name, not the fallback",
+				filename: "报告.tar",
+				fallback: "skill.zip",
+				want:     `attachment; filename="skill.tar"; filename*=UTF-8''%E6%8A%A5%E5%91%8A.tar`,
+			},
+		}
+		for _, tc := range cases {
+			Convey(tc.name, func() {
+				got := AttachmentContentDisposition(tc.filename, tc.fallback)
+				So(got, ShouldEqual, tc.want)
+				// Every emitted header must be parseable by the standard library.
+				_, params, err := mime.ParseMediaType(got)
+				So(err, ShouldBeNil)
+				So(params["filename"], ShouldNotBeEmpty)
+			})
+		}
+
+		Convey("standard library decodes filename* back to the unicode name", func() {
+			got := AttachmentContentDisposition("金额核对函数.zip", "skill.zip")
+			_, params, err := mime.ParseMediaType(got)
+			So(err, ShouldBeNil)
+			So(params["filename"], ShouldEqual, "金额核对函数.zip")
+		})
+	})
+}
+
+func TestSanitizeAttachmentFilename(t *testing.T) {
+	Convey("SanitizeAttachmentFilename", t, func() {
+		So(SanitizeAttachmentFilename("金额核对函数.zip"), ShouldEqual, "金额核对函数.zip")
+		So(SanitizeAttachmentFilename("  a/b\\c:d*e?f\"g<h>i|j.zip  "), ShouldEqual, "a_b_c_d_e_f_g_h_i_j.zip")
+		So(SanitizeAttachmentFilename("a\x00b\x1fc\x7fd.zip"), ShouldEqual, "abcd.zip")
+		So(SanitizeAttachmentFilename("..hidden"), ShouldEqual, "hidden")
+		So(SanitizeAttachmentFilename("///"), ShouldEqual, "download")
+		So(SanitizeAttachmentFilename(""), ShouldEqual, "download")
+	})
+}
+
+func TestParseContentDispositionFilename(t *testing.T) {
+	Convey("ParseContentDispositionFilename", t, func() {
+		Convey("prefers filename* over filename", func() {
+			got := ParseContentDispositionFilename(`attachment; filename="skill.zip"; filename*=UTF-8''%E9%87%91%E9%A2%9D.zip`)
+			So(got, ShouldEqual, "金额.zip")
+		})
+		Convey("keeps ascii filename when filename* is absent", func() {
+			So(ParseContentDispositionFilename(`attachment; filename="demo-skill.zip"`), ShouldEqual, "demo-skill.zip")
+			So(ParseContentDispositionFilename(`attachment; filename=demo-skill.zip`), ShouldEqual, "demo-skill.zip")
+		})
+		Convey("accepts legacy raw utf-8 inside quotes", func() {
+			So(ParseContentDispositionFilename(`attachment; filename="金额.zip"`), ShouldEqual, "金额.zip")
+		})
+		Convey("strips path components from untrusted headers", func() {
+			So(ParseContentDispositionFilename(`attachment; filename="../../x.zip"`), ShouldEqual, "x.zip")
+		})
+		Convey("returns empty for missing or unusable values", func() {
+			So(ParseContentDispositionFilename(""), ShouldEqual, "")
+			So(ParseContentDispositionFilename("attachment"), ShouldEqual, "")
+			So(ParseContentDispositionFilename(`attachment; filename=""`), ShouldEqual, "")
+			So(ParseContentDispositionFilename(`attachment; filename="///"`), ShouldEqual, "")
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Fixes the mojibake file name when downloading a skill whose name contains Chinese (or any non-ASCII) characters. Closes #1022 on the backend side; the matching Studio change is openbkn-ai/bkn-studio (fix/1022-download-filename-encoding).

## Root cause

Both skill download handlers wrote the raw UTF-8 name straight into the legacy `filename=` parameter:

```
Content-Disposition: attachment; filename="库存阈值预警通知.zip"
```

XHR / fetch expose header bytes as Latin-1, so Studio handed a mojibake string to `anchor.download`.

## Changes

- `server/utils/content_disposition.go`: new `AttachmentContentDisposition(filename, asciiFallback)` that emits an ASCII `filename=` fallback plus an RFC 5987 `filename*=UTF-8''...` parameter, after stripping CR/LF, control characters, path separators and platform-illegal characters (header injection / path smuggling). `ParseContentDispositionFilename` is the matching reader (prefers `filename*`, tolerates legacy raw UTF-8, sanitises the result).
- Public `/skills/{id}/download`, management `/skills/{id}/management/download` and capabilities-lab `/capabilities/{id}/skill/download` all use the builder.
- capabilities-lab client (`category.go`, `market.go`) reads `filename*` when it proxies a download, so the unicode name survives the hop instead of being truncated to the ASCII fallback.
- Tests: table tests for the builder (Chinese, mixed, spaces/parentheses, `%` and quotes, emoji, CRLF, `/` and `\`, empty), handler tests asserting the exact header for both endpoints, client round-trip tests. Every emitted header is also checked to round-trip through `mime.ParseMediaType`.

## Verification on 14.103.77.23

Hot-swapped the binary (built from the deployed commit e286d27 + this fix) and downloaded skill `库存阈值预警通知`:

Before:
```
content-disposition: attachment; filename="库存阈值预警通知.zip"
```

After (both `/download` and `/management/download`, zip bytes byte-identical to before):
```
content-disposition: attachment; filename="skill.zip"; filename*=UTF-8''%E5%BA%93%E5%AD%98%E9%98%88%E5%80%BC%E9%A2%84%E8%AD%A6%E9%80%9A%E7%9F%A5.zip
```

ASCII-named skills are unchanged (`attachment; filename="demand-deliverability-assessment.zip"`). The current Studio build on the test server degrades gracefully to `skill.zip` until the Studio PR lands; no more mojibake.

Not covered here: the capabilities-lab proxy download returns 502 on the test server because its loopback call to `/management/download` carries no token (401 `token is invalid`). That happens before any header is produced and predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
